### PR TITLE
feat(xlsx): add typed Rust facade

### DIFF
--- a/.changeset/quiet-tools-calculate.md
+++ b/.changeset/quiet-tools-calculate.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/xlsx": patch
+---
+
+Route workbook sessions through the shared Rust facade and harden editing, calculation, and rendering limits.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Test
         run: bun run test
 
+      - name: Check minimal Wasm features
+        run: cargo check -p xlsx-wasm --target wasm32-unknown-unknown --no-default-features
+
       - name: Build
         run: bun run build:packages
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "betteroffice-xlsx"
+version = "0.0.0"
+dependencies = [
+ "ooxml-opc",
+ "xlsx-calc",
+ "xlsx-model",
+ "xlsx-ops",
+ "xlsx-parse",
+ "xlsx-raster",
+ "xlsx-render",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,11 +585,10 @@ dependencies = [
 name = "xlsx-cli"
 version = "0.0.0"
 dependencies = [
+ "betteroffice-xlsx",
  "ooxml-opc",
  "xlsx-model",
  "xlsx-parse",
- "xlsx-raster",
- "xlsx-render",
 ]
 
 [[package]]
@@ -625,17 +637,14 @@ dependencies = [
 name = "xlsx-wasm"
 version = "0.0.0"
 dependencies = [
+ "betteroffice-xlsx",
  "js-sys",
  "ooxml-opc",
  "serde",
  "serde_json",
  "wasm-bindgen",
- "xlsx-calc",
  "xlsx-model",
- "xlsx-ops",
  "xlsx-parse",
- "xlsx-raster",
- "xlsx-render",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 The document engines are Rust crates compiled to WebAssembly for the browser and running natively on servers. Every value from a user file is treated as attacker-controlled; guards are enforced by construction at the trust boundaries.
 
+Rust consumers should use `betteroffice-xlsx`; the lower-level `xlsx-*` crates are its engine components.
+
 | crate | what it does |
 |---|---|
 | [`ooxml-opc`](crates/ooxml-opc) | OPC (zip) container read/write with decompression-bomb and path-traversal guards — shared by every format |
@@ -27,6 +29,7 @@ The document engines are Rust crates compiled to WebAssembly for the browser and
 | [`docx-wasm`](crates/docx-wasm) | the wasm boundary for the document engine |
 | [`pptx-render`](crates/pptx-render) | PPTX composed-slide to display-list compiler |
 | [`pptx-wasm`](crates/pptx-wasm) | the wasm boundary for presentation rendering |
+| [`betteroffice-xlsx`](crates/betteroffice-xlsx) | typed XLSX editor, calculation, rendering, and save facade for Rust |
 | [`xlsx-model`](crates/xlsx-model) | workbook, cells, addresses, dates, styles, number formats |
 | [`xlsx-parse`](crates/xlsx-parse) | streaming SpreadsheetML parse and serialize |
 | [`xlsx-calc`](crates/xlsx-calc) | formula engine: parser, dependency graph, incremental recalc |

--- a/crates/betteroffice-xlsx/Cargo.toml
+++ b/crates/betteroffice-xlsx/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "betteroffice-xlsx"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+description = "Typed XLSX editor, calculation, rendering, and serialization facade."
+homepage = "https://betteroffice.dev"
+repository = "https://github.com/openooxml/betteroffice"
+readme = "README.md"
+keywords = ["xlsx", "spreadsheet", "ooxml", "excel"]
+categories = ["parser-implementations", "rendering"]
+
+[features]
+default = ["raster"]
+raster = ["dep:xlsx-raster"]
+
+[dependencies]
+ooxml-opc = { path = "../ooxml-opc" }
+xlsx-model = { path = "../xlsx-model" }
+xlsx-parse = { path = "../xlsx-parse" }
+xlsx-calc = { path = "../xlsx-calc" }
+xlsx-ops = { path = "../xlsx-ops" }
+xlsx-render = { path = "../xlsx-render" }
+xlsx-raster = { path = "../xlsx-raster", optional = true }

--- a/crates/betteroffice-xlsx/README.md
+++ b/crates/betteroffice-xlsx/README.md
@@ -1,0 +1,30 @@
+# betteroffice-xlsx
+
+The typed Rust API for opening, editing, calculating, rendering, and saving XLSX
+workbooks.
+
+```rust
+use betteroffice_xlsx::{
+    CalculationOptions, CellRef, RenderOptions, SheetId, Workbook,
+};
+
+let mut workbook = Workbook::open_recalculated(
+    &xlsx_bytes,
+    CalculationOptions::default(),
+)?;
+
+workbook.edit_cell(
+    SheetId(0),
+    CellRef::parse_a1("A1").unwrap(),
+    "42",
+    CalculationOptions::default(),
+)?;
+
+let png = workbook.render_sheet(SheetId(0), &RenderOptions::default())?;
+let saved = workbook.save()?;
+# Ok::<(), betteroffice_xlsx::Error>(())
+```
+
+Saving regenerates the package from the XLSX features represented by the model;
+unsupported package parts are not retained.
+The API is experimental and may change before `0.1.0`.

--- a/crates/betteroffice-xlsx/src/error.rs
+++ b/crates/betteroffice-xlsx/src/error.rs
@@ -1,0 +1,115 @@
+use std::fmt;
+
+use crate::{CellAddress, CellRef, SheetId};
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    Package(String),
+    Spreadsheet(xlsx_parse::ParseError),
+    Operation(xlsx_ops::OpError),
+    NoSheets,
+    DuplicatePart(String),
+    SheetOutOfRange(SheetId),
+    CellOutOfRange(CellRef),
+    InvalidOperation(String),
+    ProposalNotFound(String),
+    StaleProposal(Vec<CellAddress>),
+    RangeTooLarge {
+        rows: u64,
+        cols: u64,
+        max: u64,
+    },
+    InvalidViewport,
+    DisplayTooLarge {
+        cells: u64,
+        max: u64,
+    },
+    InvalidScale(f32),
+    RenderTooLarge {
+        width: u32,
+        height: u32,
+        max: u32,
+    },
+    RenderAreaTooLarge {
+        width: u32,
+        height: u32,
+        max_pixels: u64,
+    },
+    Raster(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Package(error) => f.write_str(error),
+            Self::Spreadsheet(error) => error.fmt(f),
+            Self::Operation(error) => error.fmt(f),
+            Self::NoSheets => f.write_str("workbook has no sheets"),
+            Self::DuplicatePart(name) => write!(f, "duplicate package part: {name}"),
+            Self::SheetOutOfRange(sheet) => write!(f, "sheet {} out of range", sheet.0),
+            Self::CellOutOfRange(cell) => write!(
+                f,
+                "cell row {}, column {} is out of range",
+                u64::from(cell.row) + 1,
+                u64::from(cell.col) + 1
+            ),
+            Self::InvalidOperation(message) => f.write_str(message),
+            Self::ProposalNotFound(id) => write!(f, "no proposal {id}"),
+            Self::StaleProposal(cells) => {
+                let cells = cells
+                    .iter()
+                    .map(|address| address.cell.to_a1())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "stale: {cells}")
+            }
+            Self::RangeTooLarge { rows, cols, max } => {
+                write!(f, "range {rows}x{cols} exceeds the {max}-cell copy cap")
+            }
+            Self::InvalidViewport => f.write_str("viewport must have finite positive dimensions"),
+            Self::DisplayTooLarge { cells, max } => write!(
+                f,
+                "requested viewport spans {cells} cells, exceeds the {max}-cell display-list cap"
+            ),
+            Self::InvalidScale(scale) => {
+                write!(f, "scale must be a positive number, got {scale}")
+            }
+            Self::RenderTooLarge { width, height, max } => write!(
+                f,
+                "requested render is {width}x{height}px, exceeds the {max}px per-side cap; narrow the range or lower scale"
+            ),
+            Self::RenderAreaTooLarge {
+                width,
+                height,
+                max_pixels,
+            } => write!(
+                f,
+                "requested render is {width}x{height}px, exceeds the {max_pixels}-pixel allocation cap; narrow the range or lower scale"
+            ),
+            Self::Raster(error) => f.write_str(error),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Spreadsheet(error) => Some(error),
+            Self::Operation(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<xlsx_parse::ParseError> for Error {
+    fn from(error: xlsx_parse::ParseError) -> Self {
+        Self::Spreadsheet(error)
+    }
+}
+
+impl From<xlsx_ops::OpError> for Error {
+    fn from(error: xlsx_ops::OpError) -> Self {
+        Self::Operation(error)
+    }
+}

--- a/crates/betteroffice-xlsx/src/lib.rs
+++ b/crates/betteroffice-xlsx/src/lib.rs
@@ -1,0 +1,25 @@
+//! Typed facade for opening, editing, calculating, rendering, and saving XLSX files.
+
+mod error;
+mod types;
+mod workbook;
+
+pub use error::Error;
+pub use types::{
+    CalculationOptions, CalculationResult, CellAddress, CellEdit, CellInput, MutationResult,
+    ProposalAcceptance, ProposalEditInput, ProposalRequest, RenderOptions, RenderedPng, SheetInfo,
+};
+pub use workbook::{MAX_DISPLAY_CELLS, MAX_PIXMAP_DIM, MAX_PIXMAP_PIXELS, Workbook};
+
+pub use xlsx_model::addr::AddrError;
+pub use xlsx_model::{
+    Cell, CellRange, CellRef, CellValue, ColId, DateSystem, ErrorValue, MAX_COLS, MAX_ROWS, RowId,
+    Sheet, SheetId, Workbook as WorkbookModel,
+};
+pub use xlsx_ops::{CellState, Op, Proposal, ProposedEdit, Provenance, Transaction};
+pub use xlsx_render::{
+    Align, DisplayList, DrawCmd, GridGeometry, GridMeta, Rect, Viewport, viewport_for_range,
+    viewport_for_used_range,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/betteroffice-xlsx/src/types.rs
+++ b/crates/betteroffice-xlsx/src/types.rs
@@ -1,0 +1,94 @@
+use xlsx_model::{CellRange, CellRef, SheetId};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct CalculationOptions {
+    pub now_serial: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CellAddress {
+    pub sheet: SheetId,
+    pub cell: CellRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CellInput {
+    pub cell: CellRef,
+    pub input: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CellEdit {
+    pub cell: CellRef,
+    pub input: String,
+    pub is_formula: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SheetInfo {
+    pub sheet_names: Vec<String>,
+    pub active_sheet: SheetId,
+    pub content_width: f32,
+    pub content_height: f32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CalculationResult {
+    pub changed: Vec<CellAddress>,
+    pub cycle_cells: Vec<CellAddress>,
+    pub limited_cells: Vec<CellAddress>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MutationResult {
+    pub applied: bool,
+    pub changed: Vec<CellAddress>,
+    pub cycle_cells: Vec<CellAddress>,
+    pub limited_cells: Vec<CellAddress>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalEditInput {
+    pub sheet: SheetId,
+    pub cell: CellRef,
+    pub input: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalRequest {
+    pub agent_id: String,
+    pub note: Option<String>,
+    pub edits: Vec<ProposalEditInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalAcceptance {
+    pub proposal_id: String,
+    pub mutation: MutationResult,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderOptions {
+    pub range: Option<CellRange>,
+    pub scale: f32,
+    pub max_width: Option<u32>,
+    pub max_height: Option<u32>,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            range: None,
+            scale: 1.0,
+            max_width: None,
+            max_height: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedPng {
+    pub bytes: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -1,0 +1,1128 @@
+use std::collections::HashSet;
+
+use xlsx_calc::graph::DepGraph;
+use xlsx_calc::{RecalcResult, rebuild_and_recalc_all, recalc_after};
+use xlsx_model::{
+    CellRange, CellRef, CellValue, MAX_COLS, MAX_ROWS, Sheet, SheetId, Workbook as WorkbookModel,
+};
+use xlsx_ops::{
+    CellState, Op, Proposal, ProposalSet, ProposedEdit, Provenance, Transaction, UndoStack,
+    cell_state_for_input_no_eval,
+};
+use xlsx_render::{DisplayList, GridGeometry, Viewport, build_display_list, display_text};
+#[cfg(feature = "raster")]
+use xlsx_render::{scaled, viewport_for_range, viewport_for_used_range};
+
+use crate::{
+    CalculationOptions, CalculationResult, CellAddress, CellEdit, CellInput, Error, MutationResult,
+    ProposalAcceptance, ProposalRequest, Result, SheetInfo,
+};
+#[cfg(feature = "raster")]
+use crate::{RenderOptions, RenderedPng};
+
+const MAX_RANGE_CELLS: u64 = 100_000;
+const MAX_COL_WIDTH: f64 = 255.0;
+const MAX_ROW_HEIGHT: f64 = 409.5;
+pub const MAX_DISPLAY_CELLS: u64 = 250_000;
+pub const MAX_PIXMAP_DIM: u32 = 16_384;
+pub const MAX_PIXMAP_PIXELS: u64 = 16_777_216;
+
+pub struct Workbook {
+    model: WorkbookModel,
+    active_sheet: SheetId,
+    undo: UndoStack,
+    graph: Option<DepGraph>,
+    proposals: ProposalSet,
+    last_calculation: CalculationResult,
+}
+
+impl Workbook {
+    pub fn open(bytes: &[u8]) -> Result<Self> {
+        Self::open_internal(bytes, true)
+    }
+
+    pub fn open_for_read(bytes: &[u8]) -> Result<Self> {
+        Self::open_internal(bytes, false)
+    }
+
+    fn open_internal(bytes: &[u8], build_graph: bool) -> Result<Self> {
+        let parts = ooxml_opc::unzip_parts(bytes).map_err(Error::Package)?;
+        let mut names = HashSet::with_capacity(parts.len());
+        for (name, _) in &parts {
+            if !names.insert(name) {
+                return Err(Error::DuplicatePart(name.clone()));
+            }
+        }
+        let model = xlsx_parse::parse_workbook(&parts)?;
+        Self::from_parts(model, build_graph)
+    }
+
+    pub fn open_recalculated(bytes: &[u8], options: CalculationOptions) -> Result<Self> {
+        let mut workbook = Self::open_internal(bytes, false)?;
+        workbook.recalculate_all(options);
+        Ok(workbook)
+    }
+
+    pub fn from_model(model: WorkbookModel) -> Result<Self> {
+        Self::from_parts(model, true)
+    }
+
+    fn from_parts(model: WorkbookModel, build_graph: bool) -> Result<Self> {
+        validate_model(&model)?;
+        let graph = build_graph.then(|| DepGraph::build(&model));
+        Ok(Self {
+            model,
+            active_sheet: SheetId(0),
+            undo: UndoStack::new(),
+            graph,
+            proposals: ProposalSet::new(),
+            last_calculation: CalculationResult::default(),
+        })
+    }
+
+    pub fn save(&self) -> Result<Vec<u8>> {
+        let parts = xlsx_parse::serialize_workbook(&self.model)?;
+        ooxml_opc::rezip_parts(&parts).map_err(Error::Package)
+    }
+
+    pub fn model(&self) -> &WorkbookModel {
+        &self.model
+    }
+
+    pub fn into_model(self) -> WorkbookModel {
+        self.model
+    }
+
+    pub fn sheet(&self, sheet: SheetId) -> Result<&Sheet> {
+        self.model.sheet(sheet).ok_or(Error::SheetOutOfRange(sheet))
+    }
+
+    pub fn sheet_count(&self) -> usize {
+        self.model.sheets.len()
+    }
+
+    pub fn sheet_id(&self, name: &str) -> Option<SheetId> {
+        self.model.sheet_by_name(name).map(|(id, _)| id)
+    }
+
+    pub fn active_sheet(&self) -> SheetId {
+        self.active_sheet
+    }
+
+    pub fn set_active_sheet(&mut self, sheet: SheetId) -> Result<()> {
+        self.sheet(sheet)?;
+        self.active_sheet = sheet;
+        Ok(())
+    }
+
+    pub fn sheet_info(&self) -> Result<SheetInfo> {
+        let sheet = self.sheet(self.active_sheet)?;
+        let geometry = GridGeometry::new(sheet);
+        let (content_width, content_height) = match sheet.used_range() {
+            Some(range) => (
+                geometry.col_x(range.end.col.saturating_add(2).min(MAX_COLS)),
+                geometry.row_y(range.end.row.saturating_add(2).min(MAX_ROWS)),
+            ),
+            None => (geometry.col_x(26), geometry.row_y(50)),
+        };
+        Ok(SheetInfo {
+            sheet_names: self
+                .model
+                .sheets
+                .iter()
+                .map(|sheet| sheet.name.clone())
+                .collect(),
+            active_sheet: self.active_sheet,
+            content_width,
+            content_height,
+        })
+    }
+
+    pub fn cell(&self, sheet: SheetId, cell: CellRef) -> Result<CellEdit> {
+        self.validate_cell(cell)?;
+        let sheet_ref = self.sheet(sheet)?;
+        let (input, is_formula) = match sheet_ref.cell(cell) {
+            Some(cell) => match &cell.formula {
+                Some(formula) => (format!("={formula}"), true),
+                None => (value_to_input(&cell.value), false),
+            },
+            None => (String::new(), false),
+        };
+        Ok(CellEdit {
+            cell,
+            input,
+            is_formula,
+        })
+    }
+
+    pub fn range_cells(&self, sheet: SheetId, range: CellRange) -> Result<Vec<Vec<CellEdit>>> {
+        validate_range(range)?;
+        self.sheet(sheet)?;
+        let rows = u64::from(range.end.row - range.start.row + 1);
+        let cols = u64::from(range.end.col - range.start.col + 1);
+        if rows * cols > MAX_RANGE_CELLS {
+            return Err(Error::RangeTooLarge {
+                rows,
+                cols,
+                max: MAX_RANGE_CELLS,
+            });
+        }
+        let mut cells = Vec::with_capacity(rows as usize);
+        for row in range.start.row..=range.end.row {
+            let mut row_cells = Vec::with_capacity(cols as usize);
+            for col in range.start.col..=range.end.col {
+                row_cells.push(self.cell(sheet, CellRef::new(row, col))?);
+            }
+            cells.push(row_cells);
+        }
+        Ok(cells)
+    }
+
+    pub fn edit_cell(
+        &mut self,
+        sheet: SheetId,
+        cell: CellRef,
+        input: &str,
+        options: CalculationOptions,
+    ) -> Result<MutationResult> {
+        self.validate_target(sheet, cell)?;
+        let state = edit_cell_state(&self.model, sheet, cell, input);
+        validate_cell_state(&state)?;
+        if cell_states_semantically_equal(&current_cell_state(&self.model, sheet, cell), &state) {
+            return Ok(MutationResult::default());
+        }
+        self.ensure_graph();
+        let formula = state.formula.clone();
+        self.commit_user(vec![Op::SetCell {
+            sheet,
+            at: cell,
+            cell: state,
+        }])?;
+        self.graph.as_mut().expect("graph initialized").set_formula(
+            sheet,
+            cell,
+            formula.as_deref(),
+        );
+        let seeds = [(sheet, cell)];
+        let result = recalc_after(
+            &mut self.model,
+            self.graph.as_mut().expect("graph initialized"),
+            &seeds,
+            options.now_serial,
+        );
+        Ok(self.mutation_result(true, result, &seeds))
+    }
+
+    pub fn edit_cells(
+        &mut self,
+        sheet: SheetId,
+        edits: &[CellInput],
+        options: CalculationOptions,
+    ) -> Result<MutationResult> {
+        if edits.is_empty() {
+            return Ok(MutationResult::default());
+        }
+        self.sheet(sheet)?;
+        let mut touched = Vec::with_capacity(edits.len());
+        let mut ops = Vec::with_capacity(edits.len());
+        let mut preview = self.model.clone();
+        for edit in edits {
+            self.validate_cell(edit.cell)?;
+            let state = edit_cell_state(&preview, sheet, edit.cell, &edit.input);
+            validate_cell_state(&state)?;
+            if cell_states_semantically_equal(
+                &current_cell_state(&preview, sheet, edit.cell),
+                &state,
+            ) {
+                continue;
+            }
+            preview
+                .sheet_mut(sheet)
+                .expect("sheet validated")
+                .set_cell(edit.cell, state.clone().into());
+            touched.push((sheet, edit.cell, state.formula.clone()));
+            ops.push(Op::SetCell {
+                sheet,
+                at: edit.cell,
+                cell: state,
+            });
+        }
+        if ops.is_empty() || models_semantically_equal(&preview, &self.model) {
+            return Ok(MutationResult::default());
+        }
+        self.ensure_graph();
+        self.commit_user(ops)?;
+        for (sheet, cell, formula) in &touched {
+            self.graph.as_mut().expect("graph initialized").set_formula(
+                *sheet,
+                *cell,
+                formula.as_deref(),
+            );
+        }
+        let seeds: Vec<_> = touched
+            .iter()
+            .map(|(sheet, cell, _)| (*sheet, *cell))
+            .collect();
+        let result = recalc_after(
+            &mut self.model,
+            self.graph.as_mut().expect("graph initialized"),
+            &seeds,
+            options.now_serial,
+        );
+        Ok(self.mutation_result(true, result, &seeds))
+    }
+
+    pub fn apply_ops(
+        &mut self,
+        ops: Vec<Op>,
+        options: CalculationOptions,
+    ) -> Result<MutationResult> {
+        if ops.is_empty() {
+            return Ok(MutationResult::default());
+        }
+        let invalidates_proposals = ops.iter().any(invalidates_proposals);
+        let mut preview = self.model.clone();
+        for op in &ops {
+            validate_op(&preview, op)?;
+            validate_insert_capacity(&preview, op)?;
+            xlsx_ops::apply(&mut preview, op)?;
+            validate_model(&preview)?;
+        }
+        if preview == self.model {
+            return Ok(MutationResult::default());
+        }
+        let active_name = self.active_sheet_name();
+        self.commit_user(ops)?;
+        self.restore_active_sheet(active_name.as_deref());
+        if invalidates_proposals {
+            self.proposals.clear();
+        }
+        let result = self.rebuild_and_recalculate(options);
+        Ok(MutationResult {
+            applied: true,
+            changed: result.changed,
+            cycle_cells: result.cycle_cells,
+            limited_cells: result.limited_cells,
+        })
+    }
+
+    pub fn recalculate_all(&mut self, options: CalculationOptions) -> CalculationResult {
+        self.rebuild_and_recalculate(options)
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.undo.can_undo()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.undo.can_redo()
+    }
+
+    pub fn undo(&mut self, options: CalculationOptions) -> Result<MutationResult> {
+        let active_name = self.active_sheet_name();
+        let Some(ops) = self.undo.undo(&mut self.model)? else {
+            return Ok(MutationResult::default());
+        };
+        self.restore_active_sheet(active_name.as_deref());
+        if ops.iter().any(invalidates_proposals) {
+            self.proposals.clear();
+        }
+        let result = self.rebuild_and_recalculate(options);
+        Ok(MutationResult {
+            applied: true,
+            changed: result.changed,
+            cycle_cells: result.cycle_cells,
+            limited_cells: result.limited_cells,
+        })
+    }
+
+    pub fn redo(&mut self, options: CalculationOptions) -> Result<MutationResult> {
+        let active_name = self.active_sheet_name();
+        let Some(ops) = self.undo.redo(&mut self.model)? else {
+            return Ok(MutationResult::default());
+        };
+        self.restore_active_sheet(active_name.as_deref());
+        if ops.iter().any(invalidates_proposals) {
+            self.proposals.clear();
+        }
+        let result = self.rebuild_and_recalculate(options);
+        Ok(MutationResult {
+            applied: true,
+            changed: result.changed,
+            cycle_cells: result.cycle_cells,
+            limited_cells: result.limited_cells,
+        })
+    }
+
+    pub fn propose(
+        &mut self,
+        request: ProposalRequest,
+        options: CalculationOptions,
+    ) -> Result<Proposal> {
+        let mut preview = self.model.clone();
+        for edit in &request.edits {
+            self.validate_target(edit.sheet, edit.cell)?;
+            let state = edit_cell_state(&preview, edit.sheet, edit.cell, &edit.input);
+            validate_cell_state(&state)?;
+            preview
+                .sheet_mut(edit.sheet)
+                .ok_or(Error::SheetOutOfRange(edit.sheet))?
+                .set_cell(edit.cell, state.into());
+        }
+        rebuild_and_recalc_all(&mut preview, options.now_serial);
+
+        let mut edits = Vec::with_capacity(request.edits.len());
+        for edit in request.edits {
+            edits.push(ProposedEdit {
+                sheet: edit.sheet.0,
+                row: edit.cell.row,
+                col: edit.cell.col,
+                input: edit.input,
+                old_state: current_cell_state(&self.model, edit.sheet, edit.cell),
+                a1: edit.cell.to_a1(),
+                old_text: display_text_at(&self.model, edit.sheet, edit.cell)?,
+                new_text: display_text_at(&preview, edit.sheet, edit.cell)?,
+            });
+        }
+        let proposal = Proposal {
+            id: self.proposals.next_id(),
+            agent_id: request.agent_id,
+            note: request.note,
+            edits,
+        };
+        self.proposals.add(proposal.clone());
+        Ok(proposal)
+    }
+
+    pub fn proposals(&self) -> &[Proposal] {
+        self.proposals.list()
+    }
+
+    pub fn accept_proposal(
+        &mut self,
+        id: &str,
+        force: bool,
+        options: CalculationOptions,
+    ) -> Result<ProposalAcceptance> {
+        let proposal = self
+            .proposals
+            .list()
+            .iter()
+            .find(|proposal| proposal.id == id)
+            .cloned()
+            .ok_or_else(|| Error::ProposalNotFound(id.to_string()))?;
+
+        if proposal.edits.is_empty() {
+            self.proposals.remove(id);
+            return Ok(ProposalAcceptance {
+                proposal_id: id.to_string(),
+                mutation: MutationResult::default(),
+            });
+        }
+
+        if !force {
+            let mut stale = Vec::new();
+            for edit in &proposal.edits {
+                let address = CellAddress {
+                    sheet: SheetId(edit.sheet),
+                    cell: CellRef::new(edit.row, edit.col),
+                };
+                if current_cell_state(&self.model, address.sheet, address.cell) != edit.old_state {
+                    stale.push(address);
+                }
+            }
+            if !stale.is_empty() {
+                return Err(Error::StaleProposal(stale));
+            }
+        }
+
+        let mut touched = Vec::with_capacity(proposal.edits.len());
+        let mut ops = Vec::with_capacity(proposal.edits.len());
+        let mut preview = self.model.clone();
+        for edit in &proposal.edits {
+            let sheet = SheetId(edit.sheet);
+            let cell = CellRef::new(edit.row, edit.col);
+            self.validate_target(sheet, cell)?;
+            let state = edit_cell_state(&preview, sheet, cell, &edit.input);
+            validate_cell_state(&state)?;
+            if cell_states_semantically_equal(&current_cell_state(&preview, sheet, cell), &state) {
+                continue;
+            }
+            preview
+                .sheet_mut(sheet)
+                .expect("sheet validated")
+                .set_cell(cell, state.clone().into());
+            touched.push((sheet, cell, state.formula.clone()));
+            ops.push(Op::SetCell {
+                sheet,
+                at: cell,
+                cell: state,
+            });
+        }
+        if ops.is_empty() || models_semantically_equal(&preview, &self.model) {
+            self.proposals.remove(id);
+            return Ok(ProposalAcceptance {
+                proposal_id: id.to_string(),
+                mutation: MutationResult::default(),
+            });
+        }
+        self.ensure_graph();
+        self.commit_agent(ops, proposal.agent_id)?;
+        for (sheet, cell, formula) in &touched {
+            self.graph.as_mut().expect("graph initialized").set_formula(
+                *sheet,
+                *cell,
+                formula.as_deref(),
+            );
+        }
+        let seeds: Vec<_> = touched
+            .iter()
+            .map(|(sheet, cell, _)| (*sheet, *cell))
+            .collect();
+        let result = recalc_after(
+            &mut self.model,
+            self.graph.as_mut().expect("graph initialized"),
+            &seeds,
+            options.now_serial,
+        );
+        let mutation = self.mutation_result(true, result, &seeds);
+        self.proposals.remove(id);
+        Ok(ProposalAcceptance {
+            proposal_id: id.to_string(),
+            mutation,
+        })
+    }
+
+    pub fn reject_proposal(&mut self, id: &str) -> bool {
+        self.proposals.remove(id)
+    }
+
+    pub fn display_list(&self, viewport: &Viewport) -> Result<DisplayList> {
+        self.display_list_for(self.active_sheet, viewport)
+    }
+
+    pub fn display_list_for(&self, sheet: SheetId, viewport: &Viewport) -> Result<DisplayList> {
+        let sheet_ref = self.sheet(sheet)?;
+        validate_display_region(sheet_ref, viewport)?;
+        Ok(build_display_list(&self.model, sheet, viewport))
+    }
+
+    #[cfg(feature = "raster")]
+    pub fn render_png(&self, viewport: &Viewport) -> Result<RenderedPng> {
+        self.render_png_for(self.active_sheet, viewport)
+    }
+
+    #[cfg(feature = "raster")]
+    pub fn render_png_for(&self, sheet: SheetId, viewport: &Viewport) -> Result<RenderedPng> {
+        validate_viewport(viewport)?;
+        let width = viewport.width.ceil().max(1.0) as u32;
+        let height = viewport.height.ceil().max(1.0) as u32;
+        validate_render_size(width, height)?;
+        let display_list = self.display_list_for(sheet, viewport)?;
+        let bytes = xlsx_raster::render_png(&display_list).map_err(Error::Raster)?;
+        Ok(RenderedPng {
+            bytes,
+            width,
+            height,
+        })
+    }
+
+    #[cfg(feature = "raster")]
+    pub fn render_sheet(&self, sheet: SheetId, options: &RenderOptions) -> Result<RenderedPng> {
+        if !(options.scale.is_finite() && options.scale > 0.0) {
+            return Err(Error::InvalidScale(options.scale));
+        }
+        let sheet_ref = self.sheet(sheet)?;
+        if let Some(range) = options.range {
+            validate_range(range)?;
+        }
+        let mut viewport = match options.range {
+            Some(range) => viewport_for_range(sheet_ref, range),
+            None => viewport_for_used_range(sheet_ref),
+        };
+        if let Some(width) = options.max_width {
+            viewport.width = viewport.width.min(width as f32 / options.scale);
+        }
+        if let Some(height) = options.max_height {
+            viewport.height = viewport.height.min(height as f32 / options.scale);
+        }
+        validate_viewport(&viewport)?;
+        let width = ((viewport.width * options.scale).ceil() as u32).max(1);
+        let height = ((viewport.height * options.scale).ceil() as u32).max(1);
+        validate_render_size(width, height)?;
+        validate_display_region(sheet_ref, &viewport)?;
+        let display_list = build_display_list(&self.model, sheet, &viewport);
+        let display_list = if options.scale == 1.0 {
+            display_list
+        } else {
+            scaled(display_list, options.scale)
+        };
+        let bytes = xlsx_raster::render_png(&display_list).map_err(Error::Raster)?;
+        Ok(RenderedPng {
+            bytes,
+            width,
+            height,
+        })
+    }
+
+    pub fn format_address(&self, address: CellAddress) -> String {
+        if address.sheet == self.active_sheet {
+            address.cell.to_a1()
+        } else {
+            let name = self
+                .model
+                .sheet(address.sheet)
+                .map(|sheet| sheet.name.as_str())
+                .unwrap_or_default();
+            format!("{name}!{}", address.cell.to_a1())
+        }
+    }
+
+    fn validate_target(&self, sheet: SheetId, cell: CellRef) -> Result<()> {
+        self.sheet(sheet)?;
+        self.validate_cell(cell)
+    }
+
+    fn validate_cell(&self, cell: CellRef) -> Result<()> {
+        validate_cell_ref(cell)
+    }
+
+    fn commit_user(&mut self, ops: Vec<Op>) -> Result<()> {
+        let transaction = Transaction::new(ops, Provenance::User);
+        self.undo.commit(&mut self.model, &transaction)?;
+        Ok(())
+    }
+
+    fn commit_agent(&mut self, ops: Vec<Op>, agent_id: String) -> Result<()> {
+        let transaction = Transaction::new(ops, Provenance::Agent { id: agent_id });
+        self.undo.commit(&mut self.model, &transaction)?;
+        Ok(())
+    }
+
+    fn rebuild_and_recalculate(&mut self, options: CalculationOptions) -> CalculationResult {
+        let (graph, result) = rebuild_and_recalc_all(&mut self.model, options.now_serial);
+        self.graph = Some(graph);
+        let result = calculation_result(&result);
+        self.last_calculation = result.clone();
+        result
+    }
+
+    fn ensure_graph(&mut self) {
+        if self.graph.is_none() {
+            self.graph = Some(DepGraph::build(&self.model));
+        }
+    }
+
+    fn mutation_result(
+        &mut self,
+        applied: bool,
+        result: RecalcResult,
+        seeds: &[(SheetId, CellRef)],
+    ) -> MutationResult {
+        let seeds: HashSet<_> = seeds
+            .iter()
+            .map(|(sheet, cell)| (sheet.0, cell.row, cell.col))
+            .collect();
+        self.last_calculation = calculation_result(&result);
+        MutationResult {
+            applied,
+            changed: result
+                .changed
+                .into_iter()
+                .filter(|(sheet, cell)| !seeds.contains(&(sheet.0, cell.row, cell.col)))
+                .map(|(sheet, cell)| CellAddress { sheet, cell })
+                .collect(),
+            cycle_cells: result
+                .cycle_cells
+                .into_iter()
+                .map(|(sheet, cell)| CellAddress { sheet, cell })
+                .collect(),
+            limited_cells: result
+                .limited_cells
+                .into_iter()
+                .map(|(sheet, cell)| CellAddress { sheet, cell })
+                .collect(),
+        }
+    }
+
+    fn active_sheet_name(&self) -> Option<String> {
+        self.model
+            .sheet(self.active_sheet)
+            .map(|sheet| sheet.name.clone())
+    }
+
+    fn restore_active_sheet(&mut self, previous_name: Option<&str>) {
+        if let Some(name) = previous_name
+            && let Some((sheet, _)) = self.model.sheet_by_name(name)
+        {
+            self.active_sheet = sheet;
+            return;
+        }
+        let last = self.model.sheets.len().saturating_sub(1) as u32;
+        self.active_sheet = SheetId(self.active_sheet.0.min(last));
+    }
+
+    pub fn last_calculation(&self) -> &CalculationResult {
+        &self.last_calculation
+    }
+}
+
+fn calculation_result(result: &RecalcResult) -> CalculationResult {
+    CalculationResult {
+        changed: result
+            .changed
+            .iter()
+            .map(|&(sheet, cell)| CellAddress { sheet, cell })
+            .collect(),
+        cycle_cells: result
+            .cycle_cells
+            .iter()
+            .map(|&(sheet, cell)| CellAddress { sheet, cell })
+            .collect(),
+        limited_cells: result
+            .limited_cells
+            .iter()
+            .map(|&(sheet, cell)| CellAddress { sheet, cell })
+            .collect(),
+    }
+}
+
+fn validate_model(model: &WorkbookModel) -> Result<()> {
+    if model.sheets.is_empty() {
+        return Err(Error::NoSheets);
+    }
+    let mut names = HashSet::with_capacity(model.sheets.len());
+    for sheet in &model.sheets {
+        validate_sheet_name(&sheet.name)?;
+        if !names.insert(sheet.name.to_lowercase()) {
+            return Err(Error::InvalidOperation(format!(
+                "duplicate sheet name: {}",
+                sheet.name
+            )));
+        }
+        for (cell, stored) in sheet.iter_cells() {
+            validate_cell_ref(cell)?;
+            if matches!(stored.value, CellValue::Number { value } if !value.is_finite()) {
+                return Err(Error::InvalidOperation(
+                    "workbook contains a non-finite cell number".to_string(),
+                ));
+            }
+            if matches!(&stored.value, CellValue::Text { value } if value.chars().count() > xlsx_calc::eval::MAX_CELL_TEXT_CHARS)
+            {
+                return Err(Error::InvalidOperation(
+                    "workbook contains cell text above Excel's length limit".to_string(),
+                ));
+            }
+            if stored
+                .formula
+                .as_ref()
+                .is_some_and(|formula| formula.len() > xlsx_calc::lexer::MAX_FORMULA_BYTES)
+            {
+                return Err(Error::InvalidOperation(
+                    "workbook contains a formula above the length limit".to_string(),
+                ));
+            }
+            if stored
+                .style
+                .is_some_and(|style| style as usize >= model.styles.cell_xfs.len().max(1))
+            {
+                return Err(Error::InvalidOperation(
+                    "workbook contains an invalid cell style index".to_string(),
+                ));
+            }
+        }
+        for (&column, &width) in &sheet.col_widths {
+            if column >= MAX_COLS || !width.is_finite() || !(0.0..=MAX_COL_WIDTH).contains(&width) {
+                return Err(Error::InvalidOperation(
+                    "workbook contains an invalid column width".to_string(),
+                ));
+            }
+        }
+        for (&row, &height) in &sheet.row_heights {
+            if row >= MAX_ROWS || !height.is_finite() || !(0.0..=MAX_ROW_HEIGHT).contains(&height) {
+                return Err(Error::InvalidOperation(
+                    "workbook contains an invalid row height".to_string(),
+                ));
+            }
+        }
+        for range in &sheet.merges {
+            validate_range(*range)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_op(model: &WorkbookModel, op: &Op) -> Result<()> {
+    match op {
+        Op::SetCell { sheet, at, .. } => {
+            require_sheet(model, *sheet)?;
+            validate_cell_ref(*at)?;
+        }
+        Op::InsertRows {
+            sheet, at, count, ..
+        }
+        | Op::DeleteRows {
+            sheet, at, count, ..
+        } => {
+            require_sheet(model, *sheet)?;
+            validate_axis("row", *at, *count, MAX_ROWS)?;
+        }
+        Op::InsertCols {
+            sheet, at, count, ..
+        }
+        | Op::DeleteCols {
+            sheet, at, count, ..
+        } => {
+            require_sheet(model, *sheet)?;
+            validate_axis("column", *at, *count, MAX_COLS)?;
+        }
+        Op::SetColWidth { sheet, col, width } => {
+            require_sheet(model, *sheet)?;
+            if *col >= MAX_COLS {
+                return Err(Error::InvalidOperation(format!(
+                    "column {} is out of range",
+                    u64::from(*col) + 1
+                )));
+            }
+            if width
+                .is_some_and(|width| !width.is_finite() || !(0.0..=MAX_COL_WIDTH).contains(&width))
+            {
+                return Err(Error::InvalidOperation(format!(
+                    "column width must be between 0 and {MAX_COL_WIDTH}"
+                )));
+            }
+        }
+        Op::SetRowHeight { sheet, row, height } => {
+            require_sheet(model, *sheet)?;
+            if *row >= MAX_ROWS {
+                return Err(Error::InvalidOperation(format!(
+                    "row {} is out of range",
+                    u64::from(*row) + 1
+                )));
+            }
+            if height.is_some_and(|height| {
+                !height.is_finite() || !(0.0..=MAX_ROW_HEIGHT).contains(&height)
+            }) {
+                return Err(Error::InvalidOperation(format!(
+                    "row height must be between 0 and {MAX_ROW_HEIGHT}"
+                )));
+            }
+        }
+        Op::MergeCells { sheet, range } | Op::UnmergeCells { sheet, range } => {
+            require_sheet(model, *sheet)?;
+            validate_range(*range)?;
+        }
+        Op::AddSheet { index, .. } => {
+            if *index > model.sheets.len() {
+                return Err(Error::InvalidOperation(format!(
+                    "sheet index {index} out of range"
+                )));
+            }
+        }
+        Op::RemoveSheet { index } => {
+            if *index >= model.sheets.len() {
+                return Err(Error::InvalidOperation(format!(
+                    "sheet index {index} out of range"
+                )));
+            }
+        }
+        Op::RenameSheet { sheet, .. } => {
+            require_sheet(model, *sheet)?;
+        }
+        Op::RestoreSheet { .. } => {
+            return Err(Error::InvalidOperation(
+                "restore sheet operations are internal".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_insert_capacity(model: &WorkbookModel, op: &Op) -> Result<()> {
+    match *op {
+        Op::InsertRows {
+            sheet, at, count, ..
+        } => {
+            let sheet = require_sheet(model, sheet)?;
+            let cutoff = MAX_ROWS - count;
+            let loses_cells = sheet
+                .iter_cells()
+                .any(|(cell, _)| cell.row >= at && cell.row >= cutoff);
+            let loses_heights = sheet
+                .row_heights
+                .keys()
+                .any(|&row| row >= at && row >= cutoff);
+            let loses_merges = sheet
+                .merges
+                .iter()
+                .any(|range| range.end.row >= at && range.end.row >= cutoff);
+            if loses_cells || loses_heights || loses_merges {
+                return Err(Error::InvalidOperation(
+                    "row insertion would discard content at the sheet boundary".to_string(),
+                ));
+            }
+        }
+        Op::InsertCols {
+            sheet, at, count, ..
+        } => {
+            let sheet = require_sheet(model, sheet)?;
+            let cutoff = MAX_COLS - count;
+            let loses_cells = sheet
+                .iter_cells()
+                .any(|(cell, _)| cell.col >= at && cell.col >= cutoff);
+            let loses_widths = sheet
+                .col_widths
+                .keys()
+                .any(|&col| col >= at && col >= cutoff);
+            let loses_merges = sheet
+                .merges
+                .iter()
+                .any(|range| range.end.col >= at && range.end.col >= cutoff);
+            if loses_cells || loses_widths || loses_merges {
+                return Err(Error::InvalidOperation(
+                    "column insertion would discard content at the sheet boundary".to_string(),
+                ));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn require_sheet(model: &WorkbookModel, sheet: SheetId) -> Result<&Sheet> {
+    model.sheet(sheet).ok_or(Error::SheetOutOfRange(sheet))
+}
+
+fn validate_sheet_name(name: &str) -> Result<()> {
+    let invalid = name.is_empty()
+        || name.chars().count() > 31
+        || name.starts_with('\'')
+        || name.ends_with('\'')
+        || name
+            .chars()
+            .any(|character| matches!(character, ':' | '\\' | '/' | '?' | '*' | '[' | ']'));
+    if invalid {
+        return Err(Error::InvalidOperation(format!(
+            "invalid sheet name: {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_cell_ref(cell: CellRef) -> Result<()> {
+    if cell.row >= MAX_ROWS || cell.col >= MAX_COLS {
+        return Err(Error::CellOutOfRange(cell));
+    }
+    Ok(())
+}
+
+fn validate_range(range: CellRange) -> Result<()> {
+    validate_cell_ref(range.start)?;
+    validate_cell_ref(range.end)?;
+    if range.start.row > range.end.row || range.start.col > range.end.col {
+        return Err(Error::InvalidOperation(
+            "range start must be above and left of range end".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_cell_state(state: &CellState) -> Result<()> {
+    if matches!(state.value, CellValue::Number { value } if !value.is_finite()) {
+        return Err(Error::InvalidOperation(
+            "cell number must be finite".to_string(),
+        ));
+    }
+    if matches!(&state.value, CellValue::Text { value } if value.chars().count() > xlsx_calc::eval::MAX_CELL_TEXT_CHARS)
+    {
+        return Err(Error::InvalidOperation(
+            "cell text exceeds Excel's length limit".to_string(),
+        ));
+    }
+    if state
+        .formula
+        .as_ref()
+        .is_some_and(|formula| formula.len() > xlsx_calc::lexer::MAX_FORMULA_BYTES)
+    {
+        return Err(Error::InvalidOperation(
+            "formula exceeds the length limit".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn edit_cell_state(
+    workbook: &WorkbookModel,
+    sheet: SheetId,
+    cell: CellRef,
+    input: &str,
+) -> CellState {
+    let mut state = cell_state_for_input_no_eval(input);
+    state.style = workbook
+        .sheet(sheet)
+        .and_then(|sheet| sheet.cell(cell))
+        .and_then(|cell| cell.style);
+    state
+}
+
+fn current_cell_state(workbook: &WorkbookModel, sheet: SheetId, cell: CellRef) -> CellState {
+    workbook
+        .sheet(sheet)
+        .and_then(|sheet| sheet.cell(cell))
+        .map(CellState::from)
+        .unwrap_or_default()
+}
+
+fn cell_states_semantically_equal(left: &CellState, right: &CellState) -> bool {
+    match (&left.formula, &right.formula) {
+        (Some(left_formula), Some(right_formula)) => {
+            left_formula == right_formula && left.style == right.style
+        }
+        _ => left == right,
+    }
+}
+
+fn models_semantically_equal(left: &WorkbookModel, right: &WorkbookModel) -> bool {
+    if left.date_system != right.date_system
+        || left.shared_strings != right.shared_strings
+        || left.styles != right.styles
+        || left.sheets.len() != right.sheets.len()
+    {
+        return false;
+    }
+    left.sheets.iter().zip(&right.sheets).all(|(left, right)| {
+        if left.name != right.name
+            || left.merges != right.merges
+            || left.col_widths != right.col_widths
+            || left.row_heights != right.row_heights
+        {
+            return false;
+        }
+        let mut left_cells = left.iter_cells();
+        let mut right_cells = right.iter_cells();
+        loop {
+            match (left_cells.next(), right_cells.next()) {
+                (Some((left_at, left_cell)), Some((right_at, right_cell))) => {
+                    if left_at != right_at
+                        || !cell_states_semantically_equal(
+                            &CellState::from(left_cell),
+                            &CellState::from(right_cell),
+                        )
+                    {
+                        return false;
+                    }
+                }
+                (None, None) => return true,
+                _ => return false,
+            }
+        }
+    })
+}
+
+fn display_text_at(workbook: &WorkbookModel, sheet: SheetId, cell: CellRef) -> Result<String> {
+    let sheet_ref = workbook.sheet(sheet).ok_or(Error::SheetOutOfRange(sheet))?;
+    Ok(match sheet_ref.cell(cell) {
+        Some(cell) => display_text(&workbook.styles, workbook.date_system, cell),
+        None => String::new(),
+    })
+}
+
+fn value_to_input(value: &CellValue) -> String {
+    match value {
+        CellValue::Empty => String::new(),
+        CellValue::Number { value } => value.to_string(),
+        CellValue::Bool { value } => if *value { "TRUE" } else { "FALSE" }.to_string(),
+        CellValue::Text { value } => {
+            if !matches!(xlsx_ops::parse_input(value), xlsx_ops::ParsedInput::Text(text) if text == *value)
+            {
+                format!("'{value}")
+            } else {
+                value.clone()
+            }
+        }
+        CellValue::Error { value } => value.as_str().to_string(),
+    }
+}
+
+fn validate_viewport(viewport: &Viewport) -> Result<()> {
+    if !viewport.x.is_finite()
+        || !viewport.y.is_finite()
+        || !viewport.width.is_finite()
+        || !viewport.height.is_finite()
+        || viewport.width <= 0.0
+        || viewport.height <= 0.0
+        || !(viewport.x + viewport.width).is_finite()
+        || !(viewport.y + viewport.height).is_finite()
+    {
+        return Err(Error::InvalidViewport);
+    }
+    Ok(())
+}
+
+fn validate_display_region(sheet: &Sheet, viewport: &Viewport) -> Result<()> {
+    validate_viewport(viewport)?;
+    let geometry = GridGeometry::new(sheet);
+    let right = viewport.x + viewport.width;
+    let bottom = viewport.y + viewport.height;
+    if right > geometry.col_x(MAX_COLS) || bottom > geometry.row_y(MAX_ROWS) {
+        return Err(Error::InvalidViewport);
+    }
+    let (rows, columns) = geometry.viewport_range(viewport);
+    let row_count = u64::from(rows.end - rows.start);
+    let column_count = u64::from(columns.end - columns.start);
+    let cells = row_count.saturating_mul(column_count);
+    if cells > MAX_DISPLAY_CELLS {
+        return Err(Error::DisplayTooLarge {
+            cells,
+            max: MAX_DISPLAY_CELLS,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(feature = "raster")]
+fn validate_render_size(width: u32, height: u32) -> Result<()> {
+    if width > MAX_PIXMAP_DIM || height > MAX_PIXMAP_DIM {
+        return Err(Error::RenderTooLarge {
+            width,
+            height,
+            max: MAX_PIXMAP_DIM,
+        });
+    }
+    if u64::from(width) * u64::from(height) > MAX_PIXMAP_PIXELS {
+        return Err(Error::RenderAreaTooLarge {
+            width,
+            height,
+            max_pixels: MAX_PIXMAP_PIXELS,
+        });
+    }
+    Ok(())
+}
+
+fn validate_axis(axis: &str, at: u32, count: u32, limit: u32) -> Result<()> {
+    if count == 0 {
+        return Err(Error::InvalidOperation(format!(
+            "{axis} operation count must be positive"
+        )));
+    }
+    if at >= limit || count > limit - at {
+        return Err(Error::InvalidOperation(format!(
+            "{axis} operation exceeds sheet bounds"
+        )));
+    }
+    Ok(())
+}
+
+fn invalidates_proposals(op: &Op) -> bool {
+    matches!(
+        op,
+        Op::InsertRows { .. }
+            | Op::DeleteRows { .. }
+            | Op::InsertCols { .. }
+            | Op::DeleteCols { .. }
+            | Op::AddSheet { .. }
+            | Op::RemoveSheet { .. }
+            | Op::RenameSheet { .. }
+            | Op::RestoreSheet { .. }
+    )
+}

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -1,0 +1,585 @@
+#[cfg(feature = "raster")]
+use betteroffice_xlsx::RenderOptions;
+use betteroffice_xlsx::{
+    CalculationOptions, Cell, CellInput, CellRange, CellRef, CellValue, DrawCmd, Error, Op,
+    ProposalEditInput, ProposalRequest, Sheet, SheetId, Viewport, Workbook, WorkbookModel,
+};
+
+fn cell(address: &str) -> CellRef {
+    CellRef::parse_a1(address).unwrap()
+}
+
+fn sample_parts() -> Vec<(String, Vec<u8>)> {
+    let mut sheet = Sheet::new("Data");
+    sheet.set_cell(
+        cell("A1"),
+        Cell {
+            value: CellValue::Number { value: 10.0 },
+            style: Some(0),
+            ..Cell::default()
+        },
+    );
+    sheet.set_cell(
+        cell("A2"),
+        Cell {
+            value: CellValue::Number { value: 5.0 },
+            ..Cell::default()
+        },
+    );
+    sheet.set_cell(
+        cell("B1"),
+        Cell {
+            value: CellValue::Number { value: 999.0 },
+            formula: Some("SUM(A1:A2)".into()),
+            ..Cell::default()
+        },
+    );
+    let mut model = WorkbookModel::default();
+    model.styles.cell_xfs.push(Default::default());
+    model.sheets.push(sheet);
+    model.sheets.push(Sheet::new("Empty"));
+    xlsx_parse::serialize_workbook(&model).unwrap()
+}
+
+fn sample_xlsx() -> Vec<u8> {
+    ooxml_opc::rezip_parts(&sample_parts()).unwrap()
+}
+
+#[test]
+fn open_and_recalculation_are_explicit() {
+    let cached = Workbook::open(&sample_xlsx()).unwrap();
+    assert_eq!(
+        cached
+            .model()
+            .sheet(SheetId(0))
+            .unwrap()
+            .cell(cell("B1"))
+            .unwrap()
+            .value,
+        CellValue::Number { value: 999.0 }
+    );
+
+    let calculated =
+        Workbook::open_recalculated(&sample_xlsx(), CalculationOptions::default()).unwrap();
+    assert_eq!(
+        calculated
+            .model()
+            .sheet(SheetId(0))
+            .unwrap()
+            .cell(cell("B1"))
+            .unwrap()
+            .value,
+        CellValue::Number { value: 15.0 }
+    );
+
+    let mut read_only = Workbook::open_for_read(&sample_xlsx()).unwrap();
+    let result = read_only
+        .edit_cell(SheetId(0), cell("A1"), "20", CalculationOptions::default())
+        .unwrap();
+    assert_eq!(result.changed[0].cell, cell("B1"));
+}
+
+#[test]
+fn edits_recalculate_render_and_round_trip() {
+    let mut workbook =
+        Workbook::open_recalculated(&sample_xlsx(), CalculationOptions::default()).unwrap();
+    let result = workbook
+        .edit_cell(SheetId(0), cell("A1"), "20", CalculationOptions::default())
+        .unwrap();
+    assert_eq!(result.changed.len(), 1);
+    assert_eq!(result.changed[0].cell, cell("B1"));
+    assert_eq!(
+        workbook
+            .model()
+            .sheet(SheetId(0))
+            .unwrap()
+            .cell(cell("A1"))
+            .unwrap()
+            .style,
+        Some(0)
+    );
+
+    let display = workbook
+        .display_list(&Viewport {
+            x: 0.0,
+            y: 0.0,
+            width: 240.0,
+            height: 120.0,
+        })
+        .unwrap();
+    assert!(
+        display
+            .commands
+            .iter()
+            .any(|command| { matches!(command, DrawCmd::Text { text, .. } if text == "25") })
+    );
+
+    #[cfg(feature = "raster")]
+    {
+        let png = workbook
+            .render_sheet(
+                SheetId(0),
+                &RenderOptions {
+                    range: Some(betteroffice_xlsx::CellRange::parse_a1("A1:B2").unwrap()),
+                    ..RenderOptions::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            &png.bytes[..8],
+            &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]
+        );
+    }
+
+    let saved = workbook.save().unwrap();
+    let reopened = Workbook::open(&saved).unwrap();
+    assert_eq!(reopened.cell(SheetId(0), cell("A1")).unwrap().input, "20");
+    assert_eq!(
+        reopened.cell(SheetId(0), cell("B1")).unwrap().input,
+        "=SUM(A1:A2)"
+    );
+}
+
+#[test]
+fn undo_redo_and_proposals_share_the_typed_session() {
+    let mut workbook =
+        Workbook::open_recalculated(&sample_xlsx(), CalculationOptions::default()).unwrap();
+    workbook
+        .edit_cell(SheetId(0), cell("A1"), "20", CalculationOptions::default())
+        .unwrap();
+    assert!(workbook.can_undo());
+    assert!(
+        workbook
+            .undo(CalculationOptions::default())
+            .unwrap()
+            .applied
+    );
+    assert_eq!(workbook.cell(SheetId(0), cell("A1")).unwrap().input, "10");
+    assert!(
+        workbook
+            .redo(CalculationOptions::default())
+            .unwrap()
+            .applied
+    );
+
+    let proposal = workbook
+        .propose(
+            ProposalRequest {
+                agent_id: "agent".into(),
+                note: Some("update total".into()),
+                edits: vec![ProposalEditInput {
+                    sheet: SheetId(0),
+                    cell: cell("A1"),
+                    input: "30".into(),
+                }],
+            },
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(proposal.id, "p1");
+    assert_eq!(workbook.proposals().len(), 1);
+    let accepted = workbook
+        .accept_proposal("p1", false, CalculationOptions::default())
+        .unwrap();
+    assert_eq!(accepted.proposal_id, "p1");
+    assert_eq!(workbook.cell(SheetId(0), cell("A1")).unwrap().input, "30");
+    assert!(workbook.proposals().is_empty());
+}
+
+#[test]
+fn rejects_empty_workbook_ops_atomically() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    let result = workbook.apply_ops(
+        vec![Op::RemoveSheet { index: 1 }, Op::RemoveSheet { index: 0 }],
+        CalculationOptions::default(),
+    );
+    assert!(matches!(result, Err(Error::NoSheets)));
+    assert_eq!(workbook.sheet_count(), 2);
+}
+
+#[test]
+fn validates_raw_ops_and_noop_history() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    let result = workbook.edit_cells(
+        SheetId(0),
+        &Vec::<CellInput>::new(),
+        CalculationOptions::default(),
+    );
+    assert!(!result.unwrap().applied);
+    assert!(!workbook.can_undo());
+
+    let invalid = workbook.apply_ops(
+        vec![Op::SetColWidth {
+            sheet: SheetId(0),
+            col: 1_000_000_000,
+            width: Some(12.0),
+        }],
+        CalculationOptions::default(),
+    );
+    assert!(matches!(invalid, Err(Error::InvalidOperation(_))));
+    assert!(!workbook.can_undo());
+
+    let duplicate_name = workbook.apply_ops(
+        vec![Op::RenameSheet {
+            sheet: SheetId(0),
+            name: "Empty".into(),
+        }],
+        CalculationOptions::default(),
+    );
+    assert!(matches!(duplicate_name, Err(Error::InvalidOperation(_))));
+
+    let shifted_dimension = workbook.apply_ops(
+        vec![
+            Op::SetRowHeight {
+                sheet: SheetId(0),
+                row: betteroffice_xlsx::MAX_ROWS - 1,
+                height: Some(20.0),
+            },
+            Op::InsertRows {
+                sheet: SheetId(0),
+                at: 0,
+                count: betteroffice_xlsx::MAX_ROWS,
+            },
+        ],
+        CalculationOptions::default(),
+    );
+    assert!(matches!(shifted_dimension, Err(Error::InvalidOperation(_))));
+    assert!(!workbook.can_undo());
+}
+
+#[test]
+fn semantic_noop_preserves_redo_history() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    workbook
+        .edit_cell(SheetId(0), cell("A1"), "20", CalculationOptions::default())
+        .unwrap();
+    workbook.undo(CalculationOptions::default()).unwrap();
+    assert!(workbook.can_redo());
+
+    let formula_result = workbook
+        .edit_cells(
+            SheetId(0),
+            &[
+                CellInput {
+                    cell: cell("B1"),
+                    input: "=1".into(),
+                },
+                CellInput {
+                    cell: cell("B1"),
+                    input: "=SUM(A1:A2)".into(),
+                },
+            ],
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    assert!(!formula_result.applied);
+    assert!(workbook.can_redo());
+
+    let result = workbook
+        .edit_cell(SheetId(0), cell("A1"), "10", CalculationOptions::default())
+        .unwrap();
+    assert!(!result.applied);
+    assert!(workbook.can_redo());
+}
+
+#[test]
+fn rejects_insertions_that_discard_boundary_content() {
+    let mut sheet = Sheet::new("Data");
+    let last_row = CellRef::new(betteroffice_xlsx::MAX_ROWS - 1, 0);
+    let last_col = CellRef::new(0, betteroffice_xlsx::MAX_COLS - 1);
+    sheet.set_cell(
+        last_row,
+        Cell {
+            value: CellValue::Text {
+                value: "row edge".into(),
+            },
+            ..Cell::default()
+        },
+    );
+    sheet.set_cell(
+        last_col,
+        Cell {
+            value: CellValue::Text {
+                value: "column edge".into(),
+            },
+            ..Cell::default()
+        },
+    );
+    let mut model = WorkbookModel::default();
+    model.sheets.push(sheet);
+    let mut workbook = Workbook::from_model(model).unwrap();
+
+    let row_error = workbook
+        .apply_ops(
+            vec![Op::InsertRows {
+                sheet: SheetId(0),
+                at: 0,
+                count: 1,
+            }],
+            CalculationOptions::default(),
+        )
+        .unwrap_err();
+    assert!(matches!(row_error, Error::InvalidOperation(_)));
+    assert_eq!(
+        workbook.cell(SheetId(0), last_row).unwrap().input,
+        "row edge"
+    );
+
+    let column_error = workbook
+        .apply_ops(
+            vec![Op::InsertCols {
+                sheet: SheetId(0),
+                at: 0,
+                count: 1,
+            }],
+            CalculationOptions::default(),
+        )
+        .unwrap_err();
+    assert!(matches!(column_error, Error::InvalidOperation(_)));
+    assert_eq!(
+        workbook.cell(SheetId(0), last_col).unwrap().input,
+        "column edge"
+    );
+    assert!(!workbook.can_undo());
+}
+
+#[test]
+fn rejects_reversed_ranges_and_oversized_dimensions() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    let reversed = CellRange {
+        start: cell("B2"),
+        end: cell("A1"),
+    };
+    assert!(matches!(
+        workbook.range_cells(SheetId(0), reversed),
+        Err(Error::InvalidOperation(_))
+    ));
+    assert!(matches!(
+        workbook.apply_ops(
+            vec![Op::MergeCells {
+                sheet: SheetId(0),
+                range: reversed,
+            }],
+            CalculationOptions::default(),
+        ),
+        Err(Error::InvalidOperation(_))
+    ));
+    assert!(matches!(
+        workbook.apply_ops(
+            vec![Op::SetColWidth {
+                sheet: SheetId(0),
+                col: 0,
+                width: Some(256.0),
+            }],
+            CalculationOptions::default(),
+        ),
+        Err(Error::InvalidOperation(_))
+    ));
+    assert!(matches!(
+        workbook.apply_ops(
+            vec![Op::SetRowHeight {
+                sheet: SheetId(0),
+                row: 0,
+                height: Some(410.0),
+            }],
+            CalculationOptions::default(),
+        ),
+        Err(Error::InvalidOperation(_))
+    ));
+    assert!(matches!(
+        workbook.edit_cell(
+            SheetId(0),
+            cell("A1"),
+            &"x".repeat(xlsx_calc::eval::MAX_CELL_TEXT_CHARS + 1),
+            CalculationOptions::default(),
+        ),
+        Err(Error::InvalidOperation(_))
+    ));
+}
+
+#[test]
+fn proposal_staleness_uses_cell_state_not_display_text() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    workbook
+        .propose(
+            ProposalRequest {
+                agent_id: "agent".into(),
+                note: None,
+                edits: vec![ProposalEditInput {
+                    sheet: SheetId(0),
+                    cell: cell("B1"),
+                    input: "1".into(),
+                }],
+            },
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    workbook
+        .edit_cell(
+            SheetId(0),
+            cell("B1"),
+            "=999",
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    assert!(matches!(
+        workbook.accept_proposal("p1", false, CalculationOptions::default()),
+        Err(Error::StaleProposal(_))
+    ));
+}
+
+#[test]
+fn proposal_acceptance_applies_duplicate_targets_sequentially() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    workbook
+        .propose(
+            ProposalRequest {
+                agent_id: "agent".into(),
+                note: None,
+                edits: vec![
+                    ProposalEditInput {
+                        sheet: SheetId(0),
+                        cell: cell("A1"),
+                        input: "20".into(),
+                    },
+                    ProposalEditInput {
+                        sheet: SheetId(0),
+                        cell: cell("A1"),
+                        input: "30".into(),
+                    },
+                ],
+            },
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    workbook
+        .accept_proposal("p1", false, CalculationOptions::default())
+        .unwrap();
+    assert_eq!(workbook.cell(SheetId(0), cell("A1")).unwrap().input, "30");
+}
+
+#[test]
+fn rename_invalidates_pending_proposals() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    workbook
+        .propose(
+            ProposalRequest {
+                agent_id: "agent".into(),
+                note: None,
+                edits: vec![ProposalEditInput {
+                    sheet: SheetId(0),
+                    cell: cell("A1"),
+                    input: "=Data!A2".into(),
+                }],
+            },
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    workbook
+        .apply_ops(
+            vec![Op::RenameSheet {
+                sheet: SheetId(0),
+                name: "Renamed".into(),
+            }],
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    assert!(workbook.proposals().is_empty());
+}
+
+#[test]
+fn reports_recalculation_limits_without_overwriting_cached_values() {
+    let mut model = WorkbookModel::default();
+    model.sheets.push(Sheet::new("Data"));
+    let mut formulas = Sheet::new("Formulas");
+    formulas.set_cell(
+        cell("A1"),
+        Cell {
+            value: CellValue::Number { value: 123.0 },
+            formula: Some("SUM(Data!A1:XFD1048576)".into()),
+            ..Cell::default()
+        },
+    );
+    model.sheets.push(formulas);
+    let bytes = ooxml_opc::rezip_parts(&xlsx_parse::serialize_workbook(&model).unwrap()).unwrap();
+    let workbook = Workbook::open_recalculated(&bytes, CalculationOptions::default()).unwrap();
+    assert_eq!(
+        workbook.model().sheets[1].cell(cell("A1")).unwrap().value,
+        CellValue::Number { value: 123.0 }
+    );
+    assert_eq!(workbook.last_calculation().limited_cells.len(), 1);
+}
+
+#[test]
+fn structural_ops_invalidate_coordinate_proposals() {
+    let mut workbook = Workbook::open(&sample_xlsx()).unwrap();
+    workbook
+        .propose(
+            ProposalRequest {
+                agent_id: "agent".into(),
+                note: None,
+                edits: vec![ProposalEditInput {
+                    sheet: SheetId(0),
+                    cell: cell("A1"),
+                    input: "30".into(),
+                }],
+            },
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    workbook
+        .apply_ops(
+            vec![Op::InsertRows {
+                sheet: SheetId(0),
+                at: 0,
+                count: 1,
+            }],
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    assert!(workbook.proposals().is_empty());
+}
+
+#[test]
+fn display_lists_do_not_inherit_raster_dimension_caps() {
+    let workbook = Workbook::open(&sample_xlsx()).unwrap();
+    assert!(
+        workbook
+            .display_list(&Viewport {
+                x: 0.0,
+                y: 0.0,
+                width: 20_000.0,
+                height: 120.0,
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn display_lists_reject_excessive_cell_spans() {
+    let workbook = Workbook::open(&sample_xlsx()).unwrap();
+    let error = workbook
+        .display_list(&Viewport {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 6_000_000.0,
+        })
+        .unwrap_err();
+    assert!(matches!(error, Error::DisplayTooLarge { .. }));
+}
+
+#[cfg(feature = "raster")]
+#[test]
+fn raster_rejects_excessive_total_pixel_area() {
+    let workbook = Workbook::open(&sample_xlsx()).unwrap();
+    let error = workbook
+        .render_png(&Viewport {
+            x: 0.0,
+            y: 0.0,
+            width: 5_000.0,
+            height: 5_000.0,
+        })
+        .unwrap_err();
+    assert!(matches!(error, Error::RenderAreaTooLarge { .. }));
+}

--- a/crates/xlsx-calc/src/deps.rs
+++ b/crates/xlsx-calc/src/deps.rs
@@ -1,6 +1,8 @@
 //! dependency extraction: the set of cells/ranges a formula reads.
 
-use xlsx_model::CellRange;
+use std::collections::HashSet;
+
+use xlsx_model::{CellRange, CellRef};
 
 use crate::parser::Expr;
 
@@ -8,15 +10,21 @@ use crate::parser::Expr;
 /// `sheet` is `None` for unqualified refs. order-preserving, de-duplicated.
 pub fn references(expr: &Expr) -> Vec<(Option<String>, CellRange)> {
     let mut out = Vec::new();
-    walk(expr, &mut out);
+    let mut seen = HashSet::new();
+    walk(expr, &mut out, &mut seen);
     out
 }
 
-fn walk(expr: &Expr, out: &mut Vec<(Option<String>, CellRange)>) {
+fn walk(
+    expr: &Expr,
+    out: &mut Vec<(Option<String>, CellRange)>,
+    seen: &mut HashSet<(Option<String>, CellRange)>,
+) {
     match expr {
         Expr::Ref { sheet, cell } => {
             push_unique(
                 out,
+                seen,
                 sheet.clone(),
                 CellRange {
                     start: *cell,
@@ -25,16 +33,16 @@ fn walk(expr: &Expr, out: &mut Vec<(Option<String>, CellRange)>) {
             );
         }
         Expr::Range { sheet, range } => {
-            push_unique(out, sheet.clone(), *range);
+            push_unique(out, seen, sheet.clone(), *range);
         }
-        Expr::Unary { expr, .. } | Expr::Percent(expr) => walk(expr, out),
+        Expr::Unary { expr, .. } | Expr::Percent(expr) => walk(expr, out, seen),
         Expr::Binary { lhs, rhs, .. } => {
-            walk(lhs, out);
-            walk(rhs, out);
+            walk(lhs, out, seen);
+            walk(rhs, out, seen);
         }
         Expr::FuncCall { args, .. } => {
             for arg in args {
-                walk(arg, out);
+                walk(arg, out, seen);
             }
         }
         Expr::Number(_) | Expr::Text(_) | Expr::Bool(_) | Expr::Error(_) => {}
@@ -43,11 +51,16 @@ fn walk(expr: &Expr, out: &mut Vec<(Option<String>, CellRange)>) {
 
 fn push_unique(
     out: &mut Vec<(Option<String>, CellRange)>,
+    seen: &mut HashSet<(Option<String>, CellRange)>,
     sheet: Option<String>,
     range: CellRange,
 ) {
+    let range = CellRange::new(
+        CellRef::new(range.start.row, range.start.col),
+        CellRef::new(range.end.row, range.end.col),
+    );
     let entry = (sheet, range);
-    if !out.contains(&entry) {
+    if seen.insert(entry.clone()) {
         out.push(entry);
     }
 }
@@ -79,7 +92,7 @@ mod tests {
 
     #[test]
     fn dedups_repeated_refs() {
-        assert_eq!(refs("A1 + A1 * A1"), vec!["A1"]);
+        assert_eq!(refs("A1 + $A1 * A$1 + $A$1"), vec!["A1"]);
     }
 
     #[test]

--- a/crates/xlsx-calc/src/engine.rs
+++ b/crates/xlsx-calc/src/engine.rs
@@ -2,10 +2,11 @@
 //! could have changed, in dependency order, and report what moved.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::rc::Rc;
 
 use xlsx_model::{CellProvider, CellRef, CellValue, ColId, RowId, SheetId, Workbook};
 
-use crate::eval::{EvalContext, evaluate};
+use crate::eval::{EvalContext, EvaluationBudget, MAX_RECALCULATION_CELL_VISITS, evaluate};
 use crate::graph::DepGraph;
 use crate::parser::parse_formula;
 
@@ -14,6 +15,7 @@ use crate::parser::parse_formula;
 pub struct RecalcResult {
     pub changed: Vec<(SheetId, CellRef)>,
     pub cycle_cells: Vec<(SheetId, CellRef)>,
+    pub limited_cells: Vec<(SheetId, CellRef)>,
 }
 
 /// normalized cell identity (avoids `$`-anchor `Hash`/`Eq` mismatches).
@@ -92,10 +94,16 @@ fn run_recalc(
     now_serial: Option<f64>,
 ) -> RecalcResult {
     let (order, cycle) = topo_order(graph, &recompute);
+    let budget = Rc::new(EvaluationBudget::new(MAX_RECALCULATION_CELL_VISITS));
 
     let mut changed: Vec<(SheetId, CellRef)> = Vec::new();
+    let mut limited_cells = Vec::new();
     for u in &order {
-        if let Some(value) = eval_node(wb, *u, now_serial)
+        let (value, limited) = eval_node(wb, *u, now_serial, Rc::clone(&budget));
+        if limited {
+            limited_cells.push((u.0, cell_of(*u)));
+        }
+        if let Some(value) = value
             && write_if_changed(wb, *u, value)
         {
             changed.push((u.0, cell_of(*u)));
@@ -114,6 +122,7 @@ fn run_recalc(
     RecalcResult {
         changed,
         cycle_cells,
+        limited_cells,
     }
 }
 
@@ -173,12 +182,29 @@ fn topo_order(graph: &DepGraph, recompute: &HashSet<Key>) -> (Vec<Key>, Vec<Key>
 
 /// evaluate one formula node; `None` when the cell has no formula or it no
 /// longer parses (cached value left untouched).
-fn eval_node(wb: &Workbook, u: Key, now_serial: Option<f64>) -> Option<CellValue> {
-    let src = wb.formula(u.0, cell_of(u))?.to_string();
-    let expr = parse_formula(&src).ok()?;
-    let mut ctx = EvalContext::new(wb, u.0);
+fn eval_node(
+    wb: &Workbook,
+    u: Key,
+    now_serial: Option<f64>,
+    budget: Rc<EvaluationBudget>,
+) -> (Option<CellValue>, bool) {
+    let Some(src) = wb.formula(u.0, cell_of(u)).map(str::to_string) else {
+        return (None, false);
+    };
+    let Ok(expr) = parse_formula(&src) else {
+        return (None, false);
+    };
+    let mut ctx = EvalContext::with_budget(wb, u.0, budget);
     ctx.now_serial = now_serial;
-    Some(evaluate(&expr, &ctx))
+    let value = evaluate(&expr, &ctx);
+    if !ctx.has_unhandled_budget_error() {
+        return (Some(value), ctx.exhausted());
+    }
+    if matches!(wb.value(u.0, cell_of(u)), CellValue::Empty) {
+        (Some(value), true)
+    } else {
+        (None, true)
+    }
 }
 
 /// write `value` only if it differs from the stored value; returns whether
@@ -305,7 +331,7 @@ mod tests {
         wb.sheets.push(Sheet::new("Data"));
         let (s1, s2) = (SheetId(0), SheetId(1));
         put_num(&mut wb, s1, "A1", 7.0);
-        put_formula(&mut wb, s2, "A1", "Sheet1!A1 * 2");
+        put_formula(&mut wb, s2, "A1", "sheet1!A1 * 2");
         let (mut graph, _) = rebuild_and_recalc_all(&mut wb, None);
         assert_eq!(value(&wb, s2, "A1"), num(14.0));
 
@@ -426,6 +452,64 @@ mod tests {
         let (_, r) = rebuild_and_recalc_all(&mut wb, None);
         assert_eq!(value(&wb, s, "A1"), num(2.0));
         assert_eq!(r.changed, vec![(s, a1("A1"))]);
+    }
+
+    #[test]
+    fn exhausted_formula_budget_preserves_cached_value() {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Data"));
+        wb.sheets.push(Sheet::new("Formula"));
+        wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+            a1("A1"),
+            Cell {
+                value: num(123.0),
+                formula: Some("SUM(Data!A1:XFD1048576)".into()),
+                style: None,
+            },
+        );
+        let (_, result) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, SheetId(1), "A1"), num(123.0));
+        assert!(result.changed.is_empty());
+        assert_eq!(result.limited_cells, vec![(SheetId(1), a1("A1"))]);
+    }
+
+    #[test]
+    fn handled_budget_error_updates_the_cached_value() {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Data"));
+        wb.sheets.push(Sheet::new("Formula"));
+        put_formula(
+            &mut wb,
+            SheetId(1),
+            "A1",
+            "IFERROR(SUM(Data!A1:XFD1048576),42)",
+        );
+        let (_, result) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(value(&wb, SheetId(1), "A1"), num(42.0));
+        assert_eq!(result.limited_cells, vec![(SheetId(1), a1("A1"))]);
+    }
+
+    #[test]
+    fn handled_budget_error_can_produce_an_explicit_num_error() {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Data"));
+        wb.sheets.push(Sheet::new("Formula"));
+        wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+            a1("A1"),
+            Cell {
+                value: num(123.0),
+                formula: Some("IFERROR(SUM(Data!A1:XFD1048576),#NUM!)".into()),
+                style: None,
+            },
+        );
+        let (_, result) = rebuild_and_recalc_all(&mut wb, None);
+        assert_eq!(
+            value(&wb, SheetId(1), "A1"),
+            CellValue::Error {
+                value: xlsx_model::ErrorValue::Num
+            }
+        );
+        assert_eq!(result.limited_cells, vec![(SheetId(1), a1("A1"))]);
     }
 
     #[test]

--- a/crates/xlsx-calc/src/eval.rs
+++ b/crates/xlsx-calc/src/eval.rs
@@ -1,9 +1,37 @@
 //! tree-walking evaluator; reads cells only through `xlsx_model::CellProvider`.
 //! coercion follows excel; errors propagate leftmost-first.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use xlsx_model::{CellProvider, CellRange, CellRef, CellValue, ErrorValue, SheetId};
 
 use crate::parser::{BinaryOp, Expr, UnaryOp};
+
+pub const MAX_EVALUATION_CELL_VISITS: u64 = 1_100_000;
+pub const MAX_RECALCULATION_CELL_VISITS: u64 = 10_000_000;
+pub const MAX_CELL_TEXT_CHARS: usize = 32_767;
+
+pub(crate) struct EvaluationBudget {
+    remaining: Cell<u64>,
+}
+
+impl EvaluationBudget {
+    pub(crate) fn new(limit: u64) -> Self {
+        Self {
+            remaining: Cell::new(limit),
+        }
+    }
+
+    fn consume(&self, count: u64) -> bool {
+        let remaining = self.remaining.get();
+        if count > remaining {
+            return false;
+        }
+        self.remaining.set(remaining - count);
+        true
+    }
+}
 
 /// evaluation environment: the cell source plus the sheet unqualified refs
 /// resolve against.
@@ -12,6 +40,10 @@ pub struct EvalContext<'a> {
     pub sheet: SheetId,
     /// wall-clock as an excel date serial; `None` -> TODAY()/NOW() return #VALUE!.
     pub now_serial: Option<f64>,
+    remaining_cell_visits: Cell<u64>,
+    exhausted: Cell<bool>,
+    unhandled_budget_errors: Cell<u64>,
+    shared_budget: Option<Rc<EvaluationBudget>>,
 }
 
 impl<'a> EvalContext<'a> {
@@ -20,6 +52,10 @@ impl<'a> EvalContext<'a> {
             provider,
             sheet,
             now_serial: None,
+            remaining_cell_visits: Cell::new(MAX_EVALUATION_CELL_VISITS),
+            exhausted: Cell::new(false),
+            unhandled_budget_errors: Cell::new(0),
+            shared_budget: None,
         }
     }
 
@@ -28,7 +64,68 @@ impl<'a> EvalContext<'a> {
             provider,
             sheet,
             now_serial: Some(now_serial),
+            remaining_cell_visits: Cell::new(MAX_EVALUATION_CELL_VISITS),
+            exhausted: Cell::new(false),
+            unhandled_budget_errors: Cell::new(0),
+            shared_budget: None,
         }
+    }
+
+    pub(crate) fn with_budget(
+        provider: &'a dyn CellProvider,
+        sheet: SheetId,
+        budget: Rc<EvaluationBudget>,
+    ) -> Self {
+        Self {
+            provider,
+            sheet,
+            now_serial: None,
+            remaining_cell_visits: Cell::new(MAX_EVALUATION_CELL_VISITS),
+            exhausted: Cell::new(false),
+            unhandled_budget_errors: Cell::new(0),
+            shared_budget: Some(budget),
+        }
+    }
+
+    pub(crate) fn consume_cells(&self, count: u64) -> bool {
+        let remaining = self.remaining_cell_visits.get();
+        if count > remaining {
+            self.record_budget_error();
+            return false;
+        }
+        if self
+            .shared_budget
+            .as_ref()
+            .is_some_and(|budget| !budget.consume(count))
+        {
+            self.record_budget_error();
+            return false;
+        }
+        self.remaining_cell_visits.set(remaining - count);
+        true
+    }
+
+    pub(crate) fn exhausted(&self) -> bool {
+        self.exhausted.get()
+    }
+
+    pub(crate) fn budget_error_checkpoint(&self) -> u64 {
+        self.unhandled_budget_errors.get()
+    }
+
+    pub(crate) fn handle_budget_errors_since(&self, checkpoint: u64) {
+        self.unhandled_budget_errors
+            .set(self.unhandled_budget_errors.get().min(checkpoint));
+    }
+
+    pub(crate) fn has_unhandled_budget_error(&self) -> bool {
+        self.unhandled_budget_errors.get() != 0
+    }
+
+    fn record_budget_error(&self) {
+        self.exhausted.set(true);
+        self.unhandled_budget_errors
+            .set(self.unhandled_budget_errors.get().saturating_add(1));
     }
 }
 
@@ -37,12 +134,19 @@ pub(crate) fn err(value: ErrorValue) -> CellValue {
 }
 
 pub(crate) fn num(value: f64) -> CellValue {
-    CellValue::Number { value }
+    if value.is_finite() {
+        CellValue::Number { value }
+    } else {
+        err(ErrorValue::Num)
+    }
 }
 
 pub(crate) fn text(value: impl Into<String>) -> CellValue {
-    CellValue::Text {
-        value: value.into(),
+    let value = value.into();
+    if value.chars().count() > MAX_CELL_TEXT_CHARS {
+        err(ErrorValue::Value)
+    } else {
+        CellValue::Text { value }
     }
 }
 
@@ -86,7 +190,10 @@ pub(crate) fn resolve_ref(
         },
         None => ctx.sheet,
     };
-    ctx.provider.value(sid, cell)
+    if !ctx.consume_cells(1) {
+        return err(ErrorValue::Num);
+    }
+    normalize_provider_value(ctx.provider.value(sid, cell))
 }
 
 /// resolve a possibly sheet-qualified name to its sheet id (`None` -> the
@@ -139,7 +246,7 @@ fn eval_binary(op: BinaryOp, lhs: &Expr, rhs: &Expr, ctx: &EvalContext<'_>) -> C
                 Ok(s) => s,
                 Err(e) => return err(e),
             };
-            CellValue::Text { value: a + &b }
+            text(a + &b)
         }
         _ => compare(op, &lv, &rv),
     }
@@ -222,7 +329,8 @@ fn type_rank(v: &CellValue) -> u8 {
 pub(crate) fn to_number(v: &CellValue) -> Result<f64, ErrorValue> {
     match v {
         CellValue::Empty => Ok(0.0),
-        CellValue::Number { value } => Ok(*value),
+        CellValue::Number { value } if value.is_finite() => Ok(*value),
+        CellValue::Number { .. } => Err(ErrorValue::Num),
         CellValue::Bool { value } => Ok(if *value { 1.0 } else { 0.0 }),
         CellValue::Text { value } => parse_num(value).ok_or(ErrorValue::Value),
         CellValue::Error { value } => Err(*value),
@@ -258,7 +366,10 @@ pub(crate) fn to_bool(v: &CellValue) -> Result<bool, ErrorValue> {
 }
 
 pub(crate) fn parse_num(s: &str) -> Option<f64> {
-    s.trim().parse::<f64>().ok()
+    s.trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite())
 }
 
 /// excel "general" number formatting, good enough for text coercion: integers
@@ -283,10 +394,16 @@ pub(crate) fn range_values(
         Some(name) => ctx.provider.sheet_id(name).ok_or(ErrorValue::Ref)?,
         None => ctx.sheet,
     };
-    let mut out = Vec::new();
+    let count = range_cell_count(range).ok_or(ErrorValue::Num)?;
+    if !ctx.consume_cells(count) {
+        return Err(ErrorValue::Num);
+    }
+    let mut out = Vec::with_capacity(usize::try_from(count).map_err(|_| ErrorValue::Num)?);
     for row in range.start.row..=range.end.row {
         for col in range.start.col..=range.end.col {
-            out.push(ctx.provider.value(sid, CellRef::new(row, col)));
+            out.push(normalize_provider_value(
+                ctx.provider.value(sid, CellRef::new(row, col)),
+            ));
         }
     }
     Ok(out)
@@ -303,24 +420,43 @@ pub(crate) struct Area {
 
 impl Area {
     /// value at 0-based `(row, col)` within the area.
-    pub(crate) fn get(&self, ctx: &EvalContext<'_>, row: usize, col: usize) -> CellValue {
+    pub(crate) fn get(
+        &self,
+        ctx: &EvalContext<'_>,
+        row: usize,
+        col: usize,
+    ) -> Result<CellValue, ErrorValue> {
+        if !ctx.consume_cells(1) {
+            return Err(ErrorValue::Num);
+        }
+        Ok(self.get_unmetered(ctx, row, col))
+    }
+
+    pub(crate) fn get_unmetered(&self, ctx: &EvalContext<'_>, row: usize, col: usize) -> CellValue {
         let cell = CellRef::new(self.start.row + row as u32, self.start.col + col as u32);
-        ctx.provider.value(self.sheet, cell)
+        normalize_provider_value(ctx.provider.value(self.sheet, cell))
     }
 
     /// all values in row-major order.
-    pub(crate) fn values(&self, ctx: &EvalContext<'_>) -> Vec<CellValue> {
-        let mut out = Vec::with_capacity(self.rows * self.cols);
+    pub(crate) fn values(&self, ctx: &EvalContext<'_>) -> Result<Vec<CellValue>, ErrorValue> {
+        let count = self.cell_count().ok_or(ErrorValue::Num)?;
+        if !ctx.consume_cells(count) {
+            return Err(ErrorValue::Num);
+        }
+        let capacity = usize::try_from(count).map_err(|_| ErrorValue::Num)?;
+        let mut out = Vec::with_capacity(capacity);
         for row in 0..self.rows {
             for col in 0..self.cols {
-                out.push(self.get(ctx, row, col));
+                out.push(self.get_unmetered(ctx, row, col));
             }
         }
-        out
+        Ok(out)
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.rows * self.cols
+    pub(crate) fn cell_count(&self) -> Option<u64> {
+        u64::try_from(self.rows)
+            .ok()?
+            .checked_mul(u64::try_from(self.cols).ok()?)
     }
 }
 
@@ -341,5 +477,154 @@ pub(crate) fn as_area(arg: &Expr, ctx: &EvalContext<'_>) -> Option<Area> {
             cols: (range.end.col - range.start.col + 1) as usize,
         }),
         _ => None,
+    }
+}
+
+fn range_cell_count(range: &CellRange) -> Option<u64> {
+    let rows = u64::from(range.end.row - range.start.row + 1);
+    let cols = u64::from(range.end.col - range.start.col + 1);
+    rows.checked_mul(cols)
+}
+
+fn normalize_provider_value(value: CellValue) -> CellValue {
+    match value {
+        CellValue::Number { value } if !value.is_finite() => err(ErrorValue::Num),
+        CellValue::Text { value } if value.chars().count() > MAX_CELL_TEXT_CHARS => {
+            err(ErrorValue::Value)
+        }
+        value => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_formula;
+    use xlsx_model::{Sheet, Workbook};
+
+    #[test]
+    fn rejects_ranges_over_the_evaluation_budget() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        workbook.sheets.push(Sheet::new("Formula"));
+        let expression = parse_formula("SUM(Data!A1:XFD1048576)").unwrap();
+        let context = EvalContext::new(&workbook, SheetId(1));
+        assert_eq!(
+            evaluate(&expression, &context),
+            CellValue::Error {
+                value: ErrorValue::Num
+            }
+        );
+        assert!(context.exhausted());
+    }
+
+    #[test]
+    fn evaluates_large_ranges_within_the_cumulative_budget() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        workbook.sheets.push(Sheet::new("Formula"));
+        let expression = parse_formula("SUM(Data!A1:A100001)").unwrap();
+        let context = EvalContext::new(&workbook, SheetId(1));
+        assert_eq!(
+            evaluate(&expression, &context),
+            CellValue::Number { value: 0.0 }
+        );
+        assert!(!context.exhausted());
+    }
+
+    #[test]
+    fn metadata_functions_do_not_consume_the_referenced_area() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        let expression = parse_formula("ROWS(A1:XFD1048576)").unwrap();
+        let context = EvalContext::new(&workbook, SheetId(0));
+        assert_eq!(
+            evaluate(&expression, &context),
+            CellValue::Number { value: 1_048_576.0 }
+        );
+        assert!(!context.exhausted());
+    }
+
+    #[test]
+    fn shared_budget_applies_across_contexts() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        let budget = Rc::new(EvaluationBudget::new(1));
+        let first = EvalContext::with_budget(&workbook, SheetId(0), Rc::clone(&budget));
+        let second = EvalContext::with_budget(&workbook, SheetId(0), budget);
+        let expression = parse_formula("A1").unwrap();
+        assert_eq!(evaluate(&expression, &first), CellValue::Empty);
+        assert_eq!(
+            evaluate(&expression, &second),
+            CellValue::Error {
+                value: ErrorValue::Num
+            }
+        );
+        assert!(second.exhausted());
+    }
+
+    #[test]
+    fn criteria_short_circuit_charges_only_actual_reads() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        let expression = parse_formula("COUNTIFS(A1:A600000,\"x\",B1:B600000,\"y\")").unwrap();
+        let context = EvalContext::new(&workbook, SheetId(0));
+        assert_eq!(
+            evaluate(&expression, &context),
+            CellValue::Number { value: 0.0 }
+        );
+        assert!(!context.exhausted());
+    }
+
+    #[test]
+    fn exact_lookup_stops_after_the_first_match() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        let expression = parse_formula("VLOOKUP(0,A1:B1048576,2,FALSE)").unwrap();
+        let context = EvalContext::new(&workbook, SheetId(0));
+        assert_eq!(evaluate(&expression, &context), CellValue::Empty);
+        assert!(!context.exhausted());
+
+        let expression = parse_formula("XLOOKUP(0,A1:A1048576,B1:B1048576)").unwrap();
+        let context = EvalContext::new(&workbook, SheetId(0));
+        assert_eq!(evaluate(&expression, &context), CellValue::Empty);
+        assert!(!context.exhausted());
+    }
+
+    #[test]
+    fn non_finite_arithmetic_becomes_num_error() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        for formula in ["MEDIAN(1e308*1e308,1)", "SMALL(1e308*1e308,1)"] {
+            let expression = parse_formula(formula).unwrap();
+            let context = EvalContext::new(&workbook, SheetId(0));
+            assert_eq!(
+                evaluate(&expression, &context),
+                CellValue::Error {
+                    value: ErrorValue::Num
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn generated_text_respects_the_excel_cell_limit() {
+        let mut workbook = Workbook::default();
+        workbook.sheets.push(Sheet::new("Data"));
+        for formula in [
+            "REPT(\"xx\",1e20)",
+            "TEXTJOIN(REPT(\"x\",32767),FALSE,\"a\",\"b\")",
+            "CONCAT(REPT(\"x\",20000),REPT(\"y\",20000))",
+            "REPT(\"x\",32767)&\"x\"",
+        ] {
+            let expression = parse_formula(formula).unwrap();
+            let context = EvalContext::new(&workbook, SheetId(0));
+            assert_eq!(
+                evaluate(&expression, &context),
+                CellValue::Error {
+                    value: ErrorValue::Value
+                }
+            );
+        }
     }
 }

--- a/crates/xlsx-calc/src/functions/criteria.rs
+++ b/crates/xlsx-calc/src/functions/criteria.rs
@@ -1,7 +1,7 @@
 //! excel criteria strings shared by the *IF / *IFS family: optional comparison
 //! operator prefix, numeric or case-insensitive text compare, `*`/`?`/`~` wildcards.
 
-use xlsx_model::CellValue;
+use xlsx_model::{CellValue, ErrorValue};
 
 use crate::eval::{Area, EvalContext, as_area, evaluate, parse_num};
 use crate::parser::Expr;
@@ -229,19 +229,32 @@ pub(crate) fn collect_pairs(
 }
 
 /// flat row-major indices where every criterion matches its aligned cell.
-pub(crate) fn matching_indices(pairs: &[(Area, Criterion)], ctx: &EvalContext<'_>) -> Vec<usize> {
-    let (rows, cols) = match pairs.first() {
-        Some((a, _)) => (a.rows, a.cols),
-        None => return Vec::new(),
+pub(crate) fn matching_indices(
+    pairs: &[(Area, Criterion)],
+    ctx: &EvalContext<'_>,
+) -> Result<Vec<usize>, ErrorValue> {
+    let cols = match pairs.first() {
+        Some((a, _)) => a.cols,
+        None => return Ok(Vec::new()),
     };
-    (0..rows * cols)
-        .filter(|&i| {
-            let (r, c) = (i / cols, i % cols);
-            pairs
-                .iter()
-                .all(|(area, crit)| crit.matches(&area.get(ctx, r, c)))
-        })
-        .collect()
+    let count = pairs[0].0.cell_count().ok_or(ErrorValue::Num)?;
+    let cols = u64::try_from(cols).map_err(|_| ErrorValue::Num)?;
+    let mut matching = Vec::new();
+    for index in 0..count {
+        let row = usize::try_from(index / cols).map_err(|_| ErrorValue::Num)?;
+        let col = usize::try_from(index % cols).map_err(|_| ErrorValue::Num)?;
+        let mut matches = true;
+        for (area, criterion) in pairs {
+            if !criterion.matches(&area.get(ctx, row, col)?) {
+                matches = false;
+                break;
+            }
+        }
+        if matches {
+            matching.push(usize::try_from(index).map_err(|_| ErrorValue::Num)?);
+        }
+    }
+    Ok(matching)
 }
 
 #[cfg(test)]

--- a/crates/xlsx-calc/src/functions/info.rs
+++ b/crates/xlsx-calc/src/functions/info.rs
@@ -73,5 +73,8 @@ fn test(args: &[Expr], ctx: &EvalContext<'_>, pred: fn(&CellValue) -> bool) -> C
     if args.len() != 1 {
         return err(ErrorValue::Value);
     }
-    boolean(pred(&evaluate(&args[0], ctx)))
+    let checkpoint = ctx.budget_error_checkpoint();
+    let value = evaluate(&args[0], ctx);
+    ctx.handle_budget_errors_since(checkpoint);
+    boolean(pred(&value))
 }

--- a/crates/xlsx-calc/src/functions/logical.rs
+++ b/crates/xlsx-calc/src/functions/logical.rs
@@ -29,8 +29,12 @@ pub(crate) fn iferror(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     if args.len() != 2 {
         return err(ErrorValue::Value);
     }
+    let checkpoint = ctx.budget_error_checkpoint();
     match evaluate(&args[0], ctx) {
-        CellValue::Error { .. } => evaluate(&args[1], ctx),
+        CellValue::Error { .. } => {
+            ctx.handle_budget_errors_since(checkpoint);
+            evaluate(&args[1], ctx)
+        }
         v => v,
     }
 }

--- a/crates/xlsx-calc/src/functions/lookups.rs
+++ b/crates/xlsx-calc/src/functions/lookups.rs
@@ -56,25 +56,40 @@ fn table_lookup(args: &[Expr], ctx: &EvalContext<'_>, vertical: bool) -> CellVal
     if index as usize > depth {
         return err(ErrorValue::Ref);
     }
-    let key = |i: usize| {
-        if vertical {
+    let mut found = None;
+    for i in 0..lines {
+        let key = if vertical {
             area.get(ctx, i, 0)
         } else {
             area.get(ctx, 0, i)
+        };
+        let key = match key {
+            Ok(key) => key,
+            Err(error) => return err(error),
+        };
+        let ordering = cmp_values(&key, &target);
+        if approximate {
+            if ordering != Ordering::Greater {
+                found = Some(i);
+            } else {
+                break;
+            }
+        } else if ordering == Ordering::Equal {
+            found = Some(i);
+            break;
         }
-    };
-    let found = if approximate {
-        approximate_row(lines, &target, key)
-    } else {
-        (0..lines).find(|&i| cmp_values(&key(i), &target) == Ordering::Equal)
-    };
+    }
     match found {
         Some(i) => {
             let off = index as usize - 1;
-            if vertical {
+            let value = if vertical {
                 area.get(ctx, i, off)
             } else {
                 area.get(ctx, off, i)
+            };
+            match value {
+                Ok(value) => value,
+                Err(error) => err(error),
             }
         }
         None => err(ErrorValue::NA),
@@ -104,7 +119,10 @@ pub(crate) fn match_(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     } else {
         1
     };
-    let values = area.values(ctx);
+    let values = match area.values(ctx) {
+        Ok(values) => values,
+        Err(error) => return err(error),
+    };
     let pos = match match_type {
         0 => values
             .iter()
@@ -159,7 +177,10 @@ pub(crate) fn index(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     if row < 1 || col < 1 || row as usize > area.rows || col as usize > area.cols {
         return err(ErrorValue::Ref);
     }
-    area.get(ctx, row as usize - 1, col as usize - 1)
+    match area.get(ctx, row as usize - 1, col as usize - 1) {
+        Ok(value) => value,
+        Err(error) => err(error),
+    }
 }
 
 /// XLOOKUP(value, lookup_array, return_array, [if_not_found], ...): exact-match
@@ -180,23 +201,35 @@ pub(crate) fn xlookup(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         Some(a) => a,
         None => return err(ErrorValue::Value),
     };
-    let keys = lookup.values(ctx);
-    let results = result.values(ctx);
-    if keys.len() != results.len() {
+    if lookup.cell_count() != result.cell_count() {
         return err(ErrorValue::Value);
     }
-    match keys
-        .iter()
-        .position(|v| cmp_values(v, &target) == Ordering::Equal)
-    {
-        Some(i) => results[i].clone(),
-        None => {
-            if args.len() >= 4 {
-                evaluate(&args[3], ctx)
-            } else {
-                err(ErrorValue::NA)
-            }
+    let count = lookup.cell_count().unwrap_or(0);
+    let cols = u64::try_from(lookup.cols).unwrap_or(0);
+    for index in 0..count {
+        let row = match usize::try_from(index / cols) {
+            Ok(row) => row,
+            Err(_) => return err(ErrorValue::Num),
+        };
+        let col = match usize::try_from(index % cols) {
+            Ok(col) => col,
+            Err(_) => return err(ErrorValue::Num),
+        };
+        let key = match lookup.get(ctx, row, col) {
+            Ok(key) => key,
+            Err(error) => return err(error),
+        };
+        if cmp_values(&key, &target) == Ordering::Equal {
+            return match result.get(ctx, row, col) {
+                Ok(value) => value,
+                Err(error) => err(error),
+            };
         }
+    }
+    if args.len() >= 4 {
+        evaluate(&args[3], ctx)
+    } else {
+        err(ErrorValue::NA)
     }
 }
 

--- a/crates/xlsx-calc/src/functions/math.rs
+++ b/crates/xlsx-calc/src/functions/math.rs
@@ -75,10 +75,16 @@ fn sum_matching(
 ) -> CellValue {
     let cols = pairs[0].0.cols;
     let mut total = 0.0;
-    for i in criteria::matching_indices(pairs, ctx) {
+    let indices = match criteria::matching_indices(pairs, ctx) {
+        Ok(indices) => indices,
+        Err(error) => return err(error),
+    };
+    for i in indices {
         let (r, c) = (i / cols, i % cols);
-        if let CellValue::Number { value } = value_area.get(ctx, r, c) {
-            total += value;
+        match value_area.get(ctx, r, c) {
+            Ok(CellValue::Number { value }) => total += value,
+            Ok(_) => {}
+            Err(error) => return err(error),
         }
     }
     num(total)
@@ -94,8 +100,12 @@ pub(crate) fn sumproduct(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     for arg in args {
         match as_area(arg, ctx) {
             Some(area) => {
-                let mut col = Vec::with_capacity(area.len());
-                for v in area.values(ctx) {
+                let values = match area.values(ctx) {
+                    Ok(values) => values,
+                    Err(error) => return err(error),
+                };
+                let mut col = Vec::with_capacity(values.len());
+                for v in values {
                     match v {
                         CellValue::Number { value } => col.push(value),
                         CellValue::Error { value } => return err(value),

--- a/crates/xlsx-calc/src/functions/stats.rs
+++ b/crates/xlsx-calc/src/functions/stats.rs
@@ -1,6 +1,8 @@
 //! statistical functions. numeric aggregations ignore text/bool/blank inside
 //! references, coerce literal arguments, propagate errors.
 
+use std::collections::HashMap;
+
 use xlsx_model::{CellValue, ErrorValue};
 
 use crate::eval::{Area, EvalContext, as_area, err, evaluate, num};
@@ -37,7 +39,7 @@ pub(crate) fn median(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     match collect_numbers(args, ctx) {
         Ok(nums) if nums.is_empty() => err(ErrorValue::Num),
         Ok(mut nums) => {
-            nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            nums.sort_by(f64::total_cmp);
             let n = nums.len();
             if n % 2 == 1 {
                 num(nums[n / 2])
@@ -56,16 +58,26 @@ pub(crate) fn mode(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         Ok(n) => n,
         Err(e) => return err(e),
     };
-    // (value, count, first_index)
-    let mut best: Option<(f64, usize, usize)> = None;
+    let mut counts: HashMap<u64, (f64, usize, usize)> = HashMap::new();
     for (i, &x) in nums.iter().enumerate() {
-        let count = nums.iter().filter(|&&y| y == x).count();
+        if !x.is_finite() {
+            return err(ErrorValue::Num);
+        }
+        let key = if x == 0.0 { 0 } else { x.to_bits() };
+        counts
+            .entry(key)
+            .and_modify(|(_, count, _)| *count += 1)
+            .or_insert((x, 1, i));
+    }
+    let mut best: Option<(f64, usize, usize)> = None;
+    for (_, (value, count, first)) in counts {
         if count < 2 {
             continue;
         }
         match best {
-            Some((_, bc, bi)) if bc > count || (bc == count && bi <= i) => {}
-            _ => best = Some((x, count, i)),
+            Some((_, best_count, best_first))
+                if best_count > count || (best_count == count && best_first <= first) => {}
+            _ => best = Some((value, count, first)),
         }
     }
     match best {
@@ -122,8 +134,11 @@ pub(crate) fn rank(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     } else {
         false
     };
-    let nums: Vec<f64> = area
-        .values(ctx)
+    let values = match area.values(ctx) {
+        Ok(values) => values,
+        Err(error) => return err(error),
+    };
+    let nums: Vec<f64> = values
         .into_iter()
         .filter_map(|v| match v {
             CellValue::Number { value } => Some(value),
@@ -146,8 +161,11 @@ pub(crate) fn count(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     for arg in args {
         match as_area(arg, ctx) {
             Some(area) => {
-                count += area
-                    .values(ctx)
+                let values = match area.values(ctx) {
+                    Ok(values) => values,
+                    Err(error) => return err(error),
+                };
+                count += values
                     .iter()
                     .filter(|v| matches!(v, CellValue::Number { .. }))
                     .count() as i64;
@@ -168,8 +186,11 @@ pub(crate) fn counta(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     for arg in args {
         match as_area(arg, ctx) {
             Some(area) => {
-                count += area
-                    .values(ctx)
+                let values = match area.values(ctx) {
+                    Ok(values) => values,
+                    Err(error) => return err(error),
+                };
+                count += values
                     .iter()
                     .filter(|v| !matches!(v, CellValue::Empty))
                     .count() as i64;
@@ -193,8 +214,11 @@ pub(crate) fn countblank(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         Some(a) => a,
         None => return err(ErrorValue::Value),
     };
-    let n = area
-        .values(ctx)
+    let values = match area.values(ctx) {
+        Ok(values) => values,
+        Err(error) => return err(error),
+    };
+    let n = values
         .iter()
         .filter(|v| {
             matches!(v, CellValue::Empty)
@@ -214,12 +238,18 @@ pub(crate) fn countif(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     };
     let criterion = criteria::criterion_from_arg(&args[1], ctx);
     let pairs = [(area, criterion)];
-    num(criteria::matching_indices(&pairs, ctx).len() as f64)
+    match criteria::matching_indices(&pairs, ctx) {
+        Ok(indices) => num(indices.len() as f64),
+        Err(error) => err(error),
+    }
 }
 
 pub(crate) fn countifs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     match criteria::collect_pairs(args, ctx) {
-        Some(pairs) => num(criteria::matching_indices(&pairs, ctx).len() as f64),
+        Some(pairs) => match criteria::matching_indices(&pairs, ctx) {
+            Ok(indices) => num(indices.len() as f64),
+            Err(error) => err(error),
+        },
         None => err(ErrorValue::Value),
     }
 }
@@ -260,7 +290,10 @@ pub(crate) fn averageifs(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
 }
 
 fn average_of(pairs: &[(Area, Criterion)], value_area: &Area, ctx: &EvalContext<'_>) -> CellValue {
-    let nums = matching_numbers(pairs, value_area, ctx);
+    let nums = match matching_numbers(pairs, value_area, ctx) {
+        Ok(nums) => nums,
+        Err(error) => return err(error),
+    };
     if nums.is_empty() {
         err(ErrorValue::Div0)
     } else {
@@ -272,18 +305,24 @@ fn matching_numbers(
     pairs: &[(Area, Criterion)],
     value_area: &Area,
     ctx: &EvalContext<'_>,
-) -> Vec<f64> {
+) -> Result<Vec<f64>, ErrorValue> {
     let cols = pairs[0].0.cols;
-    criteria::matching_indices(pairs, ctx)
+    criteria::matching_indices(pairs, ctx)?
         .into_iter()
-        .filter_map(|i| {
+        .map(|i| {
             let (r, c) = (i / cols, i % cols);
-            match value_area.get(ctx, r, c) {
-                CellValue::Number { value } => Some(value),
-                _ => None,
-            }
+            value_area.get(ctx, r, c)
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()
+        .map(|values| {
+            values
+                .into_iter()
+                .filter_map(|value| match value {
+                    CellValue::Number { value } => Some(value),
+                    _ => None,
+                })
+                .collect()
+        })
 }
 
 /// sample (n-1) or population (n) variance; too few values -> #DIV/0!.
@@ -315,7 +354,7 @@ fn nth_order(args: &[Expr], ctx: &EvalContext<'_>, largest: bool) -> CellValue {
     if k < 1 || k as usize > nums.len() {
         return err(ErrorValue::Num);
     }
-    nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    nums.sort_by(f64::total_cmp);
     let idx = if largest {
         nums.len() - k as usize
     } else {

--- a/crates/xlsx-calc/src/functions/text.rs
+++ b/crates/xlsx-calc/src/functions/text.rs
@@ -4,7 +4,8 @@
 use xlsx_model::{CellValue, ErrorValue};
 
 use crate::eval::{
-    EvalContext, boolean, err, evaluate, num, parse_num, range_values, text, to_number, to_text,
+    EvalContext, MAX_CELL_TEXT_CHARS, boolean, err, evaluate, num, parse_num, range_values, text,
+    to_number, to_text,
 };
 use crate::parser::Expr;
 
@@ -99,9 +100,12 @@ pub(crate) fn mid(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         return err(ErrorValue::Value);
     }
     let chars: Vec<char> = s.chars().collect();
-    let from = (start as usize - 1).min(chars.len());
-    let to = (from + count as usize).min(chars.len());
-    text(chars[from..to].iter().collect::<String>())
+    let from = usize::try_from(start - 1)
+        .unwrap_or(usize::MAX)
+        .min(chars.len());
+    let count = usize::try_from(count).unwrap_or(usize::MAX);
+    let to = from.saturating_add(count).min(chars.len());
+    limited_text(chars[from..to].iter().collect())
 }
 
 /// FIND(find_text, within_text, [start]): case-sensitive; 1-based; not found
@@ -134,37 +138,40 @@ pub(crate) fn substitute(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         Err(e) => return err(e),
     };
     if old.is_empty() {
-        return text(s);
+        return limited_text(s);
     }
     let instance = if args.len() == 4 {
         match nth_int(args, ctx, 3) {
-            Ok(n) if n >= 1 => Some(n as usize),
+            Ok(n) if n >= 1 => Some(usize::try_from(n).unwrap_or(usize::MAX)),
             Ok(_) => return err(ErrorValue::Value),
             Err(e) => return err(e),
         }
     } else {
         None
     };
-    match instance {
-        None => text(s.replace(&old, &new)),
-        Some(target) => {
-            let mut out = String::new();
-            let mut rest = s.as_str();
-            let mut seen = 0;
-            while let Some(pos) = rest.find(&old) {
-                seen += 1;
-                out.push_str(&rest[..pos]);
-                if seen == target {
-                    out.push_str(&new);
-                } else {
-                    out.push_str(&old);
-                }
-                rest = &rest[pos + old.len()..];
-            }
-            out.push_str(rest);
-            text(out)
+    let mut out = String::new();
+    let mut chars = 0;
+    let mut rest = s.as_str();
+    let mut seen = 0;
+    while let Some(pos) = rest.find(&old) {
+        seen += 1;
+        if !append_limited(&mut out, &rest[..pos], &mut chars) {
+            return err(ErrorValue::Value);
         }
+        let replacement = if instance.is_none() || instance == Some(seen) {
+            &new
+        } else {
+            &old
+        };
+        if !append_limited(&mut out, replacement, &mut chars) {
+            return err(ErrorValue::Value);
+        }
+        rest = &rest[pos + old.len()..];
     }
+    if !append_limited(&mut out, rest, &mut chars) {
+        return err(ErrorValue::Value);
+    }
+    text(out)
 }
 
 /// REPLACE(old_text, start, num_chars, new_text): positional replacement.
@@ -192,11 +199,21 @@ pub(crate) fn replace(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         return err(ErrorValue::Value);
     }
     let chars: Vec<char> = s.chars().collect();
-    let from = (start as usize - 1).min(chars.len());
-    let to = (from + count as usize).min(chars.len());
-    let mut out: String = chars[..from].iter().collect();
-    out.push_str(&new);
-    out.extend(chars[to..].iter());
+    let from = usize::try_from(start - 1)
+        .unwrap_or(usize::MAX)
+        .min(chars.len());
+    let count = usize::try_from(count).unwrap_or(usize::MAX);
+    let to = from.saturating_add(count).min(chars.len());
+    let mut out = String::new();
+    let mut output_chars = 0;
+    let prefix: String = chars[..from].iter().collect();
+    let suffix: String = chars[to..].iter().collect();
+    if !append_limited(&mut out, &prefix, &mut output_chars)
+        || !append_limited(&mut out, &new, &mut output_chars)
+        || !append_limited(&mut out, &suffix, &mut output_chars)
+    {
+        return err(ErrorValue::Value);
+    }
     text(out)
 }
 
@@ -211,7 +228,19 @@ pub(crate) fn rept(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     };
     match nth_int(args, ctx, 1) {
         Ok(n) if n < 0 => err(ErrorValue::Value),
-        Ok(n) => text(s.repeat(n as usize)),
+        Ok(_) if s.is_empty() => text(""),
+        Ok(n) => {
+            let Ok(count) = usize::try_from(n) else {
+                return err(ErrorValue::Value);
+            };
+            let Some(chars) = s.chars().count().checked_mul(count) else {
+                return err(ErrorValue::Value);
+            };
+            if chars > MAX_CELL_TEXT_CHARS || s.len().checked_mul(count).is_none() {
+                return err(ErrorValue::Value);
+            }
+            text(s.repeat(count))
+        }
         Err(e) => err(e),
     }
 }
@@ -327,7 +356,7 @@ pub(crate) fn text_fn(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         return text("");
     }
     let formatted = numfmt::format_value(&value, &format, DateSystem::V1900);
-    text(formatted.text)
+    limited_text(formatted.text)
 }
 
 /// TEXTJOIN(delimiter, ignore_empty, text1, ...): join, optionally skipping
@@ -344,7 +373,9 @@ pub(crate) fn textjoin(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         Ok(b) => b,
         Err(e) => return err(e),
     };
-    let mut parts = Vec::new();
+    let mut output = String::new();
+    let mut output_chars = 0;
+    let mut first = true;
     for arg in &args[2..] {
         let values = match arg {
             Expr::Range { sheet, range } => match range_values(sheet, range, ctx) {
@@ -360,17 +391,26 @@ pub(crate) fn textjoin(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
                 continue;
             }
             match to_text(&v) {
-                Ok(s) => parts.push(s),
+                Ok(s) => {
+                    if !first && !append_limited(&mut output, &delim, &mut output_chars) {
+                        return err(ErrorValue::Value);
+                    }
+                    if !append_limited(&mut output, &s, &mut output_chars) {
+                        return err(ErrorValue::Value);
+                    }
+                    first = false;
+                }
                 Err(e) => return err(e),
             }
         }
     }
-    text(parts.join(&delim))
+    text(output)
 }
 
 /// CONCAT / CONCATENATE: join every argument (ranges flattened, row-major).
 pub(crate) fn concat(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
     let mut out = String::new();
+    let mut output_chars = 0;
     for arg in args {
         let values = match arg {
             Expr::Range { sheet, range } => match range_values(sheet, range, ctx) {
@@ -381,7 +421,8 @@ pub(crate) fn concat(args: &[Expr], ctx: &EvalContext<'_>) -> CellValue {
         };
         for v in values {
             match to_text(&v) {
-                Ok(s) => out.push_str(&s),
+                Ok(s) if append_limited(&mut out, &s, &mut output_chars) => {}
+                Ok(_) => return err(ErrorValue::Value),
                 Err(e) => return err(e),
             }
         }
@@ -397,12 +438,17 @@ fn one_text(args: &[Expr], ctx: &EvalContext<'_>) -> Result<String, ErrorValue> 
 }
 
 fn nth_text(args: &[Expr], ctx: &EvalContext<'_>, i: usize) -> Result<String, ErrorValue> {
-    to_text(&evaluate(&args[i], ctx))
+    let value = to_text(&evaluate(&args[i], ctx))?;
+    if value.chars().count() > MAX_CELL_TEXT_CHARS {
+        Err(ErrorValue::Value)
+    } else {
+        Ok(value)
+    }
 }
 
 fn map_text(args: &[Expr], ctx: &EvalContext<'_>, f: fn(&str) -> String) -> CellValue {
     match one_text(args, ctx) {
-        Ok(s) => text(f(&s)),
+        Ok(s) => limited_text(f(&s)),
         Err(e) => err(e),
     }
 }
@@ -418,7 +464,7 @@ fn take_end(args: &[Expr], ctx: &EvalContext<'_>, from_left: bool) -> CellValue 
     let count = if args.len() == 2 {
         match nth_int(args, ctx, 1) {
             Ok(n) if n < 0 => return err(ErrorValue::Value),
-            Ok(n) => n as usize,
+            Ok(n) => usize::try_from(n).unwrap_or(usize::MAX),
             Err(e) => return err(e),
         }
     } else {
@@ -431,7 +477,7 @@ fn take_end(args: &[Expr], ctx: &EvalContext<'_>, from_left: bool) -> CellValue 
     } else {
         &chars[chars.len() - take..]
     };
-    text(slice.iter().collect::<String>())
+    limited_text(slice.iter().collect())
 }
 
 fn locate(args: &[Expr], ctx: &EvalContext<'_>, case_sensitive: bool) -> CellValue {
@@ -448,7 +494,7 @@ fn locate(args: &[Expr], ctx: &EvalContext<'_>, case_sensitive: bool) -> CellVal
     };
     let start = if args.len() == 3 {
         match nth_int(args, ctx, 2) {
-            Ok(n) if n >= 1 => n as usize,
+            Ok(n) if n >= 1 => usize::try_from(n).unwrap_or(usize::MAX),
             Ok(_) => return err(ErrorValue::Value),
             Err(e) => return err(e),
         }
@@ -502,4 +548,24 @@ fn parse_numeric_text(s: &str) -> Option<f64> {
         return parse_num(body).map(|n| n / 100.0);
     }
     parse_num(trimmed)
+}
+
+fn limited_text(value: String) -> CellValue {
+    if value.chars().count() > MAX_CELL_TEXT_CHARS {
+        err(ErrorValue::Value)
+    } else {
+        text(value)
+    }
+}
+
+fn append_limited(output: &mut String, value: &str, chars: &mut usize) -> bool {
+    let Some(next) = chars.checked_add(value.chars().count()) else {
+        return false;
+    };
+    if next > MAX_CELL_TEXT_CHARS {
+        return false;
+    }
+    output.push_str(value);
+    *chars = next;
+    true
 }

--- a/crates/xlsx-calc/src/graph.rs
+++ b/crates/xlsx-calc/src/graph.rs
@@ -53,7 +53,7 @@ impl DepGraph {
             .sheets
             .iter()
             .enumerate()
-            .map(|(i, s)| (s.name.clone(), SheetId(i as u32)))
+            .map(|(i, s)| (s.name.to_lowercase(), SheetId(i as u32)))
             .collect();
         let mut g = DepGraph {
             names,
@@ -154,15 +154,25 @@ impl DepGraph {
     /// sheet, unknown sheet names drop the edge.
     fn resolve_edges(&self, owner: SheetId, expr: &Expr) -> Vec<(SheetId, CellRange)> {
         let mut out = Vec::new();
+        let mut seen = HashSet::new();
         for (sheet, range) in references(expr) {
             let sid = match sheet {
                 None => owner,
-                Some(name) => match self.names.get(&name) {
+                Some(name) => match self.names.get(&name.to_lowercase()) {
                     Some(id) => *id,
                     None => continue,
                 },
             };
-            out.push((sid, range));
+            let key = (
+                sid,
+                range.start.row,
+                range.start.col,
+                range.end.row,
+                range.end.col,
+            );
+            if seen.insert(key) {
+                out.push((sid, range));
+            }
         }
         out
     }
@@ -302,5 +312,22 @@ mod tests {
             .set_cell(a1("B1"), formula_cell("$A$1 + 1"));
         let g = DepGraph::build(&wb);
         assert_eq!(deps_a1(&g, "Sheet1", "A1", &wb), vec!["Sheet1!B1"]);
+    }
+
+    #[test]
+    fn resolved_sheet_aliases_deduplicate() {
+        let mut wb = wb2();
+        wb.sheet_mut(SheetId(0))
+            .unwrap()
+            .set_cell(a1("C1"), formula_cell("A1+$A$1+sheet1!A1"));
+        let graph = DepGraph::build(&wb);
+        assert_eq!(
+            graph
+                .deps
+                .get(&NodeKey::new(SheetId(0), a1("C1")))
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }

--- a/crates/xlsx-calc/src/lexer.rs
+++ b/crates/xlsx-calc/src/lexer.rs
@@ -5,6 +5,9 @@ use std::fmt;
 
 use xlsx_model::{CellRange, CellRef, ErrorValue};
 
+pub const MAX_TOKENS: usize = 10_000;
+pub const MAX_FORMULA_BYTES: usize = 32_768;
+
 /// a positioned lexer/parser error, the single error type of `parse_formula`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseError {
@@ -85,6 +88,12 @@ pub enum TokKind {
 
 /// tokenize a formula source string.
 pub fn lex(input: &str) -> Result<Vec<Token>, ParseError> {
+    if input.len() > MAX_FORMULA_BYTES {
+        return Err(ParseError::new(
+            MAX_FORMULA_BYTES,
+            "formula length exceeded cap",
+        ));
+    }
     Lexer { input, pos: 0 }.run()
 }
 
@@ -153,6 +162,9 @@ impl Lexer<'_> {
                 start,
                 end: self.pos,
             });
+            if out.len() > MAX_TOKENS {
+                return Err(ParseError::new(start, "formula token count exceeded cap"));
+            }
         }
         Ok(out)
     }
@@ -220,9 +232,13 @@ impl Lexer<'_> {
             }
         }
         let text = &self.input[start..self.pos];
-        text.parse::<f64>()
-            .map(TokKind::Num)
-            .map_err(|_| ParseError::new(start, format!("malformed number {text:?}")))
+        let value = text
+            .parse::<f64>()
+            .map_err(|_| ParseError::new(start, format!("malformed number {text:?}")))?;
+        if !value.is_finite() {
+            return Err(ParseError::new(start, "number is outside the finite range"));
+        }
+        Ok(TokKind::Num(value))
     }
 
     fn lex_string(&mut self) -> Result<TokKind, ParseError> {
@@ -479,5 +495,28 @@ mod tests {
     #[test]
     fn rejects_unexpected_char() {
         assert!(lex("1 ~ 2").is_err());
+    }
+
+    #[test]
+    fn rejects_excessive_token_count() {
+        let formula = "%".repeat(MAX_TOKENS + 1);
+        let error = lex(&formula).unwrap_err();
+        assert!(error.message.contains("token count"));
+    }
+
+    #[test]
+    fn accepts_exact_token_limit() {
+        assert_eq!(lex(&"%".repeat(MAX_TOKENS)).unwrap().len(), MAX_TOKENS);
+    }
+
+    #[test]
+    fn rejects_excessive_formula_length() {
+        let error = lex(&"x".repeat(MAX_FORMULA_BYTES + 1)).unwrap_err();
+        assert!(error.message.contains("length"));
+    }
+
+    #[test]
+    fn rejects_non_finite_number_literals() {
+        assert!(lex("1e999").unwrap_err().message.contains("finite"));
     }
 }

--- a/crates/xlsx-calc/src/parser.rs
+++ b/crates/xlsx-calc/src/parser.rs
@@ -79,7 +79,18 @@ pub fn parse_formula(src: &str) -> Result<Expr, ParseError> {
     if let Some(tok) = p.peek() {
         return Err(ParseError::new(tok.start, "unexpected trailing token"));
     }
-    Ok(expr)
+    Ok(expr.expr)
+}
+
+struct ParsedExpr {
+    expr: Expr,
+    depth: usize,
+}
+
+impl ParsedExpr {
+    fn leaf(expr: Expr) -> Self {
+        Self { expr, depth: 1 }
+    }
 }
 
 struct Parser<'a> {
@@ -116,7 +127,7 @@ impl Parser<'_> {
         }
     }
 
-    fn expr_bp(&mut self, min_bp: u8, depth: usize) -> Result<Expr, ParseError> {
+    fn expr_bp(&mut self, min_bp: u8, depth: usize) -> Result<ParsedExpr, ParseError> {
         if depth > MAX_DEPTH {
             return Err(ParseError::new(self.here(), "formula nesting too deep"));
         }
@@ -127,31 +138,46 @@ impl Parser<'_> {
             }
             self.advance();
             let rhs = self.expr_bp(r_bp, depth + 1)?;
-            lhs = Expr::Binary {
-                op,
-                lhs: Box::new(lhs),
-                rhs: Box::new(rhs),
+            let ast_depth = lhs.depth.max(rhs.depth) + 1;
+            self.validate_ast_depth(ast_depth)?;
+            lhs = ParsedExpr {
+                expr: Expr::Binary {
+                    op,
+                    lhs: Box::new(lhs.expr),
+                    rhs: Box::new(rhs.expr),
+                },
+                depth: ast_depth,
             };
         }
         Ok(lhs)
     }
 
-    fn prefix(&mut self, depth: usize) -> Result<Expr, ParseError> {
+    fn prefix(&mut self, depth: usize) -> Result<ParsedExpr, ParseError> {
         match self.peek().map(|t| &t.kind) {
             Some(TokKind::Minus) => {
                 self.advance();
                 let expr = self.expr_bp(UNARY_BP, depth + 1)?;
-                Ok(Expr::Unary {
-                    op: UnaryOp::Neg,
-                    expr: Box::new(expr),
+                let ast_depth = expr.depth + 1;
+                self.validate_ast_depth(ast_depth)?;
+                Ok(ParsedExpr {
+                    expr: Expr::Unary {
+                        op: UnaryOp::Neg,
+                        expr: Box::new(expr.expr),
+                    },
+                    depth: ast_depth,
                 })
             }
             Some(TokKind::Plus) => {
                 self.advance();
                 let expr = self.expr_bp(UNARY_BP, depth + 1)?;
-                Ok(Expr::Unary {
-                    op: UnaryOp::Plus,
-                    expr: Box::new(expr),
+                let ast_depth = expr.depth + 1;
+                self.validate_ast_depth(ast_depth)?;
+                Ok(ParsedExpr {
+                    expr: Expr::Unary {
+                        op: UnaryOp::Plus,
+                        expr: Box::new(expr.expr),
+                    },
+                    depth: ast_depth,
                 })
             }
             _ => self.postfix(depth),
@@ -159,27 +185,32 @@ impl Parser<'_> {
     }
 
     /// an atom followed by any number of `%` postfixes.
-    fn postfix(&mut self, depth: usize) -> Result<Expr, ParseError> {
+    fn postfix(&mut self, depth: usize) -> Result<ParsedExpr, ParseError> {
         let mut expr = self.atom(depth)?;
         while matches!(self.peek().map(|t| &t.kind), Some(TokKind::Percent)) {
             self.advance();
-            expr = Expr::Percent(Box::new(expr));
+            let ast_depth = expr.depth + 1;
+            self.validate_ast_depth(ast_depth)?;
+            expr = ParsedExpr {
+                expr: Expr::Percent(Box::new(expr.expr)),
+                depth: ast_depth,
+            };
         }
         Ok(expr)
     }
 
-    fn atom(&mut self, depth: usize) -> Result<Expr, ParseError> {
+    fn atom(&mut self, depth: usize) -> Result<ParsedExpr, ParseError> {
         let pos = self.here();
         let Some(tok) = self.advance() else {
             return Err(ParseError::new(pos, "unexpected end of formula"));
         };
         match tok.kind.clone() {
-            TokKind::Num(n) => Ok(Expr::Number(n)),
-            TokKind::Str(s) => Ok(Expr::Text(s)),
-            TokKind::Bool(b) => Ok(Expr::Bool(b)),
-            TokKind::ErrLit(e) => Ok(Expr::Error(e)),
-            TokKind::Ref { sheet, cell } => Ok(Expr::Ref { sheet, cell }),
-            TokKind::Range { sheet, range } => Ok(Expr::Range { sheet, range }),
+            TokKind::Num(n) => Ok(ParsedExpr::leaf(Expr::Number(n))),
+            TokKind::Str(s) => Ok(ParsedExpr::leaf(Expr::Text(s))),
+            TokKind::Bool(b) => Ok(ParsedExpr::leaf(Expr::Bool(b))),
+            TokKind::ErrLit(e) => Ok(ParsedExpr::leaf(Expr::Error(e))),
+            TokKind::Ref { sheet, cell } => Ok(ParsedExpr::leaf(Expr::Ref { sheet, cell })),
+            TokKind::Range { sheet, range } => Ok(ParsedExpr::leaf(Expr::Range { sheet, range })),
             TokKind::LParen => {
                 let inner = self.expr_bp(0, depth + 1)?;
                 self.expect(&TokKind::RParen, "')'")?;
@@ -191,12 +222,15 @@ impl Parser<'_> {
     }
 
     /// a bare name must be a function call; defined names are not supported.
-    fn func_call(&mut self, name: String, depth: usize) -> Result<Expr, ParseError> {
+    fn func_call(&mut self, name: String, depth: usize) -> Result<ParsedExpr, ParseError> {
         self.expect(&TokKind::LParen, "'(' after function name")?;
         let mut args = Vec::new();
         if matches!(self.peek().map(|t| &t.kind), Some(TokKind::RParen)) {
             self.advance();
-            return Ok(Expr::FuncCall { name, args });
+            return Ok(ParsedExpr::leaf(Expr::FuncCall {
+                name,
+                args: Vec::new(),
+            }));
         }
         loop {
             args.push(self.expr_bp(0, depth + 1)?);
@@ -211,7 +245,23 @@ impl Parser<'_> {
                 _ => return Err(ParseError::new(self.here(), "expected ',' or ')'")),
             }
         }
-        Ok(Expr::FuncCall { name, args })
+        let ast_depth = args.iter().map(|arg| arg.depth).max().unwrap_or(0) + 1;
+        self.validate_ast_depth(ast_depth)?;
+        Ok(ParsedExpr {
+            expr: Expr::FuncCall {
+                name,
+                args: args.into_iter().map(|arg| arg.expr).collect(),
+            },
+            depth: ast_depth,
+        })
+    }
+
+    fn validate_ast_depth(&self, depth: usize) -> Result<(), ParseError> {
+        if depth > MAX_DEPTH {
+            Err(ParseError::new(self.here(), "formula nesting too deep"))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -361,5 +411,29 @@ mod tests {
         let src = format!("{}1{}", "(".repeat(200), ")".repeat(200));
         let err = parse_formula(&src).unwrap_err();
         assert!(err.message.contains("too deep"));
+    }
+
+    #[test]
+    fn rejects_deep_postfix_chain() {
+        let src = format!("1{}", "%".repeat(MAX_DEPTH + 1));
+        assert!(
+            parse_formula(&src)
+                .unwrap_err()
+                .message
+                .contains("too deep")
+        );
+    }
+
+    #[test]
+    fn rejects_deep_left_associative_chain() {
+        let src = std::iter::repeat_n("1", MAX_DEPTH + 1)
+            .collect::<Vec<_>>()
+            .join("+");
+        assert!(
+            parse_formula(&src)
+                .unwrap_err()
+                .message
+                .contains("too deep")
+        );
     }
 }

--- a/crates/xlsx-calc/src/printer.rs
+++ b/crates/xlsx-calc/src/printer.rs
@@ -2,6 +2,7 @@
 //! equivalent ast.
 
 use crate::parser::{BinaryOp, Expr, UnaryOp};
+use xlsx_model::CellRef;
 
 // mirrors the parser's precedence table so parens are emitted only where
 // re-parsing would otherwise change the tree
@@ -41,7 +42,9 @@ fn sheet_prefix(sheet: &Option<String>) -> String {
         Some(name) => {
             let simple = !name.is_empty()
                 && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-                && !name.chars().next().is_some_and(|c| c.is_ascii_digit());
+                && !name.chars().next().is_some_and(|c| c.is_ascii_digit())
+                && CellRef::parse_a1(name).is_err()
+                && !is_r1c1_reference(name);
             if simple {
                 format!("{name}!")
             } else {
@@ -49,6 +52,18 @@ fn sheet_prefix(sheet: &Option<String>) -> String {
             }
         }
     }
+}
+
+fn is_r1c1_reference(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    if matches!(upper.as_str(), "R" | "C") {
+        return true;
+    }
+    let Some(rest) = upper.strip_prefix('R') else {
+        return false;
+    };
+    let digits = rest.bytes().take_while(u8::is_ascii_digit).count();
+    rest.as_bytes().get(digits) == Some(&b'C')
 }
 
 impl Expr {
@@ -132,5 +147,21 @@ mod tests {
         assert_eq!(ast.to_formula(), "(1+2)*3");
         let ast = parse_formula("1+(2*3)").unwrap();
         assert_eq!(ast.to_formula(), "1+2*3");
+    }
+
+    #[test]
+    fn quotes_cell_like_sheet_names() {
+        assert_eq!(parse_formula("'A1'!B2").unwrap().to_formula(), "'A1'!B2");
+        assert_eq!(
+            parse_formula("'R1C1'!B2").unwrap().to_formula(),
+            "'R1C1'!B2"
+        );
+        assert_eq!(parse_formula("'R'!B2").unwrap().to_formula(), "'R'!B2");
+        assert_eq!(parse_formula("'C'!B2").unwrap().to_formula(), "'C'!B2");
+        assert_eq!(parse_formula("'R4C'!B2").unwrap().to_formula(), "'R4C'!B2");
+        assert_eq!(
+            parse_formula("'R1C1b'!B2").unwrap().to_formula(),
+            "'R1C1b'!B2"
+        );
     }
 }

--- a/crates/xlsx-cli/Cargo.toml
+++ b/crates/xlsx-cli/Cargo.toml
@@ -11,8 +11,9 @@ name = "xlsx"
 path = "src/main.rs"
 
 [dependencies]
+betteroffice-xlsx = { path = "../betteroffice-xlsx", features = ["raster"] }
+
+[dev-dependencies]
 ooxml-opc = { path = "../ooxml-opc" }
 xlsx-parse = { path = "../xlsx-parse" }
 xlsx-model = { path = "../xlsx-model" }
-xlsx-render = { path = "../xlsx-render" }
-xlsx-raster = { path = "../xlsx-raster" }

--- a/crates/xlsx-cli/src/lib.rs
+++ b/crates/xlsx-cli/src/lib.rs
@@ -1,42 +1,8 @@
-//! library path behind the `xlsx` binary: load a workbook, resolve a sheet,
-//! rasterize a region to png. every entry point returns `Result<_, String>`.
+//! Library path behind the `xlsx` binary.
 
-use xlsx_model::{CellRange, SheetId, Workbook};
-use xlsx_raster::render_png;
-use xlsx_render::{build_display_list, scaled, viewport_for_range, viewport_for_used_range};
+use betteroffice_xlsx::{SheetId, Workbook};
 
-/// hard cap on either output dimension in pixels; oversized ranges are
-/// rejected before the pixmap is allocated.
-pub const MAX_PIXMAP_DIM: u32 = 16_384;
-
-/// knobs for one render: region (else the sheet's used range), output scale,
-/// and pixel caps that crop the content region.
-#[derive(Debug, Clone)]
-pub struct RenderOptions {
-    pub range: Option<CellRange>,
-    pub scale: f32,
-    pub max_width: Option<u32>,
-    pub max_height: Option<u32>,
-}
-
-impl Default for RenderOptions {
-    fn default() -> Self {
-        Self {
-            range: None,
-            scale: 1.0,
-            max_width: None,
-            max_height: None,
-        }
-    }
-}
-
-/// a rendered frame: the encoded png plus its pixel dimensions.
-#[derive(Debug, Clone)]
-pub struct RenderedPng {
-    pub bytes: Vec<u8>,
-    pub width: u32,
-    pub height: u32,
-}
+pub use betteroffice_xlsx::{MAX_PIXMAP_DIM, RenderOptions, RenderedPng};
 
 /// one-line description of a sheet for the `info` command.
 #[derive(Debug, Clone)]
@@ -48,14 +14,8 @@ pub struct SheetSummary {
     pub cell_count: usize,
 }
 
-/// unzip and parse raw `.xlsx` bytes into a workbook, refusing an empty one.
 pub fn load_workbook(bytes: &[u8]) -> Result<Workbook, String> {
-    let parts = ooxml_opc::unzip_parts(bytes)?;
-    let workbook = xlsx_parse::parse_workbook(&parts).map_err(|e| e.to_string())?;
-    if workbook.sheets.is_empty() {
-        return Err("workbook has no sheets".to_string());
-    }
-    Ok(workbook)
+    Workbook::open_for_read(bytes).map_err(|error| error.to_string())
 }
 
 /// resolve a `--sheet` selector: name match wins, then 0-based index;
@@ -64,74 +24,30 @@ pub fn resolve_sheet(wb: &Workbook, selector: Option<&str>) -> Result<SheetId, S
     let Some(sel) = selector else {
         return Ok(SheetId(0));
     };
-    if let Some((id, _)) = wb.sheet_by_name(sel) {
+    if let Some(id) = wb.sheet_id(sel) {
         return Ok(id);
     }
     if let Ok(idx) = sel.parse::<usize>() {
-        if idx < wb.sheets.len() {
+        if idx < wb.sheet_count() {
             return Ok(SheetId(idx as u32));
         }
         return Err(format!(
             "sheet index {idx} out of range (workbook has {} sheet(s))",
-            wb.sheets.len()
+            wb.sheet_count()
         ));
     }
     Err(format!("no sheet named {sel:?}"))
 }
 
-/// build the display list for the chosen region, scale it, and rasterize to
-/// png; the pixmap-dimension guard runs before anything is allocated.
 pub fn render(wb: &Workbook, sheet: SheetId, opts: &RenderOptions) -> Result<RenderedPng, String> {
-    if !(opts.scale.is_finite() && opts.scale > 0.0) {
-        return Err(format!(
-            "scale must be a positive number, got {}",
-            opts.scale
-        ));
-    }
-
-    let sheet_ref = wb
-        .sheet(sheet)
-        .ok_or_else(|| "sheet index out of range".to_string())?;
-
-    let mut vp = match opts.range {
-        Some(range) => viewport_for_range(sheet_ref, range),
-        None => viewport_for_used_range(sheet_ref),
-    };
-
-    // caps are output pixels, measured after scaling
-    if let Some(w) = opts.max_width {
-        vp.width = vp.width.min(w as f32 / opts.scale);
-    }
-    if let Some(h) = opts.max_height {
-        vp.height = vp.height.min(h as f32 / opts.scale);
-    }
-
-    let out_w = ((vp.width * opts.scale).ceil() as u32).max(1);
-    let out_h = ((vp.height * opts.scale).ceil() as u32).max(1);
-    if out_w > MAX_PIXMAP_DIM || out_h > MAX_PIXMAP_DIM {
-        return Err(format!(
-            "requested render is {out_w}x{out_h}px, exceeds the {MAX_PIXMAP_DIM}px per-side cap; \
-             narrow the range or lower --scale"
-        ));
-    }
-
-    let dl = build_display_list(wb, sheet, &vp);
-    let dl = if opts.scale == 1.0 {
-        dl
-    } else {
-        scaled(dl, opts.scale)
-    };
-    let bytes = render_png(&dl)?;
-    Ok(RenderedPng {
-        bytes,
-        width: out_w,
-        height: out_h,
-    })
+    wb.render_sheet(sheet, opts)
+        .map_err(|error| error.to_string())
 }
 
 /// one summary per sheet, in workbook order.
 pub fn sheet_summaries(wb: &Workbook) -> Vec<SheetSummary> {
-    wb.sheets
+    wb.model()
+        .sheets
         .iter()
         .enumerate()
         .map(|(i, s)| SheetSummary {

--- a/crates/xlsx-cli/src/main.rs
+++ b/crates/xlsx-cli/src/main.rs
@@ -4,8 +4,8 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use betteroffice_xlsx::CellRange;
 use xlsx_cli::{RenderOptions, load_workbook, render, resolve_sheet, sheet_summaries};
-use xlsx_model::CellRange;
 
 const USAGE: &str = "\
 xlsx — headless renderer for OpenOOXML spreadsheets
@@ -132,7 +132,7 @@ fn cmd_info(args: &[String]) -> Result<(), String> {
     let bytes = std::fs::read(&input).map_err(|e| format!("reading {}: {e}", input.display()))?;
     let wb = load_workbook(&bytes)?;
 
-    println!("{}: {} sheet(s)", input.display(), wb.sheets.len());
+    println!("{}: {} sheet(s)", input.display(), wb.sheet_count());
     for s in sheet_summaries(&wb) {
         let range = s.used_range.as_deref().unwrap_or("(empty)");
         println!(

--- a/crates/xlsx-model/src/workbook.rs
+++ b/crates/xlsx-model/src/workbook.rs
@@ -1,6 +1,7 @@
 //! sparse workbook containers and the calc-facing cell-access trait.
 
 use std::collections::BTreeMap;
+use std::ops::Range;
 
 use crate::addr::{CellRange, CellRef, ColId, RowId, SheetId};
 use crate::date::DateSystem;
@@ -52,6 +53,20 @@ impl Sheet {
             .map(|(&(row, col), cell)| (CellRef::new(row, col), cell))
     }
 
+    pub fn iter_cells_in_rect(
+        &self,
+        rows: Range<RowId>,
+        cols: Range<ColId>,
+    ) -> impl Iterator<Item = (CellRef, &Cell)> {
+        let start_col = cols.start;
+        let end_col = cols.end.max(start_col);
+        rows.flat_map(move |row| {
+            self.cells
+                .range((row, start_col)..(row, end_col))
+                .map(|(&(row, col), cell)| (CellRef::new(row, col), cell))
+        })
+    }
+
     pub fn used_range(&self) -> Option<CellRange> {
         let mut it = self.cells.keys();
         let &(r0, c0) = it.next()?;
@@ -89,10 +104,11 @@ impl Workbook {
     }
 
     pub fn sheet_by_name(&self, name: &str) -> Option<(SheetId, &Sheet)> {
+        let name = name.to_lowercase();
         self.sheets
             .iter()
             .enumerate()
-            .find(|(_, s)| s.name == name)
+            .find(|(_, sheet)| sheet.name.to_lowercase() == name)
             .map(|(i, s)| (SheetId(i as u32), s))
     }
 }
@@ -169,6 +185,7 @@ mod tests {
         );
 
         let id = wb.sheet_id("Data").unwrap();
+        assert_eq!(wb.sheet_id("data"), Some(id));
         assert_eq!(wb.value(id, a1), CellValue::Number { value: 42.0 });
         assert_eq!(wb.formula(id, a1), Some("40+2"));
         assert_eq!(
@@ -176,5 +193,27 @@ mod tests {
             CellValue::Empty
         );
         assert!(wb.sheet_id("Nope").is_none());
+    }
+
+    #[test]
+    fn iterates_only_cells_in_rectangle() {
+        let mut sheet = Sheet::new("Data");
+        for address in ["A1", "B2", "C3", "Z100"] {
+            sheet.set_cell(
+                CellRef::parse_a1(address).unwrap(),
+                Cell {
+                    value: CellValue::Number { value: 1.0 },
+                    ..Cell::default()
+                },
+            );
+        }
+        let cells: Vec<_> = sheet
+            .iter_cells_in_rect(0..3, 0..2)
+            .map(|(cell, _)| cell.to_a1())
+            .collect();
+        assert_eq!(cells, vec!["A1", "B2"]);
+        let mut reversed = 1..2;
+        std::mem::swap(&mut reversed.start, &mut reversed.end);
+        assert_eq!(sheet.iter_cells_in_rect(0..3, reversed).count(), 0);
     }
 }

--- a/crates/xlsx-ops/src/apply.rs
+++ b/crates/xlsx-ops/src/apply.rs
@@ -8,7 +8,7 @@ use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
 use xlsx_model::{Cell, CellRange, CellRef, ColId, RowId, Sheet, SheetId, Workbook};
 
 use crate::op::{CellState, Op};
-use crate::remap::remap_formulas;
+use crate::remap::{remap_formulas, rename_sheet_references};
 
 /// the inverse of an applied op: a base-vocabulary op list that, replayed in
 /// order, restores the prior workbook state.
@@ -19,6 +19,7 @@ pub struct InvertedOp(pub Vec<Op>);
 pub enum OpError {
     SheetNotFound(SheetId),
     SheetIndexOutOfRange(usize),
+    FormulaNotRewritable { sheet: SheetId, cell: CellRef },
 }
 
 impl fmt::Display for OpError {
@@ -26,6 +27,12 @@ impl fmt::Display for OpError {
         match self {
             OpError::SheetNotFound(id) => write!(f, "sheet {} not found", id.0),
             OpError::SheetIndexOutOfRange(i) => write!(f, "sheet index {i} out of range"),
+            OpError::FormulaNotRewritable { sheet, cell } => write!(
+                f,
+                "formula at sheet {}, {} cannot be safely rewritten",
+                sheet.0,
+                cell.to_a1()
+            ),
         }
     }
 }
@@ -110,11 +117,48 @@ pub fn apply(wb: &mut Workbook, op: &Op) -> Result<InvertedOp, OpError> {
         }
         Op::RemoveSheet { index } => remove_sheet(wb, *index),
         Op::RenameSheet { sheet, name } => {
-            let s = sheet_mut(wb, *sheet)?;
-            let old = std::mem::replace(&mut s.name, name.clone());
-            Ok(InvertedOp(vec![Op::RenameSheet {
+            let old = wb
+                .sheet(*sheet)
+                .ok_or(OpError::SheetNotFound(*sheet))?
+                .name
+                .clone();
+            let formulas = rename_sheet_references(wb, &old, name)?;
+            sheet_mut(wb, *sheet)?.name = name.clone();
+            Ok(InvertedOp(vec![Op::RestoreSheet {
                 sheet: *sheet,
                 name: old,
+                formulas,
+            }]))
+        }
+        Op::RestoreSheet {
+            sheet,
+            name,
+            formulas,
+        } => {
+            let old_name = wb
+                .sheet(*sheet)
+                .ok_or(OpError::SheetNotFound(*sheet))?
+                .name
+                .clone();
+            let mut old_formulas = Vec::with_capacity(formulas.len());
+            for (formula_sheet, cell, _) in formulas {
+                let sheet_ref = wb
+                    .sheet(*formula_sheet)
+                    .ok_or(OpError::SheetNotFound(*formula_sheet))?;
+                let state = sheet_ref
+                    .cell(*cell)
+                    .map(CellState::from)
+                    .unwrap_or_default();
+                old_formulas.push((*formula_sheet, *cell, state));
+            }
+            sheet_mut(wb, *sheet)?.name = name.clone();
+            for (formula_sheet, cell, state) in formulas {
+                sheet_mut(wb, *formula_sheet)?.set_cell(*cell, state.clone().into());
+            }
+            Ok(InvertedOp(vec![Op::RestoreSheet {
+                sheet: *sheet,
+                name: old_name,
+                formulas: old_formulas,
             }]))
         }
         Op::InsertRows { sheet, at, count } => insert_rows(wb, *sheet, *at, *count, op),
@@ -127,6 +171,13 @@ pub fn apply(wb: &mut Workbook, op: &Op) -> Result<InvertedOp, OpError> {
 /// apply a sequence of ops, returning the combined inverse (per-op inverses
 /// concatenated in reverse order).
 pub fn apply_ops(wb: &mut Workbook, ops: &[Op]) -> Result<Vec<Op>, OpError> {
+    let mut next = wb.clone();
+    let inverse = apply_ops_in_place(&mut next, ops)?;
+    *wb = next;
+    Ok(inverse)
+}
+
+fn apply_ops_in_place(wb: &mut Workbook, ops: &[Op]) -> Result<Vec<Op>, OpError> {
     let mut per_op: Vec<Vec<Op>> = Vec::with_capacity(ops.len());
     for op in ops {
         per_op.push(apply(wb, op)?.0);
@@ -204,7 +255,7 @@ fn insert_rows(
     count: u32,
     op: &Op,
 ) -> Result<InvertedOp, OpError> {
-    let restores = remap_formulas(wb, op);
+    let restores = remap_formulas(wb, op)?;
     let s = sheet_mut(wb, sheet)?;
     let dropped = shift_cells(s, op);
     shift_row_heights_up(s, at, count);
@@ -229,7 +280,7 @@ fn delete_rows(
     count: u32,
     op: &Op,
 ) -> Result<InvertedOp, OpError> {
-    let restores = remap_formulas(wb, op);
+    let restores = remap_formulas(wb, op)?;
     let s = sheet_mut(wb, sheet)?;
     let deleted = shift_cells(s, op);
     let dropped_heights = shift_row_heights_down(s, at, count);
@@ -264,7 +315,7 @@ fn insert_cols(
     count: u32,
     op: &Op,
 ) -> Result<InvertedOp, OpError> {
-    let restores = remap_formulas(wb, op);
+    let restores = remap_formulas(wb, op)?;
     let s = sheet_mut(wb, sheet)?;
     let dropped = shift_cells(s, op);
     shift_col_widths_up(s, at, count);
@@ -289,7 +340,7 @@ fn delete_cols(
     count: u32,
     op: &Op,
 ) -> Result<InvertedOp, OpError> {
-    let restores = remap_formulas(wb, op);
+    let restores = remap_formulas(wb, op)?;
     let s = sheet_mut(wb, sheet)?;
     let deleted = shift_cells(s, op);
     let dropped_widths = shift_col_widths_down(s, at, count);
@@ -741,19 +792,96 @@ mod tests {
     #[test]
     fn rename_sheet_round_trip() {
         let mut wb = wb_one_sheet();
+        wb.sheets.push(Sheet::new("Formula"));
+        wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+            r("A1"),
+            Cell {
+                formula: Some("Future!A1+Sheet1!A1".into()),
+                ..Cell::default()
+            },
+        );
         let inv = apply(
             &mut wb,
             &Op::RenameSheet {
                 sheet: SheetId(0),
-                name: "Renamed".into(),
+                name: "Future".into(),
             },
         )
         .unwrap();
-        assert_eq!(wb.sheets[0].name, "Renamed");
-        for iop in &inv.0 {
-            apply(&mut wb, iop).unwrap();
-        }
+        assert_eq!(wb.sheets[0].name, "Future");
+        assert_eq!(wb.formula(SheetId(1), r("A1")), Some("Future!A1+Future!A1"));
+        let redo = apply_ops(&mut wb, &inv.0).unwrap();
         assert_eq!(wb.sheets[0].name, "Sheet1");
+        assert_eq!(wb.formula(SheetId(1), r("A1")), Some("Future!A1+Sheet1!A1"));
+        apply_ops(&mut wb, &redo).unwrap();
+        assert_eq!(wb.sheets[0].name, "Future");
+        assert_eq!(wb.formula(SheetId(1), r("A1")), Some("Future!A1+Future!A1"));
+    }
+
+    #[test]
+    fn rename_undo_does_not_change_destination_only_references() {
+        let mut wb = wb_one_sheet();
+        wb.sheets.push(Sheet::new("Formula"));
+        wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+            r("A1"),
+            Cell {
+                formula: Some("Future!A1".into()),
+                ..Cell::default()
+            },
+        );
+        wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+            r("A2"),
+            Cell {
+                formula: Some("Sheet1!A1".into()),
+                ..Cell::default()
+            },
+        );
+
+        let inverse = apply(
+            &mut wb,
+            &Op::RenameSheet {
+                sheet: SheetId(0),
+                name: "Future".into(),
+            },
+        )
+        .unwrap();
+        match &inverse.0[0] {
+            Op::RestoreSheet { formulas, .. } => assert_eq!(formulas.len(), 1),
+            other => panic!("expected restore sheet inverse, got {other:?}"),
+        }
+        apply_ops(&mut wb, &inverse.0).unwrap();
+
+        assert_eq!(wb.formula(SheetId(1), r("A1")), Some("Future!A1"));
+        assert_eq!(wb.formula(SheetId(1), r("A2")), Some("Sheet1!A1"));
+    }
+
+    #[test]
+    fn rename_history_stays_constant_across_undo_redo() {
+        let mut wb = wb_one_sheet();
+        wb.sheets.push(Sheet::new("Formula"));
+        wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+            r("A1"),
+            Cell {
+                formula: Some("Sheet1!A1".into()),
+                ..Cell::default()
+            },
+        );
+        let inverse = apply(
+            &mut wb,
+            &Op::RenameSheet {
+                sheet: SheetId(0),
+                name: "Future".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(inverse.0.len(), 1);
+        let json = serde_json::to_string(&inverse.0).unwrap();
+        let decoded: Vec<Op> = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, inverse.0);
+        let redo = apply_ops(&mut wb, &inverse.0).unwrap();
+        assert_eq!(redo.len(), 1);
+        let undo = apply_ops(&mut wb, &redo).unwrap();
+        assert_eq!(undo.len(), 1);
     }
 
     #[test]
@@ -768,5 +896,32 @@ mod tests {
             },
         );
         assert_eq!(err.unwrap_err(), OpError::SheetNotFound(SheetId(3)));
+    }
+
+    #[test]
+    fn apply_ops_is_atomic_when_formula_rewriting_fails() {
+        let mut wb = wb_one_sheet();
+        let before = wb.clone();
+        let error = apply_ops(
+            &mut wb,
+            &[
+                Op::SetCell {
+                    sheet: SheetId(0),
+                    at: r("A1"),
+                    cell: CellState {
+                        formula: Some("SUM(".into()),
+                        ..CellState::default()
+                    },
+                },
+                Op::InsertRows {
+                    sheet: SheetId(0),
+                    at: 0,
+                    count: 1,
+                },
+            ],
+        )
+        .unwrap_err();
+        assert!(matches!(error, OpError::FormulaNotRewritable { .. }));
+        assert_eq!(wb, before);
     }
 }

--- a/crates/xlsx-ops/src/op.rs
+++ b/crates/xlsx-ops/src/op.rs
@@ -105,6 +105,12 @@ pub enum Op {
         sheet: SheetId,
         name: String,
     },
+    #[doc(hidden)]
+    RestoreSheet {
+        sheet: SheetId,
+        name: String,
+        formulas: Vec<(SheetId, CellRef, CellState)>,
+    },
 }
 
 /// who authored a transaction.

--- a/crates/xlsx-ops/src/proposals.rs
+++ b/crates/xlsx-ops/src/proposals.rs
@@ -3,6 +3,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::CellState;
+
 /// one cell edit inside a proposal. `input` is the raw editor string re-applied
 /// on accept and stays off the wire; `old_text`/`new_text` are display texts.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -13,6 +15,8 @@ pub struct ProposedEdit {
     pub col: u32,
     #[serde(skip)]
     pub input: String,
+    #[serde(skip)]
+    pub old_state: CellState,
     pub a1: String,
     pub old_text: String,
     pub new_text: String,
@@ -67,6 +71,10 @@ impl ProposalSet {
         self.proposals.retain(|p| p.id != id);
         before != self.proposals.len()
     }
+
+    pub fn clear(&mut self) {
+        self.proposals.clear();
+    }
 }
 
 #[cfg(test)]
@@ -79,6 +87,7 @@ mod tests {
             row: 0,
             col: 0,
             input: new.to_string(),
+            old_state: CellState::default(),
             a1: a1.to_string(),
             old_text: old.to_string(),
             new_text: new.to_string(),

--- a/crates/xlsx-ops/src/remap.rs
+++ b/crates/xlsx-ops/src/remap.rs
@@ -3,10 +3,12 @@
 
 use std::collections::HashMap;
 
+use xlsx_calc::lexer::MAX_FORMULA_BYTES;
 use xlsx_calc::parse_formula;
 use xlsx_calc::parser::Expr;
 use xlsx_model::{CellRange, CellRef, ErrorValue, SheetId, Workbook};
 
+use crate::apply::OpError;
 use crate::apply::remap_ref;
 use crate::op::{CellState, Op};
 
@@ -33,15 +35,15 @@ fn structural_target(op: &Op) -> Option<SheetId> {
 
 /// rewrite every workbook formula affected by `op`, in place, returning the
 /// inverse `SetCell` ops that restore the rewritten formulas.
-pub(crate) fn remap_formulas(wb: &mut Workbook, op: &Op) -> Vec<Op> {
+pub(crate) fn remap_formulas(wb: &mut Workbook, op: &Op) -> Result<Vec<Op>, OpError> {
     let Some(target) = structural_target(op) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let names: HashMap<String, SheetId> = wb
         .sheets
         .iter()
         .enumerate()
-        .map(|(i, s)| (s.name.clone(), SheetId(i as u32)))
+        .map(|(i, s)| (s.name.to_lowercase(), SheetId(i as u32)))
         .collect();
 
     let mut restores: Vec<Op> = Vec::new();
@@ -54,18 +56,20 @@ pub(crate) fn remap_formulas(wb: &mut Workbook, op: &Op) -> Vec<Op> {
             let Some(src) = &c.formula else {
                 continue;
             };
-            let Ok(expr) = parse_formula(src) else {
-                continue;
-            };
+            let expr = parse_formula(src)
+                .map_err(|_| OpError::FormulaNotRewritable { sheet: owner, cell })?;
             let mut changed = false;
             let new_expr = transform(&expr, op, &matches, &mut changed);
             if changed {
+                let formula = new_expr.to_formula();
+                parse_formula(&formula)
+                    .map_err(|_| OpError::FormulaNotRewritable { sheet: owner, cell })?;
                 restores.push(Op::SetCell {
                     sheet: owner,
                     at: cell,
                     cell: CellState::from(c),
                 });
-                edits.push((owner, cell, new_expr.to_formula()));
+                edits.push((owner, cell, formula));
             }
         }
     }
@@ -77,7 +81,252 @@ pub(crate) fn remap_formulas(wb: &mut Workbook, op: &Op) -> Vec<Op> {
             s.set_cell(at, cell);
         }
     }
-    restores
+    Ok(restores)
+}
+
+pub(crate) fn rename_sheet_references(
+    wb: &mut Workbook,
+    old_name: &str,
+    new_name: &str,
+) -> Result<Vec<(SheetId, CellRef, CellState)>, OpError> {
+    let mut restores = Vec::new();
+    let mut edits = Vec::new();
+    for (index, sheet) in wb.sheets.iter().enumerate() {
+        let owner = SheetId(index as u32);
+        for (cell, stored) in sheet.iter_cells() {
+            let Some(source) = &stored.formula else {
+                continue;
+            };
+            let rewritten = rename_formula_sheet(source, old_name, new_name);
+            if rewritten != *source {
+                if rewritten.len() > MAX_FORMULA_BYTES {
+                    return Err(OpError::FormulaNotRewritable { sheet: owner, cell });
+                }
+                restores.push((owner, cell, CellState::from(stored)));
+                edits.push((owner, cell, rewritten));
+            }
+        }
+    }
+    for (sheet, cell, formula) in edits {
+        let stored = wb
+            .sheet_mut(sheet)
+            .and_then(|sheet| sheet.cell(cell).cloned());
+        if let Some(mut stored) = stored {
+            stored.formula = Some(formula);
+            wb.sheet_mut(sheet)
+                .expect("sheet exists")
+                .set_cell(cell, stored);
+        }
+    }
+    Ok(restores)
+}
+
+fn rename_formula_sheet(source: &str, old_name: &str, new_name: &str) -> String {
+    if old_name == new_name {
+        return source.to_string();
+    }
+    let bytes = source.as_bytes();
+    let mut replacements = Vec::new();
+    let mut index = 0;
+    let mut bracket_depth = 0_u32;
+    while index < bytes.len() {
+        if bytes[index] == b'"' {
+            index = skip_string(source, index);
+            continue;
+        }
+        if bytes[index] == b'[' {
+            bracket_depth = bracket_depth.saturating_add(1);
+            index += 1;
+            continue;
+        }
+        if bytes[index] == b']' {
+            bracket_depth = bracket_depth.saturating_sub(1);
+            index += 1;
+            continue;
+        }
+        if bracket_depth != 0 {
+            index += source[index..]
+                .chars()
+                .next()
+                .map(char::len_utf8)
+                .unwrap_or(1);
+            continue;
+        }
+        let Some(first) = parse_sheet_token(source, index) else {
+            index += source[index..]
+                .chars()
+                .next()
+                .map(char::len_utf8)
+                .unwrap_or(1);
+            continue;
+        };
+        let external = first.start > 0 && bytes[first.start - 1] == b']';
+        if bytes.get(first.end) == Some(&b'!') {
+            if !external && sheet_names_equal(&first.name, old_name) {
+                replacements.push((first.start, first.end));
+            }
+            index = first.end + 1;
+            continue;
+        }
+        if bytes.get(first.end) == Some(&b':')
+            && let Some(second) = parse_sheet_token(source, first.end + 1)
+            && bytes.get(second.end) == Some(&b'!')
+        {
+            if !external && sheet_names_equal(&first.name, old_name) {
+                replacements.push((first.start, first.end));
+            }
+            if !external && sheet_names_equal(&second.name, old_name) {
+                replacements.push((second.start, second.end));
+            }
+            index = second.end + 1;
+            continue;
+        }
+        index = first.end;
+    }
+    if replacements.is_empty() {
+        return source.to_string();
+    }
+    let replacement = sheet_token(new_name);
+    let mut output = String::with_capacity(source.len());
+    let mut copied_until = 0;
+    for (start, end) in replacements {
+        output.push_str(&source[copied_until..start]);
+        output.push_str(&replacement);
+        copied_until = end;
+    }
+    output.push_str(&source[copied_until..]);
+    output
+}
+
+struct ParsedSheetToken {
+    start: usize,
+    end: usize,
+    name: String,
+}
+
+fn parse_sheet_token(source: &str, start: usize) -> Option<ParsedSheetToken> {
+    let bytes = source.as_bytes();
+    if bytes.get(start) == Some(&b'\'') {
+        let mut index = start + 1;
+        let mut name = String::new();
+        while index < bytes.len() {
+            if bytes[index] == b'\'' {
+                if bytes.get(index + 1) == Some(&b'\'') {
+                    name.push('\'');
+                    index += 2;
+                } else {
+                    return Some(ParsedSheetToken {
+                        start,
+                        end: index + 1,
+                        name,
+                    });
+                }
+            } else {
+                let character = source[index..].chars().next()?;
+                name.push(character);
+                index += character.len_utf8();
+            }
+        }
+        return None;
+    }
+    let first = source[start..].chars().next()?;
+    if !is_unquoted_sheet_char(first) {
+        return None;
+    }
+    let mut end = start;
+    while end < bytes.len() {
+        let character = source[end..].chars().next()?;
+        if !is_unquoted_sheet_char(character) {
+            break;
+        }
+        end += character.len_utf8();
+    }
+    Some(ParsedSheetToken {
+        start,
+        end,
+        name: source[start..end].to_string(),
+    })
+}
+
+fn skip_string(source: &str, start: usize) -> usize {
+    let bytes = source.as_bytes();
+    let mut index = start + 1;
+    while index < bytes.len() {
+        if bytes[index] == b'"' {
+            index += 1;
+            if bytes.get(index) == Some(&b'"') {
+                index += 1;
+            } else {
+                break;
+            }
+        } else {
+            index += source[index..]
+                .chars()
+                .next()
+                .map(char::len_utf8)
+                .unwrap_or(1);
+        }
+    }
+    index
+}
+
+fn sheet_names_equal(left: &str, right: &str) -> bool {
+    left.to_lowercase() == right.to_lowercase()
+}
+
+fn is_unquoted_sheet_char(character: char) -> bool {
+    !character.is_whitespace()
+        && !matches!(
+            character,
+            '"' | '\''
+                | '!'
+                | ':'
+                | '+'
+                | '-'
+                | '*'
+                | '/'
+                | '^'
+                | '&'
+                | '='
+                | '<'
+                | '>'
+                | '('
+                | ')'
+                | ','
+                | '%'
+                | '['
+                | ']'
+        )
+}
+
+fn sheet_token(name: &str) -> String {
+    let simple = !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+        && !name
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_digit())
+        && CellRef::parse_a1(name).is_err()
+        && !is_r1c1_reference(name);
+    if simple {
+        name.to_string()
+    } else {
+        format!("'{}'", name.replace('\'', "''"))
+    }
+}
+
+fn is_r1c1_reference(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    if matches!(upper.as_str(), "R" | "C") {
+        return true;
+    }
+    let Some(rest) = upper.strip_prefix('R') else {
+        return false;
+    };
+    let digits = rest.bytes().take_while(u8::is_ascii_digit).count();
+    rest.as_bytes().get(digits) == Some(&b'C')
 }
 
 /// whether a reference read from `owner` points at the edited sheet `target`.
@@ -90,7 +339,7 @@ fn resolves_to_target(
 ) -> bool {
     let resolved = match ref_sheet {
         None => Some(owner),
-        Some(name) => names.get(name).copied(),
+        Some(name) => names.get(&name.to_lowercase()).copied(),
     };
     resolved == Some(target)
 }
@@ -276,7 +525,7 @@ mod tests {
             at: 2,
             count: 3,
         };
-        let inv = remap_formulas(&mut w, &op);
+        let inv = remap_formulas(&mut w, &op).unwrap();
         assert_eq!(formula(&w, SheetId(0), "B1").as_deref(), Some("A8+1"));
         assert_eq!(inv.len(), 1);
     }
@@ -290,7 +539,7 @@ mod tests {
             at: 2,
             count: 1,
         };
-        remap_formulas(&mut w, &op);
+        remap_formulas(&mut w, &op).unwrap();
         assert_eq!(formula(&w, SheetId(0), "C1").as_deref(), Some("SUM(A1:A9)"));
     }
 
@@ -303,7 +552,7 @@ mod tests {
             at: 4,
             count: 1,
         };
-        remap_formulas(&mut w, &op);
+        remap_formulas(&mut w, &op).unwrap();
         assert_eq!(formula(&w, SheetId(0), "B1").as_deref(), Some("#REF!*2"));
     }
 
@@ -316,7 +565,7 @@ mod tests {
             at: 4,
             count: 3,
         };
-        remap_formulas(&mut w, &op);
+        remap_formulas(&mut w, &op).unwrap();
         assert_eq!(formula(&w, SheetId(0), "B1").as_deref(), Some("SUM(#REF!)"));
     }
 
@@ -329,7 +578,7 @@ mod tests {
             at: 0,
             count: 2,
         };
-        remap_formulas(&mut w, &op);
+        remap_formulas(&mut w, &op).unwrap();
         assert_eq!(formula(&w, SheetId(0), "B1").as_deref(), Some("$A$7+1"));
     }
 
@@ -342,10 +591,29 @@ mod tests {
             at: 0,
             count: 1,
         };
-        remap_formulas(&mut w, &op);
+        remap_formulas(&mut w, &op).unwrap();
         assert_eq!(
             formula(&w, SheetId(1), "A1").as_deref(),
             Some("Sheet1!A4+1")
+        );
+    }
+
+    #[test]
+    fn structural_rewrite_keeps_cell_like_sheet_name_quoted() {
+        let mut workbook = wb(&["A1", "Formula"]);
+        set_formula(&mut workbook, SheetId(1), "A1", "'A1'!A1");
+        remap_formulas(
+            &mut workbook,
+            &Op::InsertRows {
+                sheet: SheetId(0),
+                at: 0,
+                count: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            formula(&workbook, SheetId(1), "A1").as_deref(),
+            Some("'A1'!A2")
         );
     }
 
@@ -358,13 +626,13 @@ mod tests {
             at: 0,
             count: 1,
         };
-        let inv = remap_formulas(&mut w, &op);
+        let inv = remap_formulas(&mut w, &op).unwrap();
         assert_eq!(formula(&w, SheetId(1), "A1").as_deref(), Some("A5+1"));
         assert!(inv.is_empty(), "no formula changed, no inverse");
     }
 
     #[test]
-    fn unparseable_formula_left_verbatim() {
+    fn unparseable_formula_rejects_structural_rewrite() {
         let mut w = wb(&["Sheet1"]);
         set_formula(&mut w, SheetId(0), "B1", "SUM(");
         let op = Op::InsertRows {
@@ -372,9 +640,66 @@ mod tests {
             at: 0,
             count: 1,
         };
-        let inv = remap_formulas(&mut w, &op);
+        let error = remap_formulas(&mut w, &op).unwrap_err();
         assert_eq!(formula(&w, SheetId(0), "B1").as_deref(), Some("SUM("));
-        assert!(inv.is_empty());
+        assert_eq!(
+            error,
+            OpError::FormulaNotRewritable {
+                sheet: SheetId(0),
+                cell: r("B1")
+            }
+        );
+    }
+
+    #[test]
+    fn rename_preserves_formula_source_and_unsupported_syntax() {
+        let source = " SUM( Sheet1!A:A , \"Sheet1!A1\", 'SHEET1'!B2 ) ";
+        assert_eq!(
+            rename_formula_sheet(source, "Sheet1", "New Name"),
+            " SUM( 'New Name'!A:A , \"Sheet1!A1\", 'New Name'!B2 ) "
+        );
+    }
+
+    #[test]
+    fn rename_escapes_quotes_in_new_sheet_name() {
+        assert_eq!(
+            rename_formula_sheet("Sheet1!A1", "Sheet1", "Owner's Data"),
+            "'Owner''s Data'!A1"
+        );
+    }
+
+    #[test]
+    fn rename_handles_3d_refs_without_touching_external_or_structured_refs() {
+        let source = "Sheet1:Sheet3!A1+[Book.xlsx]Sheet1!A1+Table1[Sheet1!Column]+Sheet1!A1";
+        assert_eq!(
+            rename_formula_sheet(source, "Sheet1", "Renamed"),
+            "Renamed:Sheet3!A1+[Book.xlsx]Sheet1!A1+Table1[Sheet1!Column]+Renamed!A1"
+        );
+    }
+
+    #[test]
+    fn rename_rejects_formula_growth_past_the_length_cap() {
+        let mut workbook = wb(&["S", "Formula"]);
+        set_formula(&mut workbook, SheetId(1), "A1", "S!A1");
+        let original = workbook.clone();
+        let error = rename_sheet_references(&mut workbook, "S", &"x".repeat(MAX_FORMULA_BYTES))
+            .unwrap_err();
+        assert!(matches!(error, OpError::FormulaNotRewritable { .. }));
+        assert_eq!(workbook, original);
+    }
+
+    #[test]
+    fn rename_quotes_cell_like_names_and_matches_unicode_sources() {
+        assert_eq!(rename_formula_sheet("S!A1", "S", "A1"), "'A1'!A1");
+        assert_eq!(
+            rename_formula_sheet("École1!A1", "École1", "Classe"),
+            "Classe!A1"
+        );
+        assert_eq!(
+            rename_formula_sheet("Sheet😀!A1", "Sheet😀", "Renamed"),
+            "Renamed!A1"
+        );
+        assert_eq!(rename_formula_sheet("S!A1", "S", "R4C"), "'R4C'!A1");
     }
 
     #[test]

--- a/crates/xlsx-ops/src/undo.rs
+++ b/crates/xlsx-ops/src/undo.rs
@@ -36,20 +36,22 @@ impl UndoStack {
 
     /// reverse the most recent transaction, returning the ops applied.
     pub fn undo(&mut self, wb: &mut Workbook) -> Result<Option<Vec<Op>>, OpError> {
-        let Some(ops) = self.undo.pop() else {
+        let Some(ops) = self.undo.last().cloned() else {
             return Ok(None);
         };
         let redo_inverse = apply_ops(wb, &ops)?;
+        self.undo.pop();
         self.redo.push(redo_inverse);
         Ok(Some(ops))
     }
 
     /// re-apply the most recently undone transaction.
     pub fn redo(&mut self, wb: &mut Workbook) -> Result<Option<Vec<Op>>, OpError> {
-        let Some(ops) = self.redo.pop() else {
+        let Some(ops) = self.redo.last().cloned() else {
             return Ok(None);
         };
         let undo_inverse = apply_ops(wb, &ops)?;
+        self.redo.pop();
         self.undo.push(undo_inverse);
         Ok(Some(ops))
     }
@@ -146,5 +148,24 @@ mod tests {
         let mut stack = UndoStack::new();
         assert_eq!(stack.undo(&mut wb).unwrap(), None);
         assert_eq!(stack.redo(&mut wb).unwrap(), None);
+    }
+
+    #[test]
+    fn failed_undo_keeps_history_and_workbook_state() {
+        let mut wb = Workbook::default();
+        wb.sheets.push(Sheet::new("Sheet1"));
+        let before = wb.clone();
+        let mut stack = UndoStack::new();
+        stack.undo.push(vec![
+            set("A1", 1.0),
+            Op::SetCell {
+                sheet: SheetId(9),
+                at: r("A1"),
+                cell: CellState::default(),
+            },
+        ]);
+        assert!(stack.undo(&mut wb).is_err());
+        assert!(stack.can_undo());
+        assert_eq!(wb, before);
     }
 }

--- a/crates/xlsx-render/src/lib.rs
+++ b/crates/xlsx-render/src/lib.rs
@@ -199,15 +199,12 @@ fn visible_anchors<'a>(
     rows: &'a std::ops::Range<u32>,
     cols: &'a std::ops::Range<u32>,
 ) -> impl Iterator<Item = (CellRef, &'a xlsx_model::Cell)> {
-    sheet.iter_cells().filter(move |(at, _)| {
-        if !rows.contains(&at.row) || !cols.contains(&at.col) {
-            return false;
-        }
-        match covering_merge(&sheet.merges, *at) {
+    sheet.iter_cells_in_rect(rows.clone(), cols.clone()).filter(
+        move |(at, _)| match covering_merge(&sheet.merges, *at) {
             Some(m) => m.start == *at,
             None => true,
-        }
-    })
+        },
+    )
 }
 
 /// the merge (if any) that covers a cell.

--- a/crates/xlsx-wasm/Cargo.toml
+++ b/crates/xlsx-wasm/Cargo.toml
@@ -11,17 +11,16 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["raster"]
-raster = ["dep:xlsx-raster"]
+raster = ["betteroffice-xlsx/raster"]
 
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+betteroffice-xlsx = { path = "../betteroffice-xlsx", default-features = false }
+
+[dev-dependencies]
 ooxml-opc = { path = "../ooxml-opc" }
 xlsx-model = { path = "../xlsx-model" }
 xlsx-parse = { path = "../xlsx-parse" }
-xlsx-calc = { path = "../xlsx-calc" }
-xlsx-ops = { path = "../xlsx-ops" }
-xlsx-render = { path = "../xlsx-render" }
-xlsx-raster = { path = "../xlsx-raster", optional = true }

--- a/crates/xlsx-wasm/src/core.rs
+++ b/crates/xlsx-wasm/src/core.rs
@@ -1,33 +1,16 @@
-//! pure core behind the wasm boundary: `&str`/`&[u8]` in, `Result<_, String>` out.
-//! native tests call these fns directly, never the wasm wrappers (JsValue aborts).
-
-use std::collections::HashSet;
-
+#[cfg(feature = "raster")]
+use betteroffice_xlsx::RenderOptions;
+use betteroffice_xlsx::{
+    CalculationOptions, CellAddress, CellInput as WorkbookCellInput, CellRange, CellRef,
+    MutationResult, Op, Proposal, ProposalEditInput as WorkbookProposalEditInput, ProposalRequest,
+    SheetId, Viewport, Workbook,
+};
 use serde::{Deserialize, Serialize};
 
-use xlsx_calc::graph::DepGraph;
-use xlsx_calc::{RecalcResult, rebuild_and_recalc_all, recalc_after};
-use xlsx_model::{CellRange, CellRef, CellValue, SheetId, Workbook};
-use xlsx_ops::{
-    CellState, Op, Proposal, ProposalSet, ProposedEdit, Provenance, Transaction, UndoStack,
-    cell_state_for_input_no_eval,
-};
-use xlsx_render::{GridGeometry, Viewport, build_display_list, display_text};
-
-/// cap on the cells one `range_cells_json` call may materialize.
-const MAX_RANGE_CELLS: u64 = 100_000;
-
-/// an open workbook, the active sheet, edit history, dependency graph, and
-/// pending proposals; one per `XlsxDocument` handed to js.
 pub struct Session {
     workbook: Workbook,
-    sheet: SheetId,
-    undo: UndoStack,
-    graph: DepGraph,
-    proposals: ProposalSet,
 }
 
-/// chrome data: sheet tabs plus the active sheet's scrollable extent.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SheetInfo {
@@ -76,17 +59,21 @@ struct RangeArgs {
     range: String,
 }
 
-/// mutation result: applied flag, refreshed extent, and the a1 addresses of
-/// other cells changed via recalc (`Sheet!A1`-prefixed off the active sheet).
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct EditResult {
     applied: bool,
     sheet_info: SheetInfo,
     changed: Vec<String>,
+    limited_cells: Vec<String>,
 }
 
-/// editable view of one cell: a1 address, exact editor string, formula flag.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CalculationStatus {
+    limited_cells: Vec<String>,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CellEdit {
@@ -130,538 +117,315 @@ struct IdArgs {
     id: String,
 }
 
-/// wire form of `list_proposals_json`.
 #[derive(Serialize)]
 struct ProposalList<'a> {
     proposals: &'a [Proposal],
 }
 
-/// `reject_proposal_json`'s reply.
 #[derive(Serialize)]
 struct RejectResult {
     removed: bool,
 }
 
-/// `accept_proposal_json`'s reply: the edit envelope plus the proposal id.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AcceptResult {
     applied: bool,
     sheet_info: SheetInfo,
     changed: Vec<String>,
+    limited_cells: Vec<String>,
     proposal_id: String,
 }
 
-/// editor string for a stored (non-formula) value; text that would re-parse
-/// as something else gets a leading `'` so a round-trip preserves it.
-fn value_to_input(v: &CellValue) -> String {
-    match v {
-        CellValue::Empty => String::new(),
-        CellValue::Number { value } => value.to_string(),
-        CellValue::Bool { value } => if *value { "TRUE" } else { "FALSE" }.to_string(),
-        CellValue::Text { value } => {
-            if text_needs_quote(value) {
-                format!("'{value}")
-            } else {
-                value.clone()
-            }
-        }
-        CellValue::Error { value } => value.as_str().to_string(),
-    }
-}
-
-/// whether re-entering `text` verbatim would fail to yield the same text.
-fn text_needs_quote(text: &str) -> bool {
-    !matches!(xlsx_ops::parse_input(text), xlsx_ops::ParsedInput::Text(t) if t == text)
-}
-
-/// the `CellState` a proposed/accepted edit stores, carrying over the target
-/// cell's existing style so a value edit keeps its number format, as excel does.
-fn edit_cell_state(wb: &Workbook, sheet: SheetId, at: CellRef, input: &str) -> CellState {
-    let mut cell = cell_state_for_input_no_eval(input);
-    cell.style = wb
-        .sheet(sheet)
-        .and_then(|s| s.cell(at))
-        .and_then(|c| c.style);
-    cell
-}
-
-/// number-format-aware display text for a cell, matching what the grid paints;
-/// empty or missing cells yield "".
-fn display_text_at(wb: &Workbook, sheet: SheetId, at: CellRef) -> Result<String, String> {
-    let s = wb
-        .sheet(sheet)
-        .ok_or_else(|| format!("sheet {} out of range", sheet.0))?;
-    Ok(match s.cell(at) {
-        Some(cell) => display_text(&wb.styles, wb.date_system, cell),
-        None => String::new(),
-    })
-}
-
 impl Session {
-    /// open a workbook from raw `.xlsx` bytes, rebuild the dep graph, and recalc
-    /// every formula, replacing file-shipped cached values with our engine's.
-    pub fn open(bytes: &[u8], now_serial: Option<f64>) -> Result<Session, String> {
-        let parts = ooxml_opc::unzip_parts(bytes)?;
-        let mut workbook = xlsx_parse::parse_workbook(&parts).map_err(|e| e.to_string())?;
-        if workbook.sheets.is_empty() {
-            return Err("workbook has no sheets".to_string());
-        }
-        let (graph, _) = rebuild_and_recalc_all(&mut workbook, now_serial);
-        Ok(Session {
-            workbook,
-            sheet: SheetId(0),
-            undo: UndoStack::new(),
-            graph,
-            proposals: ProposalSet::new(),
-        })
+    pub fn open(bytes: &[u8], now_serial: Option<f64>) -> Result<Self, String> {
+        Workbook::open_recalculated(bytes, calculation_options(now_serial))
+            .map(|workbook| Self { workbook })
+            .map_err(|error| error.to_string())
     }
 
-    /// serialized `DisplayList` for a serialized `Viewport`.
     pub fn display_list_json(&self, viewport_json: &str) -> Result<String, String> {
-        let viewport: Viewport =
-            serde_json::from_str(viewport_json).map_err(|e| format!("bad viewport: {e}"))?;
-        let dl = build_display_list(&self.workbook, self.sheet, &viewport);
-        serde_json::to_string(&dl).map_err(|e| e.to_string())
+        let viewport: Viewport = serde_json::from_str(viewport_json)
+            .map_err(|error| format!("bad viewport: {error}"))?;
+        let display_list = self
+            .workbook
+            .display_list(&viewport)
+            .map_err(|error| error.to_string())?;
+        serde_json::to_string(&display_list).map_err(|error| error.to_string())
     }
 
-    /// render the current sheet viewport to png bytes via the tiny-skia backend.
     #[cfg(feature = "raster")]
     pub fn render_png(&self, viewport_json: &str) -> Result<Vec<u8>, String> {
-        let viewport: Viewport =
-            serde_json::from_str(viewport_json).map_err(|e| format!("bad viewport: {e}"))?;
-        let dl = build_display_list(&self.workbook, self.sheet, &viewport);
-        xlsx_raster::render_png(&dl)
+        let viewport: Viewport = serde_json::from_str(viewport_json)
+            .map_err(|error| format!("bad viewport: {error}"))?;
+        self.workbook
+            .render_png(&viewport)
+            .map(|rendered| rendered.bytes)
+            .map_err(|error| error.to_string())
     }
 
-    /// render an a1 range (default: used range) at an optional scale to png;
-    /// dimensions are capped so a hostile range cannot force an unbounded pixmap.
     #[cfg(feature = "raster")]
     pub fn render_range_png(&self, args: &str) -> Result<Vec<u8>, String> {
-        #[derive(serde::Deserialize)]
-        struct RangeArgs {
+        #[derive(Deserialize)]
+        struct Args {
             range: Option<String>,
             scale: Option<f32>,
         }
-        const MAX_DIM_PX: f32 = 16_384.0;
 
-        let a: RangeArgs = serde_json::from_str(args).map_err(|e| format!("bad args: {e}"))?;
-        let sheet = self
-            .workbook
-            .sheet(self.sheet)
-            .ok_or_else(|| "active sheet out of range".to_string())?;
-        let viewport = match &a.range {
-            Some(r) => {
-                let range =
-                    xlsx_model::CellRange::parse_a1(r).map_err(|e| format!("bad range: {e}"))?;
-                xlsx_render::viewport_for_range(sheet, range)
-            }
-            None => xlsx_render::viewport_for_used_range(sheet),
-        };
-        let scale = a.scale.unwrap_or(1.0);
-        if !(scale > 0.0 && scale.is_finite()) {
-            return Err("scale must be a positive number".to_string());
-        }
-        if viewport.width * scale > MAX_DIM_PX || viewport.height * scale > MAX_DIM_PX {
-            return Err(format!(
-                "requested render exceeds the {MAX_DIM_PX}px per-side cap; narrow the range or lower scale"
-            ));
-        }
-        let dl = build_display_list(&self.workbook, self.sheet, &viewport);
-        xlsx_raster::render_png(&xlsx_render::scaled(dl, scale))
+        let args: Args =
+            serde_json::from_str(args).map_err(|error| format!("bad args: {error}"))?;
+        let range = args
+            .range
+            .map(|range| CellRange::parse_a1(&range).map_err(|error| format!("bad range: {error}")))
+            .transpose()?;
+        self.workbook
+            .render_sheet(
+                self.workbook.active_sheet(),
+                &RenderOptions {
+                    range,
+                    scale: args.scale.unwrap_or(1.0),
+                    ..RenderOptions::default()
+                },
+            )
+            .map(|rendered| rendered.bytes)
+            .map_err(|error| error.to_string())
     }
 
-    /// sheet names, active index, and the pixel extent of the active sheet's
-    /// used range plus one blank row/col of slack.
     pub fn sheet_info_json(&self) -> Result<String, String> {
-        serde_json::to_string(&self.sheet_info()?).map_err(|e| e.to_string())
+        serde_json::to_string(&self.sheet_info()?).map_err(|error| error.to_string())
     }
 
-    fn sheet_info(&self) -> Result<SheetInfo, String> {
-        let sheet = self
-            .workbook
-            .sheet(self.sheet)
-            .ok_or_else(|| "active sheet out of range".to_string())?;
-        let geom = GridGeometry::new(sheet);
-        let (content_width, content_height) = match sheet.used_range() {
-            Some(range) => (geom.col_x(range.end.col + 2), geom.row_y(range.end.row + 2)),
-            None => (geom.col_x(26), geom.row_y(50)),
-        };
-        Ok(SheetInfo {
-            sheet_names: self
-                .workbook
-                .sheets
-                .iter()
-                .map(|s| s.name.clone())
-                .collect(),
-            active_sheet: self.sheet.0,
-            content_width,
-            content_height,
+    pub fn calculation_status_json(&self) -> Result<String, String> {
+        serde_json::to_string(&CalculationStatus {
+            limited_cells: self.changed_list(&self.workbook.last_calculation().limited_cells),
         })
+        .map_err(|error| error.to_string())
     }
 
-    /// enter one cell edit as a user `SetCell`, update the graph, and recalc
-    /// the touched cell and its dependents; returns the edit envelope.
+    pub fn set_active_sheet(&mut self, index: u32) -> Result<(), String> {
+        self.workbook
+            .set_active_sheet(SheetId(index))
+            .map_err(|error| error.to_string())
+    }
+
     pub fn edit_cell_json(
         &mut self,
         args: &str,
         now_serial: Option<f64>,
     ) -> Result<String, String> {
-        let a: EditArgs = serde_json::from_str(args).map_err(|e| format!("bad edit args: {e}"))?;
-        let sheet = SheetId(a.sheet);
-        let at = CellRef::new(a.row, a.col);
-        let cell = cell_state_for_input_no_eval(&a.input);
-        let formula = cell.formula.clone();
-        self.commit_user(vec![Op::SetCell { sheet, at, cell }])?;
-        self.graph.set_formula(sheet, at, formula.as_deref());
-        let seeds = [(sheet, at)];
-        let result = recalc_after(&mut self.workbook, &mut self.graph, &seeds, now_serial);
-        let changed = self.changed_list(&result, &seeds);
-        self.edit_result(true, changed)
+        let args: EditArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad edit args: {error}"))?;
+        let result = self
+            .workbook
+            .edit_cell(
+                SheetId(args.sheet),
+                CellRef::new(args.row, args.col),
+                &args.input,
+                calculation_options(now_serial),
+            )
+            .map_err(|error| error.to_string())?;
+        self.edit_result(result)
     }
 
-    /// enter a batch of cell edits (the paste path) as a single undo step, with
-    /// one recalc seeded by all of them so intra-batch references chain correctly.
     pub fn edit_cells_json(
         &mut self,
         args: &str,
         now_serial: Option<f64>,
     ) -> Result<String, String> {
-        let a: EditBatchArgs =
-            serde_json::from_str(args).map_err(|e| format!("bad edit args: {e}"))?;
-        let sheet = SheetId(a.sheet);
-        let mut touched: Vec<(SheetId, CellRef, Option<String>)> =
-            Vec::with_capacity(a.edits.len());
-        let ops = a
+        let args: EditBatchArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad edit args: {error}"))?;
+        let edits = args
             .edits
-            .iter()
-            .map(|e| {
-                let at = CellRef::new(e.row, e.col);
-                let cell = cell_state_for_input_no_eval(&e.input);
-                touched.push((sheet, at, cell.formula.clone()));
-                Op::SetCell { sheet, at, cell }
+            .into_iter()
+            .map(|edit| WorkbookCellInput {
+                cell: CellRef::new(edit.row, edit.col),
+                input: edit.input,
             })
-            .collect();
-        self.commit_user(ops)?;
-        for (s, at, formula) in &touched {
-            self.graph.set_formula(*s, *at, formula.as_deref());
-        }
-        let seeds: Vec<(SheetId, CellRef)> = touched.iter().map(|(s, at, _)| (*s, *at)).collect();
-        let result = recalc_after(&mut self.workbook, &mut self.graph, &seeds, now_serial);
-        let changed = self.changed_list(&result, &seeds);
-        self.edit_result(true, changed)
+            .collect::<Vec<_>>();
+        let result = self
+            .workbook
+            .edit_cells(SheetId(args.sheet), &edits, calculation_options(now_serial))
+            .map_err(|error| error.to_string())?;
+        self.edit_result(result)
     }
 
-    /// raw op-list escape hatch for structural edits, applied as one user
-    /// transaction; the graph is rebuilt and every formula recalculated.
     pub fn apply_ops_json(
         &mut self,
         transaction_json: &str,
         now_serial: Option<f64>,
     ) -> Result<String, String> {
-        let a: OpsArgs =
-            serde_json::from_str(transaction_json).map_err(|e| format!("bad ops: {e}"))?;
-        self.commit_user(a.ops)?;
-        let changed = self.rebuild_and_recalc(now_serial);
-        self.edit_result(true, changed)
+        let args: OpsArgs =
+            serde_json::from_str(transaction_json).map_err(|error| format!("bad ops: {error}"))?;
+        let result = self
+            .workbook
+            .apply_ops(args.ops, calculation_options(now_serial))
+            .map_err(|error| error.to_string())?;
+        self.edit_result(result)
     }
 
-    /// register an agent proposal without touching the workbook: a clone is
-    /// edited and recalculated so `oldText`/`newText` match what the grid paints.
+    pub fn undo_json(&mut self, now_serial: Option<f64>) -> Result<String, String> {
+        let result = self
+            .workbook
+            .undo(calculation_options(now_serial))
+            .map_err(|error| error.to_string())?;
+        self.edit_result(result)
+    }
+
+    pub fn redo_json(&mut self, now_serial: Option<f64>) -> Result<String, String> {
+        let result = self
+            .workbook
+            .redo(calculation_options(now_serial))
+            .map_err(|error| error.to_string())?;
+        self.edit_result(result)
+    }
+
+    pub fn cell_json(&self, args: &str) -> Result<String, String> {
+        let args: CellArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad cell args: {error}"))?;
+        let cell = self
+            .workbook
+            .cell(SheetId(args.sheet), CellRef::new(args.row, args.col))
+            .map_err(|error| error.to_string())?;
+        serde_json::to_string(&CellEdit {
+            a1: cell.cell.to_a1(),
+            input: cell.input,
+            is_formula: cell.is_formula,
+        })
+        .map_err(|error| error.to_string())
+    }
+
+    pub fn range_cells_json(&self, args: &str) -> Result<String, String> {
+        let args: RangeArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad range args: {error}"))?;
+        let range =
+            CellRange::parse_a1(&args.range).map_err(|error| format!("bad range: {error}"))?;
+        let cells = self
+            .workbook
+            .range_cells(SheetId(args.sheet), range)
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(|cell| CellEdit {
+                        a1: cell.cell.to_a1(),
+                        input: cell.input,
+                        is_formula: cell.is_formula,
+                    })
+                    .collect()
+            })
+            .collect();
+        serde_json::to_string(&RangeCells { cells }).map_err(|error| error.to_string())
+    }
+
     pub fn propose_json(&mut self, args: &str, now_serial: Option<f64>) -> Result<String, String> {
-        let a: ProposeArgs =
-            serde_json::from_str(args).map_err(|e| format!("bad propose args: {e}"))?;
-
-        let mut preview = self.workbook.clone();
-        for e in &a.edits {
-            let sheet = SheetId(e.sheet);
-            let at = CellRef::new(e.row, e.col);
-            let cell = edit_cell_state(&preview, sheet, at, &e.input);
-            let s = preview
-                .sheet_mut(sheet)
-                .ok_or_else(|| format!("sheet {} out of range", e.sheet))?;
-            s.set_cell(at, cell.into());
-        }
-        rebuild_and_recalc_all(&mut preview, now_serial);
-
-        let mut edits = Vec::with_capacity(a.edits.len());
-        for e in &a.edits {
-            let sheet = SheetId(e.sheet);
-            let at = CellRef::new(e.row, e.col);
-            edits.push(ProposedEdit {
-                sheet: e.sheet,
-                row: e.row,
-                col: e.col,
-                input: e.input.clone(),
-                a1: at.to_a1(),
-                old_text: display_text_at(&self.workbook, sheet, at)?,
-                new_text: display_text_at(&preview, sheet, at)?,
-            });
-        }
-
-        let id = self.proposals.next_id();
-        let proposal = Proposal {
-            id,
-            agent_id: a.agent_id,
-            note: a.note,
-            edits,
-        };
-        let json = serde_json::to_string(&proposal).map_err(|e| e.to_string())?;
-        self.proposals.add(proposal);
-        Ok(json)
+        let args: ProposeArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad propose args: {error}"))?;
+        let proposal = self
+            .workbook
+            .propose(
+                ProposalRequest {
+                    agent_id: args.agent_id,
+                    note: args.note,
+                    edits: args
+                        .edits
+                        .into_iter()
+                        .map(|edit| WorkbookProposalEditInput {
+                            sheet: SheetId(edit.sheet),
+                            cell: CellRef::new(edit.row, edit.col),
+                            input: edit.input,
+                        })
+                        .collect(),
+                },
+                calculation_options(now_serial),
+            )
+            .map_err(|error| error.to_string())?;
+        serde_json::to_string(&proposal).map_err(|error| error.to_string())
     }
 
-    /// the pending proposals under a `proposals` key.
     pub fn list_proposals_json(&self) -> Result<String, String> {
         serde_json::to_string(&ProposalList {
-            proposals: self.proposals.list(),
+            proposals: self.workbook.proposals(),
         })
-        .map_err(|e| e.to_string())
+        .map_err(|error| error.to_string())
     }
 
-    /// accept a proposal as one undo-able agent transaction and recalc. unless
-    /// `force`, errors `stale: <a1 list>` when any target's display text moved.
     pub fn accept_proposal_json(
         &mut self,
         args: &str,
         now_serial: Option<f64>,
     ) -> Result<String, String> {
-        let a: AcceptArgs =
-            serde_json::from_str(args).map_err(|e| format!("bad accept args: {e}"))?;
-        let proposal = self
-            .proposals
-            .list()
-            .iter()
-            .find(|p| p.id == a.id)
-            .cloned()
-            .ok_or_else(|| format!("no proposal {}", a.id))?;
-
-        if !a.force {
-            let stale: Vec<String> = proposal
-                .edits
-                .iter()
-                .filter_map(|e| {
-                    let cur = display_text_at(
-                        &self.workbook,
-                        SheetId(e.sheet),
-                        CellRef::new(e.row, e.col),
-                    )
-                    .ok()?;
-                    (cur != e.old_text).then(|| e.a1.clone())
-                })
-                .collect();
-            if !stale.is_empty() {
-                return Err(format!("stale: {}", stale.join(", ")));
-            }
-        }
-
-        let mut touched: Vec<(SheetId, CellRef, Option<String>)> =
-            Vec::with_capacity(proposal.edits.len());
-        let ops = proposal
-            .edits
-            .iter()
-            .map(|e| {
-                let sheet = SheetId(e.sheet);
-                let at = CellRef::new(e.row, e.col);
-                let cell = edit_cell_state(&self.workbook, sheet, at, &e.input);
-                touched.push((sheet, at, cell.formula.clone()));
-                Op::SetCell { sheet, at, cell }
-            })
-            .collect();
-        self.commit_agent(ops, proposal.agent_id.clone())?;
-        for (s, at, formula) in &touched {
-            self.graph.set_formula(*s, *at, formula.as_deref());
-        }
-        let seeds: Vec<(SheetId, CellRef)> = touched.iter().map(|(s, at, _)| (*s, *at)).collect();
-        let result = recalc_after(&mut self.workbook, &mut self.graph, &seeds, now_serial);
-        let changed = self.changed_list(&result, &seeds);
-        self.proposals.remove(&a.id);
-
-        serde_json::to_string(&AcceptResult {
-            applied: true,
-            sheet_info: self.sheet_info()?,
-            changed,
-            proposal_id: a.id,
-        })
-        .map_err(|e| e.to_string())
-    }
-
-    /// reject a proposal by id: `{"id":string}` -> `{"removed":bool}`.
-    pub fn reject_proposal_json(&mut self, args: &str) -> Result<String, String> {
-        let a: IdArgs = serde_json::from_str(args).map_err(|e| format!("bad reject args: {e}"))?;
-        let removed = self.proposals.remove(&a.id);
-        serde_json::to_string(&RejectResult { removed }).map_err(|e| e.to_string())
-    }
-
-    /// apply `ops` as one user transaction on the undo stack.
-    fn commit_user(&mut self, ops: Vec<Op>) -> Result<(), String> {
-        let tx = Transaction::new(ops, Provenance::User);
-        self.undo
-            .commit(&mut self.workbook, &tx)
-            .map_err(|e| e.to_string())
-    }
-
-    /// apply `ops` as one agent transaction; undo-able like any other.
-    fn commit_agent(&mut self, ops: Vec<Op>, agent_id: String) -> Result<(), String> {
-        let tx = Transaction::new(ops, Provenance::Agent { id: agent_id });
-        self.undo
-            .commit(&mut self.workbook, &tx)
-            .map_err(|e| e.to_string())
-    }
-
-    /// reverse the most recent transaction, then rebuild the graph and recalc;
-    /// `applied` is false when there was nothing to undo.
-    pub fn undo_json(&mut self, now_serial: Option<f64>) -> Result<String, String> {
-        let applied = self
-            .undo
-            .undo(&mut self.workbook)
-            .map_err(|e| e.to_string())?
-            .is_some();
-        let changed = if applied {
-            self.rebuild_and_recalc(now_serial)
-        } else {
-            Vec::new()
-        };
-        self.edit_result(applied, changed)
-    }
-
-    /// re-apply the most recently undone transaction; same shape as `undo_json`.
-    pub fn redo_json(&mut self, now_serial: Option<f64>) -> Result<String, String> {
-        let applied = self
-            .undo
-            .redo(&mut self.workbook)
-            .map_err(|e| e.to_string())?
-            .is_some();
-        let changed = if applied {
-            self.rebuild_and_recalc(now_serial)
-        } else {
-            Vec::new()
-        };
-        self.edit_result(applied, changed)
-    }
-
-    /// rebuild the graph and recalc every formula; returns changed a1 addresses.
-    fn rebuild_and_recalc(&mut self, now_serial: Option<f64>) -> Vec<String> {
-        let (graph, result) = rebuild_and_recalc_all(&mut self.workbook, now_serial);
-        self.graph = graph;
-        self.changed_list(&result, &[])
-    }
-
-    /// the recalc's changed cells as a1 strings, excluding the edit's own seeds.
-    fn changed_list(&self, result: &RecalcResult, seeds: &[(SheetId, CellRef)]) -> Vec<String> {
-        let seed_set: HashSet<(u32, u32, u32)> =
-            seeds.iter().map(|(s, c)| (s.0, c.row, c.col)).collect();
-        result
-            .changed
-            .iter()
-            .filter(|(s, c)| !seed_set.contains(&(s.0, c.row, c.col)))
-            .map(|(s, c)| self.a1_with_sheet(*s, *c))
-            .collect()
-    }
-
-    /// `A1` on the active sheet, else `Sheet!A1`.
-    fn a1_with_sheet(&self, sheet: SheetId, cell: CellRef) -> String {
-        if sheet == self.sheet {
-            cell.to_a1()
-        } else {
-            let name = self
-                .workbook
-                .sheet(sheet)
-                .map(|s| s.name.as_str())
-                .unwrap_or_default();
-            format!("{name}!{}", cell.to_a1())
-        }
-    }
-
-    fn edit_result(&self, applied: bool, changed: Vec<String>) -> Result<String, String> {
-        let result = EditResult {
-            applied,
-            sheet_info: self.sheet_info()?,
-            changed,
-        };
-        serde_json::to_string(&result).map_err(|e| e.to_string())
-    }
-
-    /// the editable representation of one cell.
-    pub fn cell_json(&self, args: &str) -> Result<String, String> {
-        let a: CellArgs = serde_json::from_str(args).map_err(|e| format!("bad cell args: {e}"))?;
-        let cell = self.cell_edit(SheetId(a.sheet), CellRef::new(a.row, a.col))?;
-        serde_json::to_string(&cell).map_err(|e| e.to_string())
-    }
-
-    /// a rectangular block of cells for clipboard copy; rejects ranges over
-    /// `MAX_RANGE_CELLS`.
-    pub fn range_cells_json(&self, args: &str) -> Result<String, String> {
-        let a: RangeArgs =
-            serde_json::from_str(args).map_err(|e| format!("bad range args: {e}"))?;
-        let sheet = SheetId(a.sheet);
-        let range = CellRange::parse_a1(&a.range).map_err(|e| format!("bad range: {e}"))?;
-        let rows = u64::from(range.end.row - range.start.row + 1);
-        let cols = u64::from(range.end.col - range.start.col + 1);
-        if rows * cols > MAX_RANGE_CELLS {
-            return Err(format!(
-                "range {rows}x{cols} exceeds the {MAX_RANGE_CELLS}-cell copy cap"
-            ));
-        }
-        let mut grid = Vec::with_capacity(rows as usize);
-        for r in range.start.row..=range.end.row {
-            let mut row_cells = Vec::with_capacity(cols as usize);
-            for c in range.start.col..=range.end.col {
-                row_cells.push(self.cell_edit(sheet, CellRef::new(r, c))?);
-            }
-            grid.push(row_cells);
-        }
-        serde_json::to_string(&RangeCells { cells: grid }).map_err(|e| e.to_string())
-    }
-
-    fn cell_edit(&self, sheet: SheetId, at: CellRef) -> Result<CellEdit, String> {
-        let s = self
+        let args: AcceptArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad accept args: {error}"))?;
+        let result = self
             .workbook
-            .sheet(sheet)
-            .ok_or_else(|| format!("sheet {} out of range", sheet.0))?;
-        let (input, is_formula) = match s.cell(at) {
-            Some(c) => match &c.formula {
-                Some(f) => (format!("={f}"), true),
-                None => (value_to_input(&c.value), false),
-            },
-            None => (String::new(), false),
-        };
-        Ok(CellEdit {
-            a1: at.to_a1(),
-            input,
-            is_formula,
+            .accept_proposal(&args.id, args.force, calculation_options(now_serial))
+            .map_err(|error| error.to_string())?;
+        serde_json::to_string(&AcceptResult {
+            applied: result.mutation.applied,
+            sheet_info: self.sheet_info()?,
+            changed: self.changed_list(&result.mutation.changed),
+            limited_cells: self.changed_list(&result.mutation.limited_cells),
+            proposal_id: result.proposal_id,
         })
+        .map_err(|error| error.to_string())
     }
 
-    /// serialize the current workbook back to `.xlsx` bytes.
+    pub fn reject_proposal_json(&mut self, args: &str) -> Result<String, String> {
+        let args: IdArgs =
+            serde_json::from_str(args).map_err(|error| format!("bad reject args: {error}"))?;
+        serde_json::to_string(&RejectResult {
+            removed: self.workbook.reject_proposal(&args.id),
+        })
+        .map_err(|error| error.to_string())
+    }
+
     pub fn save(&self) -> Result<Vec<u8>, String> {
-        let parts = xlsx_parse::serialize_workbook(&self.workbook).map_err(|e| e.to_string())?;
-        ooxml_opc::rezip_parts(&parts)
+        self.workbook.save().map_err(|error| error.to_string())
     }
 
-    /// switch the active sheet by index.
-    pub fn set_active_sheet(&mut self, index: u32) -> Result<(), String> {
-        if (index as usize) >= self.workbook.sheets.len() {
-            return Err(format!("sheet index {index} out of range"));
-        }
-        self.sheet = SheetId(index);
-        Ok(())
-    }
-
-    /// crate version, for wasm/js parity checks.
     pub fn version() -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
+
+    fn sheet_info(&self) -> Result<SheetInfo, String> {
+        self.workbook
+            .sheet_info()
+            .map(|info| SheetInfo {
+                sheet_names: info.sheet_names,
+                active_sheet: info.active_sheet.0,
+                content_width: info.content_width,
+                content_height: info.content_height,
+            })
+            .map_err(|error| error.to_string())
+    }
+
+    fn edit_result(&self, result: MutationResult) -> Result<String, String> {
+        serde_json::to_string(&EditResult {
+            applied: result.applied,
+            sheet_info: self.sheet_info()?,
+            changed: self.changed_list(&result.changed),
+            limited_cells: self.changed_list(&result.limited_cells),
+        })
+        .map_err(|error| error.to_string())
+    }
+
+    fn changed_list(&self, changed: &[CellAddress]) -> Vec<String> {
+        changed
+            .iter()
+            .map(|address| self.workbook.format_address(*address))
+            .collect()
+    }
+}
+
+fn calculation_options(now_serial: Option<f64>) -> CalculationOptions {
+    CalculationOptions { now_serial }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use xlsx_model::CellRef;
-    use xlsx_model::value::CellValue;
-    use xlsx_model::workbook::{Cell, Sheet};
+    use xlsx_model::{Cell, CellValue, Sheet, Workbook as WorkbookModel};
 
-    /// real `.xlsx` bytes via our own serializer + container.
     fn sample_xlsx() -> Vec<u8> {
         let mut sheet = Sheet::new("Data");
         sheet.set_cell(
@@ -680,218 +444,14 @@ mod tests {
                 ..Cell::default()
             },
         );
-        let mut second = Sheet::new("Empty");
-        second.name = "Empty".into();
-        let mut wb = Workbook::default();
-        wb.sheets.push(sheet);
-        wb.sheets.push(second);
-        let parts = xlsx_parse::serialize_workbook(&wb).unwrap();
+        let mut model = WorkbookModel::default();
+        model.sheets.push(sheet);
+        model.sheets.push(Sheet::new("Empty"));
+        let parts = xlsx_parse::serialize_workbook(&model).unwrap();
         ooxml_opc::rezip_parts(&parts).unwrap()
     }
 
-    #[test]
-    fn opens_real_bytes_and_renders() {
-        let session = Session::open(&sample_xlsx(), None).unwrap();
-        let vp = r#"{"x":0,"y":0,"width":300,"height":120}"#;
-        let json = session.display_list_json(vp).unwrap();
-        assert!(json.contains("\"commands\""));
-        assert!(json.contains("\"op\":\"fillRect\""));
-        assert!(json.contains("Hello"));
-    }
-
-    #[test]
-    fn sheet_info_and_switching() {
-        let mut session = Session::open(&sample_xlsx(), None).unwrap();
-        let info = session.sheet_info_json().unwrap();
-        assert!(info.contains("\"sheetNames\":[\"Data\",\"Empty\"]"));
-        assert!(info.contains("\"activeSheet\":0"));
-        assert!(info.contains("\"contentWidth\""));
-
-        session.set_active_sheet(1).unwrap();
-        let info = session.sheet_info_json().unwrap();
-        assert!(info.contains("\"activeSheet\":1"));
-        assert!(session.set_active_sheet(9).is_err());
-    }
-
-    #[test]
-    fn garbage_bytes_error_not_panic() {
-        assert!(Session::open(b"not a zip", None).is_err());
-        assert!(Session::open(&[], None).is_err());
-    }
-
-    #[test]
-    fn bad_viewport_is_an_error_not_a_panic() {
-        let session = Session::open(&sample_xlsx(), None).unwrap();
-        let err = session.display_list_json("not json").unwrap_err();
-        assert!(err.contains("bad viewport"));
-    }
-
-    #[test]
-    fn version_is_populated() {
-        assert!(!Session::version().is_empty());
-    }
-
-    #[test]
-    fn edit_cell_round_trips_through_cell_json() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"123"}"#, None)
-            .unwrap();
-        let c = s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#).unwrap();
-        assert!(c.contains(r#""a1":"A1""#));
-        assert!(c.contains(r#""input":"123""#));
-        assert!(c.contains(r#""isFormula":false"#));
-
-        // text that would re-parse as a number round-trips with a leading quote.
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"'42"}"#, None)
-            .unwrap();
-        let c = s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#).unwrap();
-        assert!(c.contains(r#""input":"'42""#), "got {c}");
-    }
-
-    #[test]
-    fn formula_entry_evaluates_and_reads_back() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"1"}"#, None)
-            .unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":1,"col":0,"input":"2"}"#, None)
-            .unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":2,"col":0,"input":"=SUM(A1:A2)"}"#, None)
-            .unwrap();
-
-        let c = s.cell_json(r#"{"sheet":0,"row":2,"col":0}"#).unwrap();
-        assert!(c.contains(r#""input":"=SUM(A1:A2)""#), "got {c}");
-        assert!(c.contains(r#""isFormula":true"#));
-
-        let dl = session_dl(&s);
-        assert!(dl.contains(r#""text":"3""#), "sum should render as 3: {dl}");
-    }
-
-    #[test]
-    fn batch_edit_is_single_undo_step() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        s.edit_cells_json(
-            r#"{"sheet":0,"edits":[{"row":0,"col":0,"input":"x"},{"row":0,"col":1,"input":"y"}]}"#,
-            None,
-        )
-        .unwrap();
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
-                .unwrap()
-                .contains(r#""input":"x""#)
-        );
-
-        let res = s.undo_json(None).unwrap();
-        assert!(res.contains(r#""applied":true"#));
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
-                .unwrap()
-                .contains(r#""input":"Hello""#)
-        );
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":1}"#)
-                .unwrap()
-                .contains(r#""input":"""#)
-        );
-    }
-
-    #[test]
-    fn undo_redo_restores_and_replays() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"changed"}"#, None)
-            .unwrap();
-
-        s.undo_json(None).unwrap();
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
-                .unwrap()
-                .contains(r#""input":"Hello""#),
-            "undo restores the prior value"
-        );
-
-        let res = s.redo_json(None).unwrap();
-        assert!(res.contains(r#""applied":true"#));
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
-                .unwrap()
-                .contains(r#""input":"changed""#),
-            "redo replays the edit"
-        );
-    }
-
-    #[test]
-    fn undo_with_empty_history_reports_not_applied() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        assert!(s.undo_json(None).unwrap().contains(r#""applied":false"#));
-    }
-
-    #[test]
-    fn structural_op_shifts_cell() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        s.apply_ops_json(
-            r#"{"ops":[{"type":"insertRows","sheet":0,"at":0,"count":1}]}"#,
-            None,
-        )
-        .unwrap();
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":2,"col":1}"#)
-                .unwrap()
-                .contains(r#""input":"42""#),
-            "42 shifted down to B3"
-        );
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":1,"col":1}"#)
-                .unwrap()
-                .contains(r#""input":"""#),
-            "B2 is now empty"
-        );
-    }
-
-    #[test]
-    fn save_reopens_with_edits_intact() {
-        let mut s = Session::open(&sample_xlsx(), None).unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":4,"col":4,"input":"persisted"}"#, None)
-            .unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":5,"col":4,"input":"777"}"#, None)
-            .unwrap();
-
-        let bytes = s.save().unwrap();
-        let reopened = Session::open(&bytes, None).unwrap();
-        assert!(
-            reopened
-                .cell_json(r#"{"sheet":0,"row":4,"col":4}"#)
-                .unwrap()
-                .contains(r#""input":"persisted""#)
-        );
-        assert!(
-            reopened
-                .cell_json(r#"{"sheet":0,"row":5,"col":4}"#)
-                .unwrap()
-                .contains(r#""input":"777""#)
-        );
-    }
-
-    #[test]
-    fn range_cells_shape_and_cap() {
-        let s = Session::open(&sample_xlsx(), None).unwrap();
-        let out = s
-            .range_cells_json(r#"{"sheet":0,"range":"A1:B2"}"#)
-            .unwrap();
-        assert!(out.contains(r#""input":"Hello""#));
-        assert!(out.contains(r#""input":"42""#));
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let rows = v["cells"].as_array().unwrap();
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].as_array().unwrap().len(), 2);
-
-        let err = s
-            .range_cells_json(r#"{"sheet":0,"range":"A1:D100000"}"#)
-            .unwrap_err();
-        assert!(err.contains("cap"), "got {err}");
-    }
-
-    /// `.xlsx` bytes where B1 = SUM(A1:A2) ships a deliberately wrong cached
-    /// value (999 instead of 15), so the open-time recalc has something to correct.
-    fn xlsx_with_stale_formula() -> Vec<u8> {
+    fn formula_xlsx() -> Vec<u8> {
         let mut sheet = Sheet::new("Data");
         sheet.set_cell(
             CellRef::parse_a1("A1").unwrap(),
@@ -912,334 +472,278 @@ mod tests {
             Cell {
                 value: CellValue::Number { value: 999.0 },
                 formula: Some("SUM(A1:A2)".into()),
-                style: None,
+                ..Cell::default()
             },
         );
-        let mut wb = Workbook::default();
-        wb.sheets.push(sheet);
-        let parts = xlsx_parse::serialize_workbook(&wb).unwrap();
+        let mut model = WorkbookModel::default();
+        model.sheets.push(sheet);
+        let parts = xlsx_parse::serialize_workbook(&model).unwrap();
         ooxml_opc::rezip_parts(&parts).unwrap()
     }
 
-    #[test]
-    fn open_corrects_stale_cached_formula_value() {
-        let s = Session::open(&xlsx_with_stale_formula(), None).unwrap();
-        let dl = session_dl(&s);
-        assert!(
-            dl.contains(r#""text":"15""#),
-            "B1 should recompute to 15: {dl}"
-        );
-        assert!(!dl.contains(r#""text":"999""#), "stale cache must be gone");
-    }
-
-    #[test]
-    fn edit_input_recalcs_dependent_and_reports_changed() {
-        let mut s = Session::open(&xlsx_with_stale_formula(), None).unwrap();
-        let res = s
-            .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"20"}"#, None)
-            .unwrap();
-        assert!(res.contains(r#""changed":["B1"]"#), "got {res}");
-        let dl = session_dl(&s);
-        assert!(dl.contains(r#""text":"25""#), "B1 should be 25: {dl}");
-    }
-
-    #[test]
-    fn round_trip_persists_recalculated_value() {
-        let mut s = Session::open(&xlsx_with_stale_formula(), None).unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"20"}"#, None)
-            .unwrap();
-        let bytes = s.save().unwrap();
-        let reopened = Session::open(&bytes, None).unwrap();
-        let dl = session_dl(&reopened);
-        assert!(
-            dl.contains(r#""text":"25""#),
-            "persisted B1 should be 25: {dl}"
-        );
-    }
-
-    #[test]
-    fn structural_op_remaps_formula_and_undo_restores() {
-        let mut s = Session::open(&xlsx_with_stale_formula(), None).unwrap();
-        s.apply_ops_json(
-            r#"{"ops":[{"type":"insertRows","sheet":0,"at":0,"count":1}]}"#,
-            None,
-        )
-        .unwrap();
-        let c = s.cell_json(r#"{"sheet":0,"row":1,"col":1}"#).unwrap();
-        assert!(
-            c.contains(r#""input":"=SUM(A2:A3)""#),
-            "formula should remap to SUM(A2:A3): {c}"
-        );
-
-        s.undo_json(None).unwrap();
-        let c = s.cell_json(r#"{"sheet":0,"row":0,"col":1}"#).unwrap();
-        assert!(
-            c.contains(r#""input":"=SUM(A1:A2)""#),
-            "undo restores SUM(A1:A2): {c}"
-        );
-    }
-
-    fn session_dl(s: &Session) -> String {
-        s.display_list_json(r#"{"x":0,"y":0,"width":400,"height":200}"#)
-            .unwrap()
-    }
-
-    /// `.xlsx` bytes with a currency-formatted A1 (`$#,##0.00`, value 1000) and
-    /// a plain A2 (250), for format-aware proposal previews.
-    fn xlsx_with_currency() -> Vec<u8> {
-        use xlsx_model::styles::Xf;
+    fn currency_xlsx() -> Vec<u8> {
         let mut sheet = Sheet::new("Data");
         sheet.set_cell(
             CellRef::parse_a1("A1").unwrap(),
             Cell {
                 value: CellValue::Number { value: 1000.0 },
-                formula: None,
                 style: Some(1),
-            },
-        );
-        sheet.set_cell(
-            CellRef::parse_a1("A2").unwrap(),
-            Cell {
-                value: CellValue::Number { value: 250.0 },
                 ..Cell::default()
             },
         );
-        let mut wb = Workbook::default();
-        wb.styles.num_fmts.push((164, "$#,##0.00".into()));
-        wb.styles.cell_xfs.push(Xf::default());
-        wb.styles.cell_xfs.push(Xf {
+        let mut model = WorkbookModel::default();
+        model.styles.num_fmts.push((164, "$#,##0.00".into()));
+        model.styles.cell_xfs.push(Default::default());
+        model.styles.cell_xfs.push(xlsx_model::Xf {
             num_fmt_id: Some(164),
-            ..Xf::default()
+            ..Default::default()
         });
-        wb.sheets.push(sheet);
-        let parts = xlsx_parse::serialize_workbook(&wb).unwrap();
+        model.sheets.push(sheet);
+        let parts = xlsx_parse::serialize_workbook(&model).unwrap();
         ooxml_opc::rezip_parts(&parts).unwrap()
     }
 
     #[test]
-    fn propose_leaves_workbook_untouched_with_formatted_texts() {
-        let mut s = Session::open(&xlsx_with_currency(), None).unwrap();
-        let json = s
-            .propose_json(
-                r#"{"agentId":"agent-1","note":"bump it","edits":[{"sheet":0,"row":0,"col":0,"input":"2000"}]}"#,
-                None,
-            )
+    fn preserves_display_and_sheet_info_wire_shapes() {
+        let mut session = Session::open(&sample_xlsx(), None).unwrap();
+        let display = session
+            .display_list_json(r#"{"x":0,"y":0,"width":300,"height":120}"#)
             .unwrap();
-        assert!(json.contains(r#""oldText":"$1,000.00""#), "got {json}");
-        assert!(json.contains(r#""newText":"$2,000.00""#), "got {json}");
-        assert!(json.contains(r#""a1":"A1""#));
-        assert!(json.contains(r#""agentId":"agent-1""#));
-        assert!(json.contains(r#""note":"bump it""#));
-        assert!(
-            json.contains(r#""cells":[{"#),
-            "edits serialize as cells: {json}"
-        );
+        assert!(display.contains(r#""op":"fillRect""#));
+        assert!(display.contains("Hello"));
 
+        let info = session.sheet_info_json().unwrap();
+        assert!(info.contains(r#""sheetNames":["Data","Empty"]"#));
+        assert!(info.contains(r#""activeSheet":0"#));
+        assert_eq!(
+            session.calculation_status_json().unwrap(),
+            r#"{"limitedCells":[]}"#
+        );
+        session.set_active_sheet(1).unwrap();
         assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
+            session
+                .sheet_info_json()
                 .unwrap()
-                .contains(r#""input":"1000""#),
-            "workbook must not change on propose"
+                .contains(r#""activeSheet":1"#)
         );
     }
 
     #[test]
-    fn propose_previews_evaluated_formula_value() {
-        let mut s = Session::open(&xlsx_with_currency(), None).unwrap();
-        let json = s
-            .propose_json(
-                r#"{"agentId":"a","note":null,"edits":[{"sheet":0,"row":0,"col":1,"input":"=A1+A2"}]}"#,
-                None,
-            )
+    fn edits_recalculate_undo_and_save() {
+        let mut session = Session::open(&sample_xlsx(), None).unwrap();
+        session
+            .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"1"}"#, None)
+            .unwrap();
+        session
+            .edit_cell_json(r#"{"sheet":0,"row":1,"col":0,"input":"2"}"#, None)
+            .unwrap();
+        session
+            .edit_cell_json(r#"{"sheet":0,"row":2,"col":0,"input":"=SUM(A1:A2)"}"#, None)
             .unwrap();
         assert!(
-            json.contains(r#""newText":"1250""#),
-            "formula preview: {json}"
+            session
+                .cell_json(r#"{"sheet":0,"row":2,"col":0}"#)
+                .unwrap()
+                .contains(r#""input":"=SUM(A1:A2)""#)
         );
-        assert!(json.contains(r#""oldText":"""#), "b1 starts empty: {json}");
         assert!(
-            json.contains(r#""note":null"#),
-            "null note stays null: {json}"
+            session
+                .undo_json(None)
+                .unwrap()
+                .contains(r#""applied":true"#)
+        );
+        assert!(
+            session
+                .redo_json(None)
+                .unwrap()
+                .contains(r#""applied":true"#)
+        );
+
+        let bytes = session.save().unwrap();
+        let reopened = Session::open(&bytes, None).unwrap();
+        assert!(
+            reopened
+                .cell_json(r#"{"sheet":0,"row":2,"col":0}"#)
+                .unwrap()
+                .contains(r#""isFormula":true"#)
         );
     }
 
     #[test]
-    fn accept_applies_recalcs_lands_on_undo_stack() {
-        let mut s = Session::open(&xlsx_with_currency(), None).unwrap();
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":1,"input":"=A1+A2"}"#, None)
+    fn quoted_text_and_batch_undo_keep_wire_behavior() {
+        let mut session = Session::open(&sample_xlsx(), None).unwrap();
+        session
+            .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"'42"}"#, None)
             .unwrap();
-        let p = s
-            .propose_json(
-                r#"{"agentId":"agent-1","note":null,"edits":[{"sheet":0,"row":0,"col":0,"input":"3000"}]}"#,
+        assert!(
+            session
+                .cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
+                .unwrap()
+                .contains(r#""input":"'42""#)
+        );
+
+        session
+            .edit_cells_json(
+                r#"{"sheet":0,"edits":[{"row":0,"col":0,"input":"x"},{"row":0,"col":1,"input":"y"}]}"#,
                 None,
             )
             .unwrap();
-        let id: serde_json::Value = serde_json::from_str(&p).unwrap();
-        let id = id["id"].as_str().unwrap();
-
-        let res = s
-            .accept_proposal_json(&format!(r#"{{"id":"{id}"}}"#), None)
-            .unwrap();
+        session.undo_json(None).unwrap();
         assert!(
-            res.contains(&format!(r#""proposalId":"{id}""#)),
-            "got {res}"
-        );
-        assert!(
-            res.contains(r#""changed":["B1"]"#),
-            "B1 recalculated: {res}"
-        );
-
-        let dl = session_dl(&s);
-        assert!(dl.contains(r#""text":"$3,000.00""#), "A1 formatted: {dl}");
-        assert!(dl.contains(r#""text":"3250""#), "B1 = 3000+250: {dl}");
-
-        assert!(
-            s.list_proposals_json()
+            session
+                .cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
                 .unwrap()
-                .contains(r#""proposals":[]"#)
+                .contains(r#""input":"'42""#)
         );
-        s.undo_json(None).unwrap();
-        let dl = session_dl(&s);
         assert!(
-            dl.contains(r#""text":"$1,000.00""#),
-            "undo reverts the agent edit: {dl}"
+            session
+                .cell_json(r#"{"sheet":0,"row":0,"col":1}"#)
+                .unwrap()
+                .contains(r#""input":"""#)
         );
     }
 
     #[test]
-    fn reject_drops_proposal() {
-        let mut s = Session::open(&xlsx_with_currency(), None).unwrap();
-        let p = s
-            .propose_json(
-                r#"{"agentId":"a","note":null,"edits":[{"sheet":0,"row":0,"col":0,"input":"9"}]}"#,
+    fn changed_addresses_and_range_shape_stay_stable() {
+        let mut session = Session::open(&formula_xlsx(), None).unwrap();
+        let result = session
+            .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"20"}"#, None)
+            .unwrap();
+        assert!(result.contains(r#""changed":["B1"]"#), "{result}");
+        let range = session
+            .range_cells_json(r#"{"sheet":0,"range":"A1:B2"}"#)
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&range).unwrap();
+        assert_eq!(value["cells"].as_array().unwrap().len(), 2);
+        assert_eq!(value["cells"][0].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn calculation_limits_are_visible_on_the_wire() {
+        let mut session = Session::open(&sample_xlsx(), None).unwrap();
+        let result = session
+            .edit_cell_json(
+                r#"{"sheet":0,"row":2,"col":0,"input":"=SUM(Empty!A1:XFD1048576)"}"#,
                 None,
             )
             .unwrap();
-        let id: serde_json::Value = serde_json::from_str(&p).unwrap();
-        let id = id["id"].as_str().unwrap().to_string();
-
-        assert!(
-            s.reject_proposal_json(&format!(r#"{{"id":"{id}"}}"#))
-                .unwrap()
-                .contains(r#""removed":true"#)
-        );
-        assert!(
-            s.reject_proposal_json(&format!(r#"{{"id":"{id}"}}"#))
-                .unwrap()
-                .contains(r#""removed":false"#)
-        );
-        assert!(
-            s.list_proposals_json()
-                .unwrap()
-                .contains(r#""proposals":[]"#)
-        );
-        assert!(
-            s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#)
-                .unwrap()
-                .contains(r#""input":"1000""#)
+        assert!(result.contains(r#""limitedCells":["A3"]"#), "{result}");
+        assert_eq!(
+            session.calculation_status_json().unwrap(),
+            r#"{"limitedCells":["A3"]}"#
         );
     }
 
     #[test]
-    fn accept_is_stale_when_base_moved_and_force_overrides() {
-        let mut s = Session::open(&xlsx_with_currency(), None).unwrap();
-        let p = s
-            .propose_json(
-                r#"{"agentId":"a","note":null,"edits":[{"sheet":0,"row":0,"col":0,"input":"2000"}]}"#,
+    fn structural_ops_remap_and_undo_across_the_json_boundary() {
+        let mut session = Session::open(&formula_xlsx(), None).unwrap();
+        let result = session
+            .apply_ops_json(
+                r#"{"ops":[{"type":"insertRows","sheet":0,"at":0,"count":1}]}"#,
                 None,
             )
             .unwrap();
-        let id: serde_json::Value = serde_json::from_str(&p).unwrap();
-        let id = id["id"].as_str().unwrap().to_string();
+        assert!(result.contains(r#""applied":true"#));
+        assert!(
+            session
+                .cell_json(r#"{"sheet":0,"row":1,"col":1}"#)
+                .unwrap()
+                .contains(r#""input":"=SUM(A2:A3)""#)
+        );
 
-        s.edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"1500"}"#, None)
+        session.undo_json(None).unwrap();
+        assert!(
+            session
+                .cell_json(r#"{"sheet":0,"row":0,"col":1}"#)
+                .unwrap()
+                .contains(r#""input":"=SUM(A1:A2)""#)
+        );
+    }
+
+    #[test]
+    fn proposals_preserve_wire_behavior() {
+        let mut session = Session::open(&sample_xlsx(), None).unwrap();
+        let proposal = session
+            .propose_json(
+                r#"{"agentId":"agent","note":null,"edits":[{"sheet":0,"row":0,"col":0,"input":"new"}]}"#,
+                None,
+            )
             .unwrap();
-        let err = s
-            .accept_proposal_json(&format!(r#"{{"id":"{id}"}}"#), None)
+        assert!(proposal.contains(r#""id":"p1""#));
+        assert!(proposal.contains(r#""cells":["#));
+        session
+            .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"moved"}"#, None)
+            .unwrap();
+        let error = session
+            .accept_proposal_json(r#"{"id":"p1"}"#, None)
             .unwrap_err();
-        assert!(err.starts_with("stale: "), "got {err}");
-        assert!(err.contains("A1"), "stale list names A1: {err}");
+        assert!(error.starts_with("stale: A1"));
         assert!(
-            s.list_proposals_json()
+            session
+                .accept_proposal_json(r#"{"id":"p1","force":true}"#, None)
                 .unwrap()
-                .contains(&format!(r#""id":"{id}""#))
+                .contains(r#""proposalId":"p1""#)
         );
-
-        let res = s
-            .accept_proposal_json(&format!(r#"{{"id":"{id}","force":true}}"#), None)
-            .unwrap();
-        assert!(res.contains(r#""applied":true"#), "got {res}");
-        let c = s.cell_json(r#"{"sheet":0,"row":0,"col":0}"#).unwrap();
-        assert!(c.contains(r#""input":"2000""#), "force applied: {c}");
     }
 
     #[test]
-    fn proposal_ids_increment_and_list_shape() {
-        let mut s = Session::open(&xlsx_with_currency(), None).unwrap();
-        let p1 = s
+    fn proposal_previews_remain_number_format_aware() {
+        let mut session = Session::open(&currency_xlsx(), None).unwrap();
+        let first = session
             .propose_json(
-                r#"{"agentId":"a","note":null,"edits":[{"sheet":0,"row":0,"col":0,"input":"1"}]}"#,
+                r#"{"agentId":"agent","note":null,"edits":[{"sheet":0,"row":0,"col":0,"input":"2000"}]}"#,
                 None,
             )
             .unwrap();
-        let p2 = s
+        assert!(first.contains(r#""id":"p1""#));
+        assert!(first.contains(r#""oldText":"$1,000.00""#), "{first}");
+        assert!(first.contains(r#""newText":"$2,000.00""#), "{first}");
+        let second = session
             .propose_json(
-                r#"{"agentId":"a","note":null,"edits":[{"sheet":0,"row":1,"col":0,"input":"2"}]}"#,
+                r#"{"agentId":"agent","note":null,"edits":[{"sheet":0,"row":0,"col":1,"input":"1"}]}"#,
                 None,
             )
             .unwrap();
-        assert!(p1.contains(r#""id":"p1""#), "got {p1}");
-        assert!(p2.contains(r#""id":"p2""#), "got {p2}");
+        assert!(second.contains(r#""id":"p2""#));
+        session
+            .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"3000"}"#, None)
+            .unwrap();
+        let display = session
+            .display_list_json(r#"{"x":0,"y":0,"width":200,"height":80}"#)
+            .unwrap();
+        assert!(display.contains("$3,000.00"), "{display}");
+    }
 
-        let list = s.list_proposals_json().unwrap();
-        let v: serde_json::Value = serde_json::from_str(&list).unwrap();
-        let arr = v["proposals"].as_array().unwrap();
-        assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0]["id"], "p1");
-        assert_eq!(arr[1]["id"], "p2");
+    #[test]
+    fn range_cap_and_bad_input_are_errors() {
+        let session = Session::open(&sample_xlsx(), None).unwrap();
+        assert!(session.display_list_json("not json").is_err());
+        assert!(
+            session
+                .range_cells_json(r#"{"sheet":0,"range":"A1:D100000"}"#)
+                .unwrap_err()
+                .contains("cap")
+        );
     }
 
     #[cfg(feature = "raster")]
     #[test]
-    fn render_png_produces_png_bytes() {
-        let s = Session::open(&sample_xlsx(), None).unwrap();
-        let png = s
+    fn raster_methods_produce_png() {
+        let session = Session::open(&sample_xlsx(), None).unwrap();
+        let png = session
             .render_png(r#"{"x":0,"y":0,"width":240,"height":120}"#)
             .unwrap();
-        assert!(png.len() > 8);
-        assert_eq!(
-            &png[0..8],
-            &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]
-        );
-    }
-
-    #[cfg(feature = "raster")]
-    #[test]
-    fn render_range_png_honors_range_scale_and_caps() {
-        let s = Session::open(&sample_xlsx(), None).unwrap();
-        let one = s.render_range_png(r#"{"range":"A1:B2"}"#).unwrap();
-        let two = s
+        assert_eq!(&png[..8], &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]);
+        let one = session.render_range_png(r#"{"range":"A1:B2"}"#).unwrap();
+        let two = session
             .render_range_png(r#"{"range":"A1:B2","scale":2}"#)
             .unwrap();
-        assert_eq!(&one[0..4], &[0x89, b'P', b'N', b'G']);
         assert!(two.len() > one.len());
-        assert!(s.render_range_png("{}").is_ok());
-        assert!(s.render_range_png(r#"{"range":"A1:XFD1048576"}"#).is_err());
         assert!(
-            s.render_range_png(r#"{"range":"A1:B2","scale":0}"#)
+            session
+                .render_range_png(r#"{"range":"A1:B2","scale":0}"#)
                 .is_err()
         );
-        assert!(s.render_range_png(r#"{"range":"nope"}"#).is_err());
-    }
-
-    #[cfg(feature = "raster")]
-    #[test]
-    fn render_png_bad_viewport_is_an_error() {
-        let s = Session::open(&sample_xlsx(), None).unwrap();
-        assert!(
-            s.render_png("not json")
-                .unwrap_err()
-                .contains("bad viewport")
-        );
+        assert!(session.render_range_png(r#"{"range":"nope"}"#).is_err());
     }
 }

--- a/crates/xlsx-wasm/src/lib.rs
+++ b/crates/xlsx-wasm/src/lib.rs
@@ -66,6 +66,13 @@ impl XlsxDocument {
             .map_err(|e| JsValue::from_str(&e))
     }
 
+    #[wasm_bindgen(js_name = calculationStatusJson)]
+    pub fn calculation_status_json(&self) -> Result<String, JsValue> {
+        self.session
+            .calculation_status_json()
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
     /// switch the active sheet by index.
     #[wasm_bindgen(js_name = setActiveSheet)]
     pub fn set_active_sheet(&mut self, index: u32) -> Result<(), JsValue> {

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -74,6 +74,7 @@ export type {
   CellEdit,
   CellInputEdit,
   EditResult,
+  CalculationStatus,
   Proposal,
   ProposalCell,
   ProposalEdit,

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm.d.ts
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm.d.ts
@@ -17,6 +17,7 @@ export class XlsxDocument {
      * apply a raw op list as one user transaction; returns `SheetInfo` json.
      */
     applyOpsJson(transaction_json: string): string;
+    calculationStatusJson(): string;
     /**
      * the editable representation of one cell.
      */
@@ -94,6 +95,7 @@ export interface InitOutput {
     readonly __wbg_xlsxdocument_free: (a: number, b: number) => void;
     readonly xlsxdocument_acceptProposalJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly xlsxdocument_applyOpsJson: (a: number, b: number, c: number) => [number, number, number, number];
+    readonly xlsxdocument_calculationStatusJson: (a: number) => [number, number, number, number];
     readonly xlsxdocument_cellJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly xlsxdocument_displayListJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly xlsxdocument_editCellJson: (a: number, b: number, c: number) => [number, number, number, number];

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm.js
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm.js
@@ -72,6 +72,27 @@ export class XlsxDocument {
         }
     }
     /**
+     * @returns {string}
+     */
+    calculationStatusJson() {
+        let deferred2_0;
+        let deferred2_1;
+        try {
+            const ret = wasm.xlsxdocument_calculationStatusJson(this.__wbg_ptr);
+            var ptr1 = ret[0];
+            var len1 = ret[1];
+            if (ret[3]) {
+                ptr1 = 0; len1 = 0;
+                throw takeFromExternrefTable0(ret[2]);
+            }
+            deferred2_0 = ptr1;
+            deferred2_1 = len1;
+            return getStringFromWasm0(ptr1, len1);
+        } finally {
+            wasm.__wbindgen_free(deferred2_0, deferred2_1, 1);
+        }
+    }
+    /**
      * the editable representation of one cell.
      * @param {string} args
      * @returns {string}

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm_bg.wasm.d.ts
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm_bg.wasm.d.ts
@@ -4,6 +4,7 @@ export const memory: WebAssembly.Memory;
 export const __wbg_xlsxdocument_free: (a: number, b: number) => void;
 export const xlsxdocument_acceptProposalJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const xlsxdocument_applyOpsJson: (a: number, b: number, c: number) => [number, number, number, number];
+export const xlsxdocument_calculationStatusJson: (a: number) => [number, number, number, number];
 export const xlsxdocument_cellJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const xlsxdocument_displayListJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const xlsxdocument_editCellJson: (a: number, b: number, c: number) => [number, number, number, number];

--- a/packages/xlsx/src/wasm/loader.test.ts
+++ b/packages/xlsx/src/wasm/loader.test.ts
@@ -43,6 +43,7 @@ describe('wasm loader', () => {
       expect(info.activeSheet).toBe(0);
       expect(info.contentWidth).toBeGreaterThan(0);
       expect(info.contentHeight).toBeGreaterThan(0);
+      expect(handle.calculationStatus()).toEqual({ limitedCells: [] });
     } finally {
       handle.dispose();
     }

--- a/packages/xlsx/src/wasm/loader.ts
+++ b/packages/xlsx/src/wasm/loader.ts
@@ -45,6 +45,11 @@ export interface EditResult {
   applied: boolean;
   sheetInfo: SheetInfo;
   changed?: string[];
+  limitedCells?: string[];
+}
+
+export interface CalculationStatus {
+  limitedCells: string[];
 }
 
 /**
@@ -135,6 +140,7 @@ function staleErrorFrom(message: string): StaleProposalError {
  */
 export interface WorkbookHandle {
   sheetInfo(): SheetInfo;
+  calculationStatus(): CalculationStatus;
   displayList(viewport: Viewport): DisplayList;
   setActiveSheet(index: number): void;
   /**
@@ -266,6 +272,11 @@ export function openWorkbook(bytes: Uint8Array): WorkbookHandle {
       } catch (e) {
         throw toError(e);
       }
+    },
+    calculationStatus(): CalculationStatus {
+      const fn = (doc as { calculationStatusJson?: () => string }).calculationStatusJson;
+      if (typeof fn !== 'function') return { limitedCells: [] };
+      return call<CalculationStatus>(() => fn.call(doc));
     },
     displayList(viewport: Viewport): DisplayList {
       try {


### PR DESCRIPTION
TL;DR:

Repro file:
[packages/xlsx/test-fixtures/sample.xlsx](https://github.com/openooxml/betteroffice/blob/9f24ec18e8c891f315e1bdb5b98b0e7af6e7aeaf/packages/xlsx/test-fixtures/sample.xlsx)

Summary:
- Add a typed Rust facade for opening, editing, calculating, rendering, proposing, and saving XLSX workbooks.
- Route the CLI and Wasm workbook sessions through the shared facade.
- Report calculation limits through the Wasm and TypeScript APIs.
- Harden formula evaluation, structural edits, formula remapping, undo/redo, and rendering limits.
- Add facade integration coverage, minimal-feature CI coverage, documentation, and a patch changeset.

Test plan:
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p betteroffice-xlsx --no-default-features`
- [x] `cargo test -p xlsx-wasm --no-default-features`
- [x] `cargo check -p xlsx-wasm --target wasm32-unknown-unknown --no-default-features`
- [x] `bun run test`
- [x] `bun run build:packages`
- [x] `bun run --filter './apps/demo' build`