### PR TITLE
docs: bust npm downloads badge cache (?v=2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache_2.0-4ade80.svg?style=flat-square" alt="license"></a>
-  <a href="https://www.npmjs.com/org/betteroffice"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fnpm-downloads&amp;style=flat-square&amp;logo=npm&amp;label=downloads&amp;color=CB3837&amp;cacheSeconds=86400" alt="npm downloads"></a>
+  <a href="https://www.npmjs.com/org/betteroffice"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fnpm-downloads%3Fv%3D2&amp;style=flat-square&amp;logo=npm&amp;label=downloads&amp;color=CB3837&amp;cacheSeconds=86400" alt="npm downloads"></a>
   <a href="https://crates.io/search?q=betteroffice"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fbetteroffice.dev%2Fapi%2Fcrates-downloads%3Fv%3D1&amp;style=flat-square&amp;logo=rust&amp;label=downloads&amp;color=CE412B&amp;cacheSeconds=86400" alt="crates.io downloads"></a>
   <a href="https://betteroffice.dev"><img src="https://img.shields.io/badge/betteroffice.dev-0a0a0a?style=flat-square" alt="betteroffice.dev"></a>
   <a href="https://openooxml.org"><img src="https://img.shields.io/badge/openooxml.org-0a0a0a?style=flat-square" alt="openooxml.org"></a>


### PR DESCRIPTION
TL;DR:


Summary:
- Bumps the README npm-downloads badge endpoint URL to `?v=2` so GitHub Camo and shields.io re-fetch, dropping the stale error image cached from before the endpoint fix. The endpoint is healthy (`963/month`, 200); the route ignores the extra param.

Test plan:
- [ ] badge renders a count after merge