### PR TITLE
feat: xlsx formula engine (xlsx-model + xlsx-calc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,16 +91,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "xlsx-calc"
+version = "0.0.0"
+dependencies = [
+ "xlsx-model",
+]
+
+[[package]]
+name = "xlsx-model"
+version = "0.0.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "zip"

--- a/crates/xlsx-calc/Cargo.toml
+++ b/crates/xlsx-calc/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xlsx-calc"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+description = "Formula parser, dependency graph, and recalc engine. Reads cells only through xlsx-model's CellProvider trait."
+
+[dependencies]
+xlsx-model = { path = "../xlsx-model" }

--- a/crates/xlsx-calc/README.md
+++ b/crates/xlsx-calc/README.md
@@ -1,0 +1,163 @@
+# xlsx-calc
+
+The formula engine: lexer → parser → `Expr` AST → tree-walking evaluator, plus
+per-formula reference extraction and (from the graph work) dependency tracking.
+It reads cells exclusively through `xlsx_model::CellProvider` — see
+`docs/decisions/0001-formula-engine.md`.
+
+Written spec-first from ECMA-376 Part 1 §18.17 and public Excel function
+semantics. No GPL/AGPL or proprietary spreadsheet source was consulted.
+
+## Architecture
+
+- `lexer.rs` / `parser.rs` — source → position-tagged tokens → `Expr`.
+- `eval.rs` — the evaluator and coercion machinery (`to_number`, `to_text`,
+  `to_bool`, `cmp_values`), range/`Area` access, and error propagation. It owns
+  no functions; `Expr::FuncCall` dispatches into `functions::lookup`.
+- `functions/` — the builtin library. `mod.rs` holds the name → implementation
+  registry and shared argument collectors; one module per category
+  (`math`, `stats`, `text`, `datetime`, `logical`, `lookups`, `info`) plus
+  `criteria.rs` (the shared Excel criteria-string parser and the *IF/*IFS
+  driver).
+
+Every builtin has the signature `fn(&[Expr], &EvalContext) -> CellValue` and
+receives its arguments **unevaluated**, so control-flow functions (`IF`, `IFS`,
+`SWITCH`, `IFERROR`, `IFNA`, `CHOOSE`, `AND`, `OR`) evaluate only the branches
+they take.
+
+## Registry
+
+Function names resolve **case-insensitively** (`sum`, `SUM`, `Sum` are one
+function). Aliases map to a single implementation: `CONCAT`/`CONCATENATE`,
+`MODE`/`MODE.SNGL`, `STDEV`/`STDEV.S`, `STDEVP`/`STDEV.P`, `VAR`/`VAR.S`,
+`VARP`/`VAR.P`, `RANK`/`RANK.EQ`.
+
+## Supported functions
+
+### Math
+
+| Name | Notes / deviations |
+|---|---|
+| `SUM` | Numeric cells only from references; literals coerce; errors propagate. |
+| `SUMIF(range, criteria, [sum_range])` | `sum_range` is anchored at its top-left with the criteria shape. |
+| `SUMIFS(sum_range, crit_range, crit, …)` | All ranges must share dimensions. |
+| `SUMPRODUCT(array1, [array2], …)` | Element-wise product summed; non-numeric cells = 0; arrays must match length. |
+| `PRODUCT` | No numbers → 0. |
+| `ABS`, `SIGN` | — |
+| `ROUND` | Half away from zero. |
+| `ROUNDUP` / `ROUNDDOWN` | Directional (away from / toward zero). |
+| `MROUND(n, m)` | Nearest multiple, half away from zero; opposite signs → `#NUM!`; `m=0` → 0. |
+| `CEILING(n, s)` / `FLOOR(n, s)` | Multiple of `s`; positive `n` with negative `s` → `#NUM!`; `s=0` → 0. |
+| `INT` | Floor. |
+| `TRUNC(n, [digits])` | Toward zero. |
+| `MOD(n, d)` | Sign follows divisor; `d=0` → `#DIV/0!`. |
+| `POWER`, `SQRT`, `EXP` | Non-finite result → `#NUM!`; `SQRT` of a negative → `#NUM!`. |
+| `LN`, `LOG10`, `LOG(n, [base])` | Non-positive input → `#NUM!`; `LN`/`LOG10` use the dedicated libm routine. |
+| `PI` | — |
+
+### Statistics
+
+| Name | Notes / deviations |
+|---|---|
+| `AVERAGE` | No numbers → `#DIV/0!`. |
+| `COUNT` / `COUNTA` / `COUNTBLANK` | Numeric / non-empty / empty-or-`""`. |
+| `COUNTIF`, `COUNTIFS` | Criteria via the shared parser. |
+| `AVERAGEIF(range, criteria, [avg_range])`, `AVERAGEIFS` | No matches → `#DIV/0!`. |
+| `MIN` / `MAX` | No numbers → 0. |
+| `MEDIAN` | — |
+| `MODE` (`MODE.SNGL`) | Earliest-appearing value wins ties; no repeats → `#N/A`. |
+| `STDEV`/`STDEV.S`, `STDEVP`/`STDEV.P` | Sample needs ≥2 values, population ≥1, else `#DIV/0!`. |
+| `VAR`/`VAR.S`, `VARP`/`VAR.P` | As above. |
+| `LARGE(array, k)` / `SMALL(array, k)` | `k` out of range → `#NUM!`. |
+| `RANK`/`RANK.EQ(n, ref, [order])` | Order 0/omitted = descending; ties share the best rank; absent → `#N/A`. |
+
+### Text
+
+| Name | Notes / deviations |
+|---|---|
+| `LEN`, `UPPER`, `LOWER`, `TRIM` | `TRIM` collapses runs of the ASCII space only. |
+| `LEFT`/`RIGHT(text, [n])`, `MID(text, start, count)` | 1-based; positions counted in Unicode scalar values (see below). |
+| `FIND` / `SEARCH` | `FIND` case-sensitive, `SEARCH` case-insensitive; not found → `#VALUE!`. **No wildcards in `SEARCH`.** |
+| `SUBSTITUTE(text, old, new, [instance])` | Empty `old` returns the text unchanged. |
+| `REPLACE(old, start, count, new)` | Positional. |
+| `REPT`, `EXACT`, `PROPER`, `CLEAN` | `CLEAN` strips control characters. |
+| `T` | Text passes through, everything else → `""`. |
+| `CHAR(n)` / `CODE(text)` | `CHAR` for code points 1..=255; `CODE` returns the first char's code point (Unicode, not a code page). |
+| `VALUE`, `NUMBERVALUE(text, [dec], [grp])` | `VALUE` handles a trailing `%`. |
+| `TEXT(value, format)` | **Minimal**: only `0`, `0.00`, `#,##0`, `#,##0.00`, `0%`; any other code → `#VALUE!`. |
+| `TEXTJOIN(delim, ignore_empty, …)` | `ignore_empty` also skips empty strings; ranges flatten row-major. |
+| `CONCAT` / `CONCATENATE` | Ranges flatten row-major. |
+
+### Date & time
+
+| Name | Notes / deviations |
+|---|---|
+| `DATE(y, m, d)` | Months roll into years, day is an offset (overflow rolls); years 0..=1899 → `1900+y`; result < 1 → `#NUM!`. |
+| `YEAR` / `MONTH` / `DAY` | Serial < 0 → `#NUM!`; serial 0 renders as 1900-01-00. |
+| `WEEKDAY(serial, [type])` | Types 1 (default), 2, 3, and 11..17. |
+| `EDATE` / `EOMONTH(start, months)` | `EDATE` clamps the day to the target month length. |
+| `TODAY` / `NOW` | Read `ctx.now_serial`; **absent clock → `#VALUE!`** (documented pure-engine boundary). |
+| `HOUR` / `MINUTE` / `SECOND` | Time portion rounded to the nearest second. |
+| `TIME(h, m, s)` | Fraction of a day in [0, 1); values beyond a day wrap. |
+| `DATEDIF(start, end, unit)` | Units `Y`, `M`, `D`, `YM`, `YD`, `MD`; `end < start` → `#NUM!`. |
+
+Serial ↔ calendar math is the Excel **1900 system including the deliberate leap
+bug** (serial 60 = the phantom 1900-02-29), matching `xlsx_model::date`. The
+workbook date system is not reachable through `CellProvider`, so the 1904 epoch
+is not yet wired — a follow-up.
+
+### Logical
+
+| Name | Notes |
+|---|---|
+| `IF(cond, then, [else])` | Omitted else → `FALSE`. |
+| `IFERROR(v, fallback)` | Fallback replaces any error. |
+| `IFNA(v, fallback)` | Fallback replaces only `#N/A`. |
+| `IFS(cond, val, …)` | First true condition; none → `#N/A`. |
+| `SWITCH(expr, match, result, …, [default])` | Trailing odd argument is the default; no match/default → `#N/A`. |
+| `AND` / `OR` / `NOT` / `XOR` | Blanks/text ignored; at least one logical required. |
+
+### Lookup & reference
+
+| Name | Notes / deviations |
+|---|---|
+| `VLOOKUP` / `HLOOKUP(value, table, index, [range_lookup])` | `range_lookup` defaults to TRUE (approximate on a sorted first column/row); index out of range → `#REF!`. **No wildcards in exact mode.** |
+| `MATCH(value, area, [type])` | Types 1 (default, ascending), 0 (exact), -1 (descending). **No wildcards in type 0.** |
+| `INDEX(area, row, [col])` | Single-row/column areas accept one index; out of range → `#REF!`. |
+| `XLOOKUP(value, lookup, return, [if_not_found], …)` | **Exact match only**; match/search modes beyond exact are not yet implemented. |
+| `CHOOSE(index, …)` | Only the chosen argument is evaluated. |
+| `ROW` / `COLUMN([ref])` | **A reference is required** — the evaluator has no notion of the calling cell, so the no-arg form is `#VALUE!`. |
+| `ROWS` / `COLUMNS(area)` | Dimension counts. |
+
+### Information
+
+| Name | Notes |
+|---|---|
+| `ISBLANK`, `ISNUMBER`, `ISTEXT`, `ISLOGICAL` | Type predicates; never propagate errors. |
+| `ISERROR`, `ISERR`, `ISNA` | `ISERR` excludes `#N/A`. |
+| `NA` | The `#N/A` literal. |
+| `N` | Numbers/bools → numbers, text → 0, errors pass through. |
+
+## Criteria strings
+
+Shared by the *IF/*IFS family (`criteria.rs`). A criterion is an optional
+leading comparison (`>=`, `<=`, `<>`, `>`, `<`, `=`) followed by a value; with
+no operator the comparison is equality. Numeric-looking values compare as
+numbers; everything else compares as case-insensitive text. For `=`/`<>` the
+text may contain the wildcards `*` (any run) and `?` (any single character),
+with `~` escaping a literal `*`, `?`, or `~`.
+
+## Deviations & boundaries (summary)
+
+- **Text positions** are counted in Unicode scalar values; Excel counts UTF-16
+  code units. This differs only for astral (supplementary-plane) characters.
+- **`SEARCH` / VLOOKUP / MATCH / VLOOKUP exact mode** do not implement
+  wildcards yet.
+- **`TEXT`** implements only the five format codes listed above; the full
+  §18.8.31 number-format interpreter is a separate PR.
+- **1904 date system** is not yet wired (see Date & time).
+- **`RAND` / `RANDBETWEEN`** are intentionally **not implemented** here — the
+  engine is kept pure and deterministic; volatility is handled generically by
+  the dependency graph.
+- **`TODAY` / `NOW`** return `#VALUE!` when no clock is injected via
+  `EvalContext::with_now`.

--- a/crates/xlsx-calc/examples/demo.rs
+++ b/crates/xlsx-calc/examples/demo.rs
@@ -1,0 +1,66 @@
+//! End-to-end demo: full recalc at open, then an incremental recalc after an edit.
+
+use xlsx_calc::{rebuild_and_recalc_all, recalc_after};
+use xlsx_model::{Cell, CellRef, CellValue, Sheet, SheetId, Workbook};
+
+fn number(v: f64) -> Cell {
+    Cell {
+        value: CellValue::Number { value: v },
+        formula: None,
+        style: None,
+    }
+}
+
+fn formula(src: &str) -> Cell {
+    Cell {
+        value: CellValue::Empty,
+        formula: Some(src.into()),
+        style: None,
+    }
+}
+
+fn render(wb: &Workbook, sheet: SheetId, a1: &str) -> String {
+    let at = CellRef::parse_a1(a1).unwrap();
+    let cell = wb.sheet(sheet).unwrap().cell(at);
+    let shown = match cell.map(|c| &c.value) {
+        Some(CellValue::Number { value }) => value.to_string(),
+        Some(CellValue::Text { value }) => value.clone(),
+        Some(CellValue::Bool { value }) => value.to_string().to_uppercase(),
+        Some(other) => format!("{other:?}"),
+        None => "(empty)".into(),
+    };
+    match cell.and_then(|c| c.formula.as_deref()) {
+        Some(f) => format!("{a1} = {f} -> {shown}"),
+        None => format!("{a1} = {shown}"),
+    }
+}
+
+fn main() {
+    let mut wb = Workbook::default();
+    wb.sheets.push(Sheet::new("Sheet1"));
+    let s = SheetId(0);
+    let sheet = wb.sheet_mut(s).unwrap();
+
+    sheet.set_cell(CellRef::parse_a1("A1").unwrap(), number(3.0));
+    sheet.set_cell(CellRef::parse_a1("A2").unwrap(), number(4.0));
+    sheet.set_cell(CellRef::parse_a1("A3").unwrap(), formula("A1*A2"));
+    sheet.set_cell(CellRef::parse_a1("B1").unwrap(), formula("SUM(A1:A3)"));
+    sheet.set_cell(
+        CellRef::parse_a1("B2").unwrap(),
+        formula("IF(B1>=19,\"big\",\"small\")"),
+    );
+
+    let (mut graph, opened) = rebuild_and_recalc_all(&mut wb, None);
+    println!("open: {} formulas evaluated", opened.changed.len());
+    for a1 in ["A1", "A2", "A3", "B1", "B2"] {
+        println!("  {}", render(&wb, s, a1));
+    }
+
+    let a1 = CellRef::parse_a1("A1").unwrap();
+    wb.sheet_mut(s).unwrap().set_cell(a1, number(10.0));
+    let edited = recalc_after(&mut wb, &mut graph, &[(s, a1)], None);
+    println!("edit A1=10: {} cells changed", edited.changed.len());
+    for a1 in ["A1", "A2", "A3", "B1", "B2"] {
+        println!("  {}", render(&wb, s, a1));
+    }
+}

--- a/crates/xlsx-calc/src/deps.rs
+++ b/crates/xlsx-calc/src/deps.rs
@@ -1,0 +1,94 @@
+//! dependency extraction: the set of cells/ranges a formula reads.
+
+use xlsx_model::CellRange;
+
+use crate::parser::Expr;
+
+/// collect every reference a formula reads as `(sheet, range)` pairs;
+/// `sheet` is `None` for unqualified refs. order-preserving, de-duplicated.
+pub fn references(expr: &Expr) -> Vec<(Option<String>, CellRange)> {
+    let mut out = Vec::new();
+    walk(expr, &mut out);
+    out
+}
+
+fn walk(expr: &Expr, out: &mut Vec<(Option<String>, CellRange)>) {
+    match expr {
+        Expr::Ref { sheet, cell } => {
+            push_unique(
+                out,
+                sheet.clone(),
+                CellRange {
+                    start: *cell,
+                    end: *cell,
+                },
+            );
+        }
+        Expr::Range { sheet, range } => {
+            push_unique(out, sheet.clone(), *range);
+        }
+        Expr::Unary { expr, .. } | Expr::Percent(expr) => walk(expr, out),
+        Expr::Binary { lhs, rhs, .. } => {
+            walk(lhs, out);
+            walk(rhs, out);
+        }
+        Expr::FuncCall { args, .. } => {
+            for arg in args {
+                walk(arg, out);
+            }
+        }
+        Expr::Number(_) | Expr::Text(_) | Expr::Bool(_) | Expr::Error(_) => {}
+    }
+}
+
+fn push_unique(
+    out: &mut Vec<(Option<String>, CellRange)>,
+    sheet: Option<String>,
+    range: CellRange,
+) {
+    let entry = (sheet, range);
+    if !out.contains(&entry) {
+        out.push(entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_formula;
+
+    fn refs(src: &str) -> Vec<String> {
+        references(&parse_formula(src).unwrap())
+            .into_iter()
+            .map(|(sheet, range)| match sheet {
+                Some(s) => format!("{s}!{}", range.to_a1()),
+                None => range.to_a1(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn extracts_single_cell() {
+        assert_eq!(refs("A1+1"), vec!["A1"]);
+    }
+
+    #[test]
+    fn extracts_range_and_qualified() {
+        assert_eq!(refs("SUM(A1:B2) + Sheet2!C3"), vec!["A1:B2", "Sheet2!C3"]);
+    }
+
+    #[test]
+    fn dedups_repeated_refs() {
+        assert_eq!(refs("A1 + A1 * A1"), vec!["A1"]);
+    }
+
+    #[test]
+    fn no_refs_for_literals() {
+        assert!(refs("1 + 2 * 3").is_empty());
+    }
+
+    #[test]
+    fn walks_nested_expressions() {
+        assert_eq!(refs("IF(A1>0, B1, -C1%)"), vec!["A1", "B1", "C1"]);
+    }
+}

--- a/crates/xlsx-calc/src/engine.rs
+++ b/crates/xlsx-calc/src/engine.rs
@@ -1,0 +1,461 @@
+//! recalc driver: given edited cells, re-evaluate exactly the formulas that
+//! could have changed, in dependency order, and report what moved.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use xlsx_model::{CellProvider, CellRef, CellValue, ColId, RowId, SheetId, Workbook};
+
+use crate::eval::{EvalContext, evaluate};
+use crate::graph::DepGraph;
+use crate::parser::parse_formula;
+
+/// the outcome of a recalc: cells whose displayed value changed, and cells
+/// forced to `0` by cycle participation.
+pub struct RecalcResult {
+    pub changed: Vec<(SheetId, CellRef)>,
+    pub cycle_cells: Vec<(SheetId, CellRef)>,
+}
+
+/// normalized cell identity (avoids `$`-anchor `Hash`/`Eq` mismatches).
+type Key = (SheetId, RowId, ColId);
+
+fn key(sheet: SheetId, cell: CellRef) -> Key {
+    (sheet, cell.row, cell.col)
+}
+
+fn cell_of(k: Key) -> CellRef {
+    CellRef::new(k.1, k.2)
+}
+
+/// incremental recalc after `dirty_seeds` were edited: re-evaluates their
+/// transitive dependents plus volatile cells, returns what moved.
+pub fn recalc_after(
+    wb: &mut Workbook,
+    graph: &mut DepGraph,
+    dirty_seeds: &[(SheetId, CellRef)],
+    now_serial: Option<f64>,
+) -> RecalcResult {
+    let recompute = collect_recompute(graph, dirty_seeds);
+    run_recalc(wb, graph, recompute, now_serial)
+}
+
+/// rebuild the graph from scratch and recalc every formula in dependency order.
+pub fn rebuild_and_recalc_all(
+    wb: &mut Workbook,
+    now_serial: Option<f64>,
+) -> (DepGraph, RecalcResult) {
+    let graph = DepGraph::build(wb);
+    let recompute: HashSet<Key> = graph.formula_cells().map(|(s, c)| key(s, c)).collect();
+    let result = run_recalc(wb, &graph, recompute, now_serial);
+    (graph, result)
+}
+
+/// formula cells to re-evaluate: transitive dependents of the seeds, plus
+/// volatile cells and their dependents.
+fn collect_recompute(graph: &DepGraph, seeds: &[(SheetId, CellRef)]) -> HashSet<Key> {
+    let mut recompute: HashSet<Key> = HashSet::new();
+    let mut worklist: Vec<Key> = Vec::new();
+
+    for &(sheet, cell) in seeds {
+        let k = key(sheet, cell);
+        worklist.push(k);
+        if graph.is_formula(sheet, cell) {
+            recompute.insert(k);
+        }
+    }
+    for (sheet, cell) in graph.volatile_cells() {
+        let k = key(sheet, cell);
+        recompute.insert(k);
+        worklist.push(k);
+    }
+
+    let mut expanded: HashSet<Key> = HashSet::new();
+    while let Some(k) = worklist.pop() {
+        if !expanded.insert(k) {
+            continue;
+        }
+        for (ds, dc) in graph.dependents_of(k.0, cell_of(k)) {
+            let dk = key(ds, dc);
+            recompute.insert(dk);
+            worklist.push(dk);
+        }
+    }
+    recompute
+}
+
+/// topologically order `recompute` and evaluate it, writing changed values into
+/// `wb`. cells caught in a cycle are zeroed and reported separately.
+fn run_recalc(
+    wb: &mut Workbook,
+    graph: &DepGraph,
+    recompute: HashSet<Key>,
+    now_serial: Option<f64>,
+) -> RecalcResult {
+    let (order, cycle) = topo_order(graph, &recompute);
+
+    let mut changed: Vec<(SheetId, CellRef)> = Vec::new();
+    for u in &order {
+        if let Some(value) = eval_node(wb, *u, now_serial)
+            && write_if_changed(wb, *u, value)
+        {
+            changed.push((u.0, cell_of(*u)));
+        }
+    }
+
+    let mut cycle_cells: Vec<(SheetId, CellRef)> = Vec::new();
+    for u in &cycle {
+        if write_if_changed(wb, *u, CellValue::Number { value: 0.0 }) {
+            changed.push((u.0, cell_of(*u)));
+        }
+        cycle_cells.push((u.0, cell_of(*u)));
+    }
+
+    changed.sort_by(sort_key);
+    RecalcResult {
+        changed,
+        cycle_cells,
+    }
+}
+
+/// kahn's sort over the sub-graph induced by `recompute`: returns the evaluable
+/// order and, separately, the cells caught in (or only reachable through) a cycle.
+fn topo_order(graph: &DepGraph, recompute: &HashSet<Key>) -> (Vec<Key>, Vec<Key>) {
+    let mut adj: HashMap<Key, Vec<Key>> = HashMap::new();
+    let mut indegree: HashMap<Key, usize> = recompute.iter().map(|k| (*k, 0)).collect();
+
+    for &u in recompute {
+        let mut seen: HashSet<Key> = HashSet::new();
+        for (ds, dc) in graph.dependents_of(u.0, cell_of(u)) {
+            let v = key(ds, dc);
+            if recompute.contains(&v) && seen.insert(v) {
+                adj.entry(u).or_default().push(v);
+                *indegree.get_mut(&v).unwrap() += 1;
+            }
+        }
+    }
+
+    let mut queue: VecDeque<Key> = {
+        let mut ready: Vec<Key> = recompute
+            .iter()
+            .copied()
+            .filter(|k| indegree.get(k) == Some(&0))
+            .collect();
+        ready.sort();
+        ready.into_iter().collect()
+    };
+
+    let mut order: Vec<Key> = Vec::new();
+    while let Some(u) = queue.pop_front() {
+        order.push(u);
+        if let Some(children) = adj.get(&u) {
+            let mut ready: Vec<Key> = Vec::new();
+            for &v in children {
+                let d = indegree.get_mut(&v).unwrap();
+                *d -= 1;
+                if *d == 0 {
+                    ready.push(v);
+                }
+            }
+            ready.sort();
+            queue.extend(ready);
+        }
+    }
+
+    let ordered: HashSet<Key> = order.iter().copied().collect();
+    let mut cycle: Vec<Key> = recompute
+        .iter()
+        .copied()
+        .filter(|k| !ordered.contains(k))
+        .collect();
+    cycle.sort();
+    (order, cycle)
+}
+
+/// evaluate one formula node; `None` when the cell has no formula or it no
+/// longer parses (cached value left untouched).
+fn eval_node(wb: &Workbook, u: Key, now_serial: Option<f64>) -> Option<CellValue> {
+    let src = wb.formula(u.0, cell_of(u))?.to_string();
+    let expr = parse_formula(&src).ok()?;
+    let mut ctx = EvalContext::new(wb, u.0);
+    ctx.now_serial = now_serial;
+    Some(evaluate(&expr, &ctx))
+}
+
+/// write `value` only if it differs from the stored value; returns whether
+/// anything changed. formula and style are preserved.
+fn write_if_changed(wb: &mut Workbook, u: Key, value: CellValue) -> bool {
+    if wb.value(u.0, cell_of(u)) == value {
+        return false;
+    }
+    if let Some(sheet) = wb.sheet_mut(u.0) {
+        let mut cell = sheet.cell(cell_of(u)).cloned().unwrap_or_default();
+        cell.value = value;
+        sheet.set_cell(cell_of(u), cell);
+    }
+    true
+}
+
+fn sort_key(a: &(SheetId, CellRef), b: &(SheetId, CellRef)) -> std::cmp::Ordering {
+    (a.0.0, a.1.row, a.1.col).cmp(&(b.0.0, b.1.row, b.1.col))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xlsx_model::{Cell, Sheet};
+
+    fn a1(s: &str) -> CellRef {
+        CellRef::parse_a1(s).unwrap()
+    }
+
+    fn num(v: f64) -> CellValue {
+        CellValue::Number { value: v }
+    }
+
+    /// set a literal number cell.
+    fn put_num(wb: &mut Workbook, sheet: SheetId, cell: &str, v: f64) {
+        wb.sheet_mut(sheet).unwrap().set_cell(
+            a1(cell),
+            Cell {
+                value: num(v),
+                ..Cell::default()
+            },
+        );
+    }
+
+    /// set a formula cell with an (initially blank) cached value.
+    fn put_formula(wb: &mut Workbook, sheet: SheetId, cell: &str, f: &str) {
+        wb.sheet_mut(sheet).unwrap().set_cell(
+            a1(cell),
+            Cell {
+                value: CellValue::Empty,
+                formula: Some(f.to_string()),
+                style: None,
+            },
+        );
+    }
+
+    fn value(wb: &Workbook, sheet: SheetId, cell: &str) -> CellValue {
+        wb.value(sheet, a1(cell))
+    }
+
+    fn changed_a1(r: &RecalcResult) -> Vec<String> {
+        r.changed.iter().map(|(_, c)| c.to_a1()).collect()
+    }
+
+    fn one_sheet() -> (Workbook, SheetId) {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Sheet1"));
+        (wb, SheetId(0))
+    }
+
+    #[test]
+    fn chain_propagates_transitively() {
+        let (mut wb, s) = one_sheet();
+        put_num(&mut wb, s, "A1", 1.0);
+        put_formula(&mut wb, s, "B1", "A1+1");
+        put_formula(&mut wb, s, "C1", "B1+1");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s, "B1"), num(2.0));
+        assert_eq!(value(&wb, s, "C1"), num(3.0));
+
+        put_num(&mut wb, s, "A1", 10.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A1"))], None);
+        assert_eq!(value(&wb, s, "B1"), num(11.0));
+        assert_eq!(value(&wb, s, "C1"), num(12.0));
+        assert_eq!(changed_a1(&r), vec!["B1", "C1"]);
+    }
+
+    #[test]
+    fn diamond_evaluates_each_cell_once_in_order() {
+        let (mut wb, s) = one_sheet();
+        put_num(&mut wb, s, "A1", 5.0);
+        put_formula(&mut wb, s, "B1", "A1*2");
+        put_formula(&mut wb, s, "C1", "A1+3");
+        put_formula(&mut wb, s, "D1", "B1+C1");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s, "D1"), num(18.0));
+
+        put_num(&mut wb, s, "A1", 6.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A1"))], None);
+        assert_eq!(value(&wb, s, "D1"), num(21.0));
+        assert_eq!(changed_a1(&r), vec!["B1", "C1", "D1"]);
+    }
+
+    #[test]
+    fn range_dependency_recalcs_on_interior_edit() {
+        let (mut wb, s) = one_sheet();
+        for (i, cell) in ["A1", "A2", "A3", "A4", "A5"].iter().enumerate() {
+            put_num(&mut wb, s, cell, (i + 1) as f64);
+        }
+        put_formula(&mut wb, s, "B1", "SUM(A1:A10)");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s, "B1"), num(15.0));
+
+        put_num(&mut wb, s, "A5", 100.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A5"))], None);
+        assert_eq!(value(&wb, s, "B1"), num(110.0));
+        assert_eq!(changed_a1(&r), vec!["B1"]);
+    }
+
+    #[test]
+    fn cross_sheet_chain() {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Sheet1"));
+        wb.sheets.push(Sheet::new("Data"));
+        let (s1, s2) = (SheetId(0), SheetId(1));
+        put_num(&mut wb, s1, "A1", 7.0);
+        put_formula(&mut wb, s2, "A1", "Sheet1!A1 * 2");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s2, "A1"), num(14.0));
+
+        put_num(&mut wb, s1, "A1", 8.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s1, a1("A1"))], None);
+        assert_eq!(value(&wb, s2, "A1"), num(16.0));
+        assert_eq!(r.changed, vec![(s2, a1("A1"))]);
+    }
+
+    #[test]
+    fn cycle_zeros_cells_and_recovers_when_broken() {
+        let (mut wb, s) = one_sheet();
+        put_formula(&mut wb, s, "A1", "B1+1");
+        put_formula(&mut wb, s, "B1", "A1+1");
+        let (mut graph, r) = rebuild_and_recalc_all(&mut wb, None);
+        let mut cyc: Vec<String> = r.cycle_cells.iter().map(|(_, c)| c.to_a1()).collect();
+        cyc.sort();
+        assert_eq!(cyc, vec!["A1", "B1"]);
+        assert_eq!(value(&wb, s, "A1"), num(0.0));
+        assert_eq!(value(&wb, s, "B1"), num(0.0));
+
+        put_formula(&mut wb, s, "B1", "5");
+        graph.set_formula(s, a1("B1"), Some("5"));
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("B1"))], None);
+        assert!(r.cycle_cells.is_empty());
+        assert_eq!(value(&wb, s, "B1"), num(5.0));
+        assert_eq!(value(&wb, s, "A1"), num(6.0));
+    }
+
+    #[test]
+    fn self_reference_is_a_cycle() {
+        let (mut wb, s) = one_sheet();
+        put_formula(&mut wb, s, "A1", "A1+1");
+        let (_, r) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(r.cycle_cells, vec![(s, a1("A1"))]);
+        assert_eq!(value(&wb, s, "A1"), num(0.0));
+    }
+
+    #[test]
+    fn incremental_set_formula_updates_live_edges() {
+        let (mut wb, s) = one_sheet();
+        put_num(&mut wb, s, "A1", 1.0);
+        put_num(&mut wb, s, "B1", 100.0);
+        put_formula(&mut wb, s, "C1", "A1+1");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s, "C1"), num(2.0));
+
+        put_formula(&mut wb, s, "C1", "B1+1");
+        graph.set_formula(s, a1("C1"), Some("B1+1"));
+        recalc_after(&mut wb, &mut graph, &[(s, a1("C1"))], None);
+        assert_eq!(value(&wb, s, "C1"), num(101.0));
+
+        put_num(&mut wb, s, "A1", 50.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A1"))], None);
+        assert!(r.changed.is_empty());
+        assert_eq!(value(&wb, s, "C1"), num(101.0));
+
+        put_num(&mut wb, s, "B1", 200.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("B1"))], None);
+        assert_eq!(changed_a1(&r), vec!["C1"]);
+        assert_eq!(value(&wb, s, "C1"), num(201.0));
+    }
+
+    /// overwrite a cell's cached value while keeping its formula.
+    fn set_cached(wb: &mut Workbook, sheet: SheetId, cell: &str, v: CellValue) {
+        let mut c = wb.sheet(sheet).unwrap().cell(a1(cell)).cloned().unwrap();
+        c.value = v;
+        wb.sheet_mut(sheet).unwrap().set_cell(a1(cell), c);
+    }
+
+    #[test]
+    fn volatile_cell_reevaluates_on_unrelated_edit() {
+        let (mut wb, s) = one_sheet();
+        put_num(&mut wb, s, "A1", 1.0);
+        put_formula(&mut wb, s, "B1", "A1+1");
+        put_formula(&mut wb, s, "C1", "NOW()");
+        put_formula(&mut wb, s, "D1", "C1+1");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, Some(45000.0));
+
+        let sentinel = num(-999_999.0);
+        set_cached(&mut wb, s, "C1", sentinel.clone());
+        set_cached(&mut wb, s, "D1", sentinel.clone());
+
+        put_num(&mut wb, s, "A1", 2.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A1"))], Some(45000.0));
+        assert_ne!(value(&wb, s, "C1"), sentinel);
+        assert_ne!(value(&wb, s, "D1"), sentinel);
+        assert_eq!(changed_a1(&r), vec!["B1", "C1", "D1"]);
+    }
+
+    #[test]
+    fn changed_list_excludes_unmoved_dependents() {
+        let (mut wb, s) = one_sheet();
+        put_num(&mut wb, s, "A1", 1.0);
+        put_num(&mut wb, s, "A2", 2.0);
+        put_num(&mut wb, s, "A3", 3.0);
+        put_formula(&mut wb, s, "B1", "MIN(A1:A3)");
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s, "B1"), num(1.0));
+
+        put_num(&mut wb, s, "A2", 5.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A2"))], None);
+        assert!(r.changed.is_empty(), "unmoved MIN must not be reported");
+        assert_eq!(value(&wb, s, "B1"), num(1.0));
+    }
+
+    #[test]
+    fn rebuild_corrects_stale_cached_value() {
+        let (mut wb, s) = one_sheet();
+        wb.sheet_mut(s).unwrap().set_cell(
+            a1("A1"),
+            Cell {
+                value: num(999.0),
+                formula: Some("1+1".to_string()),
+                style: None,
+            },
+        );
+        let (_, r) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, s, "A1"), num(2.0));
+        assert_eq!(r.changed, vec![(s, a1("A1"))]);
+    }
+
+    #[test]
+    #[ignore = "perf smoke; run with --release --ignored"]
+    fn ten_thousand_cell_chain_is_fast() {
+        use std::time::Instant;
+        const N: u32 = 10_000;
+        let (mut wb, s) = one_sheet();
+        put_num(&mut wb, s, "A1", 0.0);
+        for row in 1..N {
+            let cell = CellRef::new(row, 0);
+            let prev = CellRef::new(row - 1, 0).to_a1();
+            wb.sheet_mut(s).unwrap().set_cell(
+                cell,
+                Cell {
+                    value: CellValue::Empty,
+                    formula: Some(format!("{prev}+1")),
+                    style: None,
+                },
+            );
+        }
+        let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(wb.value(s, CellRef::new(N - 1, 0)), num((N - 1) as f64));
+
+        let start = Instant::now();
+        put_num(&mut wb, s, "A1", 1.0);
+        let r = recalc_after(&mut wb, &mut graph, &[(s, a1("A1"))], None);
+        let elapsed = start.elapsed();
+        assert_eq!(wb.value(s, CellRef::new(N - 1, 0)), num(N as f64));
+        assert_eq!(r.changed.len(), (N - 1) as usize);
+        assert!(elapsed.as_secs_f64() < 1.0, "recalc took {elapsed:?}");
+    }
+}

--- a/crates/xlsx-calc/src/eval.rs
+++ b/crates/xlsx-calc/src/eval.rs
@@ -1,0 +1,345 @@
+//! tree-walking evaluator; reads cells only through `xlsx_model::CellProvider`.
+//! coercion follows excel; errors propagate leftmost-first.
+
+use xlsx_model::{CellProvider, CellRange, CellRef, CellValue, ErrorValue, SheetId};
+
+use crate::parser::{BinaryOp, Expr, UnaryOp};
+
+/// evaluation environment: the cell source plus the sheet unqualified refs
+/// resolve against.
+pub struct EvalContext<'a> {
+    pub provider: &'a dyn CellProvider,
+    pub sheet: SheetId,
+    /// wall-clock as an excel date serial; `None` -> TODAY()/NOW() return #VALUE!.
+    pub now_serial: Option<f64>,
+}
+
+impl<'a> EvalContext<'a> {
+    pub fn new(provider: &'a dyn CellProvider, sheet: SheetId) -> Self {
+        Self {
+            provider,
+            sheet,
+            now_serial: None,
+        }
+    }
+
+    pub fn with_now(provider: &'a dyn CellProvider, sheet: SheetId, now_serial: f64) -> Self {
+        Self {
+            provider,
+            sheet,
+            now_serial: Some(now_serial),
+        }
+    }
+}
+
+pub(crate) fn err(value: ErrorValue) -> CellValue {
+    CellValue::Error { value }
+}
+
+pub(crate) fn num(value: f64) -> CellValue {
+    CellValue::Number { value }
+}
+
+pub(crate) fn text(value: impl Into<String>) -> CellValue {
+    CellValue::Text {
+        value: value.into(),
+    }
+}
+
+pub(crate) fn boolean(value: bool) -> CellValue {
+    CellValue::Bool { value }
+}
+
+/// evaluate an expression against a cell provider.
+pub fn evaluate(expr: &Expr, ctx: &EvalContext<'_>) -> CellValue {
+    match expr {
+        Expr::Number(n) => num(*n),
+        Expr::Text(s) => CellValue::Text { value: s.clone() },
+        Expr::Bool(b) => CellValue::Bool { value: *b },
+        Expr::Error(e) => err(*e),
+        Expr::Ref { sheet, cell } => resolve_ref(sheet, *cell, ctx),
+        // no implicit intersection: a bare range in scalar context is #VALUE!
+        Expr::Range { .. } => err(ErrorValue::Value),
+        Expr::Unary { op, expr } => eval_unary(*op, expr, ctx),
+        Expr::Binary { op, lhs, rhs } => eval_binary(*op, lhs, rhs, ctx),
+        Expr::Percent(inner) => match to_number(&evaluate(inner, ctx)) {
+            Ok(n) => num(n / 100.0),
+            Err(e) => err(e),
+        },
+        Expr::FuncCall { name, args } => match crate::functions::lookup(name) {
+            Some(f) => f(args, ctx),
+            None => err(ErrorValue::Name),
+        },
+    }
+}
+
+/// resolve a possibly sheet-qualified cell reference to its stored value.
+pub(crate) fn resolve_ref(
+    sheet: &Option<String>,
+    cell: CellRef,
+    ctx: &EvalContext<'_>,
+) -> CellValue {
+    let sid = match sheet {
+        Some(name) => match ctx.provider.sheet_id(name) {
+            Some(id) => id,
+            None => return err(ErrorValue::Ref),
+        },
+        None => ctx.sheet,
+    };
+    ctx.provider.value(sid, cell)
+}
+
+/// resolve a possibly sheet-qualified name to its sheet id (`None` -> the
+/// context sheet). returns `None` only when a named sheet does not exist.
+pub(crate) fn resolve_sheet(sheet: &Option<String>, ctx: &EvalContext<'_>) -> Option<SheetId> {
+    match sheet {
+        Some(name) => ctx.provider.sheet_id(name),
+        None => Some(ctx.sheet),
+    }
+}
+
+fn eval_unary(op: UnaryOp, expr: &Expr, ctx: &EvalContext<'_>) -> CellValue {
+    let v = evaluate(expr, ctx);
+    match to_number(&v) {
+        Ok(n) => match op {
+            UnaryOp::Neg => num(-n),
+            UnaryOp::Plus => num(n),
+        },
+        Err(e) => err(e),
+    }
+}
+
+fn eval_binary(op: BinaryOp, lhs: &Expr, rhs: &Expr, ctx: &EvalContext<'_>) -> CellValue {
+    let lv = evaluate(lhs, ctx);
+    if let CellValue::Error { value } = lv {
+        return err(value);
+    }
+    let rv = evaluate(rhs, ctx);
+    if let CellValue::Error { value } = rv {
+        return err(value);
+    }
+    match op {
+        BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow => {
+            let a = match to_number(&lv) {
+                Ok(n) => n,
+                Err(e) => return err(e),
+            };
+            let b = match to_number(&rv) {
+                Ok(n) => n,
+                Err(e) => return err(e),
+            };
+            arithmetic(op, a, b)
+        }
+        BinaryOp::Concat => {
+            let a = match to_text(&lv) {
+                Ok(s) => s,
+                Err(e) => return err(e),
+            };
+            let b = match to_text(&rv) {
+                Ok(s) => s,
+                Err(e) => return err(e),
+            };
+            CellValue::Text { value: a + &b }
+        }
+        _ => compare(op, &lv, &rv),
+    }
+}
+
+fn arithmetic(op: BinaryOp, a: f64, b: f64) -> CellValue {
+    match op {
+        BinaryOp::Add => num(a + b),
+        BinaryOp::Sub => num(a - b),
+        BinaryOp::Mul => num(a * b),
+        BinaryOp::Div => {
+            if b == 0.0 {
+                err(ErrorValue::Div0)
+            } else {
+                num(a / b)
+            }
+        }
+        BinaryOp::Pow => {
+            let r = a.powf(b);
+            if r.is_finite() {
+                num(r)
+            } else {
+                err(ErrorValue::Num)
+            }
+        }
+        _ => unreachable!("non-arithmetic op"),
+    }
+}
+
+fn compare(op: BinaryOp, lv: &CellValue, rv: &CellValue) -> CellValue {
+    use std::cmp::Ordering::*;
+    let ord = cmp_values(lv, rv);
+    let result = match op {
+        BinaryOp::Eq => ord == Equal,
+        BinaryOp::Ne => ord != Equal,
+        BinaryOp::Lt => ord == Less,
+        BinaryOp::Le => ord != Greater,
+        BinaryOp::Gt => ord == Greater,
+        BinaryOp::Ge => ord != Less,
+        _ => unreachable!("non-comparison op"),
+    };
+    CellValue::Bool { value: result }
+}
+
+/// excel cross-type ordering: number < text < bool; blanks adopt the other
+/// operand's type (0 / "" / false); text compares case-insensitively.
+pub(crate) fn cmp_values(a: &CellValue, b: &CellValue) -> std::cmp::Ordering {
+    use CellValue::*;
+    use std::cmp::Ordering::Equal;
+    match (a, b) {
+        (Number { value: x }, Number { value: y }) => x.partial_cmp(y).unwrap_or(Equal),
+        (Text { value: x }, Text { value: y }) => cmp_text(x, y),
+        (Bool { value: x }, Bool { value: y }) => x.cmp(y),
+        (Empty, Empty) => Equal,
+        (Empty, Number { value: y }) => 0.0_f64.partial_cmp(y).unwrap_or(Equal),
+        (Number { value: x }, Empty) => x.partial_cmp(&0.0).unwrap_or(Equal),
+        (Empty, Text { value: y }) => cmp_text("", y),
+        (Text { value: x }, Empty) => cmp_text(x, ""),
+        (Empty, Bool { value: y }) => false.cmp(y),
+        (Bool { value: x }, Empty) => x.cmp(&false),
+        _ => type_rank(a).cmp(&type_rank(b)),
+    }
+}
+
+fn cmp_text(a: &str, b: &str) -> std::cmp::Ordering {
+    a.to_lowercase().cmp(&b.to_lowercase())
+}
+
+fn type_rank(v: &CellValue) -> u8 {
+    match v {
+        CellValue::Empty | CellValue::Number { .. } => 0,
+        CellValue::Text { .. } => 1,
+        CellValue::Bool { .. } => 2,
+        CellValue::Error { .. } => 3,
+    }
+}
+
+/// coerce a value to a number for arithmetic. numeric text coerces (excel),
+/// non-numeric text is #VALUE!, errors propagate.
+pub(crate) fn to_number(v: &CellValue) -> Result<f64, ErrorValue> {
+    match v {
+        CellValue::Empty => Ok(0.0),
+        CellValue::Number { value } => Ok(*value),
+        CellValue::Bool { value } => Ok(if *value { 1.0 } else { 0.0 }),
+        CellValue::Text { value } => parse_num(value).ok_or(ErrorValue::Value),
+        CellValue::Error { value } => Err(*value),
+    }
+}
+
+pub(crate) fn to_text(v: &CellValue) -> Result<String, ErrorValue> {
+    match v {
+        CellValue::Empty => Ok(String::new()),
+        CellValue::Number { value } => Ok(format_number(*value)),
+        CellValue::Bool { value } => Ok(if *value { "TRUE" } else { "FALSE" }.to_string()),
+        CellValue::Text { value } => Ok(value.clone()),
+        CellValue::Error { value } => Err(*value),
+    }
+}
+
+pub(crate) fn to_bool(v: &CellValue) -> Result<bool, ErrorValue> {
+    match v {
+        CellValue::Empty => Ok(false),
+        CellValue::Bool { value } => Ok(*value),
+        CellValue::Number { value } => Ok(*value != 0.0),
+        CellValue::Text { value } => {
+            if value.eq_ignore_ascii_case("true") {
+                Ok(true)
+            } else if value.eq_ignore_ascii_case("false") {
+                Ok(false)
+            } else {
+                Err(ErrorValue::Value)
+            }
+        }
+        CellValue::Error { value } => Err(*value),
+    }
+}
+
+pub(crate) fn parse_num(s: &str) -> Option<f64> {
+    s.trim().parse::<f64>().ok()
+}
+
+/// excel "general" number formatting, good enough for text coercion: integers
+/// print without a decimal, everything else uses rust's shortest round-trip.
+pub(crate) fn format_number(n: f64) -> String {
+    if n == 0.0 {
+        return "0".to_string();
+    }
+    if n == n.trunc() && n.abs() < 1e15 {
+        return format!("{}", n as i64);
+    }
+    format!("{n}")
+}
+
+/// expand a range argument into its cell values (bounded rectangle, row-major).
+pub(crate) fn range_values(
+    sheet: &Option<String>,
+    range: &CellRange,
+    ctx: &EvalContext<'_>,
+) -> Result<Vec<CellValue>, ErrorValue> {
+    let sid = match sheet {
+        Some(name) => ctx.provider.sheet_id(name).ok_or(ErrorValue::Ref)?,
+        None => ctx.sheet,
+    };
+    let mut out = Vec::new();
+    for row in range.start.row..=range.end.row {
+        for col in range.start.col..=range.end.col {
+            out.push(ctx.provider.value(sid, CellRef::new(row, col)));
+        }
+    }
+    Ok(out)
+}
+
+/// a resolved rectangular reference: absolute top-left plus dimensions on a
+/// known sheet, for positional access by function modules.
+pub(crate) struct Area {
+    pub sheet: SheetId,
+    pub start: CellRef,
+    pub rows: usize,
+    pub cols: usize,
+}
+
+impl Area {
+    /// value at 0-based `(row, col)` within the area.
+    pub(crate) fn get(&self, ctx: &EvalContext<'_>, row: usize, col: usize) -> CellValue {
+        let cell = CellRef::new(self.start.row + row as u32, self.start.col + col as u32);
+        ctx.provider.value(self.sheet, cell)
+    }
+
+    /// all values in row-major order.
+    pub(crate) fn values(&self, ctx: &EvalContext<'_>) -> Vec<CellValue> {
+        let mut out = Vec::with_capacity(self.rows * self.cols);
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                out.push(self.get(ctx, row, col));
+            }
+        }
+        out
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.rows * self.cols
+    }
+}
+
+/// interpret an argument as a rectangular reference (1x1 for single cells);
+/// `None` for non-references or unknown sheets.
+pub(crate) fn as_area(arg: &Expr, ctx: &EvalContext<'_>) -> Option<Area> {
+    match arg {
+        Expr::Ref { sheet, cell } => Some(Area {
+            sheet: resolve_sheet(sheet, ctx)?,
+            start: *cell,
+            rows: 1,
+            cols: 1,
+        }),
+        Expr::Range { sheet, range } => Some(Area {
+            sheet: resolve_sheet(sheet, ctx)?,
+            start: range.start,
+            rows: (range.end.row - range.start.row + 1) as usize,
+            cols: (range.end.col - range.start.col + 1) as usize,
+        }),
+        _ => None,
+    }
+}

--- a/crates/xlsx-calc/src/functions/criteria.rs
+++ b/crates/xlsx-calc/src/functions/criteria.rs
@@ -1,0 +1,302 @@
+//! excel criteria strings shared by the *IF / *IFS family: optional comparison
+//! operator prefix, numeric or case-insensitive text compare, `*`/`?`/`~` wildcards.
+
+use xlsx_model::CellValue;
+
+use crate::eval::{Area, EvalContext, as_area, evaluate, parse_num};
+use crate::parser::Expr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Eq,
+    Ne,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+/// a parsed criterion ready to test cell values against.
+#[derive(Debug, Clone)]
+pub(crate) struct Criterion {
+    op: Op,
+    /// numeric target if the value parsed as a number.
+    number: Option<f64>,
+    /// the raw comparison text (lowercased), used for text comparisons.
+    text: String,
+    /// whether the text carries `*`/`?` wildcards (only meaningful for =/<>).
+    wildcard: bool,
+}
+
+impl Criterion {
+    /// build a criterion from an already-evaluated cell value.
+    pub(crate) fn from_value(v: &CellValue) -> Criterion {
+        match v {
+            CellValue::Number { value } => Criterion {
+                op: Op::Eq,
+                number: Some(*value),
+                text: String::new(),
+                wildcard: false,
+            },
+            CellValue::Bool { value } => Criterion::parse(if *value { "TRUE" } else { "FALSE" }),
+            CellValue::Text { value } => Criterion::parse(value),
+            _ => Criterion::parse(""),
+        }
+    }
+
+    /// parse a criteria string such as `">=5"`, `"<>x"`, `"5"`, `"a*"`.
+    pub(crate) fn parse(raw: &str) -> Criterion {
+        let (op, rest) = split_op(raw);
+        let number = parse_num(rest);
+        let wildcard = has_wildcard(rest);
+        Criterion {
+            op,
+            number,
+            text: rest.to_lowercase(),
+            wildcard,
+        }
+    }
+
+    /// does a cell value satisfy this criterion?
+    pub(crate) fn matches(&self, v: &CellValue) -> bool {
+        match self.op {
+            Op::Eq => self.eq_matches(v),
+            Op::Ne => !self.eq_matches(v),
+            Op::Gt | Op::Ge | Op::Lt | Op::Le => self.ord_matches(v),
+        }
+    }
+
+    fn eq_matches(&self, v: &CellValue) -> bool {
+        if let Some(target) = self.number {
+            return cell_number(v).map(|n| n == target).unwrap_or(false);
+        }
+        if self.text.is_empty() {
+            return matches!(v, CellValue::Empty);
+        }
+        let cell_text = cell_text_lower(v);
+        if self.wildcard {
+            wildcard_match(&self.text, &cell_text)
+        } else {
+            cell_text == self.text
+        }
+    }
+
+    fn ord_matches(&self, v: &CellValue) -> bool {
+        use std::cmp::Ordering;
+        let ord = if let Some(target) = self.number {
+            match cell_number(v) {
+                Some(n) => n.partial_cmp(&target),
+                None => return false,
+            }
+        } else {
+            // numeric cells never satisfy a text inequality in excel
+            match v {
+                CellValue::Text { value } => Some(value.to_lowercase().cmp(&self.text)),
+                CellValue::Empty if self.text.is_empty() => Some(Ordering::Equal),
+                _ => return false,
+            }
+        };
+        match ord {
+            Some(o) => match self.op {
+                Op::Gt => o == Ordering::Greater,
+                Op::Ge => o != Ordering::Less,
+                Op::Lt => o == Ordering::Less,
+                Op::Le => o != Ordering::Greater,
+                _ => unreachable!(),
+            },
+            None => false,
+        }
+    }
+}
+
+fn split_op(s: &str) -> (Op, &str) {
+    if let Some(rest) = s.strip_prefix(">=") {
+        (Op::Ge, rest)
+    } else if let Some(rest) = s.strip_prefix("<=") {
+        (Op::Le, rest)
+    } else if let Some(rest) = s.strip_prefix("<>") {
+        (Op::Ne, rest)
+    } else if let Some(rest) = s.strip_prefix('>') {
+        (Op::Gt, rest)
+    } else if let Some(rest) = s.strip_prefix('<') {
+        (Op::Lt, rest)
+    } else if let Some(rest) = s.strip_prefix('=') {
+        (Op::Eq, rest)
+    } else {
+        (Op::Eq, s)
+    }
+}
+
+fn cell_number(v: &CellValue) -> Option<f64> {
+    match v {
+        CellValue::Number { value } => Some(*value),
+        CellValue::Bool { value } => Some(if *value { 1.0 } else { 0.0 }),
+        CellValue::Text { value } => parse_num(value),
+        _ => None,
+    }
+}
+
+fn cell_text_lower(v: &CellValue) -> String {
+    match v {
+        CellValue::Text { value } => value.to_lowercase(),
+        CellValue::Bool { value } => if *value { "true" } else { "false" }.to_string(),
+        CellValue::Number { value } => crate::eval::format_number(*value),
+        _ => String::new(),
+    }
+}
+
+/// any metacharacter routes through the glob matcher — even fully-escaped
+/// patterns, since `~` still has to be unescaped.
+fn has_wildcard(s: &str) -> bool {
+    s.contains(['*', '?', '~'])
+}
+
+/// glob match with `*` and `?`; `~` escapes the following metacharacter.
+/// pattern and text are already lowercased.
+pub(crate) fn wildcard_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star_p, mut star_t): (Option<usize>, usize) = (None, 0);
+    while ti < t.len() {
+        let (lit, is_star, is_any) = classify(&p, pi);
+        if is_star {
+            star_p = Some(pi);
+            star_t = ti;
+            pi += 1;
+        } else if pi < p.len() && (is_any || lit == Some(t[ti])) {
+            pi += advance(&p, pi);
+            ti += 1;
+        } else if let Some(sp) = star_p {
+            pi = sp + 1;
+            star_t += 1;
+            ti = star_t;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() {
+        let (_, is_star, _) = classify(&p, pi);
+        if !is_star {
+            return false;
+        }
+        pi += 1;
+    }
+    true
+}
+
+/// interpret the pattern element at `pi`: (literal char, is `*`, is `?`).
+fn classify(p: &[char], pi: usize) -> (Option<char>, bool, bool) {
+    match p.get(pi) {
+        Some('~') => (p.get(pi + 1).copied(), false, false),
+        Some('*') => (None, true, false),
+        Some('?') => (None, false, true),
+        Some(&c) => (Some(c), false, false),
+        None => (None, false, false),
+    }
+}
+
+/// how many pattern chars a single match consumes (2 for an escape `~x`).
+fn advance(p: &[char], pi: usize) -> usize {
+    if p.get(pi) == Some(&'~') { 2 } else { 1 }
+}
+
+/// build a criterion from a criteria argument's evaluated value.
+pub(crate) fn criterion_from_arg(arg: &Expr, ctx: &EvalContext<'_>) -> Criterion {
+    Criterion::from_value(&evaluate(arg, ctx))
+}
+
+/// parse a `range, criteria, ...` tail into aligned (area, criterion) pairs;
+/// `None` on an odd count, a non-reference range, or a shape mismatch.
+pub(crate) fn collect_pairs(
+    specs: &[Expr],
+    ctx: &EvalContext<'_>,
+) -> Option<Vec<(Area, Criterion)>> {
+    if specs.is_empty() || !specs.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut pairs = Vec::new();
+    let mut dims: Option<(usize, usize)> = None;
+    for chunk in specs.chunks(2) {
+        let area = as_area(&chunk[0], ctx)?;
+        match dims {
+            Some(d) if d != (area.rows, area.cols) => return None,
+            _ => dims = Some((area.rows, area.cols)),
+        }
+        pairs.push((area, criterion_from_arg(&chunk[1], ctx)));
+    }
+    Some(pairs)
+}
+
+/// flat row-major indices where every criterion matches its aligned cell.
+pub(crate) fn matching_indices(pairs: &[(Area, Criterion)], ctx: &EvalContext<'_>) -> Vec<usize> {
+    let (rows, cols) = match pairs.first() {
+        Some((a, _)) => (a.rows, a.cols),
+        None => return Vec::new(),
+    };
+    (0..rows * cols)
+        .filter(|&i| {
+            let (r, c) = (i / cols, i % cols);
+            pairs
+                .iter()
+                .all(|(area, crit)| crit.matches(&area.get(ctx, r, c)))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn num(v: f64) -> CellValue {
+        CellValue::Number { value: v }
+    }
+    fn txt(v: &str) -> CellValue {
+        CellValue::Text { value: v.into() }
+    }
+
+    #[test]
+    fn numeric_operators() {
+        let c = Criterion::parse(">=5");
+        assert!(c.matches(&num(5.0)));
+        assert!(c.matches(&num(9.0)));
+        assert!(!c.matches(&num(4.0)));
+        assert!(!c.matches(&txt("x")));
+
+        let c = Criterion::parse("<>0");
+        assert!(c.matches(&num(3.0)));
+        assert!(!c.matches(&num(0.0)));
+
+        assert!(Criterion::parse("5").matches(&num(5.0)));
+        assert!(Criterion::parse("5").matches(&txt("5")));
+    }
+
+    #[test]
+    fn text_and_wildcards() {
+        assert!(Criterion::parse("apple").matches(&txt("Apple")));
+        assert!(!Criterion::parse("apple").matches(&txt("apples")));
+        assert!(Criterion::parse("a*").matches(&txt("Apple")));
+        assert!(Criterion::parse("a?ple").matches(&txt("apple")));
+        assert!(!Criterion::parse("a?ple").matches(&txt("aple")));
+        assert!(Criterion::parse("<>apple").matches(&txt("pear")));
+        assert!(Criterion::parse("a~*").matches(&txt("a*")));
+        assert!(!Criterion::parse("a~*").matches(&txt("ab")));
+    }
+
+    #[test]
+    fn blank_criteria() {
+        assert!(Criterion::parse("").matches(&CellValue::Empty));
+        assert!(!Criterion::parse("").matches(&txt("x")));
+    }
+
+    #[test]
+    fn wildcard_matcher_direct() {
+        assert!(wildcard_match("*", "anything"));
+        assert!(wildcard_match("h*o", "hello"));
+        assert!(wildcard_match("h*llo", "hello"));
+        assert!(!wildcard_match("h*x", "hello"));
+        assert!(wildcard_match("a*b*c", "aXXbYYc"));
+        assert!(wildcard_match("", ""));
+        assert!(!wildcard_match("", "x"));
+    }
+}

--- a/crates/xlsx-calc/src/functions/datetime.rs
+++ b/crates/xlsx-calc/src/functions/datetime.rs
@@ -1,0 +1,351 @@
+//! date and time functions on excel 1900-system serials, including the
+//! deliberate 1900 leap-year bug (serial 60 = phantom 1900-02-29).
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{EvalContext, err, evaluate, num, to_text};
+use crate::parser::Expr;
+
+use super::{nth_int, nth_number};
+
+/// the phantom 1900-02-29; serials above it are shifted by one real day.
+const PHANTOM: i64 = 60;
+/// serial = unix day count + 25568 below the phantom day (serial 1 = 1900-01-01).
+const SERIAL_OFFSET: i64 = 25_568;
+
+// howard hinnant's civil-date algorithms
+/// days since 1970-01-01 for a proleptic gregorian date.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// (year, month, day) for a day count since 1970-01-01.
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// convert a unix day count to a 1900-system serial, inserting the phantom day.
+fn unix_to_serial(unix: i64) -> i64 {
+    let base = unix + SERIAL_OFFSET;
+    if base < PHANTOM { base } else { base + 1 }
+}
+
+/// (year, month, day) for a serial. serial 60 is the phantom 1900-02-29;
+/// serial < 1 has no calendar date here (returns None).
+fn serial_to_ymd(serial: i64) -> Option<(i64, i64, i64)> {
+    if serial < 1 {
+        return None;
+    }
+    if serial == PHANTOM {
+        return Some((1900, 2, 29));
+    }
+    let adjusted = if serial > PHANTOM { serial - 1 } else { serial };
+    Some(civil_from_days(adjusted - SERIAL_OFFSET))
+}
+
+/// serial for a (year, month, day) under excel's DATE rules: months and day
+/// overflow roll over, phantom 1900-02-29 maps to serial 60.
+fn date_to_serial(year: i64, month: i64, day: i64) -> i64 {
+    if year == 1900 && month == 2 && day == 29 {
+        return PHANTOM;
+    }
+    let mut y = year;
+    let mut m = month;
+    y += (m - 1).div_euclid(12);
+    m = (m - 1).rem_euclid(12) + 1;
+    unix_to_serial(days_from_civil(y, m, 1) + (day - 1))
+}
+
+fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap(year) => 29,
+        2 => 28,
+        _ => 30,
+    }
+}
+
+fn is_leap(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+/// DATE(year, month, day). years 0..=1899 are treated as 1900+year (excel).
+pub(crate) fn date(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let (y, m, d) = match (
+        nth_int(args, ctx, 0),
+        nth_int(args, ctx, 1),
+        nth_int(args, ctx, 2),
+    ) {
+        (Ok(y), Ok(m), Ok(d)) => (y, m, d),
+        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => return err(e),
+    };
+    let y = if (0..1900).contains(&y) { y + 1900 } else { y };
+    let serial = date_to_serial(y, m, d);
+    if serial < 0 {
+        err(ErrorValue::Num)
+    } else {
+        num(serial as f64)
+    }
+}
+
+pub(crate) fn year(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    ymd_part(args, ctx, |(y, _, _)| y)
+}
+
+pub(crate) fn month(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    ymd_part(args, ctx, |(_, m, _)| m)
+}
+
+pub(crate) fn day(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    ymd_part(args, ctx, |(_, _, d)| d)
+}
+
+/// WEEKDAY(serial, [type]): type 1 (default) = 1..7 Sun..Sat; 2/11..17 shift
+/// the first day of the week; 3 = 0..6 Mon..Sun.
+pub(crate) fn weekday(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() || args.len() > 2 {
+        return err(ErrorValue::Value);
+    }
+    let serial = match nth_number(args, ctx, 0) {
+        Ok(n) => n.floor() as i64,
+        Err(e) => return err(e),
+    };
+    let kind = if args.len() == 2 {
+        match nth_int(args, ctx, 1) {
+            Ok(k) => k,
+            Err(e) => return err(e),
+        }
+    } else {
+        1
+    };
+    // d0: 0=Sat,1=Sun,...,6=Fri (serial 1 = sunday)
+    let d0 = serial.rem_euclid(7);
+    let result = match kind {
+        1 => {
+            if d0 == 0 {
+                7
+            } else {
+                d0
+            }
+        }
+        2 | 11 => (d0 + 5).rem_euclid(7) + 1,
+        3 => (d0 + 5).rem_euclid(7),
+        12..=17 => {
+            let first = (2 + (kind - 11)).rem_euclid(7);
+            (d0 - first).rem_euclid(7) + 1
+        }
+        _ => return err(ErrorValue::Num),
+    };
+    num(result as f64)
+}
+
+/// EDATE(start, months): the same day-of-month `months` away, clamped to the
+/// target month's length.
+pub(crate) fn edate(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    shifted_month(args, ctx, false)
+}
+
+/// EOMONTH(start, months): the last day of the month `months` away.
+pub(crate) fn eomonth(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    shifted_month(args, ctx, true)
+}
+
+/// TODAY(): the injected date, time truncated; no injected clock -> #VALUE!.
+pub(crate) fn today(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if !args.is_empty() {
+        return err(ErrorValue::Value);
+    }
+    match ctx.now_serial {
+        Some(s) => num(s.floor()),
+        None => err(ErrorValue::Value),
+    }
+}
+
+/// NOW(): the injected date and time. absent clock -> #VALUE!.
+pub(crate) fn now(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if !args.is_empty() {
+        return err(ErrorValue::Value);
+    }
+    match ctx.now_serial {
+        Some(s) => num(s),
+        None => err(ErrorValue::Value),
+    }
+}
+
+pub(crate) fn hour(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    time_part(args, ctx, |secs| secs / 3600)
+}
+
+pub(crate) fn minute(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    time_part(args, ctx, |secs| (secs / 60) % 60)
+}
+
+pub(crate) fn second(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    time_part(args, ctx, |secs| secs % 60)
+}
+
+/// TIME(hour, minute, second): a fraction of a day in [0, 1); overflow wraps.
+pub(crate) fn time(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let (h, m, s) = match (
+        nth_number(args, ctx, 0),
+        nth_number(args, ctx, 1),
+        nth_number(args, ctx, 2),
+    ) {
+        (Ok(h), Ok(m), Ok(s)) => (h, m, s),
+        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => return err(e),
+    };
+    let frac = (h * 3600.0 + m * 60.0 + s) / 86_400.0;
+    num(frac.rem_euclid(1.0))
+}
+
+/// DATEDIF(start, end, unit): complete intervals between two dates; units are
+/// `Y`, `M`, `D`, `YM`, `YD`, `MD`.
+pub(crate) fn datedif(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let s1 = match nth_number(args, ctx, 0) {
+        Ok(n) => n.floor() as i64,
+        Err(e) => return err(e),
+    };
+    let s2 = match nth_number(args, ctx, 1) {
+        Ok(n) => n.floor() as i64,
+        Err(e) => return err(e),
+    };
+    let unit = match to_text(&evaluate(&args[2], ctx)) {
+        Ok(s) => s.to_uppercase(),
+        Err(e) => return err(e),
+    };
+    if s2 < s1 {
+        return err(ErrorValue::Num);
+    }
+    let (a, b) = match (serial_to_ymd(s1), serial_to_ymd(s2)) {
+        (Some(a), Some(b)) => (a, b),
+        _ => return err(ErrorValue::Num),
+    };
+    let (y1, m1, d1) = a;
+    let (y2, m2, d2) = b;
+    let value = match unit.as_str() {
+        "D" => (s2 - s1) as f64,
+        "Y" => {
+            let mut years = y2 - y1;
+            if (m2, d2) < (m1, d1) {
+                years -= 1;
+            }
+            years as f64
+        }
+        "M" => complete_months(y1, m1, d1, y2, m2, d2) as f64,
+        "YM" => (complete_months(y1, m1, d1, y2, m2, d2) % 12) as f64,
+        "MD" => {
+            if d2 >= d1 {
+                (d2 - d1) as f64
+            } else {
+                let (py, pm) = if m2 == 1 { (y2 - 1, 12) } else { (y2, m2 - 1) };
+                (days_in_month(py, pm) - d1 + d2) as f64
+            }
+        }
+        "YD" => {
+            let anchor = if (m1, d1) <= (m2, d2) {
+                date_to_serial(y2, m1, d1)
+            } else {
+                date_to_serial(y2 - 1, m1, d1)
+            };
+            (s2 - anchor) as f64
+        }
+        _ => return err(ErrorValue::Value),
+    };
+    num(value)
+}
+
+fn complete_months(y1: i64, m1: i64, d1: i64, y2: i64, m2: i64, d2: i64) -> i64 {
+    let mut months = (y2 - y1) * 12 + (m2 - m1);
+    if d2 < d1 {
+        months -= 1;
+    }
+    months
+}
+
+fn ymd_part(args: &[Expr], ctx: &EvalContext<'_>, pick: fn((i64, i64, i64)) -> i64) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    let serial = match nth_number(args, ctx, 0) {
+        Ok(n) => n.floor() as i64,
+        Err(e) => return err(e),
+    };
+    // serial 0 is excel's 1900-01-00: day 0, month 1, year 1900
+    if serial == 0 {
+        return num(pick((1900, 1, 0)) as f64);
+    }
+    match serial_to_ymd(serial) {
+        Some(ymd) => num(pick(ymd) as f64),
+        None => err(ErrorValue::Num),
+    }
+}
+
+fn shifted_month(args: &[Expr], ctx: &EvalContext<'_>, end_of_month: bool) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    let serial = match nth_number(args, ctx, 0) {
+        Ok(n) => n.floor() as i64,
+        Err(e) => return err(e),
+    };
+    let months = match nth_int(args, ctx, 1) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let (y, m, d) = match serial_to_ymd(serial) {
+        Some(v) => v,
+        None => return err(ErrorValue::Num),
+    };
+    let total = (y * 12 + (m - 1)) + months;
+    let ty = total.div_euclid(12);
+    let tm = total.rem_euclid(12) + 1;
+    let target_day = if end_of_month {
+        days_in_month(ty, tm)
+    } else {
+        d.min(days_in_month(ty, tm))
+    };
+    let serial = date_to_serial(ty, tm, target_day);
+    if serial < 0 {
+        err(ErrorValue::Num)
+    } else {
+        num(serial as f64)
+    }
+}
+
+fn time_part(args: &[Expr], ctx: &EvalContext<'_>, pick: fn(i64) -> i64) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    let serial = match nth_number(args, ctx, 0) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let frac = serial - serial.floor();
+    // round to the nearest second to absorb float noise in the day fraction
+    let secs = (frac * 86_400.0).round() as i64 % 86_400;
+    num(pick(secs) as f64)
+}

--- a/crates/xlsx-calc/src/functions/info.rs
+++ b/crates/xlsx-calc/src/functions/info.rs
@@ -1,0 +1,77 @@
+//! information / type-test functions. the IS* predicates inspect their
+//! argument's type and never propagate an error.
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{EvalContext, boolean, err, evaluate, num};
+use crate::parser::Expr;
+
+pub(crate) fn isblank(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(args, ctx, |v| matches!(v, CellValue::Empty))
+}
+
+pub(crate) fn isnumber(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(args, ctx, |v| matches!(v, CellValue::Number { .. }))
+}
+
+pub(crate) fn istext(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(args, ctx, |v| matches!(v, CellValue::Text { .. }))
+}
+
+pub(crate) fn islogical(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(args, ctx, |v| matches!(v, CellValue::Bool { .. }))
+}
+
+pub(crate) fn iserror(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(args, ctx, |v| matches!(v, CellValue::Error { .. }))
+}
+
+/// ISERR: any error except #N/A.
+pub(crate) fn iserr(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(
+        args,
+        ctx,
+        |v| matches!(v, CellValue::Error { value } if *value != ErrorValue::NA),
+    )
+}
+
+pub(crate) fn isna(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    test(args, ctx, |v| {
+        matches!(
+            v,
+            CellValue::Error {
+                value: ErrorValue::NA
+            }
+        )
+    })
+}
+
+/// NA(): the #N/A error literal.
+pub(crate) fn na(args: &[Expr], _ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() {
+        err(ErrorValue::NA)
+    } else {
+        err(ErrorValue::Value)
+    }
+}
+
+/// N(value): numbers and bools become numbers, text becomes 0, errors pass
+/// through, everything else is 0.
+pub(crate) fn n(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    match evaluate(&args[0], ctx) {
+        CellValue::Number { value } => num(value),
+        CellValue::Bool { value } => num(if value { 1.0 } else { 0.0 }),
+        CellValue::Error { value } => err(value),
+        _ => num(0.0),
+    }
+}
+
+fn test(args: &[Expr], ctx: &EvalContext<'_>, pred: fn(&CellValue) -> bool) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    boolean(pred(&evaluate(&args[0], ctx)))
+}

--- a/crates/xlsx-calc/src/functions/logical.rs
+++ b/crates/xlsx-calc/src/functions/logical.rs
@@ -1,0 +1,157 @@
+//! logical functions. all take lazy arguments so only the taken branch is
+//! evaluated: IF/IFS/SWITCH/IFERROR/IFNA never touch the paths they skip.
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{EvalContext, boolean, cmp_values, err, evaluate, range_values, to_bool};
+use crate::parser::Expr;
+
+/// IF(condition, then, [else]); omitted else yields FALSE.
+pub(crate) fn if_(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 2 || args.len() > 3 {
+        return err(ErrorValue::Value);
+    }
+    match to_bool(&evaluate(&args[0], ctx)) {
+        Ok(true) => evaluate(&args[1], ctx),
+        Ok(false) => {
+            if args.len() == 3 {
+                evaluate(&args[2], ctx)
+            } else {
+                boolean(false)
+            }
+        }
+        Err(e) => err(e),
+    }
+}
+
+/// IFERROR(value, value_if_error): the fallback replaces any error.
+pub(crate) fn iferror(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match evaluate(&args[0], ctx) {
+        CellValue::Error { .. } => evaluate(&args[1], ctx),
+        v => v,
+    }
+}
+
+/// IFNA(value, value_if_na): the fallback replaces only #N/A.
+pub(crate) fn ifna(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match evaluate(&args[0], ctx) {
+        CellValue::Error {
+            value: ErrorValue::NA,
+        } => evaluate(&args[1], ctx),
+        v => v,
+    }
+}
+
+/// IFS(cond1, val1, cond2, val2, ...): the value for the first true condition;
+/// no true condition -> #N/A.
+pub(crate) fn ifs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() || !args.len().is_multiple_of(2) {
+        return err(ErrorValue::Value);
+    }
+    for pair in args.chunks(2) {
+        match to_bool(&evaluate(&pair[0], ctx)) {
+            Ok(true) => return evaluate(&pair[1], ctx),
+            Ok(false) => {}
+            Err(e) => return err(e),
+        }
+    }
+    err(ErrorValue::NA)
+}
+
+/// SWITCH(expr, match1, result1, ..., [default]): the result whose match
+/// equals `expr`; a trailing odd argument is the default.
+pub(crate) fn switch(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 3 {
+        return err(ErrorValue::Value);
+    }
+    let subject = evaluate(&args[0], ctx);
+    if let CellValue::Error { value } = subject {
+        return err(value);
+    }
+    let rest = &args[1..];
+    let mut i = 0;
+    while i + 1 < rest.len() {
+        let candidate = evaluate(&rest[i], ctx);
+        if let CellValue::Error { value } = candidate {
+            return err(value);
+        }
+        if cmp_values(&subject, &candidate) == std::cmp::Ordering::Equal {
+            return evaluate(&rest[i + 1], ctx);
+        }
+        i += 2;
+    }
+    if rest.len() % 2 == 1 {
+        evaluate(&rest[rest.len() - 1], ctx)
+    } else {
+        err(ErrorValue::NA)
+    }
+}
+
+pub(crate) fn and(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    fold_bools(args, ctx, true, |a, b| a && b)
+}
+
+pub(crate) fn or(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    fold_bools(args, ctx, false, |a, b| a || b)
+}
+
+/// XOR: true when an odd number of logical inputs are true.
+pub(crate) fn xor(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    fold_bools(args, ctx, false, |a, b| a ^ b)
+}
+
+pub(crate) fn not(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    match to_bool(&evaluate(&args[0], ctx)) {
+        Ok(b) => boolean(!b),
+        Err(e) => err(e),
+    }
+}
+
+/// fold booleans across arguments and ranges; blanks/text are ignored, errors
+/// propagate, and at least one logical value is required.
+fn fold_bools(
+    args: &[Expr],
+    ctx: &EvalContext<'_>,
+    init: bool,
+    combine: fn(bool, bool) -> bool,
+) -> CellValue {
+    let mut acc = init;
+    let mut seen = false;
+    for arg in args {
+        let values = match arg {
+            Expr::Range { sheet, range } => match range_values(sheet, range, ctx) {
+                Ok(v) => v,
+                Err(e) => return err(e),
+            },
+            _ => vec![evaluate(arg, ctx)],
+        };
+        for v in values {
+            match v {
+                CellValue::Bool { value } => {
+                    acc = combine(acc, value);
+                    seen = true;
+                }
+                CellValue::Number { value } => {
+                    acc = combine(acc, value != 0.0);
+                    seen = true;
+                }
+                CellValue::Empty | CellValue::Text { .. } => {}
+                CellValue::Error { value } => return err(value),
+            }
+        }
+    }
+    if seen {
+        boolean(acc)
+    } else {
+        err(ErrorValue::Value)
+    }
+}

--- a/crates/xlsx-calc/src/functions/lookups.rs
+++ b/crates/xlsx-calc/src/functions/lookups.rs
@@ -1,0 +1,277 @@
+//! lookup and reference functions: VLOOKUP/HLOOKUP/MATCH exact and approximate
+//! modes, INDEX area form, XLOOKUP exact-match subset.
+
+use std::cmp::Ordering;
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{Area, EvalContext, as_area, cmp_values, err, evaluate, num};
+use crate::parser::Expr;
+
+use super::{nth_int, nth_number};
+
+/// VLOOKUP(value, table, col_index, [range_lookup]). range_lookup defaults to
+/// TRUE (approximate match on a first column sorted ascending).
+pub(crate) fn vlookup(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    table_lookup(args, ctx, true)
+}
+
+/// HLOOKUP(value, table, row_index, [range_lookup]).
+pub(crate) fn hlookup(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    table_lookup(args, ctx, false)
+}
+
+fn table_lookup(args: &[Expr], ctx: &EvalContext<'_>, vertical: bool) -> CellValue {
+    if args.len() < 3 || args.len() > 4 {
+        return err(ErrorValue::Value);
+    }
+    let target = evaluate(&args[0], ctx);
+    if let CellValue::Error { value } = target {
+        return err(value);
+    }
+    let area = match as_area(&args[1], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let index = match nth_int(args, ctx, 2) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    if index < 1 {
+        return err(ErrorValue::Value);
+    }
+    let approximate = if args.len() == 4 {
+        match nth_number(args, ctx, 3) {
+            Ok(v) => v != 0.0,
+            Err(e) => return err(e),
+        }
+    } else {
+        true
+    };
+    let (lines, depth) = if vertical {
+        (area.rows, area.cols)
+    } else {
+        (area.cols, area.rows)
+    };
+    if index as usize > depth {
+        return err(ErrorValue::Ref);
+    }
+    let key = |i: usize| {
+        if vertical {
+            area.get(ctx, i, 0)
+        } else {
+            area.get(ctx, 0, i)
+        }
+    };
+    let found = if approximate {
+        approximate_row(lines, &target, key)
+    } else {
+        (0..lines).find(|&i| cmp_values(&key(i), &target) == Ordering::Equal)
+    };
+    match found {
+        Some(i) => {
+            let off = index as usize - 1;
+            if vertical {
+                area.get(ctx, i, off)
+            } else {
+                area.get(ctx, off, i)
+            }
+        }
+        None => err(ErrorValue::NA),
+    }
+}
+
+/// MATCH(value, lookup_area, [match_type]). match_type 1 (default) finds the
+/// largest value <= target in an ascending list; 0 is exact; -1 finds the
+/// smallest value >= target in a descending list.
+pub(crate) fn match_(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 2 || args.len() > 3 {
+        return err(ErrorValue::Value);
+    }
+    let target = evaluate(&args[0], ctx);
+    if let CellValue::Error { value } = target {
+        return err(value);
+    }
+    let area = match as_area(&args[1], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let match_type = if args.len() == 3 {
+        match nth_int(args, ctx, 2) {
+            Ok(n) => n,
+            Err(e) => return err(e),
+        }
+    } else {
+        1
+    };
+    let values = area.values(ctx);
+    let pos = match match_type {
+        0 => values
+            .iter()
+            .position(|v| cmp_values(v, &target) == Ordering::Equal),
+        1 => approximate_row(values.len(), &target, |i| values[i].clone()),
+        _ => {
+            let mut found = None;
+            for (i, v) in values.iter().enumerate() {
+                if cmp_values(v, &target) != Ordering::Less {
+                    found = Some(i);
+                } else {
+                    break;
+                }
+            }
+            found
+        }
+    };
+    match pos {
+        Some(i) => num(i as f64 + 1.0),
+        None => err(ErrorValue::NA),
+    }
+}
+
+/// INDEX(area, row_num, [col_num]). for a single-row or single-column area the
+/// lone index selects along that axis. 1-based; out of range -> #REF!.
+pub(crate) fn index(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 2 || args.len() > 3 {
+        return err(ErrorValue::Value);
+    }
+    let area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let first = match nth_int(args, ctx, 1) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let second = if args.len() == 3 {
+        match nth_int(args, ctx, 2) {
+            Ok(n) => Some(n),
+            Err(e) => return err(e),
+        }
+    } else {
+        None
+    };
+    let (row, col) = match second {
+        Some(c) => (first, c),
+        None if area.rows == 1 => (1, first),
+        None if area.cols == 1 => (first, 1),
+        None => return err(ErrorValue::Ref),
+    };
+    if row < 1 || col < 1 || row as usize > area.rows || col as usize > area.cols {
+        return err(ErrorValue::Ref);
+    }
+    area.get(ctx, row as usize - 1, col as usize - 1)
+}
+
+/// XLOOKUP(value, lookup_array, return_array, [if_not_found], ...): exact-match
+/// subset; a missing value returns `if_not_found` or #N/A.
+pub(crate) fn xlookup(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 3 || args.len() > 6 {
+        return err(ErrorValue::Value);
+    }
+    let target = evaluate(&args[0], ctx);
+    if let CellValue::Error { value } = target {
+        return err(value);
+    }
+    let lookup = match as_area(&args[1], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let result = match as_area(&args[2], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let keys = lookup.values(ctx);
+    let results = result.values(ctx);
+    if keys.len() != results.len() {
+        return err(ErrorValue::Value);
+    }
+    match keys
+        .iter()
+        .position(|v| cmp_values(v, &target) == Ordering::Equal)
+    {
+        Some(i) => results[i].clone(),
+        None => {
+            if args.len() >= 4 {
+                evaluate(&args[3], ctx)
+            } else {
+                err(ErrorValue::NA)
+            }
+        }
+    }
+}
+
+/// CHOOSE(index, value1, value2, ...): the index-th value (1-based); only the
+/// chosen argument is evaluated.
+pub(crate) fn choose(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 2 {
+        return err(ErrorValue::Value);
+    }
+    let idx = match nth_int(args, ctx, 0) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let choices = &args[1..];
+    if idx < 1 || idx as usize > choices.len() {
+        return err(ErrorValue::Value);
+    }
+    evaluate(&choices[idx as usize - 1], ctx)
+}
+
+/// ROW([reference]): the 1-based row of the reference's top-left cell;
+/// referenceless form is #VALUE! (calling cell unknown).
+pub(crate) fn row(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    reference_scalar(args, ctx, |area| area.start.row as f64 + 1.0)
+}
+
+/// COLUMN([reference]): the 1-based column of the reference's top-left cell.
+pub(crate) fn column(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    reference_scalar(args, ctx, |area| area.start.col as f64 + 1.0)
+}
+
+/// ROWS(area): the number of rows in a reference.
+pub(crate) fn rows(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    reference_dim(args, ctx, |area| area.rows)
+}
+
+/// COLUMNS(area): the number of columns in a reference.
+pub(crate) fn columns(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    reference_dim(args, ctx, |area| area.cols)
+}
+
+/// last index whose value is <= target scanning in order (excel's ascending
+/// approximate match); target below the first value -> None.
+fn approximate_row(
+    len: usize,
+    target: &CellValue,
+    key: impl Fn(usize) -> CellValue,
+) -> Option<usize> {
+    let mut found = None;
+    for i in 0..len {
+        if cmp_values(&key(i), target) != Ordering::Greater {
+            found = Some(i);
+        } else {
+            break;
+        }
+    }
+    found
+}
+
+fn reference_scalar(args: &[Expr], ctx: &EvalContext<'_>, pick: fn(&Area) -> f64) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    match as_area(&args[0], ctx) {
+        Some(area) => num(pick(&area)),
+        None => err(ErrorValue::Value),
+    }
+}
+
+fn reference_dim(args: &[Expr], ctx: &EvalContext<'_>, pick: fn(&Area) -> usize) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    match as_area(&args[0], ctx) {
+        Some(area) => num(pick(&area) as f64),
+        None => err(ErrorValue::Value),
+    }
+}

--- a/crates/xlsx-calc/src/functions/math.rs
+++ b/crates/xlsx-calc/src/functions/math.rs
@@ -1,0 +1,339 @@
+//! math and trig functions. rounding follows excel: ROUND is half-away-from-zero,
+//! ROUNDUP/ROUNDDOWN are directional, non-finite results are `#NUM!`.
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{Area, EvalContext, as_area, err, evaluate, num, to_number};
+use crate::parser::Expr;
+
+use super::criteria::{self, Criterion};
+use super::{collect_numbers, finite, nth_int, nth_number};
+
+pub(crate) fn sum(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match collect_numbers(args, ctx) {
+        Ok(nums) => num(nums.iter().sum()),
+        Err(e) => err(e),
+    }
+}
+
+/// PRODUCT of every numeric argument; no numbers -> 0 (excel).
+pub(crate) fn product(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match collect_numbers(args, ctx) {
+        Ok(nums) if nums.is_empty() => num(0.0),
+        Ok(nums) => num(nums.iter().product()),
+        Err(e) => err(e),
+    }
+}
+
+/// SUMIF(range, criteria, [sum_range]). sum_range is anchored at its top-left
+/// with the criteria range's shape, so a mismatched size still aligns.
+pub(crate) fn sumif(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 && args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let crit_area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let criterion = criteria::criterion_from_arg(&args[1], ctx);
+    let sum_area = if args.len() == 3 {
+        match as_area(&args[2], ctx) {
+            Some(a) => a,
+            None => return err(ErrorValue::Value),
+        }
+    } else {
+        match as_area(&args[0], ctx) {
+            Some(a) => a,
+            None => return err(ErrorValue::Value),
+        }
+    };
+    let pairs = [(crit_area, criterion)];
+    sum_matching(&pairs, &sum_area, ctx)
+}
+
+/// SUMIFS(sum_range, crit_range1, crit1, ...). all ranges share dimensions.
+pub(crate) fn sumifs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 3 {
+        return err(ErrorValue::Value);
+    }
+    let sum_area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    match criteria::collect_pairs(&args[1..], ctx) {
+        Some(pairs) if pairs[0].0.rows == sum_area.rows && pairs[0].0.cols == sum_area.cols => {
+            sum_matching(&pairs, &sum_area, ctx)
+        }
+        _ => err(ErrorValue::Value),
+    }
+}
+
+fn sum_matching(
+    pairs: &[(Area, Criterion)],
+    value_area: &Area,
+    ctx: &EvalContext<'_>,
+) -> CellValue {
+    let cols = pairs[0].0.cols;
+    let mut total = 0.0;
+    for i in criteria::matching_indices(pairs, ctx) {
+        let (r, c) = (i / cols, i % cols);
+        if let CellValue::Number { value } = value_area.get(ctx, r, c) {
+            total += value;
+        }
+    }
+    num(total)
+}
+
+/// SUMPRODUCT(array1, [array2], ...). element-wise product summed; non-numeric
+/// cells count as 0. all arrays must share the same length.
+pub(crate) fn sumproduct(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() {
+        return err(ErrorValue::Value);
+    }
+    let mut arrays: Vec<Vec<f64>> = Vec::with_capacity(args.len());
+    for arg in args {
+        match as_area(arg, ctx) {
+            Some(area) => {
+                let mut col = Vec::with_capacity(area.len());
+                for v in area.values(ctx) {
+                    match v {
+                        CellValue::Number { value } => col.push(value),
+                        CellValue::Error { value } => return err(value),
+                        _ => col.push(0.0),
+                    }
+                }
+                arrays.push(col);
+            }
+            None => match to_number(&evaluate(arg, ctx)) {
+                Ok(n) => arrays.push(vec![n]),
+                Err(e) => return err(e),
+            },
+        }
+    }
+    let len = arrays[0].len();
+    if arrays.iter().any(|a| a.len() != len) {
+        return err(ErrorValue::Value);
+    }
+    let mut total = 0.0;
+    for i in 0..len {
+        let mut prod = 1.0;
+        for a in &arrays {
+            prod *= a[i];
+        }
+        total += prod;
+    }
+    num(total)
+}
+
+pub(crate) fn abs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    unary(args, ctx, f64::abs)
+}
+
+pub(crate) fn sign(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    unary(args, ctx, |x| {
+        if x > 0.0 {
+            1.0
+        } else if x < 0.0 {
+            -1.0
+        } else {
+            0.0
+        }
+    })
+}
+
+pub(crate) fn sqrt(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match one_number(args, ctx) {
+        Ok(x) if x < 0.0 => err(ErrorValue::Num),
+        Ok(x) => num(x.sqrt()),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn exp(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match one_number(args, ctx) {
+        Ok(x) => finite(x.exp()),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn ln(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    positive_log(args, ctx, f64::ln)
+}
+
+pub(crate) fn log10(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    positive_log(args, ctx, f64::log10)
+}
+
+/// LOG(number, [base]); base defaults to 10.
+pub(crate) fn log(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() || args.len() > 2 {
+        return err(ErrorValue::Value);
+    }
+    let base = if args.len() == 2 {
+        match nth_number(args, ctx, 1) {
+            Ok(b) => b,
+            Err(e) => return err(e),
+        }
+    } else {
+        10.0
+    };
+    match nth_number(args, ctx, 0) {
+        Ok(x) if x <= 0.0 || base <= 0.0 || base == 1.0 => err(ErrorValue::Num),
+        Ok(x) => finite(x.log(base)),
+        Err(e) => err(e),
+    }
+}
+
+/// LN / LOG10: positive inputs only. uses the dedicated libm routine (not
+/// `x.log(base)`) so exact powers round-trip precisely.
+fn positive_log(args: &[Expr], ctx: &EvalContext<'_>, f: fn(f64) -> f64) -> CellValue {
+    match one_number(args, ctx) {
+        Ok(x) if x <= 0.0 => err(ErrorValue::Num),
+        Ok(x) => finite(f(x)),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn pi(args: &[Expr], _ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() {
+        num(std::f64::consts::PI)
+    } else {
+        err(ErrorValue::Value)
+    }
+}
+
+pub(crate) fn power(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match (nth_number(args, ctx, 0), nth_number(args, ctx, 1)) {
+        (Ok(x), Ok(y)) => finite(x.powf(y)),
+        (Err(e), _) | (_, Err(e)) => err(e),
+    }
+}
+
+/// MOD(n, d) = n - d*INT(n/d); sign follows the divisor. d = 0 -> #DIV/0!.
+pub(crate) fn mod_(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match (nth_number(args, ctx, 0), nth_number(args, ctx, 1)) {
+        (Ok(_), Ok(0.0)) => err(ErrorValue::Div0),
+        (Ok(n), Ok(d)) => num(n - d * (n / d).floor()),
+        (Err(e), _) | (_, Err(e)) => err(e),
+    }
+}
+
+pub(crate) fn int(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    unary(args, ctx, f64::floor)
+}
+
+/// TRUNC(number, [digits]); digits default 0. truncates toward zero.
+pub(crate) fn trunc(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    directional(args, ctx, |scaled| scaled.trunc())
+}
+
+/// ROUNDUP(number, digits): away from zero.
+pub(crate) fn roundup(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    directional(args, ctx, |scaled| {
+        if scaled < 0.0 {
+            scaled.floor()
+        } else {
+            scaled.ceil()
+        }
+    })
+}
+
+/// ROUNDDOWN(number, digits): toward zero (same as TRUNC with digits).
+pub(crate) fn rounddown(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    directional(args, ctx, |scaled| scaled.trunc())
+}
+
+/// ROUND(number, digits): half away from zero.
+pub(crate) fn round(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    let x = match nth_number(args, ctx, 0) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let digits = match nth_int(args, ctx, 1) {
+        Ok(d) => d as i32,
+        Err(e) => return err(e),
+    };
+    let factor = 10f64.powi(digits);
+    finite((x * factor).round() / factor)
+}
+
+/// MROUND(number, multiple): nearest multiple, half away from zero. opposite
+/// signs -> #NUM!; multiple 0 -> 0.
+pub(crate) fn mround(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match (nth_number(args, ctx, 0), nth_number(args, ctx, 1)) {
+        (Ok(_), Ok(0.0)) => num(0.0),
+        (Ok(x), Ok(m)) if (x < 0.0) != (m < 0.0) && x != 0.0 => err(ErrorValue::Num),
+        (Ok(x), Ok(m)) => num((x / m).round() * m),
+        (Err(e), _) | (_, Err(e)) => err(e),
+    }
+}
+
+/// CEILING(number, significance): away from zero to a multiple of significance.
+/// positive number with negative significance is #NUM!; significance 0 -> 0.
+pub(crate) fn ceiling(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    round_to_multiple(args, ctx, f64::ceil)
+}
+
+/// FLOOR(number, significance): toward zero to a multiple of significance.
+pub(crate) fn floor(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    round_to_multiple(args, ctx, f64::floor)
+}
+
+fn round_to_multiple(args: &[Expr], ctx: &EvalContext<'_>, f: fn(f64) -> f64) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match (nth_number(args, ctx, 0), nth_number(args, ctx, 1)) {
+        (Ok(_), Ok(0.0)) => num(0.0),
+        (Ok(x), Ok(s)) if x > 0.0 && s < 0.0 => err(ErrorValue::Num),
+        (Ok(x), Ok(s)) => num(f(x / s) * s),
+        (Err(e), _) | (_, Err(e)) => err(e),
+    }
+}
+
+fn one_number(args: &[Expr], ctx: &EvalContext<'_>) -> Result<f64, ErrorValue> {
+    if args.len() != 1 {
+        return Err(ErrorValue::Value);
+    }
+    nth_number(args, ctx, 0)
+}
+
+fn unary(args: &[Expr], ctx: &EvalContext<'_>, f: fn(f64) -> f64) -> CellValue {
+    match one_number(args, ctx) {
+        Ok(x) => num(f(x)),
+        Err(e) => err(e),
+    }
+}
+
+/// scale by 10^digits, apply a rounding rule, unscale.
+fn directional(args: &[Expr], ctx: &EvalContext<'_>, rule: fn(f64) -> f64) -> CellValue {
+    if args.is_empty() || args.len() > 2 {
+        return err(ErrorValue::Value);
+    }
+    let x = match nth_number(args, ctx, 0) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let digits = if args.len() == 2 {
+        match nth_int(args, ctx, 1) {
+            Ok(d) => d as i32,
+            Err(e) => return err(e),
+        }
+    } else {
+        0
+    };
+    let factor = 10f64.powi(digits);
+    finite(rule(x * factor) / factor)
+}

--- a/crates/xlsx-calc/src/functions/mod.rs
+++ b/crates/xlsx-calc/src/functions/mod.rs
@@ -1,0 +1,203 @@
+//! builtin function library: `lookup` maps a case-insensitive name to a builtin.
+//! builtins receive arguments unevaluated so control-flow can skip branches.
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{
+    EvalContext, err, evaluate, num, parse_num, range_values, resolve_ref, to_number,
+};
+use crate::parser::Expr;
+
+pub mod criteria;
+pub mod datetime;
+pub mod info;
+pub mod logical;
+pub mod lookups;
+pub mod math;
+pub mod stats;
+pub mod text;
+
+/// a builtin: lazy arguments in, one value out.
+pub type BuiltIn = fn(&[Expr], &EvalContext<'_>) -> CellValue;
+
+/// resolve a function name (case-insensitive) to its implementation; aliases
+/// map to the same function.
+pub fn lookup(name: &str) -> Option<BuiltIn> {
+    let upper = name.to_ascii_uppercase();
+    Some(match upper.as_str() {
+        "SUM" => math::sum,
+        "SUMIF" => math::sumif,
+        "SUMIFS" => math::sumifs,
+        "SUMPRODUCT" => math::sumproduct,
+        "PRODUCT" => math::product,
+        "ABS" => math::abs,
+        "SIGN" => math::sign,
+        "ROUND" => math::round,
+        "ROUNDUP" => math::roundup,
+        "ROUNDDOWN" => math::rounddown,
+        "MROUND" => math::mround,
+        "CEILING" => math::ceiling,
+        "FLOOR" => math::floor,
+        "INT" => math::int,
+        "TRUNC" => math::trunc,
+        "MOD" => math::mod_,
+        "POWER" => math::power,
+        "SQRT" => math::sqrt,
+        "EXP" => math::exp,
+        "LN" => math::ln,
+        "LOG" => math::log,
+        "LOG10" => math::log10,
+        "PI" => math::pi,
+        "AVERAGE" => stats::average,
+        "COUNT" => stats::count,
+        "COUNTA" => stats::counta,
+        "COUNTBLANK" => stats::countblank,
+        "COUNTIF" => stats::countif,
+        "COUNTIFS" => stats::countifs,
+        "AVERAGEIF" => stats::averageif,
+        "AVERAGEIFS" => stats::averageifs,
+        "MIN" => stats::min,
+        "MAX" => stats::max,
+        "MEDIAN" => stats::median,
+        "MODE" | "MODE.SNGL" => stats::mode,
+        "STDEV" | "STDEV.S" => stats::stdev_s,
+        "STDEVP" | "STDEV.P" => stats::stdev_p,
+        "VAR" | "VAR.S" => stats::var_s,
+        "VARP" | "VAR.P" => stats::var_p,
+        "LARGE" => stats::large,
+        "SMALL" => stats::small,
+        "RANK" | "RANK.EQ" => stats::rank,
+        "LEN" => text::len,
+        "LEFT" => text::left,
+        "RIGHT" => text::right,
+        "MID" => text::mid,
+        "FIND" => text::find,
+        "SEARCH" => text::search,
+        "SUBSTITUTE" => text::substitute,
+        "REPLACE" => text::replace,
+        "TRIM" => text::trim,
+        "UPPER" => text::upper,
+        "LOWER" => text::lower,
+        "PROPER" => text::proper,
+        "CLEAN" => text::clean,
+        "REPT" => text::rept,
+        "EXACT" => text::exact,
+        "T" => text::t,
+        "CHAR" => text::char_,
+        "CODE" => text::code,
+        "VALUE" => text::value,
+        "NUMBERVALUE" => text::numbervalue,
+        "TEXT" => text::text_fn,
+        "TEXTJOIN" => text::textjoin,
+        "CONCATENATE" | "CONCAT" => text::concat,
+        "DATE" => datetime::date,
+        "YEAR" => datetime::year,
+        "MONTH" => datetime::month,
+        "DAY" => datetime::day,
+        "WEEKDAY" => datetime::weekday,
+        "EDATE" => datetime::edate,
+        "EOMONTH" => datetime::eomonth,
+        "TODAY" => datetime::today,
+        "NOW" => datetime::now,
+        "HOUR" => datetime::hour,
+        "MINUTE" => datetime::minute,
+        "SECOND" => datetime::second,
+        "TIME" => datetime::time,
+        "DATEDIF" => datetime::datedif,
+        "IF" => logical::if_,
+        "IFERROR" => logical::iferror,
+        "IFNA" => logical::ifna,
+        "IFS" => logical::ifs,
+        "SWITCH" => logical::switch,
+        "AND" => logical::and,
+        "OR" => logical::or,
+        "NOT" => logical::not,
+        "XOR" => logical::xor,
+        "VLOOKUP" => lookups::vlookup,
+        "HLOOKUP" => lookups::hlookup,
+        "INDEX" => lookups::index,
+        "MATCH" => lookups::match_,
+        "XLOOKUP" => lookups::xlookup,
+        "CHOOSE" => lookups::choose,
+        "ROW" => lookups::row,
+        "COLUMN" => lookups::column,
+        "ROWS" => lookups::rows,
+        "COLUMNS" => lookups::columns,
+        "ISBLANK" => info::isblank,
+        "ISNUMBER" => info::isnumber,
+        "ISTEXT" => info::istext,
+        "ISLOGICAL" => info::islogical,
+        "ISERROR" => info::iserror,
+        "ISERR" => info::iserr,
+        "ISNA" => info::isna,
+        "NA" => info::na,
+        "N" => info::n,
+        _ => return None,
+    })
+}
+
+/// collect numbers for aggregation: referenced cells contribute only numeric
+/// values, literal/computed arguments coerce, errors propagate.
+pub(crate) fn collect_numbers(
+    args: &[Expr],
+    ctx: &EvalContext<'_>,
+) -> Result<Vec<f64>, ErrorValue> {
+    let mut nums = Vec::new();
+    for arg in args {
+        match arg {
+            Expr::Range { sheet, range } => {
+                for v in range_values(sheet, range, ctx)? {
+                    push_reference_number(&mut nums, v)?;
+                }
+            }
+            Expr::Ref { sheet, cell } => {
+                push_reference_number(&mut nums, resolve_ref(sheet, *cell, ctx))?;
+            }
+            _ => match evaluate(arg, ctx) {
+                CellValue::Number { value } => nums.push(value),
+                CellValue::Bool { value } => nums.push(if value { 1.0 } else { 0.0 }),
+                CellValue::Empty => {}
+                CellValue::Text { value } => match parse_num(&value) {
+                    Some(n) => nums.push(n),
+                    None => return Err(ErrorValue::Value),
+                },
+                CellValue::Error { value } => return Err(value),
+            },
+        }
+    }
+    Ok(nums)
+}
+
+/// a referenced cell contributes to aggregation only when numeric; errors
+/// propagate, text/bool/blank are silently skipped.
+fn push_reference_number(nums: &mut Vec<f64>, v: CellValue) -> Result<(), ErrorValue> {
+    match v {
+        CellValue::Number { value } => nums.push(value),
+        CellValue::Error { value } => return Err(value),
+        _ => {}
+    }
+    Ok(())
+}
+
+/// evaluate one argument and coerce it to a number, propagating errors.
+pub(crate) fn nth_number(
+    args: &[Expr],
+    ctx: &EvalContext<'_>,
+    i: usize,
+) -> Result<f64, ErrorValue> {
+    to_number(&evaluate(&args[i], ctx))
+}
+
+/// evaluate one argument, coerce to a number, truncate toward zero.
+pub(crate) fn nth_int(args: &[Expr], ctx: &EvalContext<'_>, i: usize) -> Result<i64, ErrorValue> {
+    Ok(nth_number(args, ctx, i)?.trunc() as i64)
+}
+
+/// finalize a computed float: non-finite results become `#NUM!`.
+pub(crate) fn finite(x: f64) -> CellValue {
+    if x.is_finite() {
+        num(x)
+    } else {
+        err(ErrorValue::Num)
+    }
+}

--- a/crates/xlsx-calc/src/functions/stats.rs
+++ b/crates/xlsx-calc/src/functions/stats.rs
@@ -1,0 +1,339 @@
+//! statistical functions. numeric aggregations ignore text/bool/blank inside
+//! references, coerce literal arguments, propagate errors.
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{Area, EvalContext, as_area, err, evaluate, num};
+use crate::parser::Expr;
+
+use super::criteria::{self, Criterion};
+use super::{collect_numbers, nth_int, nth_number};
+
+pub(crate) fn average(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match collect_numbers(args, ctx) {
+        Ok(nums) if nums.is_empty() => err(ErrorValue::Div0),
+        Ok(nums) => num(nums.iter().sum::<f64>() / nums.len() as f64),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn min(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match collect_numbers(args, ctx) {
+        Ok(nums) if nums.is_empty() => num(0.0),
+        Ok(nums) => num(nums.iter().copied().fold(f64::INFINITY, f64::min)),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn max(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match collect_numbers(args, ctx) {
+        Ok(nums) if nums.is_empty() => num(0.0),
+        Ok(nums) => num(nums.iter().copied().fold(f64::NEG_INFINITY, f64::max)),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn median(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match collect_numbers(args, ctx) {
+        Ok(nums) if nums.is_empty() => err(ErrorValue::Num),
+        Ok(mut nums) => {
+            nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let n = nums.len();
+            if n % 2 == 1 {
+                num(nums[n / 2])
+            } else {
+                num((nums[n / 2 - 1] + nums[n / 2]) / 2.0)
+            }
+        }
+        Err(e) => err(e),
+    }
+}
+
+/// MODE.SNGL: the most frequent value; the earliest-appearing one wins ties.
+/// no repeats -> #N/A.
+pub(crate) fn mode(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    let nums = match collect_numbers(args, ctx) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    // (value, count, first_index)
+    let mut best: Option<(f64, usize, usize)> = None;
+    for (i, &x) in nums.iter().enumerate() {
+        let count = nums.iter().filter(|&&y| y == x).count();
+        if count < 2 {
+            continue;
+        }
+        match best {
+            Some((_, bc, bi)) if bc > count || (bc == count && bi <= i) => {}
+            _ => best = Some((x, count, i)),
+        }
+    }
+    match best {
+        Some((v, _, _)) => num(v),
+        None => err(ErrorValue::NA),
+    }
+}
+
+pub(crate) fn stdev_s(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    variance(args, ctx, true).map(f64::sqrt).into_cell()
+}
+
+pub(crate) fn stdev_p(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    variance(args, ctx, false).map(f64::sqrt).into_cell()
+}
+
+pub(crate) fn var_s(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    variance(args, ctx, true).into_cell()
+}
+
+pub(crate) fn var_p(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    variance(args, ctx, false).into_cell()
+}
+
+/// LARGE(array, k): the kth largest value (k = 1 is the maximum).
+pub(crate) fn large(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    nth_order(args, ctx, true)
+}
+
+/// SMALL(array, k): the kth smallest value.
+pub(crate) fn small(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    nth_order(args, ctx, false)
+}
+
+/// RANK(number, ref, [order]): position of `number` among the numbers in `ref`;
+/// order omitted/0 ranks descending, nonzero ascending, ties share the best rank.
+pub(crate) fn rank(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 && args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let target = match nth_number(args, ctx, 0) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let area = match as_area(&args[1], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let ascending = if args.len() == 3 {
+        match nth_number(args, ctx, 2) {
+            Ok(o) => o != 0.0,
+            Err(e) => return err(e),
+        }
+    } else {
+        false
+    };
+    let nums: Vec<f64> = area
+        .values(ctx)
+        .into_iter()
+        .filter_map(|v| match v {
+            CellValue::Number { value } => Some(value),
+            _ => None,
+        })
+        .collect();
+    if !nums.contains(&target) {
+        return err(ErrorValue::NA);
+    }
+    let better = nums
+        .iter()
+        .filter(|&&x| if ascending { x < target } else { x > target })
+        .count();
+    num(better as f64 + 1.0)
+}
+
+/// COUNT: numeric values only; errors and non-numerics are ignored (excel).
+pub(crate) fn count(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    let mut count = 0i64;
+    for arg in args {
+        match as_area(arg, ctx) {
+            Some(area) => {
+                count += area
+                    .values(ctx)
+                    .iter()
+                    .filter(|v| matches!(v, CellValue::Number { .. }))
+                    .count() as i64;
+            }
+            None => match evaluate(arg, ctx) {
+                CellValue::Number { .. } | CellValue::Bool { .. } => count += 1,
+                CellValue::Text { value } if crate::eval::parse_num(&value).is_some() => count += 1,
+                _ => {}
+            },
+        }
+    }
+    num(count as f64)
+}
+
+/// COUNTA: every non-empty value (text and errors included).
+pub(crate) fn counta(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    let mut count = 0i64;
+    for arg in args {
+        match as_area(arg, ctx) {
+            Some(area) => {
+                count += area
+                    .values(ctx)
+                    .iter()
+                    .filter(|v| !matches!(v, CellValue::Empty))
+                    .count() as i64;
+            }
+            None => {
+                if !matches!(evaluate(arg, ctx), CellValue::Empty) {
+                    count += 1;
+                }
+            }
+        }
+    }
+    num(count as f64)
+}
+
+/// COUNTBLANK(range): empty cells and empty strings.
+pub(crate) fn countblank(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    let area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let n = area
+        .values(ctx)
+        .iter()
+        .filter(|v| {
+            matches!(v, CellValue::Empty)
+                || matches!(v, CellValue::Text { value } if value.is_empty())
+        })
+        .count();
+    num(n as f64)
+}
+
+pub(crate) fn countif(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    let area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let criterion = criteria::criterion_from_arg(&args[1], ctx);
+    let pairs = [(area, criterion)];
+    num(criteria::matching_indices(&pairs, ctx).len() as f64)
+}
+
+pub(crate) fn countifs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match criteria::collect_pairs(args, ctx) {
+        Some(pairs) => num(criteria::matching_indices(&pairs, ctx).len() as f64),
+        None => err(ErrorValue::Value),
+    }
+}
+
+/// AVERAGEIF(range, criteria, [average_range]).
+pub(crate) fn averageif(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 && args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let crit_area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let value_spec = if args.len() == 3 { &args[2] } else { &args[0] };
+    let value_area = match as_area(value_spec, ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    let criterion = criteria::criterion_from_arg(&args[1], ctx);
+    average_of(&[(crit_area, criterion)], &value_area, ctx)
+}
+
+/// AVERAGEIFS(average_range, crit_range1, crit1, ...).
+pub(crate) fn averageifs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 3 {
+        return err(ErrorValue::Value);
+    }
+    let value_area = match as_area(&args[0], ctx) {
+        Some(a) => a,
+        None => return err(ErrorValue::Value),
+    };
+    match criteria::collect_pairs(&args[1..], ctx) {
+        Some(pairs) if pairs[0].0.rows == value_area.rows && pairs[0].0.cols == value_area.cols => {
+            average_of(&pairs, &value_area, ctx)
+        }
+        _ => err(ErrorValue::Value),
+    }
+}
+
+fn average_of(pairs: &[(Area, Criterion)], value_area: &Area, ctx: &EvalContext<'_>) -> CellValue {
+    let nums = matching_numbers(pairs, value_area, ctx);
+    if nums.is_empty() {
+        err(ErrorValue::Div0)
+    } else {
+        num(nums.iter().sum::<f64>() / nums.len() as f64)
+    }
+}
+
+fn matching_numbers(
+    pairs: &[(Area, Criterion)],
+    value_area: &Area,
+    ctx: &EvalContext<'_>,
+) -> Vec<f64> {
+    let cols = pairs[0].0.cols;
+    criteria::matching_indices(pairs, ctx)
+        .into_iter()
+        .filter_map(|i| {
+            let (r, c) = (i / cols, i % cols);
+            match value_area.get(ctx, r, c) {
+                CellValue::Number { value } => Some(value),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// sample (n-1) or population (n) variance; too few values -> #DIV/0!.
+fn variance(args: &[Expr], ctx: &EvalContext<'_>, sample: bool) -> Result<f64, ErrorValue> {
+    let nums = collect_numbers(args, ctx)?;
+    let n = nums.len();
+    let denom_ok = if sample { n >= 2 } else { n >= 1 };
+    if !denom_ok {
+        return Err(ErrorValue::Div0);
+    }
+    let mean = nums.iter().sum::<f64>() / n as f64;
+    let ss: f64 = nums.iter().map(|x| (x - mean).powi(2)).sum();
+    let denom = if sample { n as f64 - 1.0 } else { n as f64 };
+    Ok(ss / denom)
+}
+
+fn nth_order(args: &[Expr], ctx: &EvalContext<'_>, largest: bool) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    let mut nums = match collect_numbers(&args[..1], ctx) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let k = match nth_int(args, ctx, 1) {
+        Ok(k) => k,
+        Err(e) => return err(e),
+    };
+    if k < 1 || k as usize > nums.len() {
+        return err(ErrorValue::Num);
+    }
+    nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let idx = if largest {
+        nums.len() - k as usize
+    } else {
+        k as usize - 1
+    };
+    num(nums[idx])
+}
+
+/// tiny helper so the variance/stdev entry points read as one expression.
+trait IntoCell {
+    fn into_cell(self) -> CellValue;
+}
+
+impl IntoCell for Result<f64, ErrorValue> {
+    fn into_cell(self) -> CellValue {
+        match self {
+            Ok(v) => num(v),
+            Err(e) => err(e),
+        }
+    }
+}

--- a/crates/xlsx-calc/src/functions/text.rs
+++ b/crates/xlsx-calc/src/functions/text.rs
@@ -1,0 +1,505 @@
+//! text functions. positions are 1-based, counted in unicode scalar values
+//! (excel counts utf-16 units). FIND is case-sensitive, SEARCH case-insensitive.
+
+use xlsx_model::{CellValue, ErrorValue};
+
+use crate::eval::{
+    EvalContext, boolean, err, evaluate, num, parse_num, range_values, text, to_number, to_text,
+};
+use crate::parser::Expr;
+
+use xlsx_model::DateSystem;
+use xlsx_model::numfmt;
+
+use super::nth_int;
+
+pub(crate) fn len(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match one_text(args, ctx) {
+        Ok(s) => num(s.chars().count() as f64),
+        Err(e) => err(e),
+    }
+}
+
+pub(crate) fn upper(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    map_text(args, ctx, |s| s.to_uppercase())
+}
+
+pub(crate) fn lower(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    map_text(args, ctx, |s| s.to_lowercase())
+}
+
+/// TRIM: collapse runs of spaces to one and strip the ends (excel trims only
+/// the ascii space, u+0020).
+pub(crate) fn trim(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    map_text(args, ctx, |s| {
+        s.split(' ')
+            .filter(|p| !p.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ")
+    })
+}
+
+/// PROPER: capitalize the first letter of each word, lowercase the rest.
+pub(crate) fn proper(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    map_text(args, ctx, |s| {
+        let mut out = String::with_capacity(s.len());
+        let mut prev_alpha = false;
+        for ch in s.chars() {
+            if ch.is_alphabetic() {
+                if prev_alpha {
+                    out.extend(ch.to_lowercase());
+                } else {
+                    out.extend(ch.to_uppercase());
+                }
+                prev_alpha = true;
+            } else {
+                out.push(ch);
+                prev_alpha = false;
+            }
+        }
+        out
+    })
+}
+
+/// CLEAN: strip non-printable control characters (below u+0020).
+pub(crate) fn clean(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    map_text(args, ctx, |s| {
+        s.chars().filter(|c| !c.is_control()).collect()
+    })
+}
+
+/// LEFT(text, [count]); count defaults to 1.
+pub(crate) fn left(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    take_end(args, ctx, true)
+}
+
+/// RIGHT(text, [count]); count defaults to 1.
+pub(crate) fn right(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    take_end(args, ctx, false)
+}
+
+/// MID(text, start, count): 1-based start, `count` characters.
+pub(crate) fn mid(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let s = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let start = match nth_int(args, ctx, 1) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let count = match nth_int(args, ctx, 2) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    if start < 1 || count < 0 {
+        return err(ErrorValue::Value);
+    }
+    let chars: Vec<char> = s.chars().collect();
+    let from = (start as usize - 1).min(chars.len());
+    let to = (from + count as usize).min(chars.len());
+    text(chars[from..to].iter().collect::<String>())
+}
+
+/// FIND(find_text, within_text, [start]): case-sensitive; 1-based; not found
+/// or an out-of-range start -> #VALUE!.
+pub(crate) fn find(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    locate(args, ctx, true)
+}
+
+/// SEARCH(find_text, within_text, [start]): case-insensitive.
+pub(crate) fn search(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    locate(args, ctx, false)
+}
+
+/// SUBSTITUTE(text, old, new, [instance]): replace `old` with `new`; with
+/// `instance` only that occurrence (1-based) is replaced.
+pub(crate) fn substitute(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 3 && args.len() != 4 {
+        return err(ErrorValue::Value);
+    }
+    let s = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let old = match nth_text(args, ctx, 1) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let new = match nth_text(args, ctx, 2) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    if old.is_empty() {
+        return text(s);
+    }
+    let instance = if args.len() == 4 {
+        match nth_int(args, ctx, 3) {
+            Ok(n) if n >= 1 => Some(n as usize),
+            Ok(_) => return err(ErrorValue::Value),
+            Err(e) => return err(e),
+        }
+    } else {
+        None
+    };
+    match instance {
+        None => text(s.replace(&old, &new)),
+        Some(target) => {
+            let mut out = String::new();
+            let mut rest = s.as_str();
+            let mut seen = 0;
+            while let Some(pos) = rest.find(&old) {
+                seen += 1;
+                out.push_str(&rest[..pos]);
+                if seen == target {
+                    out.push_str(&new);
+                } else {
+                    out.push_str(&old);
+                }
+                rest = &rest[pos + old.len()..];
+            }
+            out.push_str(rest);
+            text(out)
+        }
+    }
+}
+
+/// REPLACE(old_text, start, num_chars, new_text): positional replacement.
+pub(crate) fn replace(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 4 {
+        return err(ErrorValue::Value);
+    }
+    let s = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let start = match nth_int(args, ctx, 1) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let count = match nth_int(args, ctx, 2) {
+        Ok(n) => n,
+        Err(e) => return err(e),
+    };
+    let new = match nth_text(args, ctx, 3) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    if start < 1 || count < 0 {
+        return err(ErrorValue::Value);
+    }
+    let chars: Vec<char> = s.chars().collect();
+    let from = (start as usize - 1).min(chars.len());
+    let to = (from + count as usize).min(chars.len());
+    let mut out: String = chars[..from].iter().collect();
+    out.push_str(&new);
+    out.extend(chars[to..].iter());
+    text(out)
+}
+
+/// REPT(text, count): repeat. negative count -> #VALUE!.
+pub(crate) fn rept(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    let s = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    match nth_int(args, ctx, 1) {
+        Ok(n) if n < 0 => err(ErrorValue::Value),
+        Ok(n) => text(s.repeat(n as usize)),
+        Err(e) => err(e),
+    }
+}
+
+/// EXACT(a, b): case-sensitive equality.
+pub(crate) fn exact(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    match (nth_text(args, ctx, 0), nth_text(args, ctx, 1)) {
+        (Ok(a), Ok(b)) => boolean(a == b),
+        (Err(e), _) | (_, Err(e)) => err(e),
+    }
+}
+
+/// T(value): the value if it is text, otherwise an empty string.
+pub(crate) fn t(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    match evaluate(&args[0], ctx) {
+        v @ CellValue::Text { .. } => v,
+        CellValue::Error { value } => err(value),
+        _ => text(""),
+    }
+}
+
+/// CHAR(number): the character for a code point in 1..=255.
+pub(crate) fn char_(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 1 {
+        return err(ErrorValue::Value);
+    }
+    match nth_int(args, ctx, 0) {
+        Ok(n) if (1..=255).contains(&n) => match char::from_u32(n as u32) {
+            Some(c) => text(c.to_string()),
+            None => err(ErrorValue::Value),
+        },
+        Ok(_) => err(ErrorValue::Value),
+        Err(e) => err(e),
+    }
+}
+
+/// CODE(text): code point of the first character. empty text -> #VALUE!.
+pub(crate) fn code(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match one_text(args, ctx) {
+        Ok(s) => match s.chars().next() {
+            Some(c) => num(c as u32 as f64),
+            None => err(ErrorValue::Value),
+        },
+        Err(e) => err(e),
+    }
+}
+
+/// VALUE(text): parse text to a number; a trailing `%` scales by 1/100.
+pub(crate) fn value(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    match one_text(args, ctx) {
+        Ok(s) => match parse_numeric_text(&s) {
+            Some(n) => num(n),
+            None => err(ErrorValue::Value),
+        },
+        Err(e) => err(e),
+    }
+}
+
+/// NUMBERVALUE(text, [decimal_sep], [group_sep]): parse with explicit
+/// separators (defaults `.` and `,`).
+pub(crate) fn numbervalue(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.is_empty() || args.len() > 3 {
+        return err(ErrorValue::Value);
+    }
+    let s = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let decimal = separator(args, ctx, 1, '.');
+    let group = separator(args, ctx, 2, ',');
+    let decimal = match decimal {
+        Ok(c) => c,
+        Err(e) => return err(e),
+    };
+    let group = match group {
+        Ok(c) => c,
+        Err(e) => return err(e),
+    };
+    let cleaned: String = s
+        .chars()
+        .filter(|&c| c != group && !c.is_whitespace())
+        .map(|c| if c == decimal { '.' } else { c })
+        .collect();
+    match parse_numeric_text(&cleaned) {
+        Some(n) => num(n),
+        None => err(ErrorValue::Value),
+    }
+}
+
+/// TEXT(value, format): format through the §18.8.30–31 code language via
+/// `xlsx_model::numfmt`, assuming the 1900 date system.
+pub(crate) fn text_fn(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() != 2 {
+        return err(ErrorValue::Value);
+    }
+    let value = match evaluate(&args[0], ctx) {
+        CellValue::Error { value } => return err(value),
+        CellValue::Empty => CellValue::Number { value: 0.0 },
+        v => v,
+    };
+    let format = match nth_text(args, ctx, 1) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    // TEXT(x, "") yields an empty string in excel
+    if format.is_empty() {
+        return text("");
+    }
+    let formatted = numfmt::format_value(&value, &format, DateSystem::V1900);
+    text(formatted.text)
+}
+
+/// TEXTJOIN(delimiter, ignore_empty, text1, ...): join, optionally skipping
+/// empty values. text arguments may be ranges.
+pub(crate) fn textjoin(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    if args.len() < 3 {
+        return err(ErrorValue::Value);
+    }
+    let delim = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let ignore_empty = match to_bool_arg(args, ctx, 1) {
+        Ok(b) => b,
+        Err(e) => return err(e),
+    };
+    let mut parts = Vec::new();
+    for arg in &args[2..] {
+        let values = match arg {
+            Expr::Range { sheet, range } => match range_values(sheet, range, ctx) {
+                Ok(v) => v,
+                Err(e) => return err(e),
+            },
+            _ => vec![evaluate(arg, ctx)],
+        };
+        for v in values {
+            let empty = matches!(v, CellValue::Empty)
+                || matches!(&v, CellValue::Text { value } if value.is_empty());
+            if ignore_empty && empty {
+                continue;
+            }
+            match to_text(&v) {
+                Ok(s) => parts.push(s),
+                Err(e) => return err(e),
+            }
+        }
+    }
+    text(parts.join(&delim))
+}
+
+/// CONCAT / CONCATENATE: join every argument (ranges flattened, row-major).
+pub(crate) fn concat(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
+    let mut out = String::new();
+    for arg in args {
+        let values = match arg {
+            Expr::Range { sheet, range } => match range_values(sheet, range, ctx) {
+                Ok(v) => v,
+                Err(e) => return err(e),
+            },
+            _ => vec![evaluate(arg, ctx)],
+        };
+        for v in values {
+            match to_text(&v) {
+                Ok(s) => out.push_str(&s),
+                Err(e) => return err(e),
+            }
+        }
+    }
+    text(out)
+}
+
+fn one_text(args: &[Expr], ctx: &EvalContext<'_>) -> Result<String, ErrorValue> {
+    if args.len() != 1 {
+        return Err(ErrorValue::Value);
+    }
+    nth_text(args, ctx, 0)
+}
+
+fn nth_text(args: &[Expr], ctx: &EvalContext<'_>, i: usize) -> Result<String, ErrorValue> {
+    to_text(&evaluate(&args[i], ctx))
+}
+
+fn map_text(args: &[Expr], ctx: &EvalContext<'_>, f: fn(&str) -> String) -> CellValue {
+    match one_text(args, ctx) {
+        Ok(s) => text(f(&s)),
+        Err(e) => err(e),
+    }
+}
+
+fn take_end(args: &[Expr], ctx: &EvalContext<'_>, from_left: bool) -> CellValue {
+    if args.is_empty() || args.len() > 2 {
+        return err(ErrorValue::Value);
+    }
+    let s = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let count = if args.len() == 2 {
+        match nth_int(args, ctx, 1) {
+            Ok(n) if n < 0 => return err(ErrorValue::Value),
+            Ok(n) => n as usize,
+            Err(e) => return err(e),
+        }
+    } else {
+        1
+    };
+    let chars: Vec<char> = s.chars().collect();
+    let take = count.min(chars.len());
+    let slice = if from_left {
+        &chars[..take]
+    } else {
+        &chars[chars.len() - take..]
+    };
+    text(slice.iter().collect::<String>())
+}
+
+fn locate(args: &[Expr], ctx: &EvalContext<'_>, case_sensitive: bool) -> CellValue {
+    if args.len() != 2 && args.len() != 3 {
+        return err(ErrorValue::Value);
+    }
+    let needle = match nth_text(args, ctx, 0) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let haystack = match nth_text(args, ctx, 1) {
+        Ok(s) => s,
+        Err(e) => return err(e),
+    };
+    let start = if args.len() == 3 {
+        match nth_int(args, ctx, 2) {
+            Ok(n) if n >= 1 => n as usize,
+            Ok(_) => return err(ErrorValue::Value),
+            Err(e) => return err(e),
+        }
+    } else {
+        1
+    };
+    let hay: Vec<char> = haystack.chars().collect();
+    if start > hay.len() + 1 {
+        return err(ErrorValue::Value);
+    }
+    let (needle, tail): (String, String) = if case_sensitive {
+        (needle, hay[start - 1..].iter().collect())
+    } else {
+        (
+            needle.to_lowercase(),
+            hay[start - 1..].iter().collect::<String>().to_lowercase(),
+        )
+    };
+    match char_index_of(&tail, &needle) {
+        Some(off) => num((start + off) as f64),
+        None => err(ErrorValue::Value),
+    }
+}
+
+/// position of `needle` in `haystack` measured in characters, not bytes.
+fn char_index_of(haystack: &str, needle: &str) -> Option<usize> {
+    let byte = haystack.find(needle)?;
+    Some(haystack[..byte].chars().count())
+}
+
+fn separator(
+    args: &[Expr],
+    ctx: &EvalContext<'_>,
+    i: usize,
+    default: char,
+) -> Result<char, ErrorValue> {
+    if i >= args.len() {
+        return Ok(default);
+    }
+    let s = nth_text(args, ctx, i)?;
+    s.chars().next().ok_or(ErrorValue::Value)
+}
+
+fn to_bool_arg(args: &[Expr], ctx: &EvalContext<'_>, i: usize) -> Result<bool, ErrorValue> {
+    Ok(to_number(&evaluate(&args[i], ctx))? != 0.0)
+}
+
+fn parse_numeric_text(s: &str) -> Option<f64> {
+    let trimmed = s.trim();
+    if let Some(body) = trimmed.strip_suffix('%') {
+        return parse_num(body).map(|n| n / 100.0);
+    }
+    parse_num(trimmed)
+}

--- a/crates/xlsx-calc/src/graph.rs
+++ b/crates/xlsx-calc/src/graph.rs
@@ -1,0 +1,306 @@
+//! dependency graph: which formula cells read which cells, answering "when this
+//! cell changes, which formulas must re-evaluate?".
+
+use std::collections::{HashMap, HashSet};
+
+use xlsx_model::{CellRange, CellRef, ColId, RowId, SheetId, Workbook};
+
+use crate::deps::references;
+use crate::parser::{Expr, parse_formula};
+
+/// a formula cell, normalized so `$`-anchoring never splits a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct NodeKey {
+    sheet: SheetId,
+    row: RowId,
+    col: ColId,
+}
+
+impl NodeKey {
+    fn new(sheet: SheetId, cell: CellRef) -> Self {
+        Self {
+            sheet,
+            row: cell.row,
+            col: cell.col,
+        }
+    }
+
+    fn cell(&self) -> CellRef {
+        CellRef::new(self.row, self.col)
+    }
+}
+
+/// case-insensitive names of functions whose value can change with no input
+/// edit; cells calling them re-evaluate on every recalc.
+const VOLATILE_FNS: [&str; 4] = ["TODAY", "NOW", "RAND", "RANDBETWEEN"];
+
+pub struct DepGraph {
+    /// sheet name -> id, snapshot at build time.
+    names: HashMap<String, SheetId>,
+    /// forward edges: formula node -> the cells/ranges it reads (sheets resolved).
+    deps: HashMap<NodeKey, Vec<(SheetId, CellRange)>>,
+    /// reverse index by sheet: `(range, dependent)` pairs read into that sheet.
+    by_sheet: HashMap<SheetId, Vec<(CellRange, NodeKey)>>,
+    /// formula cells that must re-evaluate every recalc regardless of edits.
+    volatile: HashSet<NodeKey>,
+}
+
+impl DepGraph {
+    /// build the whole graph from a workbook's stored formulas; unparseable
+    /// formulas are skipped.
+    pub fn build(wb: &Workbook) -> Self {
+        let names = wb
+            .sheets
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.name.clone(), SheetId(i as u32)))
+            .collect();
+        let mut g = DepGraph {
+            names,
+            deps: HashMap::new(),
+            by_sheet: HashMap::new(),
+            volatile: HashSet::new(),
+        };
+        for (i, sheet) in wb.sheets.iter().enumerate() {
+            let sid = SheetId(i as u32);
+            for (cell, c) in sheet.iter_cells() {
+                if let Some(src) = &c.formula {
+                    g.install(NodeKey::new(sid, cell), src);
+                }
+            }
+        }
+        g
+    }
+
+    /// re-derive one node's edges after its formula changed, without touching
+    /// the rest of the graph. `None` clears the node (cell no longer a formula).
+    pub fn set_formula(&mut self, sheet: SheetId, cell: CellRef, formula: Option<&str>) {
+        let key = NodeKey::new(sheet, cell);
+        self.uninstall(key);
+        if let Some(src) = formula {
+            self.install(key, src);
+        }
+    }
+
+    /// coarse invalidation for a sheet insert: ids shift, so rebuild wholesale.
+    pub fn add_sheet(&mut self, wb: &Workbook) {
+        *self = Self::build(wb);
+    }
+
+    /// coarse invalidation for a sheet removal: ids shift, so rebuild wholesale.
+    pub fn remove_sheet(&mut self, wb: &Workbook) {
+        *self = Self::build(wb);
+    }
+
+    /// formula cells that directly read `cell` on `sheet`; may contain
+    /// duplicates, callers dedup.
+    pub fn dependents_of(
+        &self,
+        sheet: SheetId,
+        cell: CellRef,
+    ) -> impl Iterator<Item = (SheetId, CellRef)> + '_ {
+        let target = CellRef::new(cell.row, cell.col);
+        self.by_sheet
+            .get(&sheet)
+            .into_iter()
+            .flatten()
+            .filter(move |(range, _)| range.contains(target))
+            .map(|(_, node)| (node.sheet, node.cell()))
+    }
+
+    /// whether a cell is a (parseable) formula node.
+    pub fn is_formula(&self, sheet: SheetId, cell: CellRef) -> bool {
+        self.deps.contains_key(&NodeKey::new(sheet, cell))
+    }
+
+    /// every formula cell, in unspecified order.
+    pub fn formula_cells(&self) -> impl Iterator<Item = (SheetId, CellRef)> + '_ {
+        self.deps.keys().map(|k| (k.sheet, k.cell()))
+    }
+
+    /// every volatile formula cell, in unspecified order.
+    pub fn volatile_cells(&self) -> impl Iterator<Item = (SheetId, CellRef)> + '_ {
+        self.volatile.iter().map(|k| (k.sheet, k.cell()))
+    }
+
+    /// parse a formula and register its edges + volatility. no-op on parse error.
+    fn install(&mut self, key: NodeKey, src: &str) {
+        let Ok(expr) = parse_formula(src) else {
+            return;
+        };
+        let edges = self.resolve_edges(key.sheet, &expr);
+        for (sid, range) in &edges {
+            self.by_sheet.entry(*sid).or_default().push((*range, key));
+        }
+        if is_volatile(&expr) {
+            self.volatile.insert(key);
+        }
+        self.deps.insert(key, edges);
+    }
+
+    /// drop a node's edges from every index it appears in.
+    fn uninstall(&mut self, key: NodeKey) {
+        if let Some(edges) = self.deps.remove(&key) {
+            for (sid, _) in &edges {
+                if let Some(list) = self.by_sheet.get_mut(sid) {
+                    list.retain(|(_, node)| *node != key);
+                }
+            }
+        }
+        self.volatile.remove(&key);
+    }
+
+    /// resolve refs to concrete sheet ids; unqualified refs bind to the owning
+    /// sheet, unknown sheet names drop the edge.
+    fn resolve_edges(&self, owner: SheetId, expr: &Expr) -> Vec<(SheetId, CellRange)> {
+        let mut out = Vec::new();
+        for (sheet, range) in references(expr) {
+            let sid = match sheet {
+                None => owner,
+                Some(name) => match self.names.get(&name) {
+                    Some(id) => *id,
+                    None => continue,
+                },
+            };
+            out.push((sid, range));
+        }
+        out
+    }
+}
+
+/// true if any function in the tree is volatile (case-insensitive name match).
+fn is_volatile(expr: &Expr) -> bool {
+    match expr {
+        Expr::FuncCall { name, args } => {
+            let upper = name.to_ascii_uppercase();
+            VOLATILE_FNS.contains(&upper.as_str()) || args.iter().any(is_volatile)
+        }
+        Expr::Unary { expr, .. } | Expr::Percent(expr) => is_volatile(expr),
+        Expr::Binary { lhs, rhs, .. } => is_volatile(lhs) || is_volatile(rhs),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xlsx_model::{Cell, CellValue, Sheet};
+
+    fn a1(s: &str) -> CellRef {
+        CellRef::parse_a1(s).unwrap()
+    }
+
+    fn formula_cell(f: &str) -> Cell {
+        Cell {
+            value: CellValue::Empty,
+            formula: Some(f.to_string()),
+            style: None,
+        }
+    }
+
+    /// workbook with two sheets; caller populates cells.
+    fn wb2() -> Workbook {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Sheet1"));
+        wb.sheets.push(Sheet::new("Data"));
+        wb
+    }
+
+    fn deps_a1(g: &DepGraph, sheet: &str, cell: &str, wb: &Workbook) -> Vec<String> {
+        let sid = wb.sheet_by_name(sheet).unwrap().0;
+        let mut out: Vec<String> = g
+            .dependents_of(sid, a1(cell))
+            .map(|(s, c)| format!("{}!{}", wb.sheet(s).unwrap().name, c.to_a1()))
+            .collect();
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn single_cell_dependents() {
+        let mut wb = wb2();
+        wb.sheet_mut(SheetId(0))
+            .unwrap()
+            .set_cell(a1("B1"), formula_cell("A1+1"));
+        let g = DepGraph::build(&wb);
+        assert_eq!(deps_a1(&g, "Sheet1", "A1", &wb), vec!["Sheet1!B1"]);
+        assert!(deps_a1(&g, "Sheet1", "Z9", &wb).is_empty());
+    }
+
+    #[test]
+    fn range_dependents_without_materializing_edges() {
+        let mut wb = wb2();
+        wb.sheet_mut(SheetId(0))
+            .unwrap()
+            .set_cell(a1("C1"), formula_cell("SUM(A1:A1000)"));
+        let g = DepGraph::build(&wb);
+        assert_eq!(deps_a1(&g, "Sheet1", "A5", &wb), vec!["Sheet1!C1"]);
+        assert_eq!(deps_a1(&g, "Sheet1", "A1000", &wb), vec!["Sheet1!C1"]);
+        assert!(deps_a1(&g, "Sheet1", "A1001", &wb).is_empty());
+        assert_eq!(
+            g.deps
+                .get(&NodeKey::new(SheetId(0), a1("C1")))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn cross_sheet_edges_resolve_and_unknown_sheets_drop() {
+        let mut wb = wb2();
+        wb.sheet_mut(SheetId(1))
+            .unwrap()
+            .set_cell(a1("A1"), formula_cell("Sheet1!A1 + Ghost!B2"));
+        let g = DepGraph::build(&wb);
+        assert_eq!(deps_a1(&g, "Sheet1", "A1", &wb), vec!["Data!A1"]);
+        assert_eq!(
+            g.deps
+                .get(&NodeKey::new(SheetId(1), a1("A1")))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn set_formula_swaps_edges() {
+        let mut wb = wb2();
+        wb.sheet_mut(SheetId(0))
+            .unwrap()
+            .set_cell(a1("C1"), formula_cell("A1"));
+        let mut g = DepGraph::build(&wb);
+        assert_eq!(deps_a1(&g, "Sheet1", "A1", &wb), vec!["Sheet1!C1"]);
+
+        g.set_formula(SheetId(0), a1("C1"), Some("B1"));
+        assert!(deps_a1(&g, "Sheet1", "A1", &wb).is_empty());
+        assert_eq!(deps_a1(&g, "Sheet1", "B1", &wb), vec!["Sheet1!C1"]);
+
+        g.set_formula(SheetId(0), a1("C1"), None);
+        assert!(deps_a1(&g, "Sheet1", "B1", &wb).is_empty());
+        assert!(!g.is_formula(SheetId(0), a1("C1")));
+    }
+
+    #[test]
+    fn volatile_detection() {
+        let mut wb = wb2();
+        let s = wb.sheet_mut(SheetId(0)).unwrap();
+        s.set_cell(a1("A1"), formula_cell("NOW()"));
+        s.set_cell(a1("A2"), formula_cell("A1 + TODAY()"));
+        s.set_cell(a1("A3"), formula_cell("A1 + 1"));
+        let g = DepGraph::build(&wb);
+        let mut vol: Vec<String> = g.volatile_cells().map(|(_, c)| c.to_a1()).collect();
+        vol.sort();
+        assert_eq!(vol, vec!["A1", "A2"]);
+    }
+
+    #[test]
+    fn anchored_refs_normalize_to_same_node() {
+        let mut wb = wb2();
+        wb.sheet_mut(SheetId(0))
+            .unwrap()
+            .set_cell(a1("B1"), formula_cell("$A$1 + 1"));
+        let g = DepGraph::build(&wb);
+        assert_eq!(deps_a1(&g, "Sheet1", "A1", &wb), vec!["Sheet1!B1"]);
+    }
+}

--- a/crates/xlsx-calc/src/lexer.rs
+++ b/crates/xlsx-calc/src/lexer.rs
@@ -1,0 +1,483 @@
+//! formula lexer: turns source (without the leading `=`) into position-tagged
+//! tokens, resolving reference/range/sheet disambiguation.
+
+use std::fmt;
+
+use xlsx_model::{CellRange, CellRef, ErrorValue};
+
+/// a positioned lexer/parser error, the single error type of `parse_formula`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// byte offset into the source where the problem starts.
+    pub pos: usize,
+    pub message: String,
+}
+
+impl ParseError {
+    pub fn new(pos: usize, message: impl Into<String>) -> Self {
+        Self {
+            pos,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "formula error at {}: {}", self.pos, self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// error literals recognized in formulas, longest-unambiguous set from the spec.
+const ERROR_LITERALS: &[(&str, ErrorValue)] = &[
+    ("#DIV/0!", ErrorValue::Div0),
+    ("#N/A", ErrorValue::NA),
+    ("#NAME?", ErrorValue::Name),
+    ("#NULL!", ErrorValue::Null),
+    ("#NUM!", ErrorValue::Num),
+    ("#REF!", ErrorValue::Ref),
+    ("#VALUE!", ErrorValue::Value),
+    ("#SPILL!", ErrorValue::Spill),
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub kind: TokKind,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokKind {
+    Num(f64),
+    Str(String),
+    Bool(bool),
+    ErrLit(ErrorValue),
+    /// a bare word that is not a bool/ref — a function name or defined name.
+    Ident(String),
+    Ref {
+        sheet: Option<String>,
+        cell: CellRef,
+    },
+    Range {
+        sheet: Option<String>,
+        range: CellRange,
+    },
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Caret,
+    Amp,
+    Percent,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    LParen,
+    RParen,
+    Comma,
+}
+
+/// tokenize a formula source string.
+pub fn lex(input: &str) -> Result<Vec<Token>, ParseError> {
+    Lexer { input, pos: 0 }.run()
+}
+
+struct Lexer<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl Lexer<'_> {
+    fn run(mut self) -> Result<Vec<Token>, ParseError> {
+        let mut out = Vec::new();
+        loop {
+            self.skip_ws();
+            let start = self.pos;
+            let Some(c) = self.peek() else { break };
+            let kind = match c {
+                '0'..='9' | '.' => self.lex_number()?,
+                '"' => self.lex_string()?,
+                '#' => self.lex_error_literal()?,
+                '\'' => self.lex_quoted_sheet_ref()?,
+                '(' => self.punct(TokKind::LParen),
+                ')' => self.punct(TokKind::RParen),
+                ',' => self.punct(TokKind::Comma),
+                '+' => self.punct(TokKind::Plus),
+                '-' => self.punct(TokKind::Minus),
+                '*' => self.punct(TokKind::Star),
+                '/' => self.punct(TokKind::Slash),
+                '^' => self.punct(TokKind::Caret),
+                '&' => self.punct(TokKind::Amp),
+                '%' => self.punct(TokKind::Percent),
+                '=' => self.punct(TokKind::Eq),
+                '<' => {
+                    self.bump();
+                    match self.peek() {
+                        Some('=') => {
+                            self.bump();
+                            TokKind::Le
+                        }
+                        Some('>') => {
+                            self.bump();
+                            TokKind::Ne
+                        }
+                        _ => TokKind::Lt,
+                    }
+                }
+                '>' => {
+                    self.bump();
+                    match self.peek() {
+                        Some('=') => {
+                            self.bump();
+                            TokKind::Ge
+                        }
+                        _ => TokKind::Gt,
+                    }
+                }
+                c if c.is_ascii_alphabetic() || c == '$' => self.lex_word_or_ref()?,
+                other => {
+                    return Err(ParseError::new(
+                        start,
+                        format!("unexpected character {other:?}"),
+                    ));
+                }
+            };
+            out.push(Token {
+                kind,
+                start,
+                end: self.pos,
+            });
+        }
+        Ok(out)
+    }
+
+    fn punct(&mut self, kind: TokKind) -> TokKind {
+        self.bump();
+        kind
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        let c = self.peek()?;
+        self.pos += c.len_utf8();
+        Some(c)
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(c) = self.peek() {
+            if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// read a maximal `[A-Za-z0-9_.$]` run (ref parts, sheet names, func names).
+    fn read_word(&mut self) -> String {
+        let start = self.pos;
+        while let Some(c) = self.peek() {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '$' {
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        self.input[start..self.pos].to_string()
+    }
+
+    fn lex_number(&mut self) -> Result<TokKind, ParseError> {
+        let start = self.pos;
+        while self.peek().is_some_and(|c| c.is_ascii_digit()) {
+            self.bump();
+        }
+        if self.peek() == Some('.') {
+            self.bump();
+            while self.peek().is_some_and(|c| c.is_ascii_digit()) {
+                self.bump();
+            }
+        }
+        if matches!(self.peek(), Some('e' | 'E')) {
+            self.bump();
+            if matches!(self.peek(), Some('+' | '-')) {
+                self.bump();
+            }
+            let exp_start = self.pos;
+            while self.peek().is_some_and(|c| c.is_ascii_digit()) {
+                self.bump();
+            }
+            if self.pos == exp_start {
+                return Err(ParseError::new(start, "malformed number exponent"));
+            }
+        }
+        let text = &self.input[start..self.pos];
+        text.parse::<f64>()
+            .map(TokKind::Num)
+            .map_err(|_| ParseError::new(start, format!("malformed number {text:?}")))
+    }
+
+    fn lex_string(&mut self) -> Result<TokKind, ParseError> {
+        let start = self.pos;
+        self.bump();
+        let mut s = String::new();
+        loop {
+            match self.bump() {
+                None => return Err(ParseError::new(start, "unterminated string")),
+                Some('"') => {
+                    if self.peek() == Some('"') {
+                        self.bump();
+                        s.push('"');
+                    } else {
+                        break;
+                    }
+                }
+                Some(c) => s.push(c),
+            }
+        }
+        Ok(TokKind::Str(s))
+    }
+
+    fn lex_error_literal(&mut self) -> Result<TokKind, ParseError> {
+        let start = self.pos;
+        let rest = &self.input[start..];
+        for (lit, val) in ERROR_LITERALS {
+            if rest.starts_with(lit) {
+                self.pos += lit.len();
+                return Ok(TokKind::ErrLit(*val));
+            }
+        }
+        Err(ParseError::new(start, "unknown error literal"))
+    }
+
+    /// `'Quoted Sheet'!A1` or `'Quoted Sheet'!A1:B2`. `''` escapes a quote.
+    fn lex_quoted_sheet_ref(&mut self) -> Result<TokKind, ParseError> {
+        let start = self.pos;
+        self.bump();
+        let mut name = String::new();
+        loop {
+            match self.bump() {
+                None => return Err(ParseError::new(start, "unterminated sheet name")),
+                Some('\'') => {
+                    if self.peek() == Some('\'') {
+                        self.bump();
+                        name.push('\'');
+                    } else {
+                        break;
+                    }
+                }
+                Some(c) => name.push(c),
+            }
+        }
+        if self.peek() != Some('!') {
+            return Err(ParseError::new(
+                self.pos,
+                "expected '!' after quoted sheet name",
+            ));
+        }
+        self.bump();
+        self.lex_reference(Some(name), start)
+    }
+
+    /// classify a word starting with a letter or `$`: sheet-qualified ref,
+    /// cell ref, range, boolean literal, or a bare name/function.
+    fn lex_word_or_ref(&mut self) -> Result<TokKind, ParseError> {
+        let start = self.pos;
+        let word = self.read_word();
+
+        if self.peek() == Some('!') {
+            self.bump();
+            return self.lex_reference(Some(word), start);
+        }
+
+        if word.eq_ignore_ascii_case("TRUE") {
+            return Ok(TokKind::Bool(true));
+        }
+        if word.eq_ignore_ascii_case("FALSE") {
+            return Ok(TokKind::Bool(false));
+        }
+
+        // a name followed by `(` is a function even when ref-shaped (e.g. LOG10)
+        if self.peek() == Some('(') {
+            return Ok(TokKind::Ident(word));
+        }
+
+        if self.peek() == Some(':') && CellRef::parse_a1(&word).is_ok() {
+            return self.finish_range(None, &word, start);
+        }
+
+        match CellRef::parse_a1(&word) {
+            Ok(cell) => Ok(TokKind::Ref { sheet: None, cell }),
+            Err(_) => Ok(TokKind::Ident(word)),
+        }
+    }
+
+    /// parse the reference part after a resolved sheet qualifier.
+    fn lex_reference(
+        &mut self,
+        sheet: Option<String>,
+        start: usize,
+    ) -> Result<TokKind, ParseError> {
+        let word = self.read_word();
+        if self.peek() == Some(':') {
+            return self.finish_range(sheet, &word, start);
+        }
+        let cell = CellRef::parse_a1(&word)
+            .map_err(|e| ParseError::new(start, format!("invalid reference {word:?}: {e}")))?;
+        Ok(TokKind::Ref { sheet, cell })
+    }
+
+    /// consume `:end` and build a range from an already-read start segment.
+    fn finish_range(
+        &mut self,
+        sheet: Option<String>,
+        start_word: &str,
+        start: usize,
+    ) -> Result<TokKind, ParseError> {
+        self.bump();
+        let end_word = self.read_word();
+        let a = CellRef::parse_a1(start_word).map_err(|e| {
+            ParseError::new(start, format!("invalid range start {start_word:?}: {e}"))
+        })?;
+        let b = CellRef::parse_a1(&end_word)
+            .map_err(|e| ParseError::new(start, format!("invalid range end {end_word:?}: {e}")))?;
+        Ok(TokKind::Range {
+            sheet,
+            range: CellRange::new(a, b),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<TokKind> {
+        lex(src).unwrap().into_iter().map(|t| t.kind).collect()
+    }
+
+    #[test]
+    fn lexes_numbers_and_operators() {
+        assert_eq!(
+            kinds("1 + 2.5 * 3e2"),
+            vec![
+                TokKind::Num(1.0),
+                TokKind::Plus,
+                TokKind::Num(2.5),
+                TokKind::Star,
+                TokKind::Num(300.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_comparison_operators() {
+        assert_eq!(
+            kinds("<= <> >= < > ="),
+            vec![
+                TokKind::Le,
+                TokKind::Ne,
+                TokKind::Ge,
+                TokKind::Lt,
+                TokKind::Gt,
+                TokKind::Eq
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_strings_with_escaped_quotes() {
+        assert_eq!(kinds(r#""a""b""#), vec![TokKind::Str("a\"b".into())]);
+        assert_eq!(kinds(r#""""#), vec![TokKind::Str(String::new())]);
+    }
+
+    #[test]
+    fn lexes_booleans_case_insensitively() {
+        assert_eq!(
+            kinds("TRUE false True"),
+            vec![
+                TokKind::Bool(true),
+                TokKind::Bool(false),
+                TokKind::Bool(true)
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_error_literals() {
+        assert_eq!(kinds("#REF!"), vec![TokKind::ErrLit(ErrorValue::Ref)]);
+        assert_eq!(kinds("#N/A"), vec![TokKind::ErrLit(ErrorValue::NA)]);
+        assert_eq!(kinds("#DIV/0!"), vec![TokKind::ErrLit(ErrorValue::Div0)]);
+    }
+
+    #[test]
+    fn lexes_cell_refs_and_ranges() {
+        assert_eq!(
+            kinds("A1"),
+            vec![TokKind::Ref {
+                sheet: None,
+                cell: CellRef::parse_a1("A1").unwrap()
+            }]
+        );
+        assert_eq!(
+            kinds("$A$1"),
+            vec![TokKind::Ref {
+                sheet: None,
+                cell: CellRef::parse_a1("$A$1").unwrap()
+            }]
+        );
+        match &kinds("A1:B2")[0] {
+            TokKind::Range { sheet: None, range } => assert_eq!(range.to_a1(), "A1:B2"),
+            other => panic!("expected range, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lexes_sheet_qualified_refs() {
+        match &kinds("Sheet1!A1")[0] {
+            TokKind::Ref {
+                sheet: Some(s),
+                cell,
+            } => {
+                assert_eq!(s, "Sheet1");
+                assert_eq!(cell.to_a1(), "A1");
+            }
+            other => panic!("expected sheet ref, got {other:?}"),
+        }
+        match &kinds("'My Sheet'!A1:B2")[0] {
+            TokKind::Range {
+                sheet: Some(s),
+                range,
+            } => {
+                assert_eq!(s, "My Sheet");
+                assert_eq!(range.to_a1(), "A1:B2");
+            }
+            other => panic!("expected quoted sheet range, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn function_name_wins_over_ref_shape() {
+        assert_eq!(kinds("LOG10(")[0], TokKind::Ident("LOG10".into()));
+        assert_eq!(kinds("SUM(")[0], TokKind::Ident("SUM".into()));
+    }
+
+    #[test]
+    fn rejects_unterminated_string() {
+        let err = lex("\"abc").unwrap_err();
+        assert_eq!(err.pos, 0);
+    }
+
+    #[test]
+    fn rejects_unexpected_char() {
+        assert!(lex("1 ~ 2").is_err());
+    }
+}

--- a/crates/xlsx-calc/src/lib.rs
+++ b/crates/xlsx-calc/src/lib.rs
@@ -1,0 +1,28 @@
+//! formula engine: lexer -> parser -> `Expr` ast -> evaluator, plus dependency
+//! extraction. reads cells exclusively through `xlsx_model::CellProvider`.
+//!
+//! ```
+//! use xlsx_calc::{evaluate, parse_formula, EvalContext};
+//! use xlsx_model::{Sheet, SheetId, Workbook};
+//!
+//! let mut wb = Workbook::default();
+//! wb.sheets.push(Sheet::new("Sheet1"));
+//! let expr = parse_formula("1 + 2 * 3").unwrap();
+//! let ctx = EvalContext::new(&wb, SheetId(0));
+//! assert_eq!(evaluate(&expr, &ctx), xlsx_model::CellValue::Number { value: 7.0 });
+//! ```
+
+pub mod deps;
+pub mod engine;
+pub mod eval;
+pub mod functions;
+pub mod graph;
+pub mod lexer;
+pub mod parser;
+pub mod printer;
+
+pub use deps::references;
+pub use engine::{RecalcResult, rebuild_and_recalc_all, recalc_after};
+pub use eval::{EvalContext, evaluate};
+pub use lexer::{ParseError, TokKind, Token, lex};
+pub use parser::{BinaryOp, Expr, MAX_DEPTH, UnaryOp, parse_formula};

--- a/crates/xlsx-calc/src/parser.rs
+++ b/crates/xlsx-calc/src/parser.rs
@@ -1,0 +1,365 @@
+//! precedence-climbing (pratt) parser: tokens -> `Expr` ast. never panics;
+//! malformed input yields a positioned `ParseError`, nesting is depth-capped.
+
+use xlsx_model::{CellRange, CellRef, ErrorValue};
+
+use crate::lexer::{ParseError, TokKind, Token, lex};
+
+/// maximum expression nesting depth before we bail with a `ParseError`.
+pub const MAX_DEPTH: usize = 100;
+
+/// unary prefix binding power; higher than `^`'s left power (9) because excel
+/// binds unary minus tighter than exponent: `-2^2 = 4`.
+const UNARY_BP: u8 = 10;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Number(f64),
+    Text(String),
+    Bool(bool),
+    Error(ErrorValue),
+    Ref {
+        sheet: Option<String>,
+        cell: CellRef,
+    },
+    Range {
+        sheet: Option<String>,
+        range: CellRange,
+    },
+    Unary {
+        op: UnaryOp,
+        expr: Box<Expr>,
+    },
+    Binary {
+        op: BinaryOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+    Percent(Box<Expr>),
+    FuncCall {
+        name: String,
+        args: Vec<Expr>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOp {
+    Neg,
+    Plus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Pow,
+    Concat,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+/// public entry point: parse a formula body (no leading `=`) into an ast.
+pub fn parse_formula(src: &str) -> Result<Expr, ParseError> {
+    let tokens = lex(src)?;
+    if tokens.is_empty() {
+        return Err(ParseError::new(0, "empty formula"));
+    }
+    let mut p = Parser {
+        tokens: &tokens,
+        pos: 0,
+        src_len: src.len(),
+    };
+    let expr = p.expr_bp(0, 0)?;
+    if let Some(tok) = p.peek() {
+        return Err(ParseError::new(tok.start, "unexpected trailing token"));
+    }
+    Ok(expr)
+}
+
+struct Parser<'a> {
+    tokens: &'a [Token],
+    pos: usize,
+    src_len: usize,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn advance(&mut self) -> Option<&Token> {
+        let t = self.tokens.get(self.pos);
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    /// byte offset for error reporting at the current position (or end).
+    fn here(&self) -> usize {
+        self.peek().map(|t| t.start).unwrap_or(self.src_len)
+    }
+
+    fn expect(&mut self, want: &TokKind, what: &str) -> Result<(), ParseError> {
+        match self.peek() {
+            Some(t) if &t.kind == want => {
+                self.advance();
+                Ok(())
+            }
+            _ => Err(ParseError::new(self.here(), format!("expected {what}"))),
+        }
+    }
+
+    fn expr_bp(&mut self, min_bp: u8, depth: usize) -> Result<Expr, ParseError> {
+        if depth > MAX_DEPTH {
+            return Err(ParseError::new(self.here(), "formula nesting too deep"));
+        }
+        let mut lhs = self.prefix(depth)?;
+        while let Some((op, l_bp, r_bp)) = self.peek().and_then(|t| infix_binding_power(&t.kind)) {
+            if l_bp < min_bp {
+                break;
+            }
+            self.advance();
+            let rhs = self.expr_bp(r_bp, depth + 1)?;
+            lhs = Expr::Binary {
+                op,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+            };
+        }
+        Ok(lhs)
+    }
+
+    fn prefix(&mut self, depth: usize) -> Result<Expr, ParseError> {
+        match self.peek().map(|t| &t.kind) {
+            Some(TokKind::Minus) => {
+                self.advance();
+                let expr = self.expr_bp(UNARY_BP, depth + 1)?;
+                Ok(Expr::Unary {
+                    op: UnaryOp::Neg,
+                    expr: Box::new(expr),
+                })
+            }
+            Some(TokKind::Plus) => {
+                self.advance();
+                let expr = self.expr_bp(UNARY_BP, depth + 1)?;
+                Ok(Expr::Unary {
+                    op: UnaryOp::Plus,
+                    expr: Box::new(expr),
+                })
+            }
+            _ => self.postfix(depth),
+        }
+    }
+
+    /// an atom followed by any number of `%` postfixes.
+    fn postfix(&mut self, depth: usize) -> Result<Expr, ParseError> {
+        let mut expr = self.atom(depth)?;
+        while matches!(self.peek().map(|t| &t.kind), Some(TokKind::Percent)) {
+            self.advance();
+            expr = Expr::Percent(Box::new(expr));
+        }
+        Ok(expr)
+    }
+
+    fn atom(&mut self, depth: usize) -> Result<Expr, ParseError> {
+        let pos = self.here();
+        let Some(tok) = self.advance() else {
+            return Err(ParseError::new(pos, "unexpected end of formula"));
+        };
+        match tok.kind.clone() {
+            TokKind::Num(n) => Ok(Expr::Number(n)),
+            TokKind::Str(s) => Ok(Expr::Text(s)),
+            TokKind::Bool(b) => Ok(Expr::Bool(b)),
+            TokKind::ErrLit(e) => Ok(Expr::Error(e)),
+            TokKind::Ref { sheet, cell } => Ok(Expr::Ref { sheet, cell }),
+            TokKind::Range { sheet, range } => Ok(Expr::Range { sheet, range }),
+            TokKind::LParen => {
+                let inner = self.expr_bp(0, depth + 1)?;
+                self.expect(&TokKind::RParen, "')'")?;
+                Ok(inner)
+            }
+            TokKind::Ident(name) => self.func_call(name, depth),
+            other => Err(ParseError::new(pos, format!("unexpected token {other:?}"))),
+        }
+    }
+
+    /// a bare name must be a function call; defined names are not supported.
+    fn func_call(&mut self, name: String, depth: usize) -> Result<Expr, ParseError> {
+        self.expect(&TokKind::LParen, "'(' after function name")?;
+        let mut args = Vec::new();
+        if matches!(self.peek().map(|t| &t.kind), Some(TokKind::RParen)) {
+            self.advance();
+            return Ok(Expr::FuncCall { name, args });
+        }
+        loop {
+            args.push(self.expr_bp(0, depth + 1)?);
+            match self.peek().map(|t| &t.kind) {
+                Some(TokKind::Comma) => {
+                    self.advance();
+                }
+                Some(TokKind::RParen) => {
+                    self.advance();
+                    break;
+                }
+                _ => return Err(ParseError::new(self.here(), "expected ',' or ')'")),
+            }
+        }
+        Ok(Expr::FuncCall { name, args })
+    }
+}
+
+/// left/right binding powers for infix operators; `None` for non-operators.
+/// left-assoc operators use `l < r`; equal precedence stops the climb.
+fn infix_binding_power(kind: &TokKind) -> Option<(BinaryOp, u8, u8)> {
+    Some(match kind {
+        TokKind::Eq => (BinaryOp::Eq, 1, 2),
+        TokKind::Ne => (BinaryOp::Ne, 1, 2),
+        TokKind::Lt => (BinaryOp::Lt, 1, 2),
+        TokKind::Le => (BinaryOp::Le, 1, 2),
+        TokKind::Gt => (BinaryOp::Gt, 1, 2),
+        TokKind::Ge => (BinaryOp::Ge, 1, 2),
+        TokKind::Amp => (BinaryOp::Concat, 3, 4),
+        TokKind::Plus => (BinaryOp::Add, 5, 6),
+        TokKind::Minus => (BinaryOp::Sub, 5, 6),
+        TokKind::Star => (BinaryOp::Mul, 7, 8),
+        TokKind::Slash => (BinaryOp::Div, 7, 8),
+        TokKind::Caret => (BinaryOp::Pow, 9, 10),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(src: &str) -> Expr {
+        parse_formula(src).unwrap()
+    }
+
+    fn bin(op: BinaryOp, l: Expr, r: Expr) -> Expr {
+        Expr::Binary {
+            op,
+            lhs: Box::new(l),
+            rhs: Box::new(r),
+        }
+    }
+
+    #[test]
+    fn precedence_mul_over_add() {
+        assert_eq!(
+            parse("1+2*3"),
+            bin(
+                BinaryOp::Add,
+                Expr::Number(1.0),
+                bin(BinaryOp::Mul, Expr::Number(2.0), Expr::Number(3.0))
+            )
+        );
+    }
+
+    #[test]
+    fn excel_unary_minus_binds_tighter_than_power() {
+        assert_eq!(
+            parse("-2^2"),
+            bin(
+                BinaryOp::Pow,
+                Expr::Unary {
+                    op: UnaryOp::Neg,
+                    expr: Box::new(Expr::Number(2.0))
+                },
+                Expr::Number(2.0)
+            )
+        );
+    }
+
+    #[test]
+    fn power_is_left_associative() {
+        assert_eq!(
+            parse("2^3^2"),
+            bin(
+                BinaryOp::Pow,
+                bin(BinaryOp::Pow, Expr::Number(2.0), Expr::Number(3.0)),
+                Expr::Number(2.0)
+            )
+        );
+    }
+
+    #[test]
+    fn concat_looser_than_arithmetic() {
+        assert_eq!(
+            parse("1+2&3"),
+            bin(
+                BinaryOp::Concat,
+                bin(BinaryOp::Add, Expr::Number(1.0), Expr::Number(2.0)),
+                Expr::Number(3.0)
+            )
+        );
+    }
+
+    #[test]
+    fn comparison_loosest() {
+        assert_eq!(
+            parse("1+1=2"),
+            bin(
+                BinaryOp::Eq,
+                bin(BinaryOp::Add, Expr::Number(1.0), Expr::Number(1.0)),
+                Expr::Number(2.0)
+            )
+        );
+    }
+
+    #[test]
+    fn percent_binds_tightest() {
+        assert_eq!(
+            parse("-50%"),
+            Expr::Unary {
+                op: UnaryOp::Neg,
+                expr: Box::new(Expr::Percent(Box::new(Expr::Number(50.0))))
+            }
+        );
+    }
+
+    #[test]
+    fn parens_override_precedence() {
+        assert_eq!(
+            parse("(1+2)*3"),
+            bin(
+                BinaryOp::Mul,
+                bin(BinaryOp::Add, Expr::Number(1.0), Expr::Number(2.0)),
+                Expr::Number(3.0)
+            )
+        );
+    }
+
+    #[test]
+    fn function_calls_parse_args() {
+        match parse("SUM(1, A1, 2+3)") {
+            Expr::FuncCall { name, args } => {
+                assert_eq!(name, "SUM");
+                assert_eq!(args.len(), 3);
+            }
+            other => panic!("expected func call, got {other:?}"),
+        }
+        assert!(matches!(parse("PI()"), Expr::FuncCall { args, .. } if args.is_empty()));
+    }
+
+    #[test]
+    fn rejects_malformed_input() {
+        for src in ["", "1+", "(1", "1 2", "SUM(1,)", "FOO", "*1", ")"] {
+            assert!(parse_formula(src).is_err(), "should reject {src:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_excessive_nesting() {
+        let src = format!("{}1{}", "(".repeat(200), ")".repeat(200));
+        let err = parse_formula(&src).unwrap_err();
+        assert!(err.message.contains("too deep"));
+    }
+}

--- a/crates/xlsx-calc/src/printer.rs
+++ b/crates/xlsx-calc/src/printer.rs
@@ -1,0 +1,136 @@
+//! ast -> formula text; printing a parsed formula and re-parsing it yields an
+//! equivalent ast.
+
+use crate::parser::{BinaryOp, Expr, UnaryOp};
+
+// mirrors the parser's precedence table so parens are emitted only where
+// re-parsing would otherwise change the tree
+fn binary_bp(op: &BinaryOp) -> u8 {
+    match op {
+        BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
+            1
+        }
+        BinaryOp::Concat => 2,
+        BinaryOp::Add | BinaryOp::Sub => 3,
+        BinaryOp::Mul | BinaryOp::Div => 4,
+        BinaryOp::Pow => 5,
+    }
+}
+
+fn binary_token(op: &BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Pow => "^",
+        BinaryOp::Concat => "&",
+        BinaryOp::Eq => "=",
+        BinaryOp::Ne => "<>",
+        BinaryOp::Lt => "<",
+        BinaryOp::Le => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::Ge => ">=",
+    }
+}
+
+/// quote a sheet name when it needs it (anything beyond ascii alnum + `_`).
+fn sheet_prefix(sheet: &Option<String>) -> String {
+    match sheet {
+        None => String::new(),
+        Some(name) => {
+            let simple = !name.is_empty()
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                && !name.chars().next().is_some_and(|c| c.is_ascii_digit());
+            if simple {
+                format!("{name}!")
+            } else {
+                format!("'{}'!", name.replace('\'', "''"))
+            }
+        }
+    }
+}
+
+impl Expr {
+    /// render the expression as formula text (without a leading `=`).
+    pub fn to_formula(&self) -> String {
+        self.print(0)
+    }
+
+    fn print(&self, parent_bp: u8) -> String {
+        match self {
+            Expr::Number(n) => n.to_string(),
+            Expr::Text(t) => format!("\"{}\"", t.replace('"', "\"\"")),
+            Expr::Bool(b) => if *b { "TRUE" } else { "FALSE" }.to_string(),
+            Expr::Error(e) => e.as_str().to_string(),
+            Expr::Ref { sheet, cell } => format!("{}{}", sheet_prefix(sheet), cell.to_a1()),
+            Expr::Range { sheet, range } => {
+                format!("{}{}", sheet_prefix(sheet), range.to_a1())
+            }
+            Expr::Unary { op, expr } => {
+                // 6 > every binary bp: unary minus binds tighter than all binary ops
+                let inner = expr.print(6);
+                match op {
+                    UnaryOp::Neg => format!("-{inner}"),
+                    UnaryOp::Plus => format!("+{inner}"),
+                }
+            }
+            Expr::Percent(expr) => format!("{}%", expr.print(6)),
+            Expr::Binary { op, lhs, rhs } => {
+                let bp = binary_bp(op);
+                // left-associative: the right child needs parens at equal bp
+                let s = format!("{}{}{}", lhs.print(bp), binary_token(op), rhs.print(bp + 1));
+                if bp < parent_bp { format!("({s})") } else { s }
+            }
+            Expr::FuncCall { name, args } => {
+                let inner: Vec<String> = args.iter().map(|a| a.print(0)).collect();
+                format!("{}({})", name, inner.join(","))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse_formula;
+
+    #[track_caller]
+    fn round_trips(src: &str) {
+        let ast = parse_formula(src).unwrap();
+        let printed = ast.to_formula();
+        let reparsed = parse_formula(&printed).unwrap();
+        assert_eq!(ast, reparsed, "printed form {printed:?} changed the ast");
+    }
+
+    #[test]
+    fn round_trips_representative_formulas() {
+        for src in [
+            "1+2*3",
+            "(1+2)*3",
+            "-2^2",
+            "2^-3",
+            "A1+$B$2",
+            "SUM(A1:B10,3,\"x\")",
+            "IF(A1>=3,\"yes\",\"no\")",
+            "Sheet1!A1&'My Sheet'!B2",
+            "10%",
+            "(1+2)%",
+            "NOT(TRUE)",
+            "1<=2",
+            "\"he said \"\"hi\"\"\"",
+            "1-2-3",
+            "2^3^2",
+            "-(1+2)",
+        ] {
+            round_trips(src);
+        }
+    }
+
+    #[test]
+    fn emits_minimal_parens() {
+        let ast = parse_formula("(1+2)*3").unwrap();
+        assert_eq!(ast.to_formula(), "(1+2)*3");
+        let ast = parse_formula("1+(2*3)").unwrap();
+        assert_eq!(ast.to_formula(), "1+2*3");
+    }
+}

--- a/crates/xlsx-calc/tests/eval_fixtures.rs
+++ b/crates/xlsx-calc/tests/eval_fixtures.rs
@@ -1,0 +1,155 @@
+//! table-driven end-to-end tests: parse a formula, evaluate it against a small
+//! in-memory workbook (which implements `CellProvider`), assert the value.
+
+use xlsx_calc::{EvalContext, evaluate, parse_formula};
+use xlsx_model::{Cell, CellRef, CellValue, ErrorValue, Sheet, SheetId, Workbook};
+
+fn n(v: f64) -> CellValue {
+    CellValue::Number { value: v }
+}
+fn t(v: &str) -> CellValue {
+    CellValue::Text { value: v.into() }
+}
+fn b(v: bool) -> CellValue {
+    CellValue::Bool { value: v }
+}
+fn e(v: ErrorValue) -> CellValue {
+    CellValue::Error { value: v }
+}
+
+/// two-sheet fixture: Sheet1 has A1..A3 = 10/20/30, B1 = "hi", B2 = TRUE,
+/// D1 = "5" (C1 empty); Data has A1 = 100.
+fn fixture() -> Workbook {
+    let mut wb = Workbook::default();
+    let mut s1 = Sheet::new("Sheet1");
+    let put = |s: &mut Sheet, a1: &str, v: CellValue| {
+        s.set_cell(
+            CellRef::parse_a1(a1).unwrap(),
+            Cell {
+                value: v,
+                ..Cell::default()
+            },
+        );
+    };
+    put(&mut s1, "A1", n(10.0));
+    put(&mut s1, "A2", n(20.0));
+    put(&mut s1, "A3", n(30.0));
+    put(&mut s1, "B1", t("hi"));
+    put(&mut s1, "B2", b(true));
+    put(&mut s1, "D1", t("5"));
+    wb.sheets.push(s1);
+
+    let mut data = Sheet::new("Data");
+    put(&mut data, "A1", n(100.0));
+    wb.sheets.push(data);
+    wb
+}
+
+fn eval(src: &str) -> CellValue {
+    let wb = fixture();
+    let expr = parse_formula(src).expect("parse");
+    let ctx = EvalContext::new(&wb, SheetId(0));
+    evaluate(&expr, &ctx)
+}
+
+#[test]
+fn arithmetic_and_precedence() {
+    let cases: &[(&str, CellValue)] = &[
+        ("1+2*3", n(7.0)),
+        ("(1+2)*3", n(9.0)),
+        ("2^3^2", n(64.0)), // excel: left-associative
+        ("-2^2", n(4.0)),   // excel: (-2)^2
+        ("10/4", n(2.5)),
+        ("10/0", e(ErrorValue::Div0)),
+        ("50%", n(0.5)),
+        ("-50%", n(-0.5)),
+        ("2+2=4", b(true)),
+        ("2<>3", b(true)),
+        ("3<=3", b(true)),
+    ];
+    for (src, want) in cases {
+        assert_eq!(eval(src), *want, "formula {src:?}");
+    }
+}
+
+#[test]
+fn coercion_rules() {
+    let cases: &[(&str, CellValue)] = &[
+        ("TRUE+1", n(2.0)),
+        ("FALSE*5", n(0.0)),
+        ("C1+5", n(5.0)),
+        ("\"5\"+2", n(7.0)),
+        ("\"x\"+2", e(ErrorValue::Value)),
+        ("1&2", t("12")),
+        ("\"a\"&TRUE", t("aTRUE")),
+    ];
+    for (src, want) in cases {
+        assert_eq!(eval(src), *want, "formula {src:?}");
+    }
+}
+
+#[test]
+fn error_propagation() {
+    assert_eq!(eval("#REF! + 1"), e(ErrorValue::Ref));
+    assert_eq!(eval("1 + #DIV/0!"), e(ErrorValue::Div0));
+    assert_eq!(eval("#N/A + #VALUE!"), e(ErrorValue::NA));
+}
+
+#[test]
+fn references_and_sheets() {
+    let cases: &[(&str, CellValue)] = &[
+        ("A1", n(10.0)),
+        ("A1+A2", n(30.0)),
+        ("B1", t("hi")),
+        ("Data!A1", n(100.0)),
+        ("Data!A1*2", n(200.0)),
+        ("Nope!A1", e(ErrorValue::Ref)),
+        ("Z99", CellValue::Empty),
+        ("Z99+1", n(1.0)),
+    ];
+    for (src, want) in cases {
+        assert_eq!(eval(src), *want, "formula {src:?}");
+    }
+}
+
+#[test]
+fn functions() {
+    let cases: &[(&str, CellValue)] = &[
+        ("SUM(A1:A3)", n(60.0)),
+        ("SUM(A1:A3, 100)", n(160.0)),
+        ("SUM(B1:B2)", n(0.0)),
+        ("SUM(TRUE, 1)", n(2.0)),
+        ("AVERAGE(A1:A3)", n(20.0)),
+        ("AVERAGE(B1)", e(ErrorValue::Div0)),
+        ("COUNT(A1:B2)", n(2.0)),
+        ("COUNTA(A1:B2)", n(4.0)),
+        ("MIN(A1:A3)", n(10.0)),
+        ("MAX(A1:A3)", n(30.0)),
+        ("IF(A1>5, \"big\", \"small\")", t("big")),
+        ("IF(A1>50, 1)", b(false)),
+        ("AND(TRUE, A1>5)", b(true)),
+        ("OR(FALSE, A1>50)", b(false)),
+        ("NOT(A1>50)", b(true)),
+        ("ABS(-7)", n(7.0)),
+        ("ROUND(2.345, 2)", n(2.35)),
+        ("ROUND(2.5, 0)", n(3.0)),
+        ("LEN(B1)", n(2.0)),
+        ("CONCATENATE(\"a\", 1, TRUE)", t("a1TRUE")),
+        ("CONCAT(A1:A2)", t("1020")),
+        ("TRIM(\"  a   b  \")", t("a b")),
+        ("UPPER(B1)", t("HI")),
+        ("LOWER(\"HeLLo\")", t("hello")),
+        ("D1+1", n(6.0)),
+        ("NOSUCHFUNC(1)", e(ErrorValue::Name)),
+    ];
+    for (src, want) in cases {
+        assert_eq!(eval(src), *want, "formula {src:?}");
+    }
+}
+
+#[test]
+fn malformed_inputs_error_not_panic() {
+    for src in ["", "1+", "SUM(", "(1", "1 2", ")", "&1"] {
+        assert!(parse_formula(src).is_err(), "should reject {src:?}");
+    }
+}

--- a/crates/xlsx-calc/tests/functions.rs
+++ b/crates/xlsx-calc/tests/functions.rs
@@ -1,0 +1,290 @@
+//! table-driven coverage for the function library: each case parses a formula,
+//! evaluates it against a shared in-memory workbook, and asserts the value.
+
+use xlsx_calc::{EvalContext, evaluate, parse_formula};
+use xlsx_model::{Cell, CellRef, CellValue, ErrorValue, Sheet, SheetId, Workbook};
+
+fn n(v: f64) -> CellValue {
+    CellValue::Number { value: v }
+}
+fn t(v: &str) -> CellValue {
+    CellValue::Text { value: v.into() }
+}
+fn b(v: bool) -> CellValue {
+    CellValue::Bool { value: v }
+}
+fn e(v: ErrorValue) -> CellValue {
+    CellValue::Error { value: v }
+}
+
+/// fixture: A1:A5 = 10..50, B1:B5 = fruit names, C1:C5 = 1..5, E1:F4 vertical
+/// and H1:K2 horizontal lookup tables.
+fn fixture() -> Workbook {
+    let mut wb = Workbook::default();
+    let mut s = Sheet::new("Sheet1");
+    let put = |s: &mut Sheet, a1: &str, v: CellValue| {
+        s.set_cell(
+            CellRef::parse_a1(a1).unwrap(),
+            Cell {
+                value: v,
+                ..Cell::default()
+            },
+        );
+    };
+    for (i, v) in [10.0, 20.0, 30.0, 40.0, 50.0].iter().enumerate() {
+        put(&mut s, &format!("A{}", i + 1), n(*v));
+    }
+    for (i, v) in ["apple", "banana", "apple", "cherry", "apple"]
+        .iter()
+        .enumerate()
+    {
+        put(&mut s, &format!("B{}", i + 1), t(v));
+    }
+    for (i, v) in [1.0, 2.0, 3.0, 4.0, 5.0].iter().enumerate() {
+        put(&mut s, &format!("C{}", i + 1), n(*v));
+    }
+    let names = ["one", "two", "three", "four"];
+    for (i, name) in names.iter().enumerate() {
+        put(&mut s, &format!("E{}", i + 1), n(i as f64 + 1.0));
+        put(&mut s, &format!("F{}", i + 1), t(name));
+    }
+    for (i, col) in ["H", "I", "J", "K"].iter().enumerate() {
+        put(&mut s, &format!("{col}1"), n(i as f64 + 1.0));
+        put(&mut s, &format!("{col}2"), t(["a", "b", "c", "d"][i]));
+    }
+    wb.sheets.push(s);
+    wb
+}
+
+fn eval(src: &str) -> CellValue {
+    let wb = fixture();
+    let expr = parse_formula(src).expect("parse");
+    let ctx = EvalContext::new(&wb, SheetId(0));
+    evaluate(&expr, &ctx)
+}
+
+/// like `eval` but with an injected clock (2020-01-01 12:00) for TODAY/NOW.
+fn eval_now(src: &str) -> CellValue {
+    let wb = fixture();
+    let expr = parse_formula(src).expect("parse");
+    let ctx = EvalContext::with_now(&wb, SheetId(0), 43_831.5);
+    evaluate(&expr, &ctx)
+}
+
+fn check(cases: &[(&str, CellValue)]) {
+    for (src, want) in cases {
+        assert_eq!(eval(src), *want, "formula {src:?}");
+    }
+}
+
+fn approx(src: &str, want: f64) {
+    match eval(src) {
+        CellValue::Number { value } => {
+            assert!(
+                (value - want).abs() < 1e-9,
+                "formula {src:?}: {value} != {want}"
+            );
+        }
+        other => panic!("formula {src:?}: expected number, got {other:?}"),
+    }
+}
+
+#[test]
+fn math_functions() {
+    check(&[
+        ("SUMIF(A1:A5, \">=30\")", n(120.0)),
+        ("SUMIF(B1:B5, \"apple\", C1:C5)", n(9.0)),
+        ("SUMIFS(C1:C5, B1:B5, \"apple\", A1:A5, \">=30\")", n(8.0)),
+        ("SUMPRODUCT(A1:A3, C1:C3)", n(140.0)),
+        ("PRODUCT(1, 2, 3, 4)", n(24.0)),
+        ("ROUNDUP(2.1, 0)", n(3.0)),
+        ("ROUNDDOWN(2.9, 0)", n(2.0)),
+        ("MROUND(10, 3)", n(9.0)),
+        ("MROUND(-2.5, -1)", n(-3.0)),
+        ("INT(-2.5)", n(-3.0)),
+        ("TRUNC(-2.7)", n(-2.0)),
+        ("TRUNC(1.98765, 2)", n(1.98)),
+        ("MOD(-3, 2)", n(1.0)),
+        ("POWER(2, 10)", n(1024.0)),
+        ("SQRT(16)", n(4.0)),
+        ("SQRT(-1)", e(ErrorValue::Num)),
+        ("LOG(8, 2)", n(3.0)),
+        ("LOG10(1000)", n(3.0)),
+        ("SIGN(-5)", n(-1.0)),
+        ("CEILING(2.1, 1)", n(3.0)),
+        ("FLOOR(2.9, 1)", n(2.0)),
+        ("CEILING(-2.5, -1)", n(-3.0)),
+        ("ABS(-7)", n(7.0)),
+    ]);
+    approx("PI()", std::f64::consts::PI);
+    approx("LN(EXP(1))", 1.0);
+    approx("EXP(0)", 1.0);
+}
+
+#[test]
+fn stats_functions() {
+    check(&[
+        ("MEDIAN(1, 2, 3, 4)", n(2.5)),
+        ("MEDIAN(A1:A5)", n(30.0)),
+        ("MODE(1, 2, 2, 3)", n(2.0)),
+        ("MODE(1, 2, 3)", e(ErrorValue::NA)),
+        ("VARP(2, 4, 4, 4, 5, 5, 7, 9)", n(4.0)),
+        ("STDEVP(2, 4, 4, 4, 5, 5, 7, 9)", n(2.0)),
+        ("VAR(1, 2, 3, 4, 5)", n(2.5)),
+        ("LARGE(A1:A5, 1)", n(50.0)),
+        ("LARGE(A1:A5, 2)", n(40.0)),
+        ("SMALL(A1:A5, 2)", n(20.0)),
+        ("RANK(30, A1:A5)", n(3.0)),
+        ("RANK(30, A1:A5, 1)", n(3.0)),
+        ("COUNTIF(B1:B5, \"apple\")", n(3.0)),
+        ("COUNTIF(B1:B5, \"a*\")", n(3.0)),
+        ("COUNTIF(B1:B5, \"<>apple\")", n(2.0)),
+        ("COUNTIFS(B1:B5, \"apple\", A1:A5, \">=30\")", n(2.0)),
+        ("COUNTBLANK(A1:A6)", n(1.0)),
+        ("AVERAGEIF(A1:A5, \">=30\")", n(40.0)),
+        ("AVERAGEIFS(C1:C5, B1:B5, \"apple\")", n(3.0)),
+    ]);
+}
+
+#[test]
+fn text_functions() {
+    check(&[
+        ("LEFT(\"hello\", 2)", t("he")),
+        ("LEFT(\"hello\")", t("h")),
+        ("RIGHT(\"hello\", 2)", t("lo")),
+        ("MID(\"hello\", 2, 3)", t("ell")),
+        ("FIND(\"l\", \"hello\")", n(3.0)),
+        ("FIND(\"L\", \"hello\")", e(ErrorValue::Value)),
+        ("SEARCH(\"L\", \"hello\")", n(3.0)),
+        ("SUBSTITUTE(\"a-b-c\", \"-\", \"+\")", t("a+b+c")),
+        ("SUBSTITUTE(\"a-b-c\", \"-\", \"+\", 2)", t("a-b+c")),
+        ("REPLACE(\"abcdef\", 2, 3, \"XY\")", t("aXYef")),
+        ("REPT(\"ab\", 3)", t("ababab")),
+        ("EXACT(\"a\", \"a\")", b(true)),
+        ("EXACT(\"a\", \"A\")", b(false)),
+        ("PROPER(\"hello world\")", t("Hello World")),
+        ("CLEAN(CHAR(7) & \"a\")", t("a")),
+        ("CHAR(65)", t("A")),
+        ("CODE(\"A\")", n(65.0)),
+        ("VALUE(\"12.5\")", n(12.5)),
+        ("VALUE(\"50%\")", n(0.5)),
+        ("NUMBERVALUE(\"1,234.5\")", n(1234.5)),
+        ("T(\"hi\")", t("hi")),
+        ("T(5)", t("")),
+        ("TEXTJOIN(\"-\", TRUE, \"a\", \"\", \"b\")", t("a-b")),
+        ("TEXTJOIN(\"-\", FALSE, \"a\", \"\", \"b\")", t("a--b")),
+        ("TEXT(1234.5, \"#,##0.00\")", t("1,234.50")),
+        ("TEXT(0.5, \"0%\")", t("50%")),
+        ("TEXT(2.5, \"0.00\")", t("2.50")),
+        ("TEXT(0.1234, \"0.0%\")", t("12.3%")),
+        ("TEXT(-5, \"0.00;(0.00)\")", t("(5.00)")),
+        ("TEXT(12345, \"0.00E+00\")", t("1.23E+04")),
+        ("TEXT(43831, \"m/d/yyyy\")", t("1/1/2020")),
+        ("TEXT(43831, \"mmmm d, yyyy\")", t("January 1, 2020")),
+        ("TEXT(0.5, \"h:mm AM/PM\")", t("12:00 PM")),
+        ("TEXT(5, \"\")", t("")),
+        ("LEN(\"hello\")", n(5.0)),
+    ]);
+}
+
+#[test]
+fn datetime_functions() {
+    check(&[
+        ("DATE(2020, 1, 1)", n(43831.0)),
+        ("DATE(2020, 13, 1)", n(44197.0)),
+        ("DATE(1900, 1, 1)", n(1.0)),
+        ("DATE(1900, 2, 29)", n(60.0)), // the phantom leap day
+        ("DATE(1900, 3, 1)", n(61.0)),
+        ("YEAR(43831)", n(2020.0)),
+        ("MONTH(43831)", n(1.0)),
+        ("DAY(43831)", n(1.0)),
+        ("DAY(60)", n(29.0)),
+        ("MONTH(60)", n(2.0)),
+        ("DAY(59)", n(28.0)),
+        ("WEEKDAY(43831)", n(4.0)),
+        ("WEEKDAY(43831, 2)", n(3.0)),
+        ("EDATE(43831, 1)", n(43862.0)),
+        ("EOMONTH(43831, 0)", n(43861.0)),
+        ("DATEDIF(43831, 44196, \"D\")", n(365.0)),
+        ("DATEDIF(43831, 44196, \"M\")", n(11.0)),
+        ("DATEDIF(43831, 44196, \"Y\")", n(0.0)),
+        ("HOUR(0.5)", n(12.0)),
+        ("HOUR(0.75)", n(18.0)),
+        ("MINUTE(0.5)", n(0.0)),
+        ("TIME(12, 0, 0)", n(0.5)),
+        ("TODAY()", e(ErrorValue::Value)),
+        ("NOW()", e(ErrorValue::Value)),
+    ]);
+    assert_eq!(eval_now("TODAY()"), n(43831.0));
+    assert_eq!(eval_now("NOW()"), n(43831.5));
+    approx("TIME(6, 0, 0)", 0.25);
+}
+
+#[test]
+fn logical_functions() {
+    check(&[
+        ("IFERROR(1/0, \"x\")", t("x")),
+        ("IFERROR(5, \"x\")", n(5.0)),
+        ("IFNA(NA(), \"y\")", t("y")),
+        ("IFNA(1/0, \"y\")", e(ErrorValue::Div0)),
+        ("IFS(FALSE, 1, TRUE, 2)", n(2.0)),
+        ("IFS(FALSE, 1, FALSE, 2)", e(ErrorValue::NA)),
+        ("SWITCH(2, 1, \"a\", 2, \"b\", \"def\")", t("b")),
+        ("SWITCH(9, 1, \"a\", \"def\")", t("def")),
+        ("SWITCH(9, 1, \"a\")", e(ErrorValue::NA)),
+        ("XOR(TRUE, FALSE)", b(true)),
+        ("XOR(TRUE, TRUE)", b(false)),
+        ("IF(TRUE, 1, 1/0)", n(1.0)),
+        ("IFERROR(1, 1/0)", n(1.0)),
+    ]);
+}
+
+#[test]
+fn lookup_functions() {
+    check(&[
+        ("VLOOKUP(2, E1:F4, 2, FALSE)", t("two")),
+        ("VLOOKUP(2.5, E1:F4, 2)", t("two")),
+        ("VLOOKUP(9, E1:F4, 2, FALSE)", e(ErrorValue::NA)),
+        ("HLOOKUP(3, H1:K2, 2, FALSE)", t("c")),
+        ("INDEX(A1:A5, 3)", n(30.0)),
+        ("INDEX(E1:F4, 2, 2)", t("two")),
+        ("MATCH(30, A1:A5, 0)", n(3.0)),
+        ("MATCH(35, A1:A5, 1)", n(3.0)),
+        ("XLOOKUP(2, E1:E4, F1:F4)", t("two")),
+        ("XLOOKUP(9, E1:E4, F1:F4, \"none\")", t("none")),
+        ("CHOOSE(2, \"a\", \"b\", \"c\")", t("b")),
+        ("ROW(A5)", n(5.0)),
+        ("COLUMN(C1)", n(3.0)),
+        ("ROWS(A1:A5)", n(5.0)),
+        ("COLUMNS(E1:F4)", n(2.0)),
+    ]);
+}
+
+#[test]
+fn info_functions() {
+    check(&[
+        ("ISBLANK(A6)", b(true)),
+        ("ISBLANK(A1)", b(false)),
+        ("ISNUMBER(A1)", b(true)),
+        ("ISTEXT(B1)", b(true)),
+        ("ISLOGICAL(TRUE)", b(true)),
+        ("ISERROR(1/0)", b(true)),
+        ("ISERR(1/0)", b(true)),
+        ("ISERR(NA())", b(false)),
+        ("ISNA(NA())", b(true)),
+        ("NA()", e(ErrorValue::NA)),
+        ("N(5)", n(5.0)),
+        ("N(\"x\")", n(0.0)),
+        ("N(TRUE)", n(1.0)),
+    ]);
+}
+
+#[test]
+fn case_insensitive_names() {
+    check(&[
+        ("sum(A1:A5)", n(150.0)),
+        ("Vlookup(2, E1:F4, 2, false)", t("two")),
+        ("mode.sngl(1, 2, 2)", n(2.0)),
+        ("stdev.p(2, 4, 4, 4, 5, 5, 7, 9)", n(2.0)),
+    ]);
+}

--- a/crates/xlsx-model/Cargo.toml
+++ b/crates/xlsx-model/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xlsx-model"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+description = "Workbook, worksheet, and cell model for SpreadsheetML: address types, values, styles. Framework- and IO-free."
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/crates/xlsx-model/src/addr.rs
+++ b/crates/xlsx-model/src/addr.rs
@@ -1,0 +1,235 @@
+//! cell addressing. rows and cols are 0-based internally; a1 notation is
+//! 1-based and converted at parse/format time.
+
+use serde::{Deserialize, Serialize};
+
+pub type RowId = u32;
+pub type ColId = u32;
+
+pub const MAX_ROWS: u32 = 1_048_576;
+pub const MAX_COLS: u32 = 16_384;
+
+/// index of a sheet within the workbook's sheet order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SheetId(pub u32);
+
+/// a single cell address. `abs_row`/`abs_col` carry `$` anchoring so formula
+/// references survive round-trip and remap correctly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CellRef {
+    pub row: RowId,
+    pub col: ColId,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub abs_row: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub abs_col: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+impl CellRef {
+    pub fn new(row: RowId, col: ColId) -> Self {
+        Self {
+            row,
+            col,
+            abs_row: false,
+            abs_col: false,
+        }
+    }
+
+    /// parse a1 notation, e.g. `B7`, `$AA$21`. rejects out-of-range addresses.
+    pub fn parse_a1(s: &str) -> Result<Self, AddrError> {
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        let abs_col = bytes.first() == Some(&b'$');
+        if abs_col {
+            i += 1;
+        }
+        let col_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_uppercase() {
+            i += 1;
+        }
+        if i == col_start {
+            return Err(AddrError::Malformed);
+        }
+        let mut col: u64 = 0;
+        for &b in &bytes[col_start..i] {
+            col = col * 26 + (b - b'A' + 1) as u64;
+            if col > MAX_COLS as u64 {
+                return Err(AddrError::OutOfRange);
+            }
+        }
+        let abs_row = bytes.get(i) == Some(&b'$');
+        if abs_row {
+            i += 1;
+        }
+        let row_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == row_start || i != bytes.len() {
+            return Err(AddrError::Malformed);
+        }
+        let row: u64 = s[row_start..].parse().map_err(|_| AddrError::Malformed)?;
+        if row == 0 || row > MAX_ROWS as u64 {
+            return Err(AddrError::OutOfRange);
+        }
+        Ok(Self {
+            row: (row - 1) as RowId,
+            col: (col - 1) as ColId,
+            abs_row,
+            abs_col,
+        })
+    }
+
+    /// format as a1 notation, preserving `$` anchors.
+    pub fn to_a1(&self) -> String {
+        let mut out = String::new();
+        if self.abs_col {
+            out.push('$');
+        }
+        out.push_str(&col_to_letters(self.col));
+        if self.abs_row {
+            out.push('$');
+        }
+        out.push_str(&(self.row + 1).to_string());
+        out
+    }
+}
+
+/// convert a 0-based column index to letters (0 -> A, 26 -> AA).
+pub fn col_to_letters(col: ColId) -> String {
+    let mut n = col as i64 + 1;
+    let mut out = Vec::new();
+    while n > 0 {
+        n -= 1;
+        out.push(b'A' + (n % 26) as u8);
+        n /= 26;
+    }
+    out.reverse();
+    String::from_utf8(out).expect("ascii")
+}
+
+/// an inclusive rectangular range. `start` is top-left, `end` bottom-right;
+/// constructors normalize so that invariant always holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CellRange {
+    pub start: CellRef,
+    pub end: CellRef,
+}
+
+impl CellRange {
+    pub fn new(a: CellRef, b: CellRef) -> Self {
+        let start = CellRef {
+            row: a.row.min(b.row),
+            col: a.col.min(b.col),
+            ..a
+        };
+        let end = CellRef {
+            row: a.row.max(b.row),
+            col: a.col.max(b.col),
+            ..b
+        };
+        Self { start, end }
+    }
+
+    /// parse `A1:B2` (or a single `A1` as a 1x1 range).
+    pub fn parse_a1(s: &str) -> Result<Self, AddrError> {
+        match s.split_once(':') {
+            Some((a, b)) => Ok(Self::new(CellRef::parse_a1(a)?, CellRef::parse_a1(b)?)),
+            None => {
+                let c = CellRef::parse_a1(s)?;
+                Ok(Self { start: c, end: c })
+            }
+        }
+    }
+
+    pub fn to_a1(&self) -> String {
+        if self.start == self.end {
+            self.start.to_a1()
+        } else {
+            format!("{}:{}", self.start.to_a1(), self.end.to_a1())
+        }
+    }
+
+    pub fn contains(&self, cell: CellRef) -> bool {
+        cell.row >= self.start.row
+            && cell.row <= self.end.row
+            && cell.col >= self.start.col
+            && cell.col <= self.end.col
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddrError {
+    Malformed,
+    OutOfRange,
+}
+
+impl core::fmt::Display for AddrError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AddrError::Malformed => write!(f, "malformed address"),
+            AddrError::OutOfRange => write!(f, "address out of sheet bounds"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_and_formats_a1() {
+        let c = CellRef::parse_a1("B7").unwrap();
+        assert_eq!((c.row, c.col), (6, 1));
+        assert_eq!(c.to_a1(), "B7");
+
+        let c = CellRef::parse_a1("$AA$21").unwrap();
+        assert_eq!((c.row, c.col, c.abs_row, c.abs_col), (20, 26, true, true));
+        assert_eq!(c.to_a1(), "$AA$21");
+
+        assert_eq!(CellRef::parse_a1("XFD1048576").unwrap().col, MAX_COLS - 1);
+    }
+
+    #[test]
+    fn rejects_bad_addresses() {
+        for s in [
+            "", "7B", "A0", "A", "1", "a1", "A1B", "XFE1", "A1048577", "$",
+        ] {
+            assert!(CellRef::parse_a1(s).is_err(), "should reject {s:?}");
+        }
+    }
+
+    #[test]
+    fn col_letters_round_trip() {
+        for (col, s) in [
+            (0, "A"),
+            (25, "Z"),
+            (26, "AA"),
+            (701, "ZZ"),
+            (702, "AAA"),
+            (16_383, "XFD"),
+        ] {
+            assert_eq!(col_to_letters(col), s);
+            assert_eq!(CellRef::parse_a1(&format!("{s}1")).unwrap().col, col);
+        }
+    }
+
+    #[test]
+    fn ranges_normalize_and_contain() {
+        let r = CellRange::parse_a1("B2:A1").unwrap_or_else(|_| {
+            CellRange::new(
+                CellRef::parse_a1("B2").unwrap(),
+                CellRef::parse_a1("A1").unwrap(),
+            )
+        });
+        assert_eq!(r.to_a1(), "A1:B2");
+        assert!(r.contains(CellRef::new(0, 0)));
+        assert!(r.contains(CellRef::new(1, 1)));
+        assert!(!r.contains(CellRef::new(2, 0)));
+        assert_eq!(CellRange::parse_a1("C3").unwrap().to_a1(), "C3");
+    }
+}

--- a/crates/xlsx-model/src/date.rs
+++ b/crates/xlsx-model/src/date.rs
@@ -1,0 +1,57 @@
+//! excel date serials: two epochs (workbookPr/@date1904) plus the deliberate
+//! 1900 leap-year bug (serial 60 = phantom 1900-02-29, lotus 1-2-3 compat).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum DateSystem {
+    /// serial 1 = 1900-01-01; serial 60 = the phantom 1900-02-29.
+    #[default]
+    V1900,
+    /// serial 0 = 1904-01-01. no leap bug.
+    V1904,
+}
+
+impl DateSystem {
+    /// serial to days since the unix epoch, ignoring time-of-day. None where
+    /// no calendar date exists (1900 system: serial < 1 and the phantom 60).
+    pub fn serial_to_unix_days(&self, serial: f64) -> Option<i64> {
+        let whole = serial.floor() as i64;
+        match self {
+            DateSystem::V1900 => {
+                if whole < 1 {
+                    return None;
+                }
+                // serial 60 is the phantom 1900-02-29; serials past it shift back one day
+                if whole == 60 {
+                    return None;
+                }
+                let adjusted = if whole > 60 { whole - 1 } else { whole };
+                // serial 1 = 1900-01-01 = -25567 unix days, so base is -25568
+                Some(adjusted - 25_568)
+            }
+            DateSystem::V1904 => Some(whole - 24_107),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_anchors() {
+        assert_eq!(DateSystem::V1900.serial_to_unix_days(1.0), Some(-25_567));
+        assert_eq!(DateSystem::V1900.serial_to_unix_days(61.0), Some(-25_508));
+        assert_eq!(DateSystem::V1900.serial_to_unix_days(60.0), None);
+        assert_eq!(DateSystem::V1904.serial_to_unix_days(0.0), Some(-24_107));
+        assert_eq!(
+            DateSystem::V1900.serial_to_unix_days(43_831.0),
+            Some(18_262)
+        );
+        assert_eq!(
+            DateSystem::V1904.serial_to_unix_days(42_369.0),
+            Some(18_262)
+        );
+    }
+}

--- a/crates/xlsx-model/src/lib.rs
+++ b/crates/xlsx-model/src/lib.rs
@@ -1,0 +1,18 @@
+//! workbook model: address types, cell values, and the cell-access trait the
+//! calc engine reads through. pure data — no io, no xml, no dom.
+
+pub mod addr;
+pub mod date;
+pub mod numfmt;
+pub mod styles;
+pub mod value;
+pub mod workbook;
+
+pub use addr::{CellRange, CellRef, ColId, MAX_COLS, MAX_ROWS, RowId, SheetId};
+pub use date::DateSystem;
+pub use styles::{
+    Alignment, Border, BorderEdge, BorderStyle, Color, Fill, Font, FormatCode, HAlign, Stylesheet,
+    Theme, VAlign, Xf,
+};
+pub use value::{CellValue, ErrorValue};
+pub use workbook::{Cell, CellProvider, Sheet, Workbook};

--- a/crates/xlsx-model/src/numfmt.rs
+++ b/crates/xlsx-model/src/numfmt.rs
@@ -1,0 +1,1176 @@
+//! number-format code interpreter (ecma-376 §18.8.30–31): value + format code
+//! -> display string and optional bracket color. unsupported degrades to general.
+
+use serde::{Deserialize, Serialize};
+
+use crate::date::DateSystem;
+use crate::value::CellValue;
+
+/// the display string plus the `#rrggbb` color a bracket prefix (`[Red]`) requested.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct FormattedValue {
+    pub text: String,
+    pub color: Option<String>,
+}
+
+/// format a cell value with a number-format code. bools, errors, and empties
+/// ignore the code; text uses the 4th section or an `@` placeholder.
+pub fn format_value(value: &CellValue, code: &str, date_system: DateSystem) -> FormattedValue {
+    match value {
+        CellValue::Bool { value } => FormattedValue {
+            text: if *value { "TRUE" } else { "FALSE" }.to_string(),
+            color: None,
+        },
+        CellValue::Error { value } => FormattedValue {
+            text: value.as_str().to_string(),
+            color: None,
+        },
+        CellValue::Empty => FormattedValue::default(),
+        CellValue::Text { value } => format_text_value(value, code),
+        CellValue::Number { value } => format_number_value(*value, code, date_system),
+    }
+}
+
+/// the implied builtin number-format table (§18.8.30); locale-dependent ids
+/// return None so callers fall back to general.
+pub fn builtin_format_code(id: u16) -> Option<&'static str> {
+    let code = match id {
+        0 => "General",
+        1 => "0",
+        2 => "0.00",
+        3 => "#,##0",
+        4 => "#,##0.00",
+        9 => "0%",
+        10 => "0.00%",
+        11 => "0.00E+00",
+        12 => "# ?/?",
+        13 => "# ??/??",
+        14 => "m/d/yyyy",
+        15 => "d-mmm-yy",
+        16 => "d-mmm",
+        17 => "mmm-yy",
+        18 => "h:mm AM/PM",
+        19 => "h:mm:ss AM/PM",
+        20 => "h:mm",
+        21 => "h:mm:ss",
+        22 => "m/d/yyyy h:mm",
+        37 => "#,##0 ;(#,##0)",
+        38 => "#,##0 ;[Red](#,##0)",
+        39 => "#,##0.00;(#,##0.00)",
+        40 => "#,##0.00;[Red](#,##0.00)",
+        45 => "mm:ss",
+        46 => "[h]:mm:ss",
+        47 => "mmss.0",
+        48 => "##0.0E+0",
+        49 => "@",
+        _ => return None,
+    };
+    Some(code)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Tok {
+    Digit(char),
+    Dot,
+    Comma,
+    Percent,
+    Exp(bool),
+    Slash,
+    At,
+    General,
+    Literal(String),
+    Width,
+    Fill,
+    Year(u8),
+    Mon(u8), // month or minute, resolved by adjacency
+    Day(u8),
+    Hour(u8),
+    Sec(u8),
+    Elapsed(char, u8),
+    AmPm(String, String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum Cmp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Condition {
+    op: Cmp,
+    value: f64,
+}
+
+impl Condition {
+    fn matches(&self, n: f64) -> bool {
+        match self.op {
+            Cmp::Lt => n < self.value,
+            Cmp::Le => n <= self.value,
+            Cmp::Gt => n > self.value,
+            Cmp::Ge => n >= self.value,
+            Cmp::Eq => n == self.value,
+            Cmp::Ne => n != self.value,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Section {
+    toks: Vec<Tok>,
+    color: Option<String>,
+    condition: Option<Condition>,
+}
+
+impl Section {
+    fn has_date(&self) -> bool {
+        self.toks.iter().any(|t| {
+            matches!(
+                t,
+                Tok::Year(_)
+                    | Tok::Mon(_)
+                    | Tok::Day(_)
+                    | Tok::Hour(_)
+                    | Tok::Sec(_)
+                    | Tok::Elapsed(_, _)
+                    | Tok::AmPm(_, _)
+            )
+        })
+    }
+
+    fn has(&self, pred: impl Fn(&Tok) -> bool) -> bool {
+        self.toks.iter().any(pred)
+    }
+}
+
+/// split a code into sections on top-level `;` (quotes, brackets, and escapes guarded).
+fn split_sections(code: &str) -> Vec<String> {
+    let chars: Vec<char> = code.chars().collect();
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '"' => {
+                cur.push(c);
+                i += 1;
+                while i < chars.len() {
+                    cur.push(chars[i]);
+                    let done = chars[i] == '"';
+                    i += 1;
+                    if done {
+                        break;
+                    }
+                }
+            }
+            '[' => {
+                cur.push(c);
+                i += 1;
+                while i < chars.len() {
+                    cur.push(chars[i]);
+                    let done = chars[i] == ']';
+                    i += 1;
+                    if done {
+                        break;
+                    }
+                }
+            }
+            '\\' | '_' | '*' => {
+                cur.push(c);
+                i += 1;
+                if i < chars.len() {
+                    cur.push(chars[i]);
+                    i += 1;
+                }
+            }
+            ';' => {
+                out.push(std::mem::take(&mut cur));
+                i += 1;
+            }
+            _ => {
+                cur.push(c);
+                i += 1;
+            }
+        }
+    }
+    out.push(cur);
+    out
+}
+
+fn tokenize(input: &str) -> Section {
+    let chars: Vec<char> = input.chars().collect();
+    let n = chars.len();
+    let mut section = Section::default();
+    let mut i = 0;
+    while i < n {
+        let c = chars[i];
+        match c {
+            '"' => {
+                i += 1;
+                let mut s = String::new();
+                while i < n && chars[i] != '"' {
+                    s.push(chars[i]);
+                    i += 1;
+                }
+                if i < n {
+                    i += 1;
+                }
+                section.toks.push(Tok::Literal(s));
+            }
+            '\\' => {
+                i += 1;
+                if i < n {
+                    section.toks.push(Tok::Literal(chars[i].to_string()));
+                    i += 1;
+                }
+            }
+            '_' => {
+                i += 1;
+                if i < n {
+                    i += 1;
+                }
+                section.toks.push(Tok::Width);
+            }
+            '*' => {
+                i += 1;
+                if i < n {
+                    i += 1;
+                }
+                section.toks.push(Tok::Fill);
+            }
+            '[' => {
+                i += 1;
+                let mut inner = String::new();
+                while i < n && chars[i] != ']' {
+                    inner.push(chars[i]);
+                    i += 1;
+                }
+                if i < n {
+                    i += 1;
+                }
+                parse_bracket(&inner, &mut section);
+            }
+            '0' | '#' | '?' => {
+                section.toks.push(Tok::Digit(c));
+                i += 1;
+            }
+            '.' => {
+                section.toks.push(Tok::Dot);
+                i += 1;
+            }
+            ',' => {
+                section.toks.push(Tok::Comma);
+                i += 1;
+            }
+            '%' => {
+                section.toks.push(Tok::Percent);
+                i += 1;
+            }
+            '/' => {
+                section.toks.push(Tok::Slash);
+                i += 1;
+            }
+            '@' => {
+                section.toks.push(Tok::At);
+                i += 1;
+            }
+            'E' | 'e' if i + 1 < n && (chars[i + 1] == '+' || chars[i + 1] == '-') => {
+                section.toks.push(Tok::Exp(chars[i + 1] == '+'));
+                i += 2;
+            }
+            'y' | 'Y' => {
+                let cnt = run_len(&chars, i);
+                section.toks.push(Tok::Year(cnt as u8));
+                i += cnt;
+            }
+            'm' | 'M' => {
+                let cnt = run_len(&chars, i);
+                section.toks.push(Tok::Mon(cnt as u8));
+                i += cnt;
+            }
+            'd' | 'D' => {
+                let cnt = run_len(&chars, i);
+                section.toks.push(Tok::Day(cnt as u8));
+                i += cnt;
+            }
+            'h' | 'H' => {
+                let cnt = run_len(&chars, i);
+                section.toks.push(Tok::Hour(cnt as u8));
+                i += cnt;
+            }
+            's' | 'S' => {
+                let cnt = run_len(&chars, i);
+                section.toks.push(Tok::Sec(cnt as u8));
+                i += cnt;
+            }
+            'a' | 'A' => match match_ampm(&chars, i) {
+                Some((am, pm, len)) => {
+                    section.toks.push(Tok::AmPm(am, pm));
+                    i += len;
+                }
+                None => {
+                    section.toks.push(Tok::Literal(c.to_string()));
+                    i += 1;
+                }
+            },
+            'g' | 'G' if match_general(&chars, i) => {
+                section.toks.push(Tok::General);
+                i += 7;
+            }
+            _ => {
+                section.toks.push(Tok::Literal(c.to_string()));
+                i += 1;
+            }
+        }
+    }
+    section
+}
+
+fn run_len(chars: &[char], i: usize) -> usize {
+    let c = chars[i].to_ascii_lowercase();
+    let mut j = i;
+    while j < chars.len() && chars[j].to_ascii_lowercase() == c {
+        j += 1;
+    }
+    j - i
+}
+
+fn match_ampm(chars: &[char], i: usize) -> Option<(String, String, usize)> {
+    let rest: String = chars[i..].iter().collect();
+    let low = rest.to_ascii_lowercase();
+    if low.starts_with("am/pm") {
+        let am: String = chars[i..i + 2].iter().collect();
+        let pm: String = chars[i + 3..i + 5].iter().collect();
+        Some((am, pm, 5))
+    } else if low.starts_with("a/p") {
+        let am: String = chars[i..i + 1].iter().collect();
+        let pm: String = chars[i + 2..i + 3].iter().collect();
+        Some((am, pm, 3))
+    } else {
+        None
+    }
+}
+
+fn match_general(chars: &[char], i: usize) -> bool {
+    let rest: String = chars[i..].iter().collect();
+    rest.to_ascii_lowercase().starts_with("general")
+}
+
+/// interpret a `[...]` prefix: color, condition, elapsed-time field, or
+/// `[$sym-locale]` currency (strip locale, keep symbol). unknown -> drop.
+fn parse_bracket(inner: &str, section: &mut Section) {
+    let trimmed = inner.trim();
+    if let Some(hex) = color_hex(trimmed) {
+        section.color = Some(hex);
+        return;
+    }
+    if let Some(cond) = parse_condition(trimmed) {
+        section.condition = Some(cond);
+        return;
+    }
+    if let Some(tok) = parse_elapsed(trimmed) {
+        section.toks.push(tok);
+        return;
+    }
+    if let Some(rest) = trimmed.strip_prefix('$') {
+        let sym = rest.split_once('-').map_or(rest, |(s, _)| s);
+        if !sym.is_empty() {
+            section.toks.push(Tok::Literal(sym.to_string()));
+        }
+    }
+}
+
+fn color_hex(s: &str) -> Option<String> {
+    let up = s.to_ascii_uppercase();
+    let hex = match up.as_str() {
+        "BLACK" => "#000000",
+        "WHITE" => "#FFFFFF",
+        "RED" => "#FF0000",
+        "GREEN" => "#00FF00",
+        "BLUE" => "#0000FF",
+        "YELLOW" => "#FFFF00",
+        "MAGENTA" => "#FF00FF",
+        "CYAN" => "#00FFFF",
+        _ => {
+            let rest = up.strip_prefix("COLOR")?;
+            let idx: u32 = rest.trim().parse().ok()?;
+            return indexed_color(idx);
+        }
+    };
+    Some(hex.to_string())
+}
+
+/// the classic `[Color N]` palette, indices 1–8 only; higher indices are None.
+fn indexed_color(idx: u32) -> Option<String> {
+    let hex = match idx {
+        1 => "#000000",
+        2 => "#FFFFFF",
+        3 => "#FF0000",
+        4 => "#00FF00",
+        5 => "#0000FF",
+        6 => "#FFFF00",
+        7 => "#FF00FF",
+        8 => "#00FFFF",
+        _ => return None,
+    };
+    Some(hex.to_string())
+}
+
+fn parse_condition(s: &str) -> Option<Condition> {
+    let (op, rest) = if let Some(r) = s.strip_prefix(">=") {
+        (Cmp::Ge, r)
+    } else if let Some(r) = s.strip_prefix("<=") {
+        (Cmp::Le, r)
+    } else if let Some(r) = s.strip_prefix("<>") {
+        (Cmp::Ne, r)
+    } else if let Some(r) = s.strip_prefix('>') {
+        (Cmp::Gt, r)
+    } else if let Some(r) = s.strip_prefix('<') {
+        (Cmp::Lt, r)
+    } else if let Some(r) = s.strip_prefix('=') {
+        (Cmp::Eq, r)
+    } else {
+        return None;
+    };
+    let value: f64 = rest.trim().parse().ok()?;
+    Some(Condition { op, value })
+}
+
+fn parse_elapsed(s: &str) -> Option<Tok> {
+    let c0 = s.chars().next()?.to_ascii_lowercase();
+    if !matches!(c0, 'h' | 'm' | 's') {
+        return None;
+    }
+    if !s.chars().all(|c| c.to_ascii_lowercase() == c0) {
+        return None;
+    }
+    Some(Tok::Elapsed(c0, s.chars().count() as u8))
+}
+
+/// pick the section index for a number and whether to prepend a `-`:
+/// excel's sign fallback, overridden by explicit conditions tried in order.
+fn select(parsed: &[Section], n: f64) -> (usize, bool) {
+    let cap = parsed.len().min(3);
+    let has_cond = parsed[..cap].iter().any(|s| s.condition.is_some());
+    if has_cond {
+        for (i, s) in parsed.iter().enumerate() {
+            if i >= 3 {
+                break;
+            }
+            match &s.condition {
+                Some(c) => {
+                    if c.matches(n) {
+                        return (i, false);
+                    }
+                }
+                None => return (i, n < 0.0),
+            }
+        }
+        return (0, n < 0.0);
+    }
+    let count = parsed.len();
+    if n > 0.0 {
+        (0, false)
+    } else if n == 0.0 {
+        if count >= 3 { (2, false) } else { (0, false) }
+    } else if count >= 2 {
+        (1, false)
+    } else {
+        (0, true)
+    }
+}
+
+fn format_number_value(n: f64, code: &str, ds: DateSystem) -> FormattedValue {
+    let trimmed = code.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("general") {
+        return FormattedValue {
+            text: format_general(n),
+            color: None,
+        };
+    }
+    let parsed: Vec<Section> = split_sections(code).iter().map(|s| tokenize(s)).collect();
+    let (idx, auto_minus) = select(&parsed, n);
+    let sec = &parsed[idx];
+    let color = sec.color.clone();
+    let text = if sec.has_date() {
+        render_date_section(sec, n, ds)
+    } else {
+        let body = render_number_section(sec, n.abs());
+        if auto_minus { format!("-{body}") } else { body }
+    };
+    FormattedValue { text, color }
+}
+
+fn render_number_section(sec: &Section, mag: f64) -> String {
+    if sec.has(|t| matches!(t, Tok::General)) {
+        return render_general_section(sec, mag);
+    }
+    // fractions are stubbed: degrade to a general render.
+    if sec.has(|t| matches!(t, Tok::Slash)) {
+        return format_general(mag);
+    }
+    if sec.has(|t| matches!(t, Tok::Exp(_))) {
+        return render_scientific(sec, mag);
+    }
+    let total_ph = sec
+        .toks
+        .iter()
+        .filter(|t| matches!(t, Tok::Digit(_)))
+        .count();
+    let has_at = sec.has(|t| matches!(t, Tok::At));
+    if total_ph == 0 && !has_at {
+        return emit_literals_only(sec);
+    }
+
+    let dot_pos = sec.toks.iter().position(|t| matches!(t, Tok::Dot));
+    let (int_toks, frac_toks): (&[Tok], &[Tok]) = match dot_pos {
+        Some(p) => (&sec.toks[..p], &sec.toks[p + 1..]),
+        None => (&sec.toks[..], &[]),
+    };
+
+    let (grouping, scale) = scan_commas(int_toks);
+    let percent = sec
+        .toks
+        .iter()
+        .filter(|t| matches!(t, Tok::Percent))
+        .count() as i32;
+
+    let mut v = mag;
+    for _ in 0..percent {
+        v *= 100.0;
+    }
+    for _ in 0..scale {
+        v /= 1000.0;
+    }
+
+    let int_kinds: Vec<char> = digit_kinds(int_toks);
+    let frac_kinds: Vec<char> = digit_kinds(frac_toks);
+    let (int_digits, frac_digits) = split_digits(v, frac_kinds.len());
+    let int_number = build_int_number(&int_kinds, &int_digits, grouping);
+    let frac_str = build_frac(&frac_kinds, &frac_digits);
+
+    let mut out = String::new();
+    let mut int_emitted = false;
+    let mut passed_dot = false;
+    for t in &sec.toks {
+        match t {
+            Tok::Digit(_) => {
+                if !passed_dot && !int_emitted {
+                    out.push_str(&int_number);
+                    int_emitted = true;
+                }
+            }
+            Tok::Dot => {
+                passed_dot = true;
+                if !int_emitted {
+                    out.push_str(&int_number);
+                    int_emitted = true;
+                }
+                if !frac_str.is_empty() {
+                    out.push('.');
+                    out.push_str(&frac_str);
+                }
+            }
+            Tok::Comma => {}
+            Tok::Percent => out.push('%'),
+            Tok::At => out.push_str(&format_general(mag)),
+            Tok::Literal(s) => out.push_str(s),
+            Tok::Width => out.push(' '),
+            Tok::Fill => {}
+            _ => {}
+        }
+    }
+    out
+}
+
+/// classify integer-side commas: flanked by digits turns on thousands
+/// grouping; trailing ones scale the value down by 1000 each.
+fn scan_commas(int_toks: &[Tok]) -> (bool, u32) {
+    let digit_positions: Vec<usize> = int_toks
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| matches!(t, Tok::Digit(_)))
+        .map(|(i, _)| i)
+        .collect();
+    let mut grouping = false;
+    let mut scale = 0u32;
+    for (idx, t) in int_toks.iter().enumerate() {
+        if !matches!(t, Tok::Comma) {
+            continue;
+        }
+        let before = digit_positions.iter().any(|&p| p < idx);
+        let after = digit_positions.iter().any(|&p| p > idx);
+        if before && after {
+            grouping = true;
+        } else if before {
+            scale += 1;
+        }
+    }
+    (grouping, scale)
+}
+
+fn digit_kinds(toks: &[Tok]) -> Vec<char> {
+    toks.iter()
+        .filter_map(|t| match t {
+            Tok::Digit(c) => Some(*c),
+            _ => None,
+        })
+        .collect()
+}
+
+/// split a non-negative magnitude into (integer digits, fraction digits) after
+/// rounding half-away-from-zero (excel's display rule) to `frac_len` places.
+fn split_digits(mag: f64, frac_len: usize) -> (String, String) {
+    let factor = 10f64.powi(frac_len as i32);
+    let scaled = (mag * factor).round();
+    let mut s = format!("{scaled:.0}");
+    while s.len() < frac_len + 1 {
+        s.insert(0, '0');
+    }
+    let cut = s.len() - frac_len;
+    let int_part = &s[..cut];
+    let frac_part = s[cut..].to_string();
+    let int_trimmed = int_part.trim_start_matches('0');
+    (int_trimmed.to_string(), frac_part)
+}
+
+fn build_int_number(kinds: &[char], int_digits: &str, grouping: bool) -> String {
+    let dchars: Vec<char> = int_digits.chars().collect();
+    let n = dchars.len();
+    let p = kinds.len();
+    if p == 0 {
+        return group_if(int_digits, grouping);
+    }
+    let mut buf: Vec<char> = Vec::new();
+    for (j, &kind) in kinds.iter().enumerate() {
+        let rev = p - 1 - j;
+        if j == 0 {
+            let take = n.saturating_sub(rev);
+            if take == 0 {
+                if let Some(ch) = pad_char(kind) {
+                    buf.push(ch);
+                }
+            } else {
+                buf.extend_from_slice(&dchars[0..take]);
+            }
+        } else {
+            let pos = n as isize - 1 - rev as isize;
+            if pos >= 0 {
+                buf.push(dchars[pos as usize]);
+            } else if let Some(ch) = pad_char(kind) {
+                buf.push(ch);
+            }
+        }
+    }
+    let s: String = buf.into_iter().collect();
+    group_if(&s, grouping)
+}
+
+fn pad_char(kind: char) -> Option<char> {
+    match kind {
+        '0' => Some('0'),
+        '?' => Some(' '),
+        _ => None,
+    }
+}
+
+fn group_if(s: &str, grouping: bool) -> String {
+    if !grouping {
+        return s.to_string();
+    }
+    let lead = s.chars().take_while(|c| *c == ' ').count();
+    let (spaces, rest) = s.split_at(lead);
+    format!("{spaces}{}", group_thousands(rest))
+}
+
+fn group_thousands(digits: &str) -> String {
+    let n = digits.len();
+    let mut out = String::with_capacity(n + n / 3);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (n - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// place fraction digits into placeholders, suppressing trailing insignificant
+/// ones: `#` drops, `?` pads a space, `0` keeps the zero.
+fn build_frac(kinds: &[char], frac_digits: &str) -> String {
+    let fchars: Vec<char> = frac_digits.chars().collect();
+    let q = kinds.len();
+    let mut out = String::new();
+    for j in 0..q {
+        let significant = (j..q).any(|k| fchars[k] != '0' || kinds[k] == '0');
+        if significant {
+            out.push(fchars[j]);
+        } else if kinds[j] == '?' {
+            out.push(' ');
+        }
+    }
+    out
+}
+
+fn emit_literals_only(sec: &Section) -> String {
+    let mut out = String::new();
+    for t in &sec.toks {
+        match t {
+            Tok::Literal(s) => out.push_str(s),
+            Tok::Width => out.push(' '),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn render_general_section(sec: &Section, mag: f64) -> String {
+    let mut out = String::new();
+    for t in &sec.toks {
+        match t {
+            Tok::General => out.push_str(&format_general(mag)),
+            Tok::Literal(s) => out.push_str(s),
+            Tok::Width => out.push(' '),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// `0.00E+00` / engineering `##0.0E+0`: the count of integer placeholders sets
+/// the exponent step, so the mantissa's integer part fills 1..=p digits.
+fn render_scientific(sec: &Section, mag: f64) -> String {
+    let exp_idx = sec
+        .toks
+        .iter()
+        .position(|t| matches!(t, Tok::Exp(_)))
+        .unwrap();
+    let plus = matches!(sec.toks[exp_idx], Tok::Exp(true));
+    let mant_toks = &sec.toks[..exp_idx];
+    let exp_toks = &sec.toks[exp_idx + 1..];
+
+    let mant_dot = mant_toks.iter().position(|t| matches!(t, Tok::Dot));
+    let (mi, mf): (&[Tok], &[Tok]) = match mant_dot {
+        Some(p) => (&mant_toks[..p], &mant_toks[p + 1..]),
+        None => (mant_toks, &[]),
+    };
+    let int_kinds = digit_kinds(mi);
+    let frac_kinds = digit_kinds(mf);
+    let p = int_kinds.len().max(1) as i32;
+    let qf = frac_kinds.len();
+
+    let percent = sec
+        .toks
+        .iter()
+        .filter(|t| matches!(t, Tok::Percent))
+        .count() as i32;
+    let mut v = mag;
+    for _ in 0..percent {
+        v *= 100.0;
+    }
+
+    let (mant_out, exp_val) = if v == 0.0 {
+        (build_mantissa(&int_kinds, &frac_kinds, 0.0), 0i32)
+    } else {
+        let e = v.log10().floor() as i32;
+        let mut exp = e.div_euclid(p) * p;
+        let mut m = v / 10f64.powi(exp);
+        let mut mant = build_mantissa(&int_kinds, &frac_kinds, m);
+        // rounding can overflow the mantissa (9.99 -> 10): bump exponent, recompute
+        let (id, _) = split_digits(m, qf);
+        if id.len() as i32 > p {
+            exp += p;
+            m = v / 10f64.powi(exp);
+            mant = build_mantissa(&int_kinds, &frac_kinds, m);
+        }
+        (mant, exp)
+    };
+
+    let exp_width = exp_toks
+        .iter()
+        .filter(|t| matches!(t, Tok::Digit('0')))
+        .count()
+        .max(1);
+    let sign = if exp_val < 0 {
+        "-"
+    } else if plus {
+        "+"
+    } else {
+        ""
+    };
+    let exp_digits = format!("{:0width$}", exp_val.unsigned_abs(), width = exp_width);
+
+    let prefix = leading_literals(mant_toks);
+    let suffix = trailing_literals(exp_toks);
+    format!("{prefix}{mant_out}E{sign}{exp_digits}{suffix}")
+}
+
+fn build_mantissa(int_kinds: &[char], frac_kinds: &[char], m: f64) -> String {
+    let (int_digits, frac_digits) = split_digits(m, frac_kinds.len());
+    let int_number = build_int_number(int_kinds, &int_digits, false);
+    let frac_str = build_frac(frac_kinds, &frac_digits);
+    if frac_str.is_empty() {
+        int_number
+    } else {
+        format!("{int_number}.{frac_str}")
+    }
+}
+
+fn leading_literals(toks: &[Tok]) -> String {
+    let mut out = String::new();
+    for t in toks {
+        match t {
+            Tok::Literal(s) => out.push_str(s),
+            Tok::Digit(_) | Tok::Dot => break,
+            _ => {}
+        }
+    }
+    out
+}
+
+fn trailing_literals(toks: &[Tok]) -> String {
+    let mut out = String::new();
+    for t in toks {
+        if let Tok::Literal(s) = t {
+            out.push_str(s);
+        }
+    }
+    out
+}
+
+/// excel's "general" render: signed, ~11 significant digits, switching to
+/// scientific outside roughly 1e-4 .. 1e11.
+fn format_general(n: f64) -> String {
+    if !n.is_finite() {
+        return if n.is_nan() {
+            "NaN".to_string()
+        } else if n > 0.0 {
+            "INF".to_string()
+        } else {
+            "-INF".to_string()
+        };
+    }
+    if n == 0.0 {
+        return "0".to_string();
+    }
+    let neg = n < 0.0;
+    let a = n.abs();
+    let e = a.log10().floor() as i32;
+    let body = if !(-4..11).contains(&e) {
+        general_scientific(a, e)
+    } else {
+        let decimals = (10 - e).clamp(0, 15) as usize;
+        let mut s = round_fixed(a, decimals);
+        trim_trailing_zeros(&mut s);
+        s
+    };
+    if neg { format!("-{body}") } else { body }
+}
+
+fn general_scientific(a: f64, e: i32) -> String {
+    let mant = a / 10f64.powi(e);
+    let mut m = round_fixed(mant, 5);
+    trim_trailing_zeros(&mut m);
+    let sign = if e < 0 { '-' } else { '+' };
+    format!("{m}E{sign}{:02}", e.unsigned_abs())
+}
+
+fn round_fixed(a: f64, decimals: usize) -> String {
+    let factor = 10f64.powi(decimals as i32);
+    let r = (a * factor).round() / factor;
+    format!("{r:.decimals$}")
+}
+
+fn trim_trailing_zeros(s: &mut String) {
+    if s.contains('.') {
+        while s.ends_with('0') {
+            s.pop();
+        }
+        if s.ends_with('.') {
+            s.pop();
+        }
+    }
+}
+
+fn format_text_value(text: &str, code: &str) -> FormattedValue {
+    let parsed: Vec<Section> = split_sections(code).iter().map(|s| tokenize(s)).collect();
+    let sec = if parsed.len() >= 4 {
+        Some(&parsed[3])
+    } else {
+        parsed.iter().find(|s| s.has(|t| matches!(t, Tok::At)))
+    };
+    match sec {
+        Some(s) => {
+            let mut out = String::new();
+            for t in &s.toks {
+                match t {
+                    Tok::At => out.push_str(text),
+                    Tok::Literal(l) => out.push_str(l),
+                    Tok::Width => out.push(' '),
+                    _ => {}
+                }
+            }
+            FormattedValue {
+                text: out,
+                color: s.color.clone(),
+            }
+        }
+        None => FormattedValue {
+            text: text.to_string(),
+            color: None,
+        },
+    }
+}
+
+const MONTH_FULL: [&str; 12] = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+
+const DAY_FULL: [&str; 7] = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+];
+
+/// render a serial through a date/time section; negatives show excel's `#######`.
+fn render_date_section(sec: &Section, serial: f64, ds: DateSystem) -> String {
+    if serial < 0.0 {
+        return "#######".to_string();
+    }
+    let secfrac = fractional_second_digits(&sec.toks);
+    let sub = 10i128.pow(secfrac);
+    let total_subunits = (serial * 86400.0 * sub as f64).round() as i128;
+    let day_span = 86_400i128 * sub;
+    let day_serial = total_subunits.div_euclid(day_span) as i64;
+    let within = total_subunits.rem_euclid(day_span);
+    let whole_seconds = (within / sub) as i64;
+    let frac_units = (within % sub) as i64;
+    let hour24 = whole_seconds / 3600;
+    let minute = (whole_seconds % 3600) / 60;
+    let second = whole_seconds % 60;
+    let elapsed_seconds = (total_subunits / sub) as i64;
+
+    let (year, month, day) = match serial_to_civil(day_serial, ds) {
+        Some(v) => v,
+        None => return "#######".to_string(),
+    };
+    let weekday = weekday_sun0(year, month, day);
+    let ampm = sec.has(|t| matches!(t, Tok::AmPm(_, _)));
+    let minute_flags = minute_flags(&sec.toks);
+
+    let mut out = String::new();
+    let mut i = 0;
+    while i < sec.toks.len() {
+        match &sec.toks[i] {
+            Tok::Year(c) => out.push_str(&fmt_year(year, *c)),
+            Tok::Mon(c) => {
+                if minute_flags[i] {
+                    out.push_str(&fmt_two(minute, *c));
+                } else {
+                    out.push_str(&fmt_month(month, *c));
+                }
+            }
+            Tok::Day(c) => out.push_str(&fmt_day(day, weekday, *c)),
+            Tok::Hour(c) => {
+                let h = if ampm {
+                    ((hour24 + 11) % 12) + 1
+                } else {
+                    hour24
+                };
+                out.push_str(&fmt_two(h, *c));
+            }
+            Tok::Sec(c) => out.push_str(&fmt_two(second, *c)),
+            Tok::Elapsed(ch, c) => {
+                let val = match ch {
+                    'h' => elapsed_seconds / 3600,
+                    'm' => elapsed_seconds / 60,
+                    _ => elapsed_seconds,
+                };
+                out.push_str(&format!("{val:0width$}", width = *c as usize));
+            }
+            Tok::AmPm(am, pm) => out.push_str(if hour24 < 12 { am } else { pm }),
+            Tok::Dot => {
+                let mut cnt = 0;
+                let mut j = i + 1;
+                while j < sec.toks.len() && matches!(sec.toks[j], Tok::Digit(_)) {
+                    cnt += 1;
+                    j += 1;
+                }
+                if cnt > 0 {
+                    let padded = format!("{frac_units:0width$}", width = secfrac as usize);
+                    out.push('.');
+                    out.push_str(&padded[..cnt.min(padded.len())]);
+                    i = j;
+                    continue;
+                }
+                out.push('.');
+            }
+            // in a date section, slash and comma are literal separators, not number ops
+            Tok::Slash => out.push('/'),
+            Tok::Comma => out.push(','),
+            Tok::Literal(s) => out.push_str(s),
+            Tok::Width => out.push(' '),
+            _ => {}
+        }
+        i += 1;
+    }
+    out
+}
+
+/// fractional-second precision: digit count directly after the first `.`.
+fn fractional_second_digits(toks: &[Tok]) -> u32 {
+    for (k, t) in toks.iter().enumerate() {
+        if !matches!(t, Tok::Dot) {
+            continue;
+        }
+        let mut cnt = 0u32;
+        let mut j = k + 1;
+        while j < toks.len() && matches!(toks[j], Tok::Digit(_)) {
+            cnt += 1;
+            j += 1;
+        }
+        if cnt > 0 {
+            return cnt;
+        }
+    }
+    0
+}
+
+/// mark which `Mon` tokens are minutes: an `m` run next to an hour (before)
+/// or seconds (after) field is minutes, else a month.
+fn minute_flags(toks: &[Tok]) -> Vec<bool> {
+    let mut cats: Vec<(usize, char)> = Vec::new();
+    for (k, t) in toks.iter().enumerate() {
+        match t {
+            Tok::Hour(_) => cats.push((k, 'h')),
+            Tok::Mon(_) => cats.push((k, 'm')),
+            Tok::Sec(_) => cats.push((k, 's')),
+            Tok::Elapsed(c, _) => cats.push((k, *c)),
+            _ => {}
+        }
+    }
+    let mut flags = vec![false; toks.len()];
+    for (pos, (k, c)) in cats.iter().enumerate() {
+        if *c != 'm' {
+            continue;
+        }
+        let prev = pos.checked_sub(1).map(|p| cats[p].1);
+        let next = cats.get(pos + 1).map(|x| x.1);
+        if prev == Some('h') || next == Some('s') {
+            flags[*k] = true;
+        }
+    }
+    flags
+}
+
+fn fmt_year(y: i64, c: u8) -> String {
+    if c <= 2 {
+        format!("{:02}", y.rem_euclid(100))
+    } else {
+        format!("{y:04}")
+    }
+}
+
+fn fmt_two(v: i64, c: u8) -> String {
+    if c <= 1 {
+        format!("{v}")
+    } else {
+        format!("{v:02}")
+    }
+}
+
+fn fmt_month(m: i64, c: u8) -> String {
+    let idx = (m.clamp(1, 12) - 1) as usize;
+    match c {
+        1 => format!("{m}"),
+        2 => format!("{m:02}"),
+        3 => MONTH_FULL[idx][..3].to_string(),
+        4 => MONTH_FULL[idx].to_string(),
+        _ => MONTH_FULL[idx][..1].to_string(),
+    }
+}
+
+fn fmt_day(d: i64, weekday: usize, c: u8) -> String {
+    match c {
+        1 => format!("{d}"),
+        2 => format!("{d:02}"),
+        3 => DAY_FULL[weekday][..3].to_string(),
+        _ => DAY_FULL[weekday].to_string(),
+    }
+}
+
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// (year, month, day) for an integer serial. 1900 system: serial 60 is the
+/// phantom 1900-02-29, serial 0 is excel's 1900-01-00.
+fn serial_to_civil(serial: i64, ds: DateSystem) -> Option<(i64, i64, i64)> {
+    match ds {
+        DateSystem::V1900 => {
+            if serial < 0 {
+                None
+            } else if serial == 0 {
+                Some((1900, 1, 0))
+            } else if serial == 60 {
+                Some((1900, 2, 29))
+            } else {
+                let adjusted = if serial > 60 { serial - 1 } else { serial };
+                Some(civil_from_days(adjusted - 25_568))
+            }
+        }
+        DateSystem::V1904 => {
+            if serial < 0 {
+                None
+            } else {
+                Some(civil_from_days(serial - 24_107))
+            }
+        }
+    }
+}
+
+/// day of week with Sunday = 0 (proleptic gregorian; 1970-01-01 was Thursday).
+fn weekday_sun0(y: i64, m: i64, d: i64) -> usize {
+    (days_from_civil(y, m, d) + 4).rem_euclid(7) as usize
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/xlsx-model/src/numfmt.rs
+++ b/crates/xlsx-model/src/numfmt.rs
@@ -432,10 +432,8 @@ fn parse_condition(s: &str) -> Option<Condition> {
         (Cmp::Gt, r)
     } else if let Some(r) = s.strip_prefix('<') {
         (Cmp::Lt, r)
-    } else if let Some(r) = s.strip_prefix('=') {
-        (Cmp::Eq, r)
     } else {
-        return None;
+        (Cmp::Eq, s.strip_prefix('=')?)
     };
     let value: f64 = rest.trim().parse().ok()?;
     Some(Condition { op, value })

--- a/crates/xlsx-model/src/numfmt/tests.rs
+++ b/crates/xlsx-model/src/numfmt/tests.rs
@@ -1,0 +1,339 @@
+use super::*;
+use crate::value::ErrorValue;
+
+fn num(v: f64) -> CellValue {
+    CellValue::Number { value: v }
+}
+
+fn fv(v: f64, code: &str) -> String {
+    format_value(&num(v), code, DateSystem::V1900).text
+}
+
+fn fv04(v: f64, code: &str) -> String {
+    format_value(&num(v), code, DateSystem::V1904).text
+}
+
+fn color(v: f64, code: &str) -> Option<String> {
+    format_value(&num(v), code, DateSystem::V1900).color
+}
+
+fn time_serial(secs: f64) -> f64 {
+    secs / 86_400.0
+}
+
+#[test]
+fn builtin_table_ids() {
+    assert_eq!(builtin_format_code(0), Some("General"));
+    assert_eq!(builtin_format_code(1), Some("0"));
+    assert_eq!(builtin_format_code(2), Some("0.00"));
+    assert_eq!(builtin_format_code(3), Some("#,##0"));
+    assert_eq!(builtin_format_code(4), Some("#,##0.00"));
+    assert_eq!(builtin_format_code(9), Some("0%"));
+    assert_eq!(builtin_format_code(10), Some("0.00%"));
+    assert_eq!(builtin_format_code(11), Some("0.00E+00"));
+    assert_eq!(builtin_format_code(12), Some("# ?/?"));
+    assert_eq!(builtin_format_code(13), Some("# ??/??"));
+    assert_eq!(builtin_format_code(14), Some("m/d/yyyy"));
+    assert_eq!(builtin_format_code(15), Some("d-mmm-yy"));
+    assert_eq!(builtin_format_code(16), Some("d-mmm"));
+    assert_eq!(builtin_format_code(17), Some("mmm-yy"));
+    assert_eq!(builtin_format_code(18), Some("h:mm AM/PM"));
+    assert_eq!(builtin_format_code(19), Some("h:mm:ss AM/PM"));
+    assert_eq!(builtin_format_code(20), Some("h:mm"));
+    assert_eq!(builtin_format_code(21), Some("h:mm:ss"));
+    assert_eq!(builtin_format_code(22), Some("m/d/yyyy h:mm"));
+    assert_eq!(builtin_format_code(37), Some("#,##0 ;(#,##0)"));
+    assert_eq!(builtin_format_code(38), Some("#,##0 ;[Red](#,##0)"));
+    assert_eq!(builtin_format_code(39), Some("#,##0.00;(#,##0.00)"));
+    assert_eq!(builtin_format_code(40), Some("#,##0.00;[Red](#,##0.00)"));
+    assert_eq!(builtin_format_code(45), Some("mm:ss"));
+    assert_eq!(builtin_format_code(46), Some("[h]:mm:ss"));
+    assert_eq!(builtin_format_code(47), Some("mmss.0"));
+    assert_eq!(builtin_format_code(48), Some("##0.0E+0"));
+    assert_eq!(builtin_format_code(49), Some("@"));
+    assert_eq!(builtin_format_code(5), None);
+    assert_eq!(builtin_format_code(8), None);
+    assert_eq!(builtin_format_code(23), None);
+    assert_eq!(builtin_format_code(44), None);
+    assert_eq!(builtin_format_code(163), None);
+    assert_eq!(builtin_format_code(164), None);
+}
+
+#[test]
+fn builtin_number_renders() {
+    assert_eq!(fv(1234.5, "General"), "1234.5");
+    assert_eq!(fv(1234.0, "0"), "1234");
+    assert_eq!(fv(1234.56, "0"), "1235");
+    assert_eq!(fv(1234.5, "0.00"), "1234.50");
+    assert_eq!(fv(1234567.0, "#,##0"), "1,234,567");
+    assert_eq!(fv(1234.5, "#,##0.00"), "1,234.50");
+    assert_eq!(fv(0.5, "0%"), "50%");
+    assert_eq!(fv(0.5, "0.00%"), "50.00%");
+    assert_eq!(fv(12345.0, "0.00E+00"), "1.23E+04");
+    assert_eq!(fv(12345.0, "##0.0E+0"), "12.3E+3");
+    assert_eq!(fv(1234.0, "@"), "1234");
+}
+
+#[test]
+fn builtin_date_renders() {
+    assert_eq!(fv(43831.0, "m/d/yyyy"), "1/1/2020");
+    assert_eq!(fv(43831.0, "d-mmm-yy"), "1-Jan-20");
+    assert_eq!(fv(43831.0, "d-mmm"), "1-Jan");
+    assert_eq!(fv(43831.0, "mmm-yy"), "Jan-20");
+    assert_eq!(fv(43831.5, "m/d/yyyy h:mm"), "1/1/2020 12:00");
+}
+
+#[test]
+fn builtin_time_renders() {
+    assert_eq!(fv(0.5, "h:mm AM/PM"), "12:00 PM");
+    assert_eq!(fv(0.5, "h:mm:ss AM/PM"), "12:00:00 PM");
+    assert_eq!(fv(0.5, "h:mm"), "12:00");
+    assert_eq!(fv(0.5, "h:mm:ss"), "12:00:00");
+    assert_eq!(fv(time_serial(90.0), "mm:ss"), "01:30");
+    assert_eq!(fv(1.5, "[h]:mm:ss"), "36:00:00");
+}
+
+#[test]
+fn sections_by_sign() {
+    assert_eq!(fv(5.0, "0.00"), "5.00");
+    assert_eq!(fv(-5.0, "0.00"), "-5.00");
+    assert_eq!(fv(0.0, "0.00"), "0.00");
+    assert_eq!(fv(5.0, "0.00;(0.00)"), "5.00");
+    assert_eq!(fv(-5.0, "0.00;(0.00)"), "(5.00)");
+    assert_eq!(fv(0.0, "0.00;(0.00)"), "0.00");
+    assert_eq!(fv(5.0, "\"pos\";\"neg\";\"zero\""), "pos");
+    assert_eq!(fv(-5.0, "\"pos\";\"neg\";\"zero\""), "neg");
+    assert_eq!(fv(0.0, "\"pos\";\"neg\";\"zero\""), "zero");
+    assert_eq!(fv(5.0, ";;;"), "");
+}
+
+#[test]
+fn conditions_override_selection() {
+    assert_eq!(fv(150.0, "[>=100]0;0"), "150");
+    assert_eq!(fv(50.0, "[>=100]0;0"), "50");
+    assert_eq!(fv(-5.0, "[<0]\"neg\";[>=0]\"pos\""), "neg");
+    assert_eq!(fv(5.0, "[<0]\"neg\";[>=0]\"pos\""), "pos");
+    assert_eq!(fv(150.0, "[Red][>50]0;[Blue]0"), "150");
+    assert_eq!(
+        color(150.0, "[Red][>50]0;[Blue]0"),
+        Some("#FF0000".to_string())
+    );
+    assert_eq!(fv(30.0, "[Red][>50]0;[Blue]0"), "30");
+    assert_eq!(
+        color(30.0, "[Red][>50]0;[Blue]0"),
+        Some("#0000FF".to_string())
+    );
+}
+
+#[test]
+fn thousands_and_scaling() {
+    assert_eq!(fv(1234567.0, "#,##0"), "1,234,567");
+    assert_eq!(fv(12.0, "#,##0"), "12");
+    assert_eq!(fv(0.0, "#,##0"), "0");
+    assert_eq!(fv(1234567.0, "#,##0,"), "1,235");
+    assert_eq!(fv(1234567890.0, "0,,"), "1235");
+    assert_eq!(fv(5.0, "000"), "005");
+    assert_eq!(fv(5.0, "00,000"), "00,005");
+}
+
+#[test]
+fn percent_and_scientific() {
+    assert_eq!(fv(0.5, "0%"), "50%");
+    assert_eq!(fv(0.1234, "0.0%"), "12.3%");
+    assert_eq!(fv(1.0, "0%"), "100%");
+    assert_eq!(fv(12345.0, "0.00E+00"), "1.23E+04");
+    assert_eq!(fv(-12345.0, "0.00E+00"), "-1.23E+04");
+    assert_eq!(fv(0.0, "0.0E+0"), "0.0E+0");
+    assert_eq!(fv(0.00012345, "0.00E+00"), "1.23E-04");
+    assert_eq!(fv(12345.0, "##0.0E+0"), "12.3E+3");
+}
+
+#[test]
+fn digit_placeholder_padding() {
+    assert_eq!(fv(5.0, "??0"), "  5");
+    assert_eq!(fv(5.0, "???0"), "   5");
+    assert_eq!(fv(1.5, "0.??"), "1.5 ");
+    assert_eq!(fv(1.5, "0.00"), "1.50");
+    assert_eq!(fv(3.4, "0.0#"), "3.4");
+    assert_eq!(fv(3.46, "0.0#"), "3.46");
+    assert_eq!(fv(3.5, "0.##"), "3.5");
+    assert_eq!(fv(0.5, "#.00"), ".50");
+    assert_eq!(fv(0.5, "0.00"), "0.50");
+    assert_eq!(fv(12.3, ".00"), "12.30");
+}
+
+#[test]
+fn rounding_is_half_away_from_zero() {
+    assert_eq!(fv(2.5, "0"), "3");
+    assert_eq!(fv(3.5, "0"), "4");
+    assert_eq!(fv(-2.5, "0"), "-3");
+    assert_eq!(fv(0.125, "0.00"), "0.13");
+    assert_eq!(fv(2.674, "0.00"), "2.67");
+}
+
+#[test]
+fn date_anchors_and_phantom_day() {
+    // the deliberate 1900 leap-year bug: serial 60 is the phantom 1900-02-29.
+    assert_eq!(fv(60.0, "m/d/yyyy"), "2/29/1900");
+    assert_eq!(fv(59.0, "m/d/yyyy"), "2/28/1900");
+    assert_eq!(fv(61.0, "m/d/yyyy"), "3/1/1900");
+    assert_eq!(fv(1.0, "m/d/yyyy"), "1/1/1900");
+    assert_eq!(fv(43831.0, "yyyy"), "2020");
+    assert_eq!(fv(43831.0, "yy"), "20");
+    assert_eq!(fv(-5.0, "m/d/yyyy"), "#######");
+}
+
+#[test]
+fn date_systems_agree_on_calendar() {
+    assert_eq!(fv(43831.0, "m/d/yyyy"), "1/1/2020");
+    assert_eq!(fv04(42369.0, "m/d/yyyy"), "1/1/2020");
+    assert_eq!(fv04(0.0, "m/d/yyyy"), "1/1/1904");
+}
+
+#[test]
+fn month_and_day_name_widths() {
+    assert_eq!(fv(43831.0, "mmmm d, yyyy"), "January 1, 2020");
+    assert_eq!(fv(43831.0, "mmm"), "Jan");
+    assert_eq!(fv(43831.0, "mmmmm"), "J");
+    assert_eq!(fv(43831.0, "dddd"), "Wednesday");
+    assert_eq!(fv(43831.0, "ddd"), "Wed");
+    assert_eq!(fv(43831.0, "dd/mm/yyyy"), "01/01/2020");
+}
+
+#[test]
+fn minute_versus_month_disambiguation() {
+    assert_eq!(fv(43831.0, "m/d"), "1/1");
+    assert_eq!(fv(0.5, "h:mm"), "12:00");
+    assert_eq!(fv(time_serial(90.0), "mm:ss"), "01:30");
+    assert_eq!(fv(43831.5, "m/d/yyyy h:mm"), "1/1/2020 12:00");
+}
+
+#[test]
+fn am_pm_switch() {
+    assert_eq!(fv(0.25, "h:mm AM/PM"), "6:00 AM");
+    assert_eq!(fv(0.75, "h:mm AM/PM"), "6:00 PM");
+    assert_eq!(fv(0.0, "h AM/PM"), "12 AM");
+    assert_eq!(fv(0.5, "h AM/PM"), "12 PM");
+    assert_eq!(fv(0.25, "h:mm A/P"), "6:00 A");
+    assert_eq!(fv(0.75, "h:mm A/P"), "6:00 P");
+}
+
+#[test]
+fn elapsed_time_beyond_a_day() {
+    assert_eq!(fv(1.5, "[h]:mm"), "36:00");
+    assert_eq!(fv(1.5, "[h]:mm:ss"), "36:00:00");
+    assert_eq!(fv(1.0, "[h]"), "24");
+    assert_eq!(fv(1.0, "[mm]"), "1440");
+    assert_eq!(fv(time_serial(90.0), "[ss]"), "90");
+}
+
+#[test]
+fn fractional_seconds() {
+    assert_eq!(fv(time_serial(1.5), "ss.0"), "01.5");
+    assert_eq!(fv(time_serial(1.25), "ss.00"), "01.25");
+}
+
+#[test]
+fn colors_named_and_indexed() {
+    assert_eq!(color(5.0, "[Red]0"), Some("#FF0000".to_string()));
+    assert_eq!(color(5.0, "[Blue]0"), Some("#0000FF".to_string()));
+    assert_eq!(color(5.0, "[Green]0"), Some("#00FF00".to_string()));
+    assert_eq!(color(5.0, "[Magenta]0"), Some("#FF00FF".to_string()));
+    assert_eq!(color(5.0, "[Cyan]0"), Some("#00FFFF".to_string()));
+    assert_eq!(color(5.0, "[Yellow]0"), Some("#FFFF00".to_string()));
+    assert_eq!(color(5.0, "[White]0"), Some("#FFFFFF".to_string()));
+    assert_eq!(color(5.0, "[Black]0"), Some("#000000".to_string()));
+    assert_eq!(color(5.0, "[Color 3]0"), Some("#FF0000".to_string()));
+    assert_eq!(color(5.0, "[Color 99]0"), None);
+    assert_eq!(fv(5.0, "[Red]0.00"), "5.00");
+    assert_eq!(
+        color(-1234.0, "#,##0 ;[Red](#,##0)"),
+        Some("#FF0000".to_string())
+    );
+    assert_eq!(color(1234.0, "#,##0 ;[Red](#,##0)"), None);
+    assert_eq!(fv(-1234.0, "#,##0 ;[Red](#,##0)"), "(1,234)");
+    assert_eq!(fv(1234.0, "#,##0 ;[Red](#,##0)"), "1,234 ");
+}
+
+#[test]
+fn text_values_and_placeholder() {
+    let hello = CellValue::Text {
+        value: "hello".to_string(),
+    };
+    let out = format_value(&hello, "0.00;-0.00;0.00;\"txt: \"@", DateSystem::V1900);
+    assert_eq!(out.text, "txt: hello");
+    assert_eq!(format_value(&hello, "@", DateSystem::V1900).text, "hello");
+    assert_eq!(
+        format_value(&hello, "0.00", DateSystem::V1900).text,
+        "hello"
+    );
+    let colored = format_value(&hello, "[Red]@", DateSystem::V1900);
+    assert_eq!(colored.text, "hello");
+    assert_eq!(colored.color, Some("#FF0000".to_string()));
+}
+
+#[test]
+fn bools_errors_empty() {
+    assert_eq!(
+        format_value(&CellValue::Bool { value: true }, "0", DateSystem::V1900).text,
+        "TRUE"
+    );
+    assert_eq!(
+        format_value(
+            &CellValue::Bool { value: false },
+            "m/d/yyyy",
+            DateSystem::V1900
+        )
+        .text,
+        "FALSE"
+    );
+    assert_eq!(
+        format_value(
+            &CellValue::Error {
+                value: ErrorValue::Div0
+            },
+            "0.00",
+            DateSystem::V1900
+        )
+        .text,
+        "#DIV/0!"
+    );
+    assert_eq!(
+        format_value(&CellValue::Empty, "0.00", DateSystem::V1900).text,
+        ""
+    );
+}
+
+#[test]
+fn general_edge_cases() {
+    assert_eq!(fv(0.0, "General"), "0");
+    assert_eq!(fv(-0.0, "General"), "0");
+    assert_eq!(fv(42.0, "General"), "42");
+    assert_eq!(fv(-42.0, "General"), "-42");
+    assert_eq!(fv(0.5, "General"), "0.5");
+    assert_eq!(fv(12.375, "General"), "12.375");
+    assert_eq!(fv(1e11, "General"), "1E+11");
+    assert_eq!(fv(123456789012.0, "General"), "1.23457E+11");
+    assert_eq!(fv(0.0000001, "General"), "1E-07");
+    assert_eq!(fv(-1234.5, "General"), "-1234.5");
+    assert_eq!(fv(1000000000.0, "General"), "1000000000");
+    assert_eq!(fv(42.0, ""), "42");
+}
+
+#[test]
+fn unsupported_constructs_degrade() {
+    assert_eq!(fv(0.5, "# ?/?"), "0.5");
+    assert_eq!(fv(2.75, "# ??/??"), "2.75");
+    assert_eq!(fv(5.0, "[$$-409]#,##0.00"), "$5.00");
+    assert_eq!(fv(5.0, "[$-409]0"), "5");
+    assert_eq!(fv(1234.0, "$#,##0"), "$1,234");
+    assert_eq!(fv(5.0, "0_)"), "5 ");
+    assert_eq!(fv(5.0, "0*x"), "5");
+}
+
+#[test]
+fn escaped_and_quoted_literals() {
+    assert_eq!(fv(5.0, "0\" kg\""), "5 kg");
+    assert_eq!(fv(5.0, "0\\ \\k\\g"), "5 kg");
+    assert_eq!(fv(100.0, "\"$\"#,##0"), "$100");
+}

--- a/crates/xlsx-model/src/styles.rs
+++ b/crates/xlsx-model/src/styles.rs
@@ -1,0 +1,514 @@
+//! style types (fonts, fills, borders, xf chains, theme colors). pure data;
+//! the cellXfs indirection chain is walked through the `Stylesheet` accessors.
+
+use serde::Serialize;
+
+/// a color reference as it appears in a `<color>` element (§18.8.3).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum Color {
+    /// resolved `#rrggbb` (alpha dropped at parse; excel stores `aarrggbb`).
+    Rgb(String),
+    /// theme slot index (see [`Theme::slot`]) plus a signed tint in [-1.0, 1.0].
+    Theme { idx: u8, tint: f64 },
+    /// index into the legacy 64-entry palette.
+    Indexed(u8),
+    /// system/automatic color; the host decides (usually black text).
+    Auto,
+}
+
+impl Color {
+    /// resolve to a final `#rrggbb`, or `None` for automatic/out-of-range.
+    pub fn resolve(&self, theme: &Theme) -> Option<String> {
+        match self {
+            Color::Rgb(s) => Some(s.clone()),
+            Color::Auto => None,
+            Color::Indexed(i) => indexed_color(*i).map(str::to_string),
+            Color::Theme { idx, tint } => {
+                let base = theme.slot(*idx)?;
+                Some(apply_tint(base, *tint))
+            }
+        }
+    }
+}
+
+/// a cell font. only the facets we render are modelled; unset fields inherit.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct Font {
+    pub name: Option<String>,
+    pub size_pt: Option<f64>,
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub strike: bool,
+    pub color: Option<Color>,
+}
+
+/// a cell fill. non-solid patterns collapse to their foreground color.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub enum Fill {
+    #[default]
+    None,
+    Solid(Color),
+}
+
+/// border line weight/style, collapsed from the full sml set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum BorderStyle {
+    Thin,
+    Medium,
+    Thick,
+    Dashed,
+    Dotted,
+    Double,
+    Hair,
+}
+
+impl BorderStyle {
+    /// map an sml `ST_BorderStyle` token; unknown weights fall back to `thin`.
+    pub fn from_sml(s: &str) -> Self {
+        match s {
+            "thin" => BorderStyle::Thin,
+            "medium" | "mediumDashed" | "mediumDashDot" | "mediumDashDotDot" => BorderStyle::Medium,
+            "thick" => BorderStyle::Thick,
+            "dashed" | "dashDot" | "dashDotDot" | "slantDashDot" => BorderStyle::Dashed,
+            "dotted" => BorderStyle::Dotted,
+            "double" => BorderStyle::Double,
+            "hair" => BorderStyle::Hair,
+            _ => BorderStyle::Thin,
+        }
+    }
+
+    /// the sml token for this weight.
+    pub fn as_sml(&self) -> &'static str {
+        match self {
+            BorderStyle::Thin => "thin",
+            BorderStyle::Medium => "medium",
+            BorderStyle::Thick => "thick",
+            BorderStyle::Dashed => "dashed",
+            BorderStyle::Dotted => "dotted",
+            BorderStyle::Double => "double",
+            BorderStyle::Hair => "hair",
+        }
+    }
+}
+
+/// one edge of a cell border.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BorderEdge {
+    pub style: BorderStyle,
+    pub color: Option<Color>,
+}
+
+/// the four cell edges; `None` on an edge means no border there.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct Border {
+    pub left: Option<BorderEdge>,
+    pub right: Option<BorderEdge>,
+    pub top: Option<BorderEdge>,
+    pub bottom: Option<BorderEdge>,
+}
+
+/// horizontal alignment (`ST_HorizontalAlignment`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum HAlign {
+    General,
+    Left,
+    Center,
+    Right,
+    Fill,
+    Justify,
+    CenterContinuous,
+    Distributed,
+}
+
+impl HAlign {
+    pub fn from_sml(s: &str) -> Option<Self> {
+        Some(match s {
+            "general" => HAlign::General,
+            "left" => HAlign::Left,
+            "center" => HAlign::Center,
+            "right" => HAlign::Right,
+            "fill" => HAlign::Fill,
+            "justify" => HAlign::Justify,
+            "centerContinuous" => HAlign::CenterContinuous,
+            "distributed" => HAlign::Distributed,
+            _ => return None,
+        })
+    }
+
+    pub fn as_sml(&self) -> &'static str {
+        match self {
+            HAlign::General => "general",
+            HAlign::Left => "left",
+            HAlign::Center => "center",
+            HAlign::Right => "right",
+            HAlign::Fill => "fill",
+            HAlign::Justify => "justify",
+            HAlign::CenterContinuous => "centerContinuous",
+            HAlign::Distributed => "distributed",
+        }
+    }
+}
+
+/// vertical alignment (`ST_VerticalAlignment`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum VAlign {
+    Top,
+    Center,
+    Bottom,
+    Justify,
+    Distributed,
+}
+
+impl VAlign {
+    pub fn from_sml(s: &str) -> Option<Self> {
+        Some(match s {
+            "top" => VAlign::Top,
+            "center" => VAlign::Center,
+            "bottom" => VAlign::Bottom,
+            "justify" => VAlign::Justify,
+            "distributed" => VAlign::Distributed,
+            _ => return None,
+        })
+    }
+
+    pub fn as_sml(&self) -> &'static str {
+        match self {
+            VAlign::Top => "top",
+            VAlign::Center => "center",
+            VAlign::Bottom => "bottom",
+            VAlign::Justify => "justify",
+            VAlign::Distributed => "distributed",
+        }
+    }
+}
+
+/// cell text alignment; unset horizontal defaults to `general`, vertical to `bottom`.
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct Alignment {
+    pub h: Option<HAlign>,
+    pub v: Option<VAlign>,
+    pub wrap_text: bool,
+}
+
+impl Alignment {
+    /// true when the element carries no meaningful alignment.
+    pub fn is_empty(&self) -> bool {
+        self.h.is_none() && self.v.is_none() && !self.wrap_text
+    }
+}
+
+/// a cell format record (`CT_Xf` in cellXfs). a `None` pool index means
+/// "inherit / default", not "index 0".
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct Xf {
+    pub font: Option<u32>,
+    pub fill: Option<u32>,
+    pub border: Option<u32>,
+    pub num_fmt_id: Option<u16>,
+    pub alignment: Option<Alignment>,
+}
+
+/// the workbook theme colors in clrScheme declaration order
+/// `[dk1, lt1, dk2, lt2, accent1..6, hlink, folHlink]`; index via [`Theme::slot`].
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Theme {
+    pub colors: [String; 12],
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Theme {
+            colors: [
+                "#000000".into(),
+                "#ffffff".into(),
+                "#44546a".into(),
+                "#e7e6e6".into(),
+                "#4472c4".into(),
+                "#ed7d31".into(),
+                "#a5a5a5".into(),
+                "#ffc000".into(),
+                "#5b9bd5".into(),
+                "#70ad47".into(),
+                "#0563c1".into(),
+                "#954f72".into(),
+            ],
+        }
+    }
+}
+
+impl Theme {
+    /// resolve a `theme="n"` index to a slot color. excel's index order swaps
+    /// the first two light/dark pairs relative to declaration order.
+    pub fn slot(&self, idx: u8) -> Option<&str> {
+        let pos = match idx {
+            0 => 1,
+            1 => 0,
+            2 => 3,
+            3 => 2,
+            n => n as usize,
+        };
+        self.colors.get(pos).map(String::as_str)
+    }
+}
+
+/// the parsed style tables plus the resolved theme. a cell's `s` indexes
+/// `cell_xfs`; `num_fmts` holds only custom codes (id >= 164).
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+pub struct Stylesheet {
+    pub fonts: Vec<Font>,
+    pub fills: Vec<Fill>,
+    pub borders: Vec<Border>,
+    pub cell_xfs: Vec<Xf>,
+    pub num_fmts: Vec<(u16, String)>,
+    pub theme: Theme,
+}
+
+/// resolved number format for a cell: a custom code string or a builtin id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FormatCode<'a> {
+    Custom(&'a str),
+    Builtin(u16),
+}
+
+impl Stylesheet {
+    /// true when no style data is present, so the serializer skips the part.
+    pub fn is_empty(&self) -> bool {
+        self.fonts.is_empty()
+            && self.fills.is_empty()
+            && self.borders.is_empty()
+            && self.cell_xfs.is_empty()
+            && self.num_fmts.is_empty()
+            && self.theme == Theme::default()
+    }
+
+    /// the `Xf` a cell's `s` index selects.
+    pub fn xf(&self, style_index: u32) -> Option<&Xf> {
+        self.cell_xfs.get(style_index as usize)
+    }
+
+    /// resolved font for a cell style, or `None` when inherited/unset.
+    pub fn font_for(&self, style_index: u32) -> Option<&Font> {
+        let idx = self.xf(style_index)?.font?;
+        self.fonts.get(idx as usize)
+    }
+
+    /// resolved fill for a cell style.
+    pub fn fill_for(&self, style_index: u32) -> Option<&Fill> {
+        let idx = self.xf(style_index)?.fill?;
+        self.fills.get(idx as usize)
+    }
+
+    /// resolved border for a cell style.
+    pub fn border_for(&self, style_index: u32) -> Option<&Border> {
+        let idx = self.xf(style_index)?.border?;
+        self.borders.get(idx as usize)
+    }
+
+    /// resolved alignment for a cell style.
+    pub fn alignment_for(&self, style_index: u32) -> Option<&Alignment> {
+        self.xf(style_index)?.alignment.as_ref()
+    }
+
+    /// the number-format for a cell style: custom code when id >= 164, else the
+    /// builtin id. a missing/unset xf resolves to builtin `0` (General).
+    pub fn format_code_for(&self, style_index: u32) -> FormatCode<'_> {
+        let id = self
+            .xf(style_index)
+            .and_then(|xf| xf.num_fmt_id)
+            .unwrap_or(0);
+        if id >= 164
+            && let Some((_, code)) = self.num_fmts.iter().find(|(k, _)| *k == id)
+        {
+            return FormatCode::Custom(code);
+        }
+        FormatCode::Builtin(id)
+    }
+}
+
+/// apply a spreadsheetml tint to a `#rrggbb` in hsl luminance per §18.8.3:
+/// negative darkens (`L*(1+tint)`), positive lightens (`L*(1-tint)+tint`).
+fn apply_tint(hex: &str, tint: f64) -> String {
+    let (r, g, b) = match parse_hex(hex) {
+        Some(rgb) => rgb,
+        None => return hex.to_string(),
+    };
+    if tint == 0.0 {
+        return format!("#{r:02x}{g:02x}{b:02x}");
+    }
+    let (h, s, l) = rgb_to_hsl(r, g, b);
+    let l2 = if tint < 0.0 {
+        l * (1.0 + tint)
+    } else {
+        l * (1.0 - tint) + tint
+    }
+    .clamp(0.0, 1.0);
+    let (r2, g2, b2) = hsl_to_rgb(h, s, l2);
+    format!("#{r2:02x}{g2:02x}{b2:02x}")
+}
+
+/// parse `#rrggbb` (leading `#` optional) into `(r, g, b)` bytes.
+fn parse_hex(hex: &str) -> Option<(u8, u8, u8)> {
+    let h = hex.strip_prefix('#').unwrap_or(hex);
+    if h.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&h[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&h[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&h[4..6], 16).ok()?;
+    Some((r, g, b))
+}
+
+/// rgb bytes -> hsl with hue in degrees [0,360) and s/l in [0,1].
+fn rgb_to_hsl(r: u8, g: u8, b: u8) -> (f64, f64, f64) {
+    let (r, g, b) = (r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let l = (max + min) / 2.0;
+    let d = max - min;
+    if d == 0.0 {
+        return (0.0, 0.0, l);
+    }
+    let s = d / (1.0 - (2.0 * l - 1.0).abs());
+    let h = if max == r {
+        60.0 * (((g - b) / d).rem_euclid(6.0))
+    } else if max == g {
+        60.0 * ((b - r) / d + 2.0)
+    } else {
+        60.0 * ((r - g) / d + 4.0)
+    };
+    (h, s, l)
+}
+
+/// hsl (hue degrees, s/l in [0,1]) -> rgb bytes, rounding each channel.
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let hp = h / 60.0;
+    let x = c * (1.0 - (hp.rem_euclid(2.0) - 1.0).abs());
+    let (r1, g1, b1) = match hp as i32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let m = l - c / 2.0;
+    let to_byte = |v: f64| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
+    (to_byte(r1), to_byte(g1), to_byte(b1))
+}
+
+/// the legacy 64-entry indexed palette (biff8 default); system indices 64/65
+/// resolve to `None`.
+fn indexed_color(i: u8) -> Option<&'static str> {
+    const PALETTE: [&str; 64] = [
+        "#000000", "#ffffff", "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ff00ff", "#00ffff",
+        "#000000", "#ffffff", "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ff00ff", "#00ffff",
+        "#800000", "#008000", "#000080", "#808000", "#800080", "#008080", "#c0c0c0", "#808080",
+        "#9999ff", "#993366", "#ffffcc", "#ccffff", "#660066", "#ff8080", "#0066cc", "#ccccff",
+        "#000080", "#ff00ff", "#ffff00", "#00ffff", "#800080", "#800000", "#008080", "#0000ff",
+        "#00ccff", "#ccffff", "#ccffcc", "#ffff99", "#99ccff", "#ff99cc", "#cc99ff", "#ffcc99",
+        "#3366ff", "#33cccc", "#99cc00", "#ffcc00", "#ff9900", "#ff6600", "#666699", "#969696",
+        "#003366", "#339966", "#003300", "#333300", "#993300", "#993366", "#333399", "#333333",
+    ];
+    PALETTE.get(i as usize).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn theme_slot_swaps_first_two_pairs() {
+        let t = Theme::default();
+        assert_eq!(t.slot(0), Some("#ffffff"));
+        assert_eq!(t.slot(1), Some("#000000"));
+        assert_eq!(t.slot(2), Some("#e7e6e6"));
+        assert_eq!(t.slot(3), Some("#44546a"));
+        assert_eq!(t.slot(4), Some("#4472c4"));
+        assert_eq!(t.slot(11), Some("#954f72"));
+        assert_eq!(t.slot(12), None);
+    }
+
+    #[test]
+    fn tint_zero_is_identity() {
+        let t = Theme::default();
+        let c = Color::Theme { idx: 4, tint: 0.0 };
+        assert_eq!(c.resolve(&t).as_deref(), Some("#4472c4"));
+    }
+
+    #[test]
+    fn tint_negative_darkens_accent1_matches_excel() {
+        let t = Theme::default();
+        let c = Color::Theme {
+            idx: 4,
+            tint: -0.25,
+        };
+        assert_eq!(c.resolve(&t).as_deref(), Some("#2f5597"));
+    }
+
+    #[test]
+    fn tint_positive_lightens_accent1_matches_excel() {
+        let t = Theme::default();
+        let c = Color::Theme { idx: 4, tint: 0.4 };
+        assert_eq!(c.resolve(&t).as_deref(), Some("#8faadc"));
+    }
+
+    #[test]
+    fn indexed_and_rgb_and_auto_resolve() {
+        let t = Theme::default();
+        assert_eq!(Color::Indexed(2).resolve(&t).as_deref(), Some("#ff0000"));
+        assert_eq!(Color::Indexed(64).resolve(&t), None);
+        assert_eq!(
+            Color::Rgb("#123456".into()).resolve(&t).as_deref(),
+            Some("#123456")
+        );
+        assert_eq!(Color::Auto.resolve(&t), None);
+    }
+
+    #[test]
+    fn accessors_walk_the_indirection_chain() {
+        let mut ss = Stylesheet {
+            fonts: vec![
+                Font::default(),
+                Font {
+                    bold: true,
+                    ..Font::default()
+                },
+            ],
+            fills: vec![Fill::None, Fill::Solid(Color::Rgb("#ffff00".into()))],
+            borders: vec![Border::default()],
+            cell_xfs: vec![
+                Xf::default(),
+                Xf {
+                    font: Some(1),
+                    fill: Some(1),
+                    border: Some(0),
+                    num_fmt_id: Some(164),
+                    alignment: Some(Alignment {
+                        h: Some(HAlign::Center),
+                        v: Some(VAlign::Center),
+                        wrap_text: true,
+                    }),
+                },
+            ],
+            num_fmts: vec![(164, "0.0\"%\"".into())],
+            theme: Theme::default(),
+        };
+
+        assert!(ss.font_for(1).unwrap().bold);
+        assert_eq!(
+            ss.fill_for(1),
+            Some(&Fill::Solid(Color::Rgb("#ffff00".into())))
+        );
+        assert_eq!(ss.border_for(1), Some(&Border::default()));
+        assert_eq!(ss.format_code_for(1), FormatCode::Custom("0.0\"%\""));
+        assert_eq!(ss.format_code_for(0), FormatCode::Builtin(0));
+        assert!(ss.font_for(0).is_none());
+        assert!(ss.xf(99).is_none());
+        assert_eq!(ss.format_code_for(99), FormatCode::Builtin(0));
+
+        ss.cell_xfs[1].num_fmt_id = Some(14);
+        assert_eq!(ss.format_code_for(1), FormatCode::Builtin(14));
+    }
+}

--- a/crates/xlsx-model/src/value.rs
+++ b/crates/xlsx-model/src/value.rs
@@ -1,0 +1,58 @@
+//! cell values. numbers are f64 like excel; dates are numbers + a number
+//! format, never a distinct storage type.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum CellValue {
+    #[default]
+    Empty,
+    Number {
+        value: f64,
+    },
+    Text {
+        value: String,
+    },
+    Bool {
+        value: bool,
+    },
+    Error {
+        value: ErrorValue,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ErrorValue {
+    #[serde(rename = "#DIV/0!")]
+    Div0,
+    #[serde(rename = "#N/A")]
+    NA,
+    #[serde(rename = "#NAME?")]
+    Name,
+    #[serde(rename = "#NULL!")]
+    Null,
+    #[serde(rename = "#NUM!")]
+    Num,
+    #[serde(rename = "#REF!")]
+    Ref,
+    #[serde(rename = "#VALUE!")]
+    Value,
+    #[serde(rename = "#SPILL!")]
+    Spill,
+}
+
+impl ErrorValue {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorValue::Div0 => "#DIV/0!",
+            ErrorValue::NA => "#N/A",
+            ErrorValue::Name => "#NAME?",
+            ErrorValue::Null => "#NULL!",
+            ErrorValue::Num => "#NUM!",
+            ErrorValue::Ref => "#REF!",
+            ErrorValue::Value => "#VALUE!",
+            ErrorValue::Spill => "#SPILL!",
+        }
+    }
+}

--- a/crates/xlsx-model/src/workbook.rs
+++ b/crates/xlsx-model/src/workbook.rs
@@ -1,0 +1,180 @@
+//! sparse workbook containers and the calc-facing cell-access trait.
+
+use std::collections::BTreeMap;
+
+use crate::addr::{CellRange, CellRef, ColId, RowId, SheetId};
+use crate::date::DateSystem;
+use crate::styles::Stylesheet;
+use crate::value::CellValue;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Cell {
+    pub value: CellValue,
+    /// original formula text without the leading `=`, if any.
+    pub formula: Option<String>,
+    /// index into the workbook style table (cellXfs).
+    pub style: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Sheet {
+    pub name: String,
+    cells: BTreeMap<(RowId, ColId), Cell>,
+    pub merges: Vec<CellRange>,
+    pub col_widths: BTreeMap<ColId, f64>,
+    pub row_heights: BTreeMap<RowId, f64>,
+}
+
+impl Sheet {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn cell(&self, at: CellRef) -> Option<&Cell> {
+        self.cells.get(&(at.row, at.col))
+    }
+
+    pub fn set_cell(&mut self, at: CellRef, cell: Cell) {
+        if cell == Cell::default() {
+            self.cells.remove(&(at.row, at.col));
+        } else {
+            self.cells.insert((at.row, at.col), cell);
+        }
+    }
+
+    /// ordered iteration over occupied cells (row-major).
+    pub fn iter_cells(&self) -> impl Iterator<Item = (CellRef, &Cell)> {
+        self.cells
+            .iter()
+            .map(|(&(row, col), cell)| (CellRef::new(row, col), cell))
+    }
+
+    pub fn used_range(&self) -> Option<CellRange> {
+        let mut it = self.cells.keys();
+        let &(r0, c0) = it.next()?;
+        let (mut min_r, mut max_r, mut min_c, mut max_c) = (r0, r0, c0, c0);
+        for &(r, c) in it {
+            min_r = min_r.min(r);
+            max_r = max_r.max(r);
+            min_c = min_c.min(c);
+            max_c = max_c.max(c);
+        }
+        Some(CellRange::new(
+            CellRef::new(min_r, min_c),
+            CellRef::new(max_r, max_c),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Workbook {
+    pub sheets: Vec<Sheet>,
+    pub date_system: DateSystem,
+    /// shared string table as parsed; kept for round-trip fidelity.
+    pub shared_strings: Vec<String>,
+    /// parsed style tables + theme; a cell's `style` indexes `styles.cell_xfs`.
+    pub styles: Stylesheet,
+}
+
+impl Workbook {
+    pub fn sheet(&self, id: SheetId) -> Option<&Sheet> {
+        self.sheets.get(id.0 as usize)
+    }
+
+    pub fn sheet_mut(&mut self, id: SheetId) -> Option<&mut Sheet> {
+        self.sheets.get_mut(id.0 as usize)
+    }
+
+    pub fn sheet_by_name(&self, name: &str) -> Option<(SheetId, &Sheet)> {
+        self.sheets
+            .iter()
+            .enumerate()
+            .find(|(_, s)| s.name == name)
+            .map(|(i, s)| (SheetId(i as u32), s))
+    }
+}
+
+/// read access the calc engine evaluates through.
+pub trait CellProvider {
+    fn value(&self, sheet: SheetId, at: CellRef) -> CellValue;
+    fn formula(&self, sheet: SheetId, at: CellRef) -> Option<&str>;
+    fn sheet_id(&self, name: &str) -> Option<SheetId>;
+}
+
+impl CellProvider for Workbook {
+    fn value(&self, sheet: SheetId, at: CellRef) -> CellValue {
+        self.sheet(sheet)
+            .and_then(|s| s.cell(at))
+            .map(|c| c.value.clone())
+            .unwrap_or_default()
+    }
+
+    fn formula(&self, sheet: SheetId, at: CellRef) -> Option<&str> {
+        self.sheet(sheet)?.cell(at)?.formula.as_deref()
+    }
+
+    fn sheet_id(&self, name: &str) -> Option<SheetId> {
+        self.sheet_by_name(name).map(|(id, _)| id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparse_set_get_and_used_range() {
+        let mut sheet = Sheet::new("Sheet1");
+        assert!(sheet.used_range().is_none());
+
+        let b2 = CellRef::parse_a1("B2").unwrap();
+        let d7 = CellRef::parse_a1("D7").unwrap();
+        sheet.set_cell(
+            b2,
+            Cell {
+                value: CellValue::Number { value: 1.0 },
+                ..Cell::default()
+            },
+        );
+        sheet.set_cell(
+            d7,
+            Cell {
+                value: CellValue::Text { value: "x".into() },
+                ..Cell::default()
+            },
+        );
+
+        assert_eq!(sheet.used_range().unwrap().to_a1(), "B2:D7");
+        assert_eq!(sheet.iter_cells().count(), 2);
+
+        sheet.set_cell(b2, Cell::default());
+        assert_eq!(sheet.used_range().unwrap().to_a1(), "D7");
+    }
+
+    #[test]
+    fn workbook_cell_provider() {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Data"));
+        let a1 = CellRef::parse_a1("A1").unwrap();
+        wb.sheet_mut(SheetId(0)).unwrap().set_cell(
+            a1,
+            Cell {
+                value: CellValue::Number { value: 42.0 },
+                formula: Some("40+2".into()),
+                style: None,
+            },
+        );
+
+        let id = wb.sheet_id("Data").unwrap();
+        assert_eq!(wb.value(id, a1), CellValue::Number { value: 42.0 });
+        assert_eq!(wb.formula(id, a1), Some("40+2"));
+        assert_eq!(
+            wb.value(id, CellRef::parse_a1("Z9").unwrap()),
+            CellValue::Empty
+        );
+        assert!(wb.sheet_id("Nope").is_none());
+    }
+}


### PR DESCRIPTION
TL;DR:
port xlsx engine &/ model from private repo

Summary:
- Ports `xlsx-model` (addresses, values, dates, styles, numfmt, `CellProvider`) and `xlsx-calc` (lexer, parser, evaluator, dep graph, incremental recalc engine) from the xlsx repo into the workspace.
- Comment-cleanup pass per AGENTS.md: ~130 inline comments and long module docs stripped; 22 kept, each a spec quirk that reads as a bug without it (1900 phantom leap day, numfmt month-vs-minute adjacency, excel's `-2^2 = 4`, etc.).
- Verified token-identical to the source modulo comments (comment-stripped diff over all 30 files), so no code drift in the port.
- Adds `examples/demo.rs`: builds a workbook, full recalc at open, then incremental recalc after an edit (`cargo run --example demo -p xlsx-calc`).

Test plan:
- [x] Rust gate is green (98 tests + doctest across ooxml-opc, xlsx-model, xlsx-calc)
- [x] `cargo run --example demo -p xlsx-calc` shows correct open + incremental recalc

🤖 Generated with [Claude Code](https://claude.com/claude-code)