### PR TITLE
ci: deploy web/demo/docs to Cloudflare on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ matrix.app }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [web, demo, docs]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: matrix.app == 'demo'
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        if: matrix.app == 'demo'
+
+      - name: Install wasm-pack
+        if: matrix.app == 'demo'
+        run: cargo install wasm-pack --version 0.15.0 --locked
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bun run --filter './apps/${{ matrix.app }}' deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: deploy
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
TL;DR:

Summary:

- New `deploy.yml` workflow deploys `apps/web`, `apps/demo`, and `apps/docs` to Cloudflare Workers via each app's `deploy` script (`opennextjs-cloudflare build && deploy`), run as a three-app matrix.
- Triggers on `release: published` (the changesets flow creates a GitHub Release on publish) and on manual `workflow_dispatch`.
- The `demo` leg installs the Rust toolchain (`wasm32-unknown-unknown`) and wasm-pack 0.15.0 for its wasm `prebuild`; `web`/`docs` skip that.
- A `deploy` concurrency group queues overlapping runs so releases don't race.
- Auth comes from `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` repo secrets, which do not exist yet and must be added by a maintainer before the first run.

Test plan:

- [ ] Add `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` repo secrets
- [ ] Trigger a release / `workflow_dispatch` and confirm all three apps deploy