### PR TITLE
feat: corporate cla signing via the bot

### DIFF
--- a/.github/cla/cla.sh
+++ b/.github/cla/cla.sh
@@ -57,7 +57,15 @@ cla_render_unsigned_comment() {
 ${sign_phrase}
 \`\`\`
 
-Contributing as part of your job? Then please also have your employer sign the [Corporate CLA](${ccla_url}) — your signature covers you, theirs covers them.
+Contributing as part of your job? Then your employer can sign the [Corporate CLA](${ccla_url}) instead: an authorized representative posts a comment on this pull request in exactly this format —
+
+\`\`\`
+I have read the CCLA Document and I hereby sign the CCLA
+company: <legal entity name>
+designated: @<github-handle> @<github-handle>
+\`\`\`
+
+Everyone on the designated list is covered by the corporate signature.
 
 The check updates on its own once you have signed; you can also re-run it any time by commenting \`!cla-check\`.
 
@@ -82,26 +90,87 @@ cla_init_signatures() {
   [ -f "$signatures_file" ] || echo '{"signedContributors":[]}' > "$signatures_file"
 }
 
+cla_init_ccla() {
+  local ccla_file="$1"
+  mkdir -p "$(dirname "$ccla_file")"
+  [ -f "$ccla_file" ] || echo '{"signedEntities":[]}' > "$ccla_file"
+}
+
+# "company: Acme GmbH" line of a corporate sign comment -> "Acme GmbH"
+cla_ccla_parse_company() {
+  printf '%s\n' "$1" | tr -d '\r' | sed -n 's/^company:[[:space:]]*//p' | head -1
+}
+
+# "designated: @a, @b" line -> "a b"
+cla_ccla_parse_designated() {
+  printf '%s\n' "$1" | tr -d '\r' | sed -n 's/^designated:[[:space:]]*//p' | head -1 | tr ',@' '  ' | xargs
+}
+
+# 0 if $login is on any signed entity's designated list.
+cla_ccla_covered() {
+  local login="$1" ccla_file="$2"
+  [ -f "$ccla_file" ] || return 1
+  local count
+  count=$(jq --arg l "$login" \
+    '[.signedEntities[].designated[] | select(. == $l)] | length' "$ccla_file")
+  [ "$count" != "0" ]
+}
+
+# Always appends; rows are an amendment history, coverage is the union.
+cla_add_ccla_signature() {
+  local entity="$1" rep_login="$2" rep_id="$3" ts="$4" pr="$5" designated="$6" ccla_file="$7"
+  local designated_json
+  designated_json=$(printf '%s' "$designated" | jq -R 'split(" ") | map(select(length > 0))')
+  jq --arg entity "$entity" --arg rep "$rep_login" --argjson rep_id "$rep_id" \
+    --arg ts "$ts" --argjson pr "$pr" --argjson designated "$designated_json" \
+    '.signedEntities += [{entity: $entity, signed_by: $rep, signed_by_id: $rep_id, signed_at: $ts, pull_request_no: $pr, designated: $designated}]' \
+    "$ccla_file" > "$ccla_file.tmp"
+  mv "$ccla_file.tmp" "$ccla_file"
+}
+
 # Orchestrates the workflow; the only function with side effects. Env: REPO,
 # PR_NUMBER, EVENT_NAME, ALLOWLIST, CLA_URL, SIGN_PHRASE (+ COMMENT_USER_*).
 cla_main() {
   local signatures="signatures/v1/cla.json"
+  local ccla="signatures/v1/ccla.json"
+  local ccla_phrase='I have read the CCLA Document and I hereby sign the CCLA'
   local marker='<!-- cla-bot -->'
 
   cla_init_signatures "$signatures"
+  cla_init_ccla "$ccla"
 
+  # a bare !cla-check retrigger must not record anything, so match the body
   if [ "${EVENT_NAME:-}" = "issue_comment" ]; then
-    if cla_should_skip "$COMMENT_USER_LOGIN" "$ALLOWLIST" "${CLA_ORG:-}"; then
-      : # exempt — no signature row needed
-    elif ! cla_signed "$COMMENT_USER_ID" "$signatures"; then
-      cla_add_signature "$COMMENT_USER_LOGIN" "$COMMENT_USER_ID" \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PR_NUMBER" "$signatures"
-      git config user.name "$GIT_AUTHOR_NAME"
-      git config user.email "$GIT_AUTHOR_EMAIL"
-      git add "$signatures"
-      git commit -m "Record CLA signature for @${COMMENT_USER_LOGIN} (PR #${PR_NUMBER})"
-      # the push works because the App is on the main ruleset's bypass list
-      git push origin main
+    local comment_body="${COMMENT_BODY:-}"
+    if [[ "$comment_body" == *"$ccla_phrase"* ]]; then
+      local entity designated
+      entity=$(cla_ccla_parse_company "$comment_body")
+      designated=$(cla_ccla_parse_designated "$comment_body")
+      if [ -n "$entity" ] && [ -n "$designated" ]; then
+        cla_add_ccla_signature "$entity" "$COMMENT_USER_LOGIN" "$COMMENT_USER_ID" \
+          "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PR_NUMBER" "$designated" "$ccla"
+        git config user.name "$GIT_AUTHOR_NAME"
+        git config user.email "$GIT_AUTHOR_EMAIL"
+        git add "$ccla"
+        git commit -m "Record CCLA signature for ${entity} (PR #${PR_NUMBER})"
+        # the push works because the App is on the main ruleset's bypass list
+        git push origin main
+      else
+        echo "WARN: corporate sign comment missing company:/designated: lines; not recorded" >&2
+      fi
+    elif [[ "$comment_body" == *"$SIGN_PHRASE"* ]]; then
+      if cla_should_skip "$COMMENT_USER_LOGIN" "$ALLOWLIST" "${CLA_ORG:-}"; then
+        : # exempt — no signature row needed
+      elif ! cla_signed "$COMMENT_USER_ID" "$signatures"; then
+        cla_add_signature "$COMMENT_USER_LOGIN" "$COMMENT_USER_ID" \
+          "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PR_NUMBER" "$signatures"
+        git config user.name "$GIT_AUTHOR_NAME"
+        git config user.email "$GIT_AUTHOR_EMAIL"
+        git add "$signatures"
+        git commit -m "Record CLA signature for @${COMMENT_USER_LOGIN} (PR #${PR_NUMBER})"
+        # the push works because the App is on the main ruleset's bypass list
+        git push origin main
+      fi
     fi
   fi
 
@@ -144,6 +213,8 @@ cla_main() {
   if cla_should_skip "$pr_author_login" "$ALLOWLIST" "${CLA_ORG:-}"; then
     pr_author_signed=true
   elif [ -n "$pr_author_id" ] && cla_signed "$pr_author_id" "$signatures"; then
+    pr_author_signed=true
+  elif cla_ccla_covered "$pr_author_login" "$ccla"; then
     pr_author_signed=true
   fi
 

--- a/.github/cla/cla.sh
+++ b/.github/cla/cla.sh
@@ -49,12 +49,15 @@ cla_should_skip() {
 # The leading @-mention notifies once; sticky-comment edits don't re-notify.
 cla_render_unsigned_comment() {
   local cla_url="$1" sign_phrase="$2" marker="$3" pr_author_login="$4"
+  local ccla_url="${cla_url%CLA.md}CCLA.md"
   cat <<EOF
 @${pr_author_login} thanks a lot for the contribution! Before we can merge it, we need your one-time signature on the [OpenOOXML Contributor License Agreement](${cla_url}). To sign, post a comment on this pull request with exactly:
 
 \`\`\`
 ${sign_phrase}
 \`\`\`
+
+Contributing as part of your job? Then please also have your employer sign the [Corporate CLA](${ccla_url}) — your signature covers you, theirs covers them.
 
 The check updates on its own once you have signed; you can also re-run it any time by commenting \`!cla-check\`.
 

--- a/.github/cla/cla.test.sh
+++ b/.github/cla/cla.test.sh
@@ -129,6 +129,8 @@ case "$body" in *"I sign"*) ok=1 ;; *) ok=0 ;; esac
 assert_eq "includes the sign phrase" "1" "$ok"
 case "$body" in *'`!cla-check`'*) ok=1 ;; *) ok=0 ;; esac
 assert_eq "mentions the !cla-check keyword in a code span" "1" "$ok"
+case "$body" in *"https://e.x/CCLA.md"*) ok=1 ;; *) ok=0 ;; esac
+assert_eq "links the corporate CLA next to the individual one" "1" "$ok"
 case "$body" in *"<!-- m -->"*) ok=1 ;; *) ok=0 ;; esac
 assert_eq "includes sticky-comment marker" "1" "$ok"
 

--- a/.github/cla/cla.test.sh
+++ b/.github/cla/cla.test.sh
@@ -131,6 +131,25 @@ case "$body" in *'`!cla-check`'*) ok=1 ;; *) ok=0 ;; esac
 assert_eq "mentions the !cla-check keyword in a code span" "1" "$ok"
 case "$body" in *"https://e.x/CCLA.md"*) ok=1 ;; *) ok=0 ;; esac
 assert_eq "links the corporate CLA next to the individual one" "1" "$ok"
+case "$body" in *"I have read the CCLA Document and I hereby sign the CCLA"*) ok=1 ;; *) ok=0 ;; esac
+assert_eq "shows the corporate sign format" "1" "$ok"
+
+echo
+echo "corporate sign flow:"
+ccla_body=$'I have read the CCLA Document and I hereby sign the CCLA\r\ncompany: Acme GmbH\r\ndesignated: @alice, @bob'
+assert_eq "company parses (crlf tolerated)" "Acme GmbH" "$(cla_ccla_parse_company "$ccla_body")"
+assert_eq "designated parses, @ and commas stripped" "alice bob" "$(cla_ccla_parse_designated "$ccla_body")"
+assert_eq "missing company line -> empty" "" "$(cla_ccla_parse_company "no structured lines here")"
+
+CCLA_FILE="$TMPDIR/ccla.json"
+cla_init_ccla "$CCLA_FILE"
+assert_eq "ccla ledger initialized empty" '{"signedEntities":[]}' "$(jq -c . "$CCLA_FILE")"
+cla_add_ccla_signature "Acme GmbH" "rep" 777 "2026-07-12T10:00:00Z" 9 "alice bob" "$CCLA_FILE"
+assert_eq "entity row recorded with designated list" '["alice","bob"]' \
+  "$(jq -c '.signedEntities[0].designated' "$CCLA_FILE")"
+assert_true  "designated employee is covered"     cla_ccla_covered "alice" "$CCLA_FILE"
+assert_false "non-designated login is not covered" cla_ccla_covered "mallory" "$CCLA_FILE"
+assert_false "missing ledger file -> not covered"  cla_ccla_covered "alice" "$TMPDIR/nope.json"
 case "$body" in *"<!-- m -->"*) ok=1 ;; *) ok=0 ;; esac
 assert_eq "includes sticky-comment marker" "1" "$ok"
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,6 +27,7 @@ jobs:
        github.event.issue.pull_request != null &&
        github.event.comment.user.login != 'openooxml-bot[bot]' &&
        (contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA') ||
+        contains(github.event.comment.body, 'I have read the CCLA Document and I hereby sign the CCLA') ||
         contains(github.event.comment.body, '!cla-check')))
     steps:
       - name: Mint App installation token
@@ -52,6 +53,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
           COMMENT_USER_ID: ${{ github.event.comment.user.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
           # exempt bots, plus maintainer handles in case the org lookup fails
           ALLOWLIST: 'dependabot[bot] github-actions[bot] renovate[bot] eliahilse'
           # org members are exempt; leave empty to disable the org check


### PR DESCRIPTION
TL;DR:

Summary:
- An authorized representative can now sign the CCLA directly on a PR: comment `I have read the CCLA Document and I hereby sign the CCLA` plus `company:` and `designated:` lines (GitHub handles). The bot records it to `signatures/v1/ccla.json` and pushes to main, same as individual signatures.
- PR authors on any signed entity's designated list pass the CLA check without an individual signature (per CCLA §5 they're covered by the corporate grant); coverage is the union across recorded rows, so a re-sign with an updated list amends.
- The bot's please-sign comment shows both paths: the individual phrase, and the corporate format for people contributing on work time.
- Fixes an inherited bug: the script now matches the comment body before recording, so a bare `!cla-check` retrigger no longer records the commenter as a signer. (docx has the same bug — worth backporting.)
- Malformed corporate comments (missing `company:`/`designated:`) are logged and not recorded.

Test plan:
- [x] `bash .github/cla/cla.test.sh` — 53 passed
- [x] End-to-end: corporate sign comment from a test account records the entity and flips a designated author's check to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)