### PR TITLE
ci(release): publish Rust crates

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,19 +1,21 @@
 # Changesets
 
 This folder holds the release queue. Every code PR that changes a published
-package (`@betteroffice/*` under `packages/`) adds a changeset:
+npm package or Rust crate adds a changeset:
 
 ```bash
 bun changeset
 ```
 
 Pick the affected packages and the bump (`patch` / `minor` / `major`), then
-commit the generated `.changeset/*.md`. On merge to `main`, the Release
-workflow opens a `chore: release` PR that applies the bumps and CHANGELOG
-entries; merging that PR publishes to npm.
+commit the generated `.changeset/*.md`. Select `@betteroffice/rust-crates` for
+Cargo changes. On merge to `main`, the Release workflow opens a
+`chore: release` PR that applies the bumps and CHANGELOG entries; merging that
+PR publishes to npm and crates.io.
 
 Each format is its own fixed group — `xlsx` and `xlsx-react` version in
-lockstep, independent of `docx`. Apps under `apps/` are private and never
-published.
+lockstep, independent of `docx`. The eight publishable Rust crates use one
+lockstep version independent from npm. Apps and other private packages are
+never published.
 
 Skip the changeset for test/docs/CI-only PRs.

--- a/.changeset/clean-crates-release.md
+++ b/.changeset/clean-crates-release.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Publish the Rust XLSX engine crates under BetterOffice names through the shared release workflow.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  },
   "ignore": []
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
         if: steps.ws.outputs.present == 'true'
         run: cargo test
 
+      - name: Package publishable crates
+        if: steps.ws.outputs.present == 'true'
+        run: node scripts/publish-crates.mjs --dry-run
+
       - name: License and advisory gate
         if: steps.ws.outputs.present == 'true'
         uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Pending changesets → open/update a "chore: release" PR (version bumps +
-# CHANGELOGs). No pending changesets → run the gate and publish to npm.
+# CHANGELOGs). No pending changesets → run the gate and publish packages.
 on:
   push:
     branches: [main]
@@ -13,9 +13,10 @@ concurrency:
 
 jobs:
   release:
+    if: github.ref == 'refs/heads/main'
     name: Release
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       contents: write
       pull-requests: write
@@ -50,12 +51,10 @@ jobs:
           echo "publishing=$([ "$count" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.pending.outputs.publishing == 'true'
         with:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.pending.outputs.publishing == 'true'
 
       - name: Install wasm-pack
         if: steps.pending.outputs.publishing == 'true'
@@ -73,9 +72,32 @@ jobs:
         if: steps.pending.outputs.publishing == 'true'
         run: bun run build:packages
 
+      - name: Detect crates.io bootstrap token
+        id: crates-bootstrap
+        if: steps.pending.outputs.publishing == 'true'
+        env:
+          TOKEN: ${{ secrets.CRATES_IO_BOOTSTRAP_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to crates.io
+        id: crates-auth
+        if: steps.pending.outputs.publishing == 'true' && steps.crates-bootstrap.outputs.enabled != 'true'
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish Rust crates
+        if: steps.pending.outputs.publishing == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_BOOTSTRAP_TOKEN || steps.crates-auth.outputs.token }}
+        run: bun run publish:crates
+
       # changesets does not rewrite the workspace: protocol here, so pin it to
       # concrete versions before publish (ephemeral checkout; source is unchanged).
-      - name: Pin workspace deps for publish
+      - name: Pin workspace deps for npm publish
         if: steps.pending.outputs.publishing == 'true'
         run: node scripts/rewrite-workspace-deps.mjs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "betteroffice-opc"
+version = "0.0.0"
+dependencies = [
+ "zip",
+]
+
+[[package]]
 name = "betteroffice-xlsx"
 version = "0.0.0"
 dependencies = [
- "ooxml-opc",
- "xlsx-calc",
- "xlsx-model",
- "xlsx-ops",
- "xlsx-parse",
- "xlsx-raster",
- "xlsx-render",
+ "betteroffice-opc",
+ "betteroffice-xlsx-calc",
+ "betteroffice-xlsx-model",
+ "betteroffice-xlsx-ops",
+ "betteroffice-xlsx-parse",
+ "betteroffice-xlsx-raster",
+ "betteroffice-xlsx-render",
+]
+
+[[package]]
+name = "betteroffice-xlsx-calc"
+version = "0.0.0"
+dependencies = [
+ "betteroffice-xlsx-model",
+]
+
+[[package]]
+name = "betteroffice-xlsx-model"
+version = "0.0.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "betteroffice-xlsx-ops"
+version = "0.0.0"
+dependencies = [
+ "betteroffice-xlsx-calc",
+ "betteroffice-xlsx-model",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "betteroffice-xlsx-parse"
+version = "0.0.0"
+dependencies = [
+ "betteroffice-xlsx-model",
+ "quick-xml",
+]
+
+[[package]]
+name = "betteroffice-xlsx-raster"
+version = "0.0.0"
+dependencies = [
+ "betteroffice-xlsx-render",
+ "rustybuzz",
+ "tiny-skia",
+]
+
+[[package]]
+name = "betteroffice-xlsx-render"
+version = "0.0.0"
+dependencies = [
+ "betteroffice-xlsx-model",
+ "serde",
 ]
 
 [[package]]
@@ -108,9 +164,9 @@ dependencies = [
 name = "docx-wasm"
 version = "0.0.0"
 dependencies = [
+ "betteroffice-opc",
  "docx-layout",
  "js-sys",
- "ooxml-opc",
  "ooxml-text",
  "serde_json",
  "wasm-bindgen",
@@ -241,13 +297,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "ooxml-opc"
-version = "0.0.0"
-dependencies = [
- "zip",
-]
 
 [[package]]
 name = "ooxml-text"
@@ -575,76 +624,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "xlsx-calc"
-version = "0.0.0"
-dependencies = [
- "xlsx-model",
-]
-
-[[package]]
 name = "xlsx-cli"
 version = "0.0.0"
 dependencies = [
+ "betteroffice-opc",
  "betteroffice-xlsx",
- "ooxml-opc",
- "xlsx-model",
- "xlsx-parse",
-]
-
-[[package]]
-name = "xlsx-model"
-version = "0.0.0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "xlsx-ops"
-version = "0.0.0"
-dependencies = [
- "serde",
- "serde_json",
- "xlsx-calc",
- "xlsx-model",
-]
-
-[[package]]
-name = "xlsx-parse"
-version = "0.0.0"
-dependencies = [
- "quick-xml",
- "xlsx-model",
-]
-
-[[package]]
-name = "xlsx-raster"
-version = "0.0.0"
-dependencies = [
- "rustybuzz",
- "tiny-skia",
- "xlsx-render",
-]
-
-[[package]]
-name = "xlsx-render"
-version = "0.0.0"
-dependencies = [
- "serde",
- "xlsx-model",
+ "betteroffice-xlsx-model",
+ "betteroffice-xlsx-parse",
 ]
 
 [[package]]
 name = "xlsx-wasm"
 version = "0.0.0"
 dependencies = [
+ "betteroffice-opc",
  "betteroffice-xlsx",
+ "betteroffice-xlsx-model",
+ "betteroffice-xlsx-parse",
  "js-sys",
- "ooxml-opc",
  "serde",
  "serde_json",
  "wasm-bindgen",
- "xlsx-model",
- "xlsx-parse",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,23 @@
 members = ["crates/*"]
 resolver = "3"
 
+[workspace.package]
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+homepage = "https://betteroffice.dev"
+repository = "https://github.com/openooxml/betteroffice"
+
+[workspace.dependencies]
+betteroffice-xlsx = { path = "crates/betteroffice-xlsx", version = "0.0.0", default-features = false }
+ooxml-opc = { package = "betteroffice-opc", path = "crates/ooxml-opc", version = "0.0.0" }
+xlsx-model = { package = "betteroffice-xlsx-model", path = "crates/xlsx-model", version = "0.0.0" }
+xlsx-parse = { package = "betteroffice-xlsx-parse", path = "crates/xlsx-parse", version = "0.0.0" }
+xlsx-calc = { package = "betteroffice-xlsx-calc", path = "crates/xlsx-calc", version = "0.0.0" }
+xlsx-ops = { package = "betteroffice-xlsx-ops", path = "crates/xlsx-ops", version = "0.0.0" }
+xlsx-render = { package = "betteroffice-xlsx-render", path = "crates/xlsx-render", version = "0.0.0" }
+xlsx-raster = { package = "betteroffice-xlsx-raster", path = "crates/xlsx-raster", version = "0.0.0" }
+
 [profile.release]
 opt-level = "s"
 lto = true

--- a/README.md
+++ b/README.md
@@ -19,23 +19,23 @@
 
 The document engines are Rust crates compiled to WebAssembly for the browser and running natively on servers. Every value from a user file is treated as attacker-controlled; guards are enforced by construction at the trust boundaries.
 
-Rust consumers should use `betteroffice-xlsx`; the lower-level `xlsx-*` crates are its engine components.
+Rust consumers should use `betteroffice-xlsx`; the lower-level `betteroffice-xlsx-*` crates are its engine components.
 
 | crate | what it does |
 |---|---|
-| [`ooxml-opc`](crates/ooxml-opc) | OPC (zip) container read/write with decompression-bomb and path-traversal guards — shared by every format |
+| [`betteroffice-opc`](crates/ooxml-opc) | OPC (zip) container read/write with decompression-bomb and path-traversal guards — shared by every format |
 | [`ooxml-text`](crates/ooxml-text) | shared font storage, shaping, bidi, line breaking, and glyph outlines |
 | [`docx-layout`](crates/docx-layout) | DOCX pagination and display-list generation |
 | [`docx-wasm`](crates/docx-wasm) | the wasm boundary for the document engine |
 | [`pptx-render`](crates/pptx-render) | PPTX composed-slide to display-list compiler |
 | [`pptx-wasm`](crates/pptx-wasm) | the wasm boundary for presentation rendering |
 | [`betteroffice-xlsx`](crates/betteroffice-xlsx) | typed XLSX editor, calculation, rendering, and save facade for Rust |
-| [`xlsx-model`](crates/xlsx-model) | workbook, cells, addresses, dates, styles, number formats |
-| [`xlsx-parse`](crates/xlsx-parse) | streaming SpreadsheetML parse and serialize |
-| [`xlsx-calc`](crates/xlsx-calc) | formula engine: parser, dependency graph, incremental recalc |
-| [`xlsx-ops`](crates/xlsx-ops) | invertible edit operations, undo, address remapping, proposals |
-| [`xlsx-render`](crates/xlsx-render) | grid geometry and display list |
-| [`xlsx-raster`](crates/xlsx-raster) | headless raster backend (tiny-skia), pixel-identical everywhere |
+| [`betteroffice-xlsx-model`](crates/xlsx-model) | workbook, cells, addresses, dates, styles, number formats |
+| [`betteroffice-xlsx-parse`](crates/xlsx-parse) | streaming SpreadsheetML parse and serialize |
+| [`betteroffice-xlsx-calc`](crates/xlsx-calc) | formula engine: parser, dependency graph, incremental recalc |
+| [`betteroffice-xlsx-ops`](crates/xlsx-ops) | invertible edit operations, undo, address remapping, proposals |
+| [`betteroffice-xlsx-render`](crates/xlsx-render) | grid geometry and display list |
+| [`betteroffice-xlsx-raster`](crates/xlsx-raster) | headless raster backend (tiny-skia), pixel-identical everywhere |
 | [`xlsx-wasm`](crates/xlsx-wasm) | the wasm boundary for the spreadsheet engine |
 | [`xlsx-cli`](crates/xlsx-cli) | render and inspect workbooks from the command line |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+Changesets drive npm and crates.io releases through the same release PR.
+
+## Changesets
+
+Run `bun changeset` and select every affected npm package. Select
+`@betteroffice/rust-crates` when a change affects the published Rust API or
+implementation. The eight Rust crates version and publish in lockstep,
+independently from npm versions.
+
+Merging a changeset opens or updates `chore: release`. Merging that release PR
+publishes every unpublished npm and Cargo version. The Cargo publisher checks
+crates.io before each upload, so rerunning a partial release resumes safely.
+
+## Initial crates.io release
+
+The first publication requires a crates.io API token because Trusted
+Publishing can only be configured after a crate exists.
+
+1. Create a short-lived crates.io token authorized to publish new crates.
+2. Add it to the repository as `CRATES_IO_BOOTSTRAP_TOKEN` before merging the
+   initial release PR.
+3. Merge the release PR and confirm all eight crates were published.
+4. Add a GitHub Trusted Publisher to each crate with owner `openooxml`,
+   repository `betteroffice`, and workflow `release.yml`.
+5. Remove the GitHub secret and revoke the bootstrap token.
+
+Subsequent releases use `rust-lang/crates-io-auth-action` and GitHub OIDC to
+obtain a short-lived crates.io token.
+
+## Publish order
+
+The workflow publishes dependencies before consumers:
+
+```text
+betteroffice-opc, betteroffice-xlsx-model
+betteroffice-xlsx-parse, betteroffice-xlsx-calc, betteroffice-xlsx-render
+betteroffice-xlsx-ops, betteroffice-xlsx-raster
+betteroffice-xlsx
+```
+
+Cargo versions and internal registry requirements live in the root
+`Cargo.toml`. `scripts/version-packages.mjs` synchronizes them with the private
+Changesets marker in `crates/package.json`.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -35,7 +35,7 @@ file serves as the copy of the license for this derivation.
 `crates/xlsx-raster/assets/Carlito-Regular.ttf` is vendored unmodified from
 the google/fonts repository, `ofl/carlito` (https://github.com/google/fonts);
 upstream project https://github.com/googlefonts/carlito. The bytes are
-compiled into the `xlsx-raster` crate via `include_bytes!`.
+compiled into the `betteroffice-xlsx-raster` crate via `include_bytes!`.
 
 Copyright 2013 The Carlito Project Authors, with Reserved Font Name "Carlito".
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/demo": {
       "name": "@betteroffice/demo",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "@betteroffice/xlsx": "workspace:*",
         "@betteroffice/xlsx-react": "workspace:*",
@@ -89,9 +89,13 @@
         "wrangler": "^4.106.0",
       },
     },
+    "crates": {
+      "name": "@betteroffice/rust-crates",
+      "version": "0.0.0",
+    },
     "packages/xlsx": {
       "name": "@betteroffice/xlsx",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^26.0.0",
@@ -101,7 +105,7 @@
     },
     "packages/xlsx-react": {
       "name": "@betteroffice/xlsx-react",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "dependencies": {
         "@betteroffice/xlsx": "workspace:*",
       },
@@ -297,6 +301,8 @@
     "@betteroffice/demo": ["@betteroffice/demo@workspace:apps/demo"],
 
     "@betteroffice/docs": ["@betteroffice/docs@workspace:apps/docs"],
+
+    "@betteroffice/rust-crates": ["@betteroffice/rust-crates@workspace:crates"],
 
     "@betteroffice/web": ["@betteroffice/web@workspace:apps/web"],
 

--- a/crates/betteroffice-xlsx/Cargo.toml
+++ b/crates/betteroffice-xlsx/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "betteroffice-xlsx"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Typed XLSX editor, calculation, rendering, and serialization facade."
-homepage = "https://betteroffice.dev"
-repository = "https://github.com/openooxml/betteroffice"
 readme = "README.md"
 keywords = ["xlsx", "spreadsheet", "ooxml", "excel"]
 categories = ["parser-implementations", "rendering"]
@@ -16,10 +16,10 @@ default = ["raster"]
 raster = ["dep:xlsx-raster"]
 
 [dependencies]
-ooxml-opc = { path = "../ooxml-opc" }
-xlsx-model = { path = "../xlsx-model" }
-xlsx-parse = { path = "../xlsx-parse" }
-xlsx-calc = { path = "../xlsx-calc" }
-xlsx-ops = { path = "../xlsx-ops" }
-xlsx-render = { path = "../xlsx-render" }
-xlsx-raster = { path = "../xlsx-raster", optional = true }
+ooxml-opc.workspace = true
+xlsx-model.workspace = true
+xlsx-parse.workspace = true
+xlsx-calc.workspace = true
+xlsx-ops.workspace = true
+xlsx-render.workspace = true
+xlsx-raster = { workspace = true, optional = true }

--- a/crates/docx-wasm/Cargo.toml
+++ b/crates/docx-wasm/Cargo.toml
@@ -15,7 +15,7 @@ wasm-opt = ["-O3"]
 [dependencies]
 docx-layout = { path = "../docx-layout" }
 js-sys = "0.3"
-ooxml-opc = { path = "../ooxml-opc" }
+ooxml-opc.workspace = true
 ooxml-text = { path = "../ooxml-text" }
 wasm-bindgen = "0.2"
 

--- a/crates/ooxml-opc/Cargo.toml
+++ b/crates/ooxml-opc/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
-name = "ooxml-opc"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-opc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "OPC (OOXML zip) container reader/writer with zip-bomb and path-traversal guards enforced by construction."
+
+[lib]
+name = "ooxml_opc"
 
 [dependencies]
 zip = { version = "8", default-features = false, features = ["deflate"] }

--- a/crates/package.json
+++ b/crates/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@betteroffice/rust-crates",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "typecheck": "true"
+  }
+}

--- a/crates/xlsx-calc/Cargo.toml
+++ b/crates/xlsx-calc/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
-name = "xlsx-calc"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
-description = "Formula parser, dependency graph, and recalc engine. Reads cells only through xlsx-model's CellProvider trait."
+name = "betteroffice-xlsx-calc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
+description = "Formula parser, dependency graph, and recalc engine for BetterOffice XLSX workbooks."
+
+[lib]
+name = "xlsx_calc"
 
 [dependencies]
-xlsx-model = { path = "../xlsx-model" }
+xlsx-model.workspace = true

--- a/crates/xlsx-calc/README.md
+++ b/crates/xlsx-calc/README.md
@@ -1,9 +1,8 @@
-# xlsx-calc
+# betteroffice-xlsx-calc
 
 The formula engine: lexer → parser → `Expr` AST → tree-walking evaluator, plus
-per-formula reference extraction and (from the graph work) dependency tracking.
-It reads cells exclusively through `xlsx_model::CellProvider` — see
-`docs/decisions/0001-formula-engine.md`.
+per-formula reference extraction and dependency tracking. It reads cells
+exclusively through `xlsx_model::CellProvider`.
 
 Written spec-first from ECMA-376 Part 1 §18.17 and public Excel function
 semantics. No GPL/AGPL or proprietary spreadsheet source was consulted.

--- a/crates/xlsx-cli/Cargo.toml
+++ b/crates/xlsx-cli/Cargo.toml
@@ -11,9 +11,9 @@ name = "xlsx"
 path = "src/main.rs"
 
 [dependencies]
-betteroffice-xlsx = { path = "../betteroffice-xlsx", features = ["raster"] }
+betteroffice-xlsx = { workspace = true, features = ["raster"] }
 
 [dev-dependencies]
-ooxml-opc = { path = "../ooxml-opc" }
-xlsx-parse = { path = "../xlsx-parse" }
-xlsx-model = { path = "../xlsx-model" }
+ooxml-opc.workspace = true
+xlsx-parse.workspace = true
+xlsx-model.workspace = true

--- a/crates/xlsx-model/Cargo.toml
+++ b/crates/xlsx-model/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
-name = "xlsx-model"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-xlsx-model"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Workbook, worksheet, and cell model for SpreadsheetML: address types, values, styles. Framework- and IO-free."
+
+[lib]
+name = "xlsx_model"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/xlsx-ops/Cargo.toml
+++ b/crates/xlsx-ops/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
-name = "xlsx-ops"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-xlsx-ops"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Invertible op log: undo/redo, provenance-tagged proposals, address remapping, collab-ready serialization."
+
+[lib]
+name = "xlsx_ops"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-xlsx-model = { path = "../xlsx-model" }
-xlsx-calc = { path = "../xlsx-calc" }
+xlsx-model.workspace = true
+xlsx-calc.workspace = true
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/xlsx-parse/Cargo.toml
+++ b/crates/xlsx-parse/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
-name = "xlsx-parse"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
-description = "Streaming SpreadsheetML parser and serializer (quick-xml) building the xlsx-model workbook."
+name = "betteroffice-xlsx-parse"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
+description = "Streaming SpreadsheetML parser and serializer building the BetterOffice workbook model."
+
+[lib]
+name = "xlsx_parse"
 
 [dependencies]
 quick-xml = "0.41"
-xlsx-model = { path = "../xlsx-model" }
+xlsx-model.workspace = true

--- a/crates/xlsx-raster/Cargo.toml
+++ b/crates/xlsx-raster/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "xlsx-raster"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-xlsx-raster"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Server-side raster backend (tiny-skia) for the display list. Never part of the wasm build."
+
+[lib]
+name = "xlsx_raster"
 
 [dependencies]
 tiny-skia = "0.11"
 rustybuzz = "0.20"
-xlsx-render = { path = "../xlsx-render" }
+xlsx-render.workspace = true

--- a/crates/xlsx-raster/assets/README.md
+++ b/crates/xlsx-raster/assets/README.md
@@ -6,7 +6,7 @@
 - **Why:** metric-compatible with Calibri (Excel's default UI/body font), so text
   laid out against Calibri metrics renders at the same advances without shipping
   a proprietary font. Chosen for headless, deterministic rendering — the bytes
-  are compiled into `xlsx-raster` via `include_bytes!`, so there is no system
+  are compiled into `betteroffice-xlsx-raster` via `include_bytes!`, so there is no system
   font access and output is identical on every machine and in CI.
 - **License:** SIL Open Font License, Version 1.1 — see `OFL.txt` in this
   directory. The OFL applies to this font asset only, not to the crate's code

--- a/crates/xlsx-raster/tests/golden.rs
+++ b/crates/xlsx-raster/tests/golden.rs
@@ -1,5 +1,5 @@
 //! png golden harness: scenarios are byte-compared against committed pngs.
-//! regenerate deliberately with `GOLDEN_UPDATE=1 cargo test -p xlsx-raster`.
+//! regenerate deliberately with `GOLDEN_UPDATE=1 cargo test -p betteroffice-xlsx-raster`.
 
 use std::path::PathBuf;
 
@@ -209,14 +209,14 @@ fn check(name: &str, dl: &DisplayList) {
     }
     let expected = std::fs::read(&path).unwrap_or_else(|_| {
         panic!(
-            "missing golden {}: regenerate with `GOLDEN_UPDATE=1 cargo test -p xlsx-raster`",
+            "missing golden {}: regenerate with `GOLDEN_UPDATE=1 cargo test -p betteroffice-xlsx-raster`",
             path.display()
         )
     });
     assert!(
         actual == expected,
         "golden mismatch for {name}: if intended, regenerate with \
-         `GOLDEN_UPDATE=1 cargo test -p xlsx-raster`"
+         `GOLDEN_UPDATE=1 cargo test -p betteroffice-xlsx-raster`"
     );
 }
 

--- a/crates/xlsx-render/Cargo.toml
+++ b/crates/xlsx-render/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
-name = "xlsx-render"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-xlsx-render"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Grid layout and target-agnostic display list. Never imports canvas, DOM, or any raster backend."
+
+[lib]
+name = "xlsx_render"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-xlsx-model = { path = "../xlsx-model" }
+xlsx-model.workspace = true

--- a/crates/xlsx-wasm/Cargo.toml
+++ b/crates/xlsx-wasm/Cargo.toml
@@ -18,9 +18,9 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-betteroffice-xlsx = { path = "../betteroffice-xlsx", default-features = false }
+betteroffice-xlsx = { workspace = true, default-features = false }
 
 [dev-dependencies]
-ooxml-opc = { path = "../ooxml-opc" }
-xlsx-model = { path = "../xlsx-model" }
-xlsx-parse = { path = "../xlsx-parse" }
+ooxml-opc.workspace = true
+xlsx-model.workspace = true
+xlsx-parse.workspace = true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": ["apps/*", "packages/*", "crates"],
   "scripts": {
     "dev": "bun run --filter './apps/web' dev",
     "dev:docs": "bun run --filter './apps/docs' dev",
@@ -18,8 +18,10 @@
     "typecheck": "bun run --filter '*' typecheck",
     "rust:check": "cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test",
     "changeset": "changeset",
-    "version-packages": "changeset version",
-    "release": "bun run build:packages && changeset publish",
+    "version-packages": "node scripts/version-packages.mjs",
+    "publish:crates": "node scripts/publish-crates.mjs",
+    "publish:packages": "bun run publish:crates && node scripts/rewrite-workspace-deps.mjs && changeset publish",
+    "release": "bun run build:packages && bun run publish:packages",
     "preview": "bun run --filter './apps/web' preview",
     "deploy": "bun run --filter './apps/web' deploy",
     "cf-typegen": "bun run --filter './apps/web' cf-typegen"

--- a/scripts/publish-crates.mjs
+++ b/scripts/publish-crates.mjs
@@ -1,0 +1,159 @@
+import {
+  RUST_CRATES,
+  cargoMetadata,
+  run,
+  rustReleaseVersion,
+  validateRustTrain
+} from './rust-crates.mjs';
+
+const USER_AGENT = 'betteroffice-release (https://github.com/openooxml/betteroffice)';
+const EXPECTED_OWNER = process.env.CRATES_IO_OWNER ?? 'eliahilse';
+const WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+const WAIT_INTERVAL_MS = 10 * 1000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchRegistry(url) {
+  let lastError;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: { 'User-Agent': USER_AGENT },
+        cache: 'no-store'
+      });
+    } catch (error) {
+      lastError = error;
+      await sleep(2 ** attempt * 1000);
+      continue;
+    }
+    if (response.ok || response.status === 404) return response;
+    if (response.status !== 429 && response.status < 500) {
+      throw new Error(`${url} returned ${response.status}`);
+    }
+    lastError = new Error(`${url} returned ${response.status}`);
+    await sleep(2 ** attempt * 1000);
+  }
+  throw lastError;
+}
+
+async function crateVersion(name, version) {
+  const response = await fetchRegistry(
+    `https://crates.io/api/v1/crates/${encodeURIComponent(name)}/${encodeURIComponent(version)}`
+  );
+  if (response.status === 404) return null;
+  return (await response.json()).version;
+}
+
+async function assertCrateOwnership(name) {
+  const response = await fetchRegistry(
+    `https://crates.io/api/v1/crates/${encodeURIComponent(name)}/owners`
+  );
+  if (response.status === 404) throw new Error(`${name} has no crates.io owners`);
+  const owners = await response.json();
+  if (!owners.users?.some((owner) => owner.login === EXPECTED_OWNER)) {
+    throw new Error(`${name} is not owned by ${EXPECTED_OWNER}`);
+  }
+}
+
+function sparseIndexPath(name) {
+  const normalized = name.toLowerCase();
+  if (normalized.length === 1) return `1/${normalized}`;
+  if (normalized.length === 2) return `2/${normalized}`;
+  if (normalized.length === 3) return `3/${normalized[0]}/${normalized}`;
+  return `${normalized.slice(0, 2)}/${normalized.slice(2, 4)}/${normalized}`;
+}
+
+async function indexHasVersion(name, version) {
+  const response = await fetchRegistry(`https://index.crates.io/${sparseIndexPath(name)}`);
+  if (response.status === 404) return false;
+  const entries = (await response.text())
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return entries.some((entry) => entry.vers === version && !entry.yanked);
+}
+
+async function waitFor(description, predicate) {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    console.log(`Waiting for ${description}...`);
+    await sleep(WAIT_INTERVAL_MS);
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function waitForRegistry(name, version) {
+  await waitFor(`${name}@${version} on crates.io`, async () => {
+    const found = await crateVersion(name, version);
+    if (found?.yanked) throw new Error(`${name}@${version} is yanked`);
+    return found !== null;
+  });
+  await assertCrateOwnership(name);
+  await waitFor(`${name}@${version} in the sparse index`, () => indexHasVersion(name, version));
+}
+
+function publishDryRun() {
+  for (const crate of RUST_CRATES) {
+    run('cargo', [
+      'package',
+      '--no-verify',
+      '--exclude-lockfile',
+      '--allow-dirty',
+      '--locked',
+      '-p',
+      crate.name
+    ]);
+  }
+}
+
+async function publish() {
+  const version = rustReleaseVersion();
+  const packages = validateRustTrain(cargoMetadata(), version);
+
+  if (process.argv.includes('--dry-run')) {
+    publishDryRun();
+    return;
+  }
+  if (version === '0.0.0') {
+    console.log('Rust release train is unreleased; skipping crates.io publication.');
+    return;
+  }
+
+  for (const crate of RUST_CRATES) {
+    const existing = await crateVersion(crate.name, version);
+    if (existing) {
+      if (existing.yanked) throw new Error(`${crate.name}@${version} is yanked`);
+      console.log(`${crate.name}@${version} is already published.`);
+      await waitForRegistry(crate.name, version);
+      continue;
+    }
+
+    const internalDependencies = packages
+      .get(crate.name)
+      .dependencies.filter((dependency) => packages.has(dependency.name));
+    for (const dependency of internalDependencies) {
+      await waitForRegistry(dependency.name, version);
+    }
+
+    if (!process.env.CARGO_REGISTRY_TOKEN) {
+      throw new Error('CARGO_REGISTRY_TOKEN is required to publish Rust crates');
+    }
+
+    const result = run(
+      'cargo',
+      ['publish', '--locked', '--registry', 'crates-io', '-p', crate.name],
+      { allowFailure: true }
+    );
+    if (result.status !== 0 && !(await crateVersion(crate.name, version))) {
+      throw new Error(`Failed to publish ${crate.name}@${version}`);
+    }
+    await waitForRegistry(crate.name, version);
+  }
+}
+
+await publish();

--- a/scripts/rust-crates.mjs
+++ b/scripts/rust-crates.mjs
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+export const RUST_RELEASE_MANIFEST = 'crates/package.json';
+export const WORKSPACE_MANIFEST = 'Cargo.toml';
+
+export const RUST_CRATES = [
+  { name: 'betteroffice-opc', dependency: 'ooxml-opc' },
+  { name: 'betteroffice-xlsx-model', dependency: 'xlsx-model' },
+  { name: 'betteroffice-xlsx-parse', dependency: 'xlsx-parse' },
+  { name: 'betteroffice-xlsx-calc', dependency: 'xlsx-calc' },
+  { name: 'betteroffice-xlsx-render', dependency: 'xlsx-render' },
+  { name: 'betteroffice-xlsx-ops', dependency: 'xlsx-ops' },
+  { name: 'betteroffice-xlsx-raster', dependency: 'xlsx-raster' },
+  { name: 'betteroffice-xlsx', dependency: 'betteroffice-xlsx' }
+];
+
+export function rustReleaseVersion() {
+  return JSON.parse(readFileSync(RUST_RELEASE_MANIFEST, 'utf8')).version;
+}
+
+export function run(command, args, { capture = false, allowFailure = false } = {}) {
+  const result = spawnSync(command, args, {
+    encoding: capture ? 'utf8' : undefined,
+    stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    env: process.env
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !allowFailure) {
+    if (capture && result.stderr) process.stderr.write(result.stderr);
+    throw new Error(`${command} ${args.join(' ')} exited with ${result.status}`);
+  }
+  return result;
+}
+
+export function cargoMetadata({ locked = true } = {}) {
+  const args = ['metadata', '--format-version', '1'];
+  if (locked) args.push('--locked');
+  const result = run('cargo', args, { capture: true });
+  return JSON.parse(result.stdout);
+}
+
+export function validateRustTrain(metadata, version) {
+  const packages = new Map(metadata.packages.map((pkg) => [pkg.name, pkg]));
+  const positions = new Map(RUST_CRATES.map((crate, index) => [crate.name, index]));
+  const rustPackages = new Map();
+
+  for (const [index, crate] of RUST_CRATES.entries()) {
+    const pkg = packages.get(crate.name);
+    if (!pkg) throw new Error(`Cargo package ${crate.name} is missing`);
+    if (pkg.version !== version) {
+      throw new Error(`${crate.name} is ${pkg.version}; expected ${version}`);
+    }
+    if (JSON.stringify(pkg.publish) !== '["crates-io"]') {
+      throw new Error(`${crate.name} must publish only to crates-io`);
+    }
+    rustPackages.set(crate.name, pkg);
+    for (const dependency of pkg.dependencies) {
+      const dependencyIndex = positions.get(dependency.name);
+      if (dependencyIndex !== undefined && dependencyIndex >= index) {
+        throw new Error(`${crate.name} must follow ${dependency.name} in publish order`);
+      }
+    }
+  }
+
+  return rustPackages;
+}

--- a/scripts/version-packages.mjs
+++ b/scripts/version-packages.mjs
@@ -1,0 +1,82 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  RUST_CRATES,
+  WORKSPACE_MANIFEST,
+  cargoMetadata,
+  run,
+  rustReleaseVersion,
+  validateRustTrain
+} from './rust-crates.mjs';
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function workspaceVersion(source) {
+  const section = source.match(/\[workspace\.package\]\n([\s\S]*?)(?=\n\[|$)/);
+  const version = section?.[1].match(/^version = "([^"]+)"$/m)?.[1];
+  if (!version) throw new Error('workspace.package.version is missing');
+  return version;
+}
+
+function synchronizeCargoVersion(source, from, to) {
+  if (workspaceVersion(source) !== from) {
+    throw new Error(`Cargo release train does not match ${from}`);
+  }
+
+  let updated = source.replace(
+    /(\[workspace\.package\]\n[\s\S]*?^version = ")[^"]+("$)/m,
+    `$1${to}$2`
+  );
+
+  for (const crate of RUST_CRATES) {
+    const key = escapeRegExp(crate.dependency);
+    const pattern = new RegExp(`^(${key} = \\{[^\\n]*version = ")[^"]+("[^\\n]*\\})$`, 'm');
+    if (!pattern.test(updated)) {
+      throw new Error(`workspace dependency ${crate.dependency} has no version`);
+    }
+    updated = updated.replace(pattern, `$1${to}$2`);
+  }
+
+  return updated;
+}
+
+function validate(version, locked) {
+  const metadata = cargoMetadata({ locked });
+  validateRustTrain(metadata, version);
+}
+
+const checkOnly = process.argv.includes('--check');
+const before = rustReleaseVersion();
+const cargoBefore = readFileSync(WORKSPACE_MANIFEST, 'utf8');
+if (workspaceVersion(cargoBefore) !== before) {
+  throw new Error(`Rust changeset marker is ${before}, but Cargo is ${workspaceVersion(cargoBefore)}`);
+}
+
+if (checkOnly) {
+  const simulated = synchronizeCargoVersion(cargoBefore, before, '999.999.999');
+  if (workspaceVersion(simulated) !== '999.999.999') {
+    throw new Error('Cargo release train version synchronization failed');
+  }
+  validate(before, true);
+  console.log(`Rust release train is synchronized at ${before}.`);
+  process.exit(0);
+}
+
+run('bun', ['run', 'changeset', 'version']);
+const after = rustReleaseVersion();
+
+if (after !== before) {
+  writeFileSync(
+    WORKSPACE_MANIFEST,
+    synchronizeCargoVersion(readFileSync(WORKSPACE_MANIFEST, 'utf8'), before, after)
+  );
+  validate(after, false);
+}
+
+validate(after, true);
+console.log(
+  after === before
+    ? `Rust release train remains at ${after}.`
+    : `Synchronized Rust release train ${before} -> ${after}.`
+);


### PR DESCRIPTION
TL;DR:

Summary:
- Publish the XLSX Rust engine under branded `betteroffice-*` crate names while preserving existing Rust import names.
- Version the eight publishable crates in lockstep through the existing Changesets release PR cycle.
- Publish crates dependency-first with bootstrap-token support, Trusted Publishing, ownership checks, and resumable reruns.
- Add Cargo package validation to CI and document the initial and ongoing release process.

Test plan:
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo test -p betteroffice-xlsx --no-default-features`
- [x] `cargo test -p xlsx-wasm --no-default-features`
- [x] `cargo check -p xlsx-wasm --target wasm32-unknown-unknown --no-default-features`
- [x] `node scripts/version-packages.mjs --check`
- [x] `node scripts/publish-crates.mjs --dry-run`
- [x] `bun install --frozen-lockfile`
- [x] `bun run --filter './packages/*' typecheck`
- [x] `bun run test`
- [x] `bun run build:packages`
