### PR TITLE
chore(xlsx): changeset for 0.0.3 and readme usage samples

### DIFF
--- a/.changeset/pin-xlsx-react-dependency.md
+++ b/.changeset/pin-xlsx-react-dependency.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/xlsx": patch
+"@betteroffice/xlsx-react": patch
+---
+
+Fix `@betteroffice/xlsx-react` so its dependency on `@betteroffice/xlsx` resolves to the matching published version.

--- a/packages/xlsx-react/README.md
+++ b/packages/xlsx-react/README.md
@@ -2,7 +2,7 @@
 
 React chrome for the BetterOffice XLSX editor — wraps
 [`@betteroffice/xlsx`](https://www.npmjs.com/package/@betteroffice/xlsx) in a
-React component with selection, keyboard, and clipboard wired up.
+drop-in `<XlsxEditor>` component with selection, keyboard, and clipboard wired up.
 
 > **Experimental (`0.0.x`).** The API is unstable and may change in any release.
 
@@ -11,5 +11,41 @@ bun add @betteroffice/xlsx-react @betteroffice/xlsx react react-dom
 ```
 
 `react` and `react-dom` (18 or 19) are peer dependencies.
+
+## Usage
+
+```tsx
+import { useState } from "react";
+import { XlsxEditor } from "@betteroffice/xlsx-react";
+
+export function App() {
+  const [file, setFile] = useState<Uint8Array>();
+
+  return (
+    <>
+      <input
+        type="file"
+        accept=".xlsx"
+        onChange={async (e) => {
+          const f = e.target.files?.[0];
+          if (f) setFile(new Uint8Array(await f.arrayBuffer()));
+        }}
+      />
+      <XlsxEditor
+        file={file}
+        fileName="workbook.xlsx"
+        onSave={(bytes) => {
+          // edited .xlsx bytes; without onSave the save button downloads them
+          console.log(`saved ${bytes.length} bytes`);
+        }}
+      />
+    </>
+  );
+}
+```
+
+Props: `file` (a `Uint8Array` of `.xlsx` bytes — omit it to render an empty
+frame), `fileName`, `onSave`, `onReady` (a handle for host/agent-driven edits),
+and `className`.
 
 Docs: https://betteroffice.dev · Apache-2.0.

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -1,8 +1,9 @@
 # @betteroffice/xlsx
 
-Framework-free core for the BetterOffice XLSX editor — display list, viewport
-math, and the wasm loader. The Rust engine (parse, calc, render) is compiled to
-WebAssembly and bundled in, so there is no separate asset to host.
+Framework-free core for the BetterOffice XLSX editor — the Rust engine (parse,
+calc, render) compiled to WebAssembly and bundled in, plus display-list,
+viewport, hit-test, and accessibility helpers. There's no separate wasm asset to
+host.
 
 > **Experimental (`0.0.x`).** The API is unstable and may change in any release.
 
@@ -10,6 +11,23 @@ WebAssembly and bundled in, so there is no separate asset to host.
 bun add @betteroffice/xlsx
 ```
 
-For a React integration, see [`@betteroffice/xlsx-react`](https://www.npmjs.com/package/@betteroffice/xlsx-react).
+Most apps want the turnkey React component in
+[`@betteroffice/xlsx-react`](https://www.npmjs.com/package/@betteroffice/xlsx-react).
+Reach for this package directly to render a spreadsheet onto your own canvas.
+
+## Usage
+
+```ts
+import { openWorkbook } from "@betteroffice/xlsx";
+
+// parse + load into the wasm engine (calc-ready)
+const bytes = new Uint8Array(await file.arrayBuffer());
+const workbook = openWorkbook(bytes);
+```
+
+From the returned handle you compose the geometry and rendering helpers this
+package exports onto your own `<canvas>` 2D context — `paintDisplayList`,
+`cellAtPoint` / `cellRect` / `rangeRect` (hit-testing), the `viewport` math,
+`buildA11yGrid`, and `toTsv` / `fromTsv` (clipboard).
 
 Docs: https://betteroffice.dev · Apache-2.0.


### PR DESCRIPTION
Patch changeset releasing the xlsx packages at 0.0.3 — fixes the mismatched `@betteroffice/xlsx` dependency published in `xlsx-react@0.0.2` — and adds usage samples to both package READMEs.