### PR TITLE
feat(web): show crates.io downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,52 +5,25 @@
 </p>
 
 <p align="center">
-  Documents, spreadsheets, and presentations — engines in Rust, editors in TypeScript, everything client-side.
+  Rust-native OOXML engines with collaboration and agent editing at the core.<br>
+  WebAssembly for browsers. Headless APIs for servers. Native Rust where you need it.
 </p>
 
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-4ade80.svg?style=flat-square" alt="license"></a>
   <a href="https://www.npmjs.com/org/betteroffice"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fnpm-downloads&amp;style=flat-square&amp;logo=npm&amp;label=downloads&amp;color=CB3837&amp;cacheSeconds=86400" alt="npm downloads"></a>
+  <a href="https://crates.io/search?q=betteroffice"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fcrates-downloads%3Fv%3D1&amp;style=flat-square&amp;logo=rust&amp;label=downloads&amp;color=CE412B&amp;cacheSeconds=86400" alt="crates.io downloads"></a>
   <a href="https://betteroffice.dev"><img src="https://img.shields.io/badge/betteroffice.dev-0a0a0a?style=flat-square" alt="betteroffice.dev"></a>
   <a href="https://openooxml.org"><img src="https://img.shields.io/badge/openooxml.org-0a0a0a?style=flat-square" alt="openooxml.org"></a>
 </p>
 
-## Engines
-
-The document engines are Rust crates compiled to WebAssembly for the browser and running natively on servers. Every value from a user file is treated as attacker-controlled; guards are enforced by construction at the trust boundaries.
-
-Rust consumers should use `betteroffice-xlsx`; the lower-level `betteroffice-xlsx-*` crates are its engine components.
-
-| crate | what it does |
-|---|---|
-| [`betteroffice-opc`](crates/ooxml-opc) | OPC (zip) container read/write with decompression-bomb and path-traversal guards — shared by every format |
-| [`ooxml-text`](crates/ooxml-text) | shared font storage, shaping, bidi, line breaking, and glyph outlines |
-| [`docx-layout`](crates/docx-layout) | DOCX pagination and display-list generation |
-| [`docx-wasm`](crates/docx-wasm) | the wasm boundary for the document engine |
-| [`pptx-render`](crates/pptx-render) | PPTX composed-slide to display-list compiler |
-| [`pptx-wasm`](crates/pptx-wasm) | the wasm boundary for presentation rendering |
-| [`betteroffice-xlsx`](crates/betteroffice-xlsx) | typed XLSX editor, calculation, rendering, and save facade for Rust |
-| [`betteroffice-xlsx-model`](crates/xlsx-model) | workbook, cells, addresses, dates, styles, number formats |
-| [`betteroffice-xlsx-parse`](crates/xlsx-parse) | streaming SpreadsheetML parse and serialize |
-| [`betteroffice-xlsx-calc`](crates/xlsx-calc) | formula engine: parser, dependency graph, incremental recalc |
-| [`betteroffice-xlsx-ops`](crates/xlsx-ops) | invertible edit operations, undo, address remapping, proposals |
-| [`betteroffice-xlsx-render`](crates/xlsx-render) | grid geometry and display list |
-| [`betteroffice-xlsx-raster`](crates/xlsx-raster) | headless raster backend (tiny-skia), pixel-identical everywhere |
-| [`xlsx-wasm`](crates/xlsx-wasm) | the wasm boundary for the spreadsheet engine |
-| [`xlsx-cli`](crates/xlsx-cli) | render and inspect workbooks from the command line |
-
 ## Packages
 
-The editor packages will ship under the `@betteroffice` scope: a framework-free core per format, with thin framework adapters on top.
-
-| package | |
+| package | what it does |
 |---|---|
-| `@betteroffice/docx` | word processing core |
-| `@betteroffice/docx-react` | React chrome for the docx editor |
-| `@betteroffice/xlsx` | spreadsheet core |
-| `@betteroffice/xlsx-react` | React chrome for the spreadsheet |
-| `@betteroffice/pptx` | presentation core |
-| `@betteroffice/pptx-react` | React chrome for presentations |
+| [`betteroffice-xlsx`](https://crates.io/crates/betteroffice-xlsx) | typed Rust API for opening, editing, calculating, rendering, and saving XLSX workbooks |
+| [`@betteroffice/xlsx`](https://www.npmjs.com/package/@betteroffice/xlsx) | framework-free spreadsheet core powered by the Rust engine through WebAssembly |
+| [`@betteroffice/xlsx-react`](https://www.npmjs.com/package/@betteroffice/xlsx-react) | drop-in React spreadsheet editor |
 
 ## Structure
 

--- a/apps/web/app/api/crates-downloads/route.test.js
+++ b/apps/web/app/api/crates-downloads/route.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { officialCrateNames, rollingDownloads } from "./route.ts";
+
+describe("crates.io downloads", () => {
+  test("keeps only BetterOffice crates from this repository", () => {
+    expect(
+      officialCrateNames([
+        {
+          name: "betteroffice-xlsx",
+          repository: "https://github.com/openooxml/betteroffice.git",
+        },
+        {
+          name: "betteroffice-opc",
+          repository: "https://github.com/openooxml/betteroffice/",
+        },
+        {
+          name: "betteroffice-unrelated",
+          repository: "https://github.com/example/unrelated",
+        },
+        {
+          name: "another-crate",
+          repository: "https://github.com/openooxml/betteroffice",
+        },
+      ]),
+    ).toEqual(["betteroffice-xlsx", "betteroffice-opc"]);
+  });
+
+  test("sums the latest 30 UTC dates across current and older versions", () => {
+    expect(
+      rollingDownloads(
+        {
+          version_downloads: [
+            { date: "2026-06-18", downloads: 100 },
+            { date: "2026-06-19", downloads: 2 },
+            { date: "2026-07-18", downloads: 3 },
+          ],
+          meta: {
+            extra_downloads: [{ date: "2026-07-01", downloads: 5 }],
+          },
+        },
+        new Date("2026-07-18T18:00:00Z"),
+      ),
+    ).toBe(10);
+  });
+
+  test("rejects malformed download counts", () => {
+    expect(() =>
+      rollingDownloads({
+        version_downloads: [{ date: "2026-07-18", downloads: -1 }],
+        meta: { extra_downloads: [] },
+      }),
+    ).toThrow("Invalid crates.io download history");
+  });
+});

--- a/apps/web/app/api/crates-downloads/route.ts
+++ b/apps/web/app/api/crates-downloads/route.ts
@@ -1,0 +1,116 @@
+const CACHE_CONTROL =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800";
+const CRATES_API = "https://crates.io/api/v1";
+const OFFICIAL_REPOSITORY = "https://github.com/openooxml/betteroffice";
+const USER_AGENT =
+  "betteroffice.dev downloads badge (https://github.com/openooxml/betteroffice)";
+
+interface CrateSummary {
+  name: string;
+  repository: string | null;
+}
+
+interface DownloadEntry {
+  date: string;
+  downloads: number;
+}
+
+interface DownloadHistory {
+  version_downloads: DownloadEntry[];
+  meta: { extra_downloads: DownloadEntry[] };
+}
+
+function normalizeRepository(repository: string | null) {
+  return repository?.replace(/\.git$/, "").replace(/\/$/, "");
+}
+
+export function officialCrateNames(crates: CrateSummary[]) {
+  return crates
+    .filter(
+      (crate) =>
+        crate.name.startsWith("betteroffice-") &&
+        normalizeRepository(crate.repository) === OFFICIAL_REPOSITORY,
+    )
+    .map((crate) => crate.name);
+}
+
+export function rollingDownloads(
+  history: DownloadHistory,
+  now = new Date(),
+) {
+  const cutoff = new Date(now);
+  cutoff.setUTCHours(0, 0, 0, 0);
+  cutoff.setUTCDate(cutoff.getUTCDate() - 29);
+  const cutoffDate = cutoff.toISOString().slice(0, 10);
+  const entries = [
+    ...history.version_downloads,
+    ...history.meta.extra_downloads,
+  ];
+
+  return entries.reduce((total, entry) => {
+    if (
+      !/^\d{4}-\d{2}-\d{2}$/.test(entry.date) ||
+      !Number.isSafeInteger(entry.downloads) ||
+      entry.downloads < 0
+    ) {
+      throw new Error("Invalid crates.io download history");
+    }
+    return entry.date >= cutoffDate ? total + entry.downloads : total;
+  }, 0);
+}
+
+export async function GET() {
+  try {
+    const cratesResponse = await fetch(
+      `${CRATES_API}/crates?page=1&per_page=100&q=betteroffice`,
+      { headers: { "User-Agent": USER_AGENT } },
+    );
+
+    if (!cratesResponse.ok) {
+      throw new Error(`crates.io search failed: ${cratesResponse.status}`);
+    }
+
+    const search = (await cratesResponse.json()) as { crates: CrateSummary[] };
+    const crateNames = officialCrateNames(search.crates);
+    if (crateNames.length === 0) {
+      throw new Error("No public BetterOffice crates found");
+    }
+
+    const counts = await Promise.all(
+      crateNames.map(async (crateName) => {
+        const response = await fetch(
+          `${CRATES_API}/crates/${encodeURIComponent(crateName)}/downloads`,
+          { headers: { "User-Agent": USER_AGENT } },
+        );
+        if (!response.ok) {
+          throw new Error(
+            `crates.io downloads request failed for ${crateName}: ${response.status}`,
+          );
+        }
+        return rollingDownloads((await response.json()) as DownloadHistory);
+      }),
+    );
+    const downloads = counts.reduce((total, count) => total + count, 0);
+
+    return Response.json(
+      {
+        schemaVersion: 1,
+        label: "crates.io downloads",
+        message: `${downloads.toLocaleString("en-US")}/month`,
+        color: "orange",
+      },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  } catch {
+    return Response.json(
+      {
+        schemaVersion: 1,
+        label: "crates.io downloads",
+        message: "unavailable",
+        color: "lightgrey",
+        isError: true,
+      },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy:docs": "bun run --filter './apps/docs' deploy",
     "deploy:demo": "bun run --filter './apps/demo' deploy",
     "build": "bun run --filter './apps/web' build",
-    "test": "bun run build:xlsx-wasm && bun test packages",
+    "test": "bun run build:xlsx-wasm && bun test packages apps/web/app/api",
     "typecheck": "bun run --filter '*' typecheck",
     "rust:check": "cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test",
     "changeset": "changeset",


### PR DESCRIPTION
TL;DR:

Summary:
- Add a monthly download endpoint for official BetterOffice crates
- Show aggregate crates.io downloads alongside npm in the project README
- Focus the package list on the user-facing XLSX packages

Test plan:
- [x] `bun test apps/web/app/api/crates-downloads/route.test.js`
- [x] `bun run --filter ./apps/web typecheck`
- [x] `bun run --filter ./apps/web build`
- [x] `bun run test`