### PR TITLE
fix: ignore rustybuzz unmaintained advisory pending harfrust migration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ version = 2
 yanked = "warn"
 ignore = [
   { id = "RUSTSEC-2026-0192", reason = "unmaintained ttf-parser, transitive via rustybuzz; migration tracked to fontations" },
+  { id = "RUSTSEC-2026-0206", reason = "rustybuzz declared unmaintained; migration to harfrust tracked with the fontations move" },
 ]
 
 [bans]


### PR DESCRIPTION
TL;DR:

Summary:
- RUSTSEC-2026-0206 published today: rustybuzz is now declared unmaintained (successor: harfrust). This fails the cargo-deny advisories gate on every PR since the advisory DB refresh, unrelated to PR content.
- Adds it to the deny.toml ignore list with the same rationale as the existing ttf-parser exception — both resolve together with the planned fontations/harfrust migration in xlsx-raster.

Test plan:
- [x] Rust gate green on this PR
- [x] Re-run the failed gate on #18 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)