### PR TITLE
ci: add security audit + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/apps/web"
+      - "/apps/docs"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Report all advisories
+        run: bun audit
+        continue-on-error: true
+
+      - name: Fail on high or critical advisories
+        run: bun audit --audit-level=high


### PR DESCRIPTION
TL;DR:


Summary:
- Add a CI workflow that runs `bun audit` on pull requests and pushes to `main`: it reports every advisory (including moderate/low) in the log, and fails the build only on high/critical.
- Add Dependabot: weekly `npm` updates across the workspace (`/`, `/apps/web`, `/apps/docs`) plus `github-actions`, with minor/patch grouped into a single PR and a 7-day cooldown that matches the `bunfig` minimum-release-age guard so proposed versions always install.

Test plan:
- [x] The `Security audit` CI job passes on this PR
- [x] Dependabot config is accepted (no error under Insights → Dependency graph → Dependabot)