### PR TITLE
feat(web): show aggregate npm downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-4ade80.svg?style=flat-square" alt="license"></a>
+  <a href="https://www.npmjs.com/org/betteroffice"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fnpm-downloads&amp;style=flat-square&amp;logo=npm&amp;label=downloads&amp;color=CB3837&amp;cacheSeconds=86400" alt="npm downloads"></a>
   <a href="https://betteroffice.dev"><img src="https://img.shields.io/badge/betteroffice.dev-0a0a0a?style=flat-square" alt="betteroffice.dev"></a>
   <a href="https://openooxml.org"><img src="https://img.shields.io/badge/openooxml.org-0a0a0a?style=flat-square" alt="openooxml.org"></a>
 </p>

--- a/apps/web/app/api/npm-downloads/route.ts
+++ b/apps/web/app/api/npm-downloads/route.ts
@@ -1,0 +1,70 @@
+const CACHE_CONTROL =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800";
+
+export async function GET() {
+  try {
+    const packagesResponse = await fetch(
+      "https://registry.npmjs.org/-/org/betteroffice/package?format=cli",
+    );
+
+    if (!packagesResponse.ok) {
+      throw new Error(`npm packages request failed: ${packagesResponse.status}`);
+    }
+
+    const packageAccess = (await packagesResponse.json()) as Record<
+      string,
+      string
+    >;
+    const packageNames = Object.keys(packageAccess).filter((name) =>
+      name.startsWith("@betteroffice/"),
+    );
+
+    if (packageNames.length === 0) {
+      throw new Error("No public @betteroffice packages found");
+    }
+
+    const counts = await Promise.all(
+      packageNames.map(async (packageName) => {
+        const response = await fetch(
+          `https://api.npmjs.org/downloads/point/last-month/${encodeURIComponent(packageName)}`,
+        );
+
+        if (!response.ok) {
+          throw new Error(
+            `npm downloads request failed for ${packageName}: ${response.status}`,
+          );
+        }
+
+        const data = (await response.json()) as { downloads: number };
+
+        if (!Number.isSafeInteger(data.downloads)) {
+          throw new Error(`Invalid npm download count for ${packageName}`);
+        }
+
+        return data.downloads;
+      }),
+    );
+    const downloads = counts.reduce((total, count) => total + count, 0);
+
+    return Response.json(
+      {
+        schemaVersion: 1,
+        label: "npm downloads",
+        message: `${downloads.toLocaleString("en-US")}/month`,
+        color: "brightgreen",
+      },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  } catch {
+    return Response.json(
+      {
+        schemaVersion: 1,
+        label: "npm downloads",
+        message: "unavailable",
+        color: "lightgrey",
+        isError: true,
+      },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}


### PR DESCRIPTION
TL;DR:

Before/After:
Before: No aggregate npm download badge.

After:

[![npm downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fnpm-downloads&style=flat-square&logo=npm&label=downloads&color=CB3837&cacheSeconds=86400)](https://www.npmjs.com/org/betteroffice)

Summary:
- Add a cached Shields endpoint that aggregates monthly downloads for public `@betteroffice/*` packages.
- Show the aggregate in the repository README using npm brand styling.

Test plan:
- [x] Run the web TypeScript check.
- [x] Verify the endpoint against live npm data.
- [x] Build the worker with OpenNext for Cloudflare.
- [x] Verify the deployed endpoint and Shields badge.