### PR TITLE
feat(pptx): add display-list render crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pptx-render"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "pptx-wasm"
+version = "0.0.0"
+dependencies = [
+ "pptx-render",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The document engines are Rust crates compiled to WebAssembly for the browser and
 | crate | what it does |
 |---|---|
 | [`ooxml-opc`](crates/ooxml-opc) | OPC (zip) container read/write with decompression-bomb and path-traversal guards — shared by every format |
+| [`ooxml-text`](crates/ooxml-text) | shared font storage, shaping, bidi, line breaking, and glyph outlines |
+| [`docx-layout`](crates/docx-layout) | DOCX pagination and display-list generation |
+| [`docx-wasm`](crates/docx-wasm) | the wasm boundary for the document engine |
+| [`pptx-render`](crates/pptx-render) | PPTX composed-slide to display-list compiler |
+| [`pptx-wasm`](crates/pptx-wasm) | the wasm boundary for presentation rendering |
 | [`xlsx-model`](crates/xlsx-model) | workbook, cells, addresses, dates, styles, number formats |
 | [`xlsx-parse`](crates/xlsx-parse) | streaming SpreadsheetML parse and serialize |
 | [`xlsx-calc`](crates/xlsx-calc) | formula engine: parser, dependency graph, incremental recalc |
@@ -29,8 +34,6 @@ The document engines are Rust crates compiled to WebAssembly for the browser and
 | [`xlsx-raster`](crates/xlsx-raster) | headless raster backend (tiny-skia), pixel-identical everywhere |
 | [`xlsx-wasm`](crates/xlsx-wasm) | the wasm boundary for the spreadsheet engine |
 | [`xlsx-cli`](crates/xlsx-cli) | render and inspect workbooks from the command line |
-
-The docx and pptx engines are next: the docx layout kernel and text stack move in from the [OpenOOXML docx editor](https://github.com/openooxml/docx), and pptx follows on the shared foundations.
 
 ## Packages
 

--- a/crates/pptx-render/Cargo.toml
+++ b/crates/pptx-render/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pptx-render"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+description = "PPTX composed-slide to target-neutral display-list compiler."
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/pptx-render/src/display_list.rs
+++ b/crates/pptx-render/src/display_list.rs
@@ -1,0 +1,216 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const CONTRACT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfaceDisplayList {
+    pub contract_version: u32,
+    pub width: f32,
+    pub height: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background: Option<Paint>,
+    pub primitives: Vec<Primitive>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum Paint {
+    Solid {
+        color: String,
+    },
+    Gradient {
+        gradient_type: GradientType,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        angle_deg: Option<f32>,
+        stops: Vec<GradientStop>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GradientType {
+    Linear,
+    Radial,
+    Rectangular,
+    Path,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GradientStop {
+    pub position: f32,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Stroke {
+    pub color: String,
+    pub width: f32,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dashed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transform {
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub rotation_deg: f32,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub flip_h: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub flip_v: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum Primitive {
+    Shape {
+        object_id: u32,
+        name: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        geometry: String,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        adjust_values: BTreeMap<String, f32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fill: Option<Paint>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stroke: Option<Stroke>,
+        #[serde(default, skip_serializing_if = "Transform::is_identity")]
+        transform: Transform,
+    },
+    Image {
+        object_id: u32,
+        name: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        asset_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stroke: Option<Stroke>,
+        #[serde(default, skip_serializing_if = "Transform::is_identity")]
+        transform: Transform,
+    },
+    TextBox {
+        object_id: u32,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        anchor: TextAnchor,
+        paragraphs: Vec<TextParagraph>,
+        #[serde(default, skip_serializing_if = "Transform::is_identity")]
+        transform: Transform,
+    },
+    Placeholder {
+        object_id: u32,
+        name: String,
+        x: f32,
+        y: f32,
+        w: f32,
+        h: f32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        #[serde(default, skip_serializing_if = "Transform::is_identity")]
+        transform: Transform,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TextAnchor {
+    Top,
+    Center,
+    Bottom,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextParagraph {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub align: Option<TextAlign>,
+    pub level: u32,
+    pub runs: Vec<TextRun>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TextAlign {
+    Left,
+    Center,
+    Right,
+    Justify,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextRun {
+    pub text: String,
+    pub font_family: String,
+    pub font_size_pt: f32,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub bold: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub italic: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub underline: bool,
+    pub color: String,
+}
+
+impl Transform {
+    pub fn is_identity(&self) -> bool {
+        self.rotation_deg == 0.0 && !self.flip_h && !self.flip_v
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn is_zero(value: &f32) -> bool {
+    *value == 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_transform_is_omitted_from_json() {
+        let list = SurfaceDisplayList {
+            contract_version: CONTRACT_VERSION,
+            width: 100.0,
+            height: 50.0,
+            background: None,
+            primitives: vec![Primitive::Placeholder {
+                object_id: 1,
+                name: "chart".into(),
+                x: 0.0,
+                y: 0.0,
+                w: 10.0,
+                h: 10.0,
+                label: Some("Chart".into()),
+                transform: Transform::default(),
+            }],
+        };
+
+        let json = serde_json::to_string(&list).expect("serialize display list");
+        assert!(!json.contains("transform"));
+        assert!(json.contains("contractVersion"));
+    }
+}

--- a/crates/pptx-render/src/lib.rs
+++ b/crates/pptx-render/src/lib.rs
@@ -1,0 +1,355 @@
+//! PPTX display-list compiler.
+
+mod display_list;
+
+pub use display_list::*;
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ComposedSlide {
+    width_px: f32,
+    height_px: f32,
+    #[serde(default)]
+    background: Option<Paint>,
+    shapes: Vec<ComposedShape>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+enum ComposedShape {
+    Shape {
+        #[serde(flatten)]
+        base: ShapeBase,
+        geometry: String,
+        #[serde(default)]
+        adjust_values: BTreeMap<String, f32>,
+        #[serde(default)]
+        fill: Option<Paint>,
+        #[serde(default)]
+        stroke: Option<ComposedStroke>,
+        #[serde(default)]
+        text: Option<ComposedText>,
+    },
+    Picture {
+        #[serde(flatten)]
+        base: ShapeBase,
+        #[serde(default)]
+        image_part_path: Option<String>,
+        #[serde(default)]
+        stroke: Option<ComposedStroke>,
+    },
+    TablePlaceholder {
+        #[serde(flatten)]
+        base: ShapeBase,
+    },
+    ChartPlaceholder {
+        #[serde(flatten)]
+        base: ShapeBase,
+    },
+    Unknown {
+        #[serde(flatten)]
+        base: ShapeBase,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ShapeBase {
+    id: u32,
+    name: String,
+    rect: Rect,
+    rotation_deg: f32,
+    #[serde(default)]
+    flip_h: bool,
+    #[serde(default)]
+    flip_v: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct Rect {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ComposedStroke {
+    color_hex: String,
+    width_px: f32,
+    #[serde(default)]
+    dash: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ComposedText {
+    paragraphs: Vec<ComposedParagraph>,
+    anchor: ComposedAnchor,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum ComposedAnchor {
+    T,
+    Ctr,
+    B,
+}
+
+#[derive(Debug, Deserialize)]
+struct ComposedParagraph {
+    #[serde(default)]
+    align: Option<ComposedAlign>,
+    level: u32,
+    runs: Vec<ComposedRun>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum ComposedAlign {
+    L,
+    Ctr,
+    R,
+    Just,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ComposedRun {
+    text: String,
+    font_family: String,
+    font_size_pt: f32,
+    #[serde(default)]
+    bold: bool,
+    #[serde(default)]
+    italic: bool,
+    #[serde(default)]
+    underline: bool,
+    color_hex: String,
+}
+
+pub fn compile_json(slide_json: &str) -> Result<String, String> {
+    let slide: ComposedSlide = serde_json::from_str(slide_json)
+        .map_err(|error| format!("invalid composed slide: {error}"))?;
+    serde_json::to_string(&compile(slide))
+        .map_err(|error| format!("could not serialize display list: {error}"))
+}
+
+fn compile(slide: ComposedSlide) -> SurfaceDisplayList {
+    let mut primitives = Vec::with_capacity(slide.shapes.len() * 2);
+    for shape in slide.shapes {
+        match shape {
+            ComposedShape::Shape {
+                base,
+                geometry,
+                adjust_values,
+                fill,
+                stroke,
+                text,
+            } => {
+                let transform = transform(&base);
+                primitives.push(Primitive::Shape {
+                    object_id: base.id,
+                    name: base.name,
+                    x: base.rect.x,
+                    y: base.rect.y,
+                    w: base.rect.w,
+                    h: base.rect.h,
+                    geometry,
+                    adjust_values,
+                    fill,
+                    stroke: stroke.map(Into::into),
+                    transform,
+                });
+                if let Some(text) = text {
+                    primitives.push(text_primitive(base.id, base.rect, transform, text));
+                }
+            }
+            ComposedShape::Picture {
+                base,
+                image_part_path,
+                stroke,
+            } => {
+                let transform = transform(&base);
+                primitives.push(Primitive::Image {
+                    object_id: base.id,
+                    name: base.name,
+                    x: base.rect.x,
+                    y: base.rect.y,
+                    w: base.rect.w,
+                    h: base.rect.h,
+                    asset_id: image_part_path,
+                    stroke: stroke.map(Into::into),
+                    transform,
+                });
+            }
+            ComposedShape::TablePlaceholder { base } => {
+                primitives.push(placeholder(base, Some("Table")))
+            }
+            ComposedShape::ChartPlaceholder { base } => {
+                primitives.push(placeholder(base, Some("Chart")))
+            }
+            ComposedShape::Unknown { base } => primitives.push(placeholder(base, None)),
+        }
+    }
+
+    SurfaceDisplayList {
+        contract_version: CONTRACT_VERSION,
+        width: slide.width_px,
+        height: slide.height_px,
+        background: slide.background.or_else(|| {
+            Some(Paint::Solid {
+                color: "#ffffff".into(),
+            })
+        }),
+        primitives,
+    }
+}
+
+fn transform(base: &ShapeBase) -> Transform {
+    Transform {
+        rotation_deg: base.rotation_deg,
+        flip_h: base.flip_h,
+        flip_v: base.flip_v,
+    }
+}
+
+fn placeholder(base: ShapeBase, label: Option<&str>) -> Primitive {
+    let transform = transform(&base);
+    Primitive::Placeholder {
+        object_id: base.id,
+        name: base.name,
+        x: base.rect.x,
+        y: base.rect.y,
+        w: base.rect.w,
+        h: base.rect.h,
+        label: label.map(str::to_owned),
+        transform,
+    }
+}
+
+fn text_primitive(
+    object_id: u32,
+    rect: Rect,
+    transform: Transform,
+    text: ComposedText,
+) -> Primitive {
+    Primitive::TextBox {
+        object_id,
+        x: rect.x,
+        y: rect.y,
+        w: rect.w,
+        h: rect.h,
+        anchor: match text.anchor {
+            ComposedAnchor::T => TextAnchor::Top,
+            ComposedAnchor::Ctr => TextAnchor::Center,
+            ComposedAnchor::B => TextAnchor::Bottom,
+        },
+        paragraphs: text
+            .paragraphs
+            .into_iter()
+            .map(|paragraph| TextParagraph {
+                align: paragraph.align.map(|align| match align {
+                    ComposedAlign::L => TextAlign::Left,
+                    ComposedAlign::Ctr => TextAlign::Center,
+                    ComposedAlign::R => TextAlign::Right,
+                    ComposedAlign::Just => TextAlign::Justify,
+                }),
+                level: paragraph.level,
+                runs: paragraph
+                    .runs
+                    .into_iter()
+                    .map(|run| TextRun {
+                        text: run.text,
+                        font_family: run.font_family,
+                        font_size_pt: run.font_size_pt,
+                        bold: run.bold,
+                        italic: run.italic,
+                        underline: run.underline,
+                        color: run.color_hex,
+                    })
+                    .collect(),
+            })
+            .collect(),
+        transform,
+    }
+}
+
+impl From<ComposedStroke> for Stroke {
+    fn from(stroke: ComposedStroke) -> Self {
+        Self {
+            color: stroke.color_hex,
+            width: stroke.width_px,
+            dashed: stroke.dash,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compiles_shape_and_text_in_paint_order() {
+        let json = r##"{
+          "widthPx":1280,"heightPx":720,
+          "shapes":[{
+            "kind":"shape","id":7,"name":"Title",
+            "rect":{"x":10,"y":20,"w":300,"h":80},
+            "rotationDeg":15,"geometry":"roundRect","adjustValues":{"adj":0.2},
+            "fill":{"kind":"solid","color":"#4472c4"},
+            "text":{"anchor":"ctr","paragraphs":[{"align":"ctr","level":0,"runs":[{
+              "text":"Hello","fontFamily":"Aptos","fontSizePt":24,"bold":true,
+              "colorHex":"#ffffff"
+            }]}]}
+          }]
+        }"##;
+
+        let output: serde_json::Value =
+            serde_json::from_str(&compile_json(json).expect("compile")).expect("display list json");
+        assert_eq!(output["contractVersion"], CONTRACT_VERSION);
+        assert_eq!(output["primitives"][0]["kind"], "shape");
+        assert_eq!(output["primitives"][1]["kind"], "textBox");
+        assert_eq!(output["primitives"][1]["objectId"], 7);
+        assert_eq!(output["primitives"][1]["anchor"], "center");
+    }
+
+    #[test]
+    fn rejects_invalid_composed_json() {
+        let error = compile_json("{}").expect_err("missing dimensions must fail");
+        assert!(error.starts_with("invalid composed slide:"));
+    }
+
+    #[test]
+    fn defaults_surface_background_to_white() {
+        let output: serde_json::Value = serde_json::from_str(
+            &compile_json(r#"{"widthPx":10,"heightPx":10,"shapes":[]}"#).expect("compile"),
+        )
+        .expect("json");
+        assert_eq!(output["background"]["color"], "#ffffff");
+    }
+
+    #[test]
+    fn paint_type_round_trips_through_input() {
+        let input = r##"{
+          "widthPx":10,"heightPx":10,
+          "background":{"kind":"gradient","gradientType":"linear","angleDeg":90,
+            "stops":[{"position":0,"color":"#000000"},{"position":1,"color":"#ffffff"}]},
+          "shapes":[]
+        }"##;
+        let output: serde_json::Value =
+            serde_json::from_str(&compile_json(input).expect("compile")).expect("json");
+        assert_eq!(output["background"]["gradientType"], "linear");
+        assert_eq!(
+            output["background"]["stops"][1]["position"].as_f64(),
+            Some(1.0)
+        );
+    }
+}

--- a/crates/pptx-wasm/Cargo.toml
+++ b/crates/pptx-wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pptx-wasm"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+description = "The wasm-bindgen boundary for PPTX display-list compilation."
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O3"]
+
+[dependencies]
+pptx-render = { path = "../pptx-render" }
+wasm-bindgen = "0.2"

--- a/crates/pptx-wasm/src/lib.rs
+++ b/crates/pptx-wasm/src/lib.rs
@@ -1,0 +1,13 @@
+//! PPTX display-list wasm boundary.
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = compileSlideJson)]
+pub fn compile_slide_json(slide_json: &str) -> Result<String, JsValue> {
+    pptx_render::compile_json(slide_json).map_err(|error| JsValue::from_str(&error))
+}
+
+#[wasm_bindgen(js_name = rendererVersion)]
+pub fn renderer_version() -> String {
+    env!("CARGO_PKG_VERSION").to_owned()
+}


### PR DESCRIPTION
TL;DR:

Summary:
- add a versioned PPTX surface display-list contract and composed-slide compiler
- add a thin wasm-bindgen boundary for coarse JSON slide compilation
- list the landed DOCX and PPTX engine crates in the repository overview

Test plan:
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo check --target wasm32-unknown-unknown -p pptx-wasm`