### PR TITLE
feat(pptx): add typed Rust facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "betteroffice-pptx"
+version = "0.0.1"
+dependencies = [
+ "pptx-edit",
+ "pptx-parse",
+ "pptx-render",
+]
+
+[[package]]
 name = "betteroffice-xlsx"
 version = "0.0.1"
 dependencies = [

--- a/crates/betteroffice-pptx/Cargo.toml
+++ b/crates/betteroffice-pptx/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "betteroffice-pptx"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+# Publishing is gated on the lower-level PPTX crates being published.
+publish = false
+description = "Typed native Rust facade for parsing, editing, rendering, and saving PPTX presentations."
+readme = "README.md"
+keywords = ["pptx", "powerpoint", "ooxml", "presentationml"]
+categories = ["parser-implementations", "rendering"]
+
+[dependencies]
+pptx-edit = { path = "../pptx-edit" }
+pptx-parse = { path = "../pptx-parse" }
+pptx-render = { path = "../pptx-render" }

--- a/crates/betteroffice-pptx/README.md
+++ b/crates/betteroffice-pptx/README.md
@@ -1,0 +1,54 @@
+# betteroffice-pptx
+
+The typed native Rust API for opening, inspecting, collaboratively editing,
+laying out, and saving PPTX presentations. Parsed PresentationML and Yrs deck
+state are exposed as Rust structs; native calls do not cross a JSON or
+`JsValue` boundary.
+
+```rust
+use betteroffice_pptx::{EditCtx, Presentation};
+
+let mut presentation = Presentation::open(&pptx_bytes)?;
+let snapshot = presentation.snapshot()?;
+let slide = &snapshot.slides[0];
+let shape = &slide.shapes[0];
+
+presentation.move_shape(
+    &EditCtx::local("example"),
+    &slide.id,
+    &shape.id,
+    914_400,
+    914_400,
+)?;
+
+presentation.register_font("Inter", false, false, &font_bytes)?;
+let rendered = presentation.render_slide(0)?;
+let saved = presentation.save()?;
+# Ok::<(), betteroffice_pptx::Error>(())
+```
+
+The display list contains vector geometry, images, shaped text, caret data, and
+hit-test metadata. Register at least one font face before rendering a slide that
+contains text.
+
+Saving currently byte-preserves the parsed source package. Yrs edits affect the
+typed deck snapshot and rendered display lists, but are not yet projected back
+into PresentationML parts. Persisting edited deck state is a lower-engine
+follow-up. Added or removed slides and shapes therefore remain live editing and
+collaboration operations until that projection exists.
+
+The WASM crate surface remains available in `pptx-edit` for JavaScript clients;
+this facade deliberately exposes the same native engine operations without its
+JSON argument and result wrappers. The API is experimental and may change
+before `0.1.0`.
+
+## Support Matrix
+
+| Capability | Native facade |
+| --- | --- |
+| Presentation, slide, master, layout, shape, text, theme, and media inspection | Yes |
+| Yrs slide, shape, and text editing | Yes |
+| Yrs v1 state vectors, diffs, updates, undo, and redo | Yes |
+| Slide display lists and hit testing | Yes |
+| Byte-preserving source package save | Yes |
+| Persist Yrs edits into PresentationML | Follow-up |

--- a/crates/betteroffice-pptx/src/error.rs
+++ b/crates/betteroffice-pptx/src/error.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    Parse(pptx_parse::PptxError),
+    Edit(pptx_edit::EditError),
+    Render(pptx_render::RenderError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(error) => error.fmt(formatter),
+            Self::Edit(error) => error.fmt(formatter),
+            Self::Render(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(error) => Some(error),
+            Self::Edit(error) => Some(error),
+            Self::Render(error) => Some(error),
+        }
+    }
+}
+
+impl From<pptx_parse::PptxError> for Error {
+    fn from(error: pptx_parse::PptxError) -> Self {
+        Self::Parse(error)
+    }
+}
+
+impl From<pptx_edit::EditError> for Error {
+    fn from(error: pptx_edit::EditError) -> Self {
+        Self::Edit(error)
+    }
+}
+
+impl From<pptx_render::RenderError> for Error {
+    fn from(error: pptx_render::RenderError) -> Self {
+        Self::Render(error)
+    }
+}

--- a/crates/betteroffice-pptx/src/lib.rs
+++ b/crates/betteroffice-pptx/src/lib.rs
@@ -1,0 +1,11 @@
+//! Typed native facade for opening, editing, rendering, and saving PPTX files.
+
+mod error;
+mod presentation;
+mod types;
+
+pub use error::Error;
+pub use presentation::Presentation;
+pub use types::*;
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/betteroffice-pptx/src/presentation.rs
+++ b/crates/betteroffice-pptx/src/presentation.rs
@@ -1,0 +1,264 @@
+use pptx_edit::{
+    DeckSession, DeckSnapshot, EditCtx, ShapeDraft, ShapeReceipt, SlideReceipt, StorySnapshot,
+    TextReceipt, TextStyle, TextStylePatch, TransformReceipt,
+};
+use pptx_parse::{
+    MediaPart, ParseLimits, PptxPackage, Presentation as PresentationModel, Slide, SlideLayout,
+    SlideMaster, ThemePart,
+};
+use pptx_render::{RenderedSlide, SlideRenderer};
+
+use crate::Result;
+
+const STANDALONE_CLIENT_ID: u64 = 1;
+
+pub struct Presentation {
+    session: DeckSession,
+    renderer: SlideRenderer,
+}
+
+impl Presentation {
+    pub fn open(bytes: &[u8]) -> Result<Self> {
+        Self::open_with_limits_internal(bytes, &ParseLimits::default(), STANDALONE_CLIENT_ID)
+    }
+
+    pub fn open_with_limits(bytes: &[u8], limits: &ParseLimits) -> Result<Self> {
+        Self::open_with_limits_internal(bytes, limits, STANDALONE_CLIENT_ID)
+    }
+
+    pub fn open_collaborative(bytes: &[u8], client_id: u64) -> Result<Self> {
+        Self::open_with_limits_internal(bytes, &ParseLimits::default(), client_id)
+    }
+
+    pub fn open_collaborative_with_limits(
+        bytes: &[u8],
+        client_id: u64,
+        limits: &ParseLimits,
+    ) -> Result<Self> {
+        Self::open_with_limits_internal(bytes, limits, client_id)
+    }
+
+    fn open_with_limits_internal(
+        bytes: &[u8],
+        limits: &ParseLimits,
+        client_id: u64,
+    ) -> Result<Self> {
+        let package = pptx_parse::parse_pptx_with_limits(bytes, limits)?;
+        let session = DeckSession::from_package(package, client_id)?;
+        Ok(Self {
+            session,
+            renderer: SlideRenderer::new(),
+        })
+    }
+
+    pub fn client_id(&self) -> u64 {
+        self.session.client_id()
+    }
+
+    pub fn package(&self) -> &PptxPackage {
+        self.session.package()
+    }
+
+    pub fn model(&self) -> &PresentationModel {
+        &self.package().presentation
+    }
+
+    pub fn slides(&self) -> &[Slide] {
+        &self.package().slides
+    }
+
+    pub fn layouts(&self) -> &[SlideLayout] {
+        &self.package().layouts
+    }
+
+    pub fn masters(&self) -> &[SlideMaster] {
+        &self.package().masters
+    }
+
+    pub fn themes(&self) -> &[ThemePart] {
+        &self.package().themes
+    }
+
+    pub fn media(&self) -> &[MediaPart] {
+        &self.package().media
+    }
+
+    pub fn snapshot(&self) -> Result<DeckSnapshot> {
+        Ok(self.session.snapshot()?)
+    }
+
+    pub fn story(&self, story_id: &str) -> Result<StorySnapshot> {
+        Ok(self.session.story(story_id)?)
+    }
+
+    pub fn insert_slide(
+        &self,
+        context: &EditCtx,
+        index: u32,
+        layout_part_path: Option<&str>,
+    ) -> Result<SlideReceipt> {
+        Ok(self
+            .session
+            .insert_slide(context, index, layout_part_path)?)
+    }
+
+    pub fn delete_slide(&self, context: &EditCtx, slide_id: &str) -> Result<SlideReceipt> {
+        Ok(self.session.delete_slide(context, slide_id)?)
+    }
+
+    pub fn move_slide(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        to_index: u32,
+    ) -> Result<SlideReceipt> {
+        Ok(self.session.move_slide(context, slide_id, to_index)?)
+    }
+
+    pub fn add_text_box(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        draft: &ShapeDraft,
+    ) -> Result<ShapeReceipt> {
+        Ok(self.session.add_text_box(context, slide_id, draft)?)
+    }
+
+    pub fn remove_shape(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        shape_id: &str,
+    ) -> Result<ShapeReceipt> {
+        Ok(self.session.remove_shape(context, slide_id, shape_id)?)
+    }
+
+    pub fn move_shape(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        shape_id: &str,
+        x: i64,
+        y: i64,
+    ) -> Result<TransformReceipt> {
+        Ok(self.session.move_shape(context, slide_id, shape_id, x, y)?)
+    }
+
+    pub fn resize_shape(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        shape_id: &str,
+        width: i64,
+        height: i64,
+    ) -> Result<TransformReceipt> {
+        Ok(self
+            .session
+            .resize_shape(context, slide_id, shape_id, width, height)?)
+    }
+
+    pub fn insert_text(
+        &self,
+        context: &EditCtx,
+        story_id: &str,
+        index: u32,
+        text: &str,
+        style: &TextStyle,
+    ) -> Result<TextReceipt> {
+        Ok(self
+            .session
+            .insert_text(context, story_id, index, text, style)?)
+    }
+
+    pub fn delete_text(
+        &self,
+        context: &EditCtx,
+        story_id: &str,
+        start: u32,
+        end: u32,
+    ) -> Result<TextReceipt> {
+        Ok(self.session.delete_text(context, story_id, start, end)?)
+    }
+
+    pub fn format_text(
+        &self,
+        context: &EditCtx,
+        story_id: &str,
+        start: u32,
+        end: u32,
+        patch: &TextStylePatch,
+    ) -> Result<TextReceipt> {
+        Ok(self
+            .session
+            .format_text(context, story_id, start, end, patch)?)
+    }
+
+    pub fn insert_paragraph_break(
+        &self,
+        context: &EditCtx,
+        story_id: &str,
+        index: u32,
+    ) -> Result<TextReceipt> {
+        Ok(self
+            .session
+            .insert_paragraph_break(context, story_id, index)?)
+    }
+
+    pub fn register_font(
+        &mut self,
+        family: &str,
+        bold: bool,
+        italic: bool,
+        bytes: &[u8],
+    ) -> Result<u32> {
+        Ok(self.renderer.register_font(family, bold, italic, bytes)?)
+    }
+
+    pub fn render_slide(&self, slide_index: usize) -> Result<RenderedSlide> {
+        let snapshot = self.session.snapshot()?;
+        Ok(self
+            .renderer
+            .layout_slide(self.session.package(), &snapshot, slide_index)?)
+    }
+
+    /// Serializes the byte-preserved source package.
+    pub fn save(&self) -> Result<Vec<u8>> {
+        Ok(pptx_parse::write_pptx(self.session.package())?)
+    }
+
+    pub fn encode_state_vector_v1(&self) -> Vec<u8> {
+        self.session.encode_state_vector_v1()
+    }
+
+    pub fn encode_state_as_update_v1(&self) -> Vec<u8> {
+        self.session.encode_state_as_update_v1()
+    }
+
+    pub fn encode_diff_v1(&self, remote_state_vector: &[u8]) -> Result<Vec<u8>> {
+        Ok(self.session.encode_diff_v1(remote_state_vector)?)
+    }
+
+    pub fn apply_update_v1(&self, update: &[u8]) -> Result<DeckSnapshot> {
+        Ok(self.session.apply_update_v1(update)?)
+    }
+
+    pub fn undo(&self) -> bool {
+        self.session.undo()
+    }
+
+    pub fn redo(&self) -> bool {
+        self.session.redo()
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.session.can_undo()
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.session.can_redo()
+    }
+
+    pub fn add_undo_barrier(&self) {
+        self.session.add_undo_barrier();
+    }
+}

--- a/crates/betteroffice-pptx/src/types.rs
+++ b/crates/betteroffice-pptx/src/types.rs
@@ -1,0 +1,20 @@
+pub use pptx_edit::{
+    DeckSnapshot, EditCtx, EditError, EditOrigin, ParagraphSnapshot, ShapeDraft, ShapeKind,
+    ShapeReceipt, ShapeRect, ShapeSnapshot, SlideReceipt, SlideSnapshot, StorySnapshot,
+    TextReceipt, TextRunSnapshot, TextStyle, TextStylePatch, TransformReceipt, UpdateEvent,
+    UpdateOrigin,
+};
+pub use pptx_parse::{
+    Bullet, GraphicFrame, GraphicFrameData, GroupShape, MediaPart, ParagraphProperties,
+    ParseLimits, Picture, PictureCrop, Placeholder, PptxError, PptxPackage,
+    Presentation as PresentationModel, Relationship, RunProperties, Shape, ShapeBase, ShapeNode,
+    ShapeTransform, Slide, SlideLayout, SlideMaster, SlideReference, TargetMode, TextAutofit,
+    TextBody, TextParagraph as ModelTextParagraph, TextRun as ModelTextRun, TextStyleSet,
+    ThemePart,
+};
+pub use pptx_render::{
+    CONTRACT_VERSION, CaretStop, GradientStop, GradientType, HitTestResult, Paint, PositionedGlyph,
+    PositionedTextLine, PositionedTextRun, Primitive, RenderError, RenderedSlide, Stroke,
+    SurfaceDisplayList, TextAlign, TextAnchor, TextParagraph as DisplayTextParagraph,
+    TextRun as DisplayTextRun, Transform,
+};

--- a/crates/betteroffice-pptx/tests/facade.rs
+++ b/crates/betteroffice-pptx/tests/facade.rs
@@ -1,0 +1,93 @@
+use betteroffice_pptx::{EditCtx, Error, Presentation, ShapeNode};
+
+const FIXTURE: &[u8] = include_bytes!("../../../apps/demo/public/betteroffice-demo.pptx");
+const FONT: &[u8] = include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+
+#[test]
+fn opens_edits_renders_saves_and_reopens() {
+    let mut presentation = Presentation::open(FIXTURE).unwrap();
+    assert_eq!(presentation.slides().len(), 3);
+    assert_eq!(presentation.layouts().len(), 1);
+    assert_eq!(presentation.masters().len(), 1);
+    assert!(presentation.slides().iter().any(|slide| {
+        slide.shapes.iter().any(|shape| {
+            matches!(shape, ShapeNode::Shape(shape) if shape.text.as_ref().is_some_and(|body| {
+                body.paragraphs.iter().flat_map(|paragraph| &paragraph.runs).any(|run| run.text.contains("Rust"))
+            }))
+        })
+    }));
+
+    let before = presentation.snapshot().unwrap();
+    let slide_id = before.slides[0].id.clone();
+    let shape_id = before.slides[0].shapes[0].id.clone();
+    let receipt = presentation
+        .move_shape(
+            &EditCtx::local("facade-test"),
+            &slide_id,
+            &shape_id,
+            1_111_111,
+            2_222_222,
+        )
+        .unwrap();
+    assert_eq!((receipt.after.x, receipt.after.y), (1_111_111, 2_222_222));
+    let after = presentation.snapshot().unwrap();
+    assert_eq!(
+        (after.slides[0].shapes[0].x, after.slides[0].shapes[0].y),
+        (1_111_111, 2_222_222)
+    );
+
+    for bold in [false, true] {
+        presentation
+            .register_font("Inter", bold, false, FONT)
+            .unwrap();
+    }
+    let rendered = presentation.render_slide(0).unwrap();
+    assert_eq!(
+        (rendered.display_list.width, rendered.display_list.height),
+        (1280.0, 720.0)
+    );
+    assert!(!rendered.display_list.primitives.is_empty());
+
+    let saved = presentation.save().unwrap();
+    let reopened = Presentation::open(&saved).unwrap();
+    assert_eq!(reopened.slides().len(), 3);
+    assert_eq!(reopened.package().presentation.slides.len(), 3);
+}
+
+#[test]
+fn collaborative_facade_exchanges_typed_updates() {
+    let left = Presentation::open_collaborative(FIXTURE, 101).unwrap();
+    let right = Presentation::open_collaborative(FIXTURE, 202).unwrap();
+    let before = left.snapshot().unwrap();
+    let slide_id = before.slides[0].id.clone();
+    let shape_id = before.slides[0].shapes[0].id.clone();
+
+    left.move_shape(
+        &EditCtx::local("left"),
+        &slide_id,
+        &shape_id,
+        3_333_333,
+        4_444_444,
+    )
+    .unwrap();
+    let update = left
+        .encode_diff_v1(&right.encode_state_vector_v1())
+        .unwrap();
+    let snapshot = right.apply_update_v1(&update).unwrap();
+
+    assert_eq!(
+        (
+            snapshot.slides[0].shapes[0].x,
+            snapshot.slides[0].shapes[0].y
+        ),
+        (3_333_333, 4_444_444)
+    );
+}
+
+#[test]
+fn reports_native_parse_errors() {
+    assert!(matches!(
+        Presentation::open(b"not a presentation"),
+        Err(Error::Parse(_))
+    ));
+}

--- a/crates/pptx-edit/src/lib.rs
+++ b/crates/pptx-edit/src/lib.rs
@@ -49,10 +49,26 @@ pub struct DeckSession {
 
 impl DeckSession {
     pub fn open(bytes: &[u8], client_id: u64) -> EditResult<Self> {
-        validate_client_id(client_id)?;
         let package =
             pptx_parse::parse_pptx(bytes).map_err(|error| EditError::Parse(error.to_string()))?;
         let fingerprint = format!("{:x}", Sha256::digest(bytes));
+        Self::from_package_with_fingerprint(package, fingerprint, client_id)
+    }
+
+    /// Opens an edit session from an already parsed package.
+    pub fn from_package(package: PptxPackage, client_id: u64) -> EditResult<Self> {
+        let bytes = pptx_parse::write_pptx(&package)
+            .map_err(|error| EditError::Parse(error.to_string()))?;
+        let fingerprint = format!("{:x}", Sha256::digest(bytes));
+        Self::from_package_with_fingerprint(package, fingerprint, client_id)
+    }
+
+    fn from_package_with_fingerprint(
+        package: PptxPackage,
+        fingerprint: String,
+        client_id: u64,
+    ) -> EditResult<Self> {
+        validate_client_id(client_id)?;
         let bootstrap = doc_with_client_id(BOOTSTRAP_CLIENT_ID);
         deck::seed_doc(&bootstrap, &package, &fingerprint)?;
         let baseline = bootstrap


### PR DESCRIPTION
TL;DR:

Summary:
- Add a typed native `betteroffice-pptx` facade for parsed presentation structure, Yrs editing and collaboration, slide display lists, and source-package serialization.
- Re-export PPTX model, edit, and render contract types behind one Rust API without JSON or `JsValue` calls.
- Add a native `DeckSession::from_package` constructor so facade opening preserves typed parse errors and avoids reparsing.
- Keep publishing disabled until the lower PPTX crates are publishable, and document edited PresentationML persistence as a follow-up.
- Cover fixture-backed structure reads, native edits, rendering, save/reopen, collaboration updates, and parse errors.

Test plan:
- [x] `cargo test --workspace`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`