### PR TITLE
docs(agents): scope PR and commit titles as type(scope)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 
 NO inline comments unless the code is not understandable without them. Docstrings must be extremely concise.
 
+## Titles
+
+PR and commit titles use scoped conventional commits: `type(scope): summary`. Scope is the affected area — a format (`docx`, `xlsx`, `pptx`), a shared crate (`opc`, `text`), or an area (`ci`, `deps`, `web`, `agents`). Keep the summary concise and imperative.
+
+Examples: `feat(docx): layout engine`, `fix(xlsx): formula precedence`, `ci(deps): bump actions/checkout`.
+
 ## PR style
 
 PR bodies follow this template:


### PR DESCRIPTION
TL;DR:
pr titles agents.md

Summary:
- Adopt scoped conventional-commit titles (`type(scope): summary`) for PRs and commits, documented under a new "Titles" section in AGENTS.md.

Test plan:
- [x] Docs-only; convention reads correctly and matches existing PR history