### PR TITLE
chore: cargo dependabot and pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+TL;DR:
+<one or two human-written sentences on what this PR does>
+
+Summary:
+- <what changed, not how>
+
+Test plan:
+- [ ] <checks the author fulfills before requesting review>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,19 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
TL;DR:
cargo dependabot/pr template

Summary:
- Dependabot now watches the `cargo` ecosystem (nine crates previously unmonitored): weekly, grouped minor/patch, same cooldown as npm.
- `PULL_REQUEST_TEMPLATE.md` so external contributors get the TL;DR / Summary / Test plan shape by default.

Test plan:
- [x] Dependabot config parses (validated locally)
- [x] Template pre-fills on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)