### PR TITLE
chore: add individual and corporate contributor license agreements

### DIFF
--- a/CCLA.md
+++ b/CCLA.md
@@ -1,0 +1,137 @@
+# OpenOOXML Corporate Contributor License Agreement
+
+Thank you for your organization's interest in contributing to software
+projects maintained by the OpenOOXML project and its maintainers
+("Us"). This Agreement clarifies the intellectual property license
+granted with Contributions from any legal entity. This license is for
+Your protection as a Contributor as well as the protection of Us and
+recipients of software distributed by Us; it does not change Your
+rights to use Your own Contributions for any other purpose.
+
+This version of the Agreement allows a corporation or other legal
+entity to submit Contributions to Us, to authorize Contributions
+submitted by its designated employees and contractors, and to grant
+copyright and patent licenses covering those Contributions.
+
+You accept and agree to the following terms and conditions for
+Contributions submitted to Us by Your Designated Employees. Except
+for the license granted herein to Us and recipients of software
+distributed by Us, You reserve all right, title, and interest in and
+to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the legal entity making this Agreement
+with Us and all other entities that control, are controlled by, or
+are under common control with that entity. For the purposes of this
+definition, "control" means (i) the power, direct or indirect, to
+cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or
+more of the outstanding shares, or (iii) beneficial ownership of
+such entity.
+
+"Contribution" shall mean any original work of authorship, including
+any modifications or additions to an existing work, that is
+intentionally submitted by You to Us for inclusion in, or
+documentation of, any of the products owned or managed by Us
+(the "Work"). For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication
+sent to Us or our representatives, including but not limited to
+communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on
+behalf of, Us for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or
+otherwise designated in writing by You as "Not a Contribution."
+
+"Designated Employees" shall mean the employees and contractors
+identified by You, by GitHub username, as authorized to submit
+Contributions on Your behalf.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby
+grant to Us and to recipients of software distributed by Us a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby
+grant to Us and to recipients of software distributed by Us a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by
+Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You
+or any other entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that Your Contribution, or the Work to which
+You have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity
+under this Agreement for that Contribution or Work shall terminate
+as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above
+license. You represent further that the person executing this
+Agreement is authorized to enter into this Agreement on Your
+behalf, and that each of Your Designated Employees is authorized
+to submit Contributions on Your behalf.
+
+You represent that each of Your Contributions is Your original
+creation (see Section 8 for submissions on behalf of others). You
+represent that Your Contribution submissions include complete
+details of any third-party license or other restriction (including,
+but not limited to, related patents and trademarks) of which You
+are personally aware and which are associated with any part of
+Your Contributions.
+
+## 5. Designated Employees
+
+You will identify Your initial Designated Employees when entering
+into this Agreement. It is Your responsibility to notify Us when
+any change is required to the list of Designated Employees
+authorized to submit Contributions on Your behalf. Contributions
+submitted by persons You have not identified as Designated
+Employees are not covered by this Agreement.
+
+## 6. Support
+
+You are not expected to provide support for Your Contributions,
+except to the extent You desire to provide support. You may
+provide support for free, for a fee, or not at all. Unless
+required by applicable law or agreed to in writing, You provide
+Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+## 7. Notification
+
+You agree to notify Us of any facts or circumstances of which You
+become aware that would make these representations inaccurate in
+any respect.
+
+## 8. Submissions on behalf of others
+
+Should You wish to submit work that is not Your original creation,
+You may submit it to Us separately from any Contribution,
+identifying the complete details of its source and of any license
+or other restriction (including, but not limited to, related
+patents, trademarks, and license agreements) of which You are
+personally aware, and conspicuously marking the work as
+"Submitted on behalf of a third-party: [named here]".
+
+---
+
+By having an authorized representative sign this Agreement — as
+instructed by the project's CLA assistant, or in writing to the
+maintainers — and identifying You and Your initial Designated
+Employees, You accept and agree to these terms for Contributions
+submitted by Your Designated Employees to OpenOOXML projects.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,114 @@
+# OpenOOXML Individual Contributor License Agreement
+
+Thank you for your interest in contributing to software projects
+maintained by the OpenOOXML project and its maintainers ("Us"). This Agreement clarifies the
+intellectual property license granted with Contributions from any
+person or entity. This license is for Your protection as a
+Contributor as well as the protection of Us and recipients of
+software distributed by Us; it does not change Your rights to use
+Your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to Us. Except for the
+license granted herein to Us and recipients of software distributed
+by Us, You reserve all right, title, and interest in and to Your
+Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement
+with Us.
+
+"Contribution" shall mean any original work of authorship, including
+any modifications or additions to an existing work, that is
+intentionally submitted by You to Us for inclusion in, or
+documentation of, any of the products owned or managed by Us
+(the "Work"). For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication
+sent to Us or our representatives, including but not limited to
+communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on
+behalf of, Us for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or
+otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby
+grant to Us and to recipients of software distributed by Us a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby
+grant to Us and to recipients of software distributed by Us a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by
+Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You
+or any other entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that Your Contribution, or the Work to which
+You have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity
+under this Agreement for that Contribution or Work shall terminate
+as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above
+license. If Your employer(s) has rights to intellectual property
+that You create that includes Your Contributions, You represent
+that You have received permission to make Contributions on behalf
+of that employer, that Your employer has waived such rights for
+Your Contributions to Us, or that Your employer has executed a
+separate Corporate Contributor License Agreement with Us.
+
+You represent that each of Your Contributions is Your original
+creation (see Section 7 for submissions on behalf of others). You
+represent that Your Contribution submissions include complete
+details of any third-party license or other restriction (including,
+but not limited to, related patents and trademarks) of which You
+are personally aware and which are associated with any part of
+Your Contributions.
+
+## 5. Support
+
+You are not expected to provide support for Your Contributions,
+except to the extent You desire to provide support. You may
+provide support for free, for a fee, or not at all. Unless
+required by applicable law or agreed to in writing, You provide
+Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+## 6. Notification
+
+You agree to notify Us of any facts or circumstances of which You
+become aware that would make these representations inaccurate in
+any respect.
+
+## 7. Submissions on behalf of others
+
+Should You wish to submit work that is not Your original creation,
+You may submit it to Us separately from any Contribution,
+identifying the complete details of its source and of any license
+or other restriction (including, but not limited to, related
+patents, trademarks, and license agreements) of which You are
+personally aware, and conspicuously marking the work as
+"Submitted on behalf of a third-party: [named here]".
+
+---
+
+By signing this Agreement on a pull request as instructed by the
+project's CLA assistant, You accept and agree to these terms for
+Your present and future Contributions to OpenOOXML projects.


### PR DESCRIPTION
TL;DR:
CLA/CCLA

Summary:
- Adds `CLA.md`, the OpenOOXML Individual CLA — ported verbatim from the docx repo (Apache ICLA-derived: broad copyright grant incl. sublicensing, patent grant with litigation termination, originality/rights representations).
- Adds `CCLA.md`, the Corporate CLA — same Apache-template adaptation in the same voice, closing the dangling "separate Corporate Contributor License Agreement" reference in CLA.md §4. Entities sign via an authorized representative and designate covered employees by GitHub username (§5).
- Documents only; the CLA bot, signing workflow, and signature ledger follow in a separate PR.

Test plan:
- [x] CLA.md text is identical to docx's (version2)
- [x] CCLA.md §2/§3 grants match CLA.md §2/§3 verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)