### PR TITLE
feat(docx): add native umbrella crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "betteroffice-docx"
+version = "0.0.1"
+dependencies = [
+ "betteroffice-opc",
+ "docx-edit",
+ "docx-layout",
+ "docx-parse",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "betteroffice-opc"
 version = "0.0.1"
 dependencies = [

--- a/crates/betteroffice-docx/Cargo.toml
+++ b/crates/betteroffice-docx/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "betteroffice-docx"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+# Publishing is gated on the lower-level DOCX crates becoming publishable.
+publish = false
+description = "Typed native Rust facade for DOCX parsing, editing, layout, and serialization."
+readme = "README.md"
+keywords = ["docx", "word", "ooxml", "wordprocessingml"]
+categories = ["parser-implementations", "rendering"]
+
+[dependencies]
+docx-edit = { path = "../docx-edit" }
+docx-layout = { path = "../docx-layout" }
+docx-parse = { path = "../docx-parse" }
+sha2 = "0.10"
+
+[dev-dependencies]
+ooxml-opc = { package = "betteroffice-opc", path = "../ooxml-opc" }
+serde_json = "1"

--- a/crates/betteroffice-docx/README.md
+++ b/crates/betteroffice-docx/README.md
@@ -1,0 +1,36 @@
+# betteroffice-docx
+
+The typed native Rust API for opening, inspecting, editing, laying out, and
+saving DOCX documents. Parsing and serialization use the native OOXML model,
+while paragraph edits use the Yrs-backed editing core without crossing a JSON
+or wasm boundary.
+
+```rust
+use betteroffice_docx::{Document, get_paragraph_text};
+
+let mut document = Document::open(&docx_bytes)?;
+let paragraph_id = document.paragraphs()[0].para_id.clone().unwrap();
+
+document.replace_paragraph_text(&paragraph_id, "Updated in Rust")?;
+assert_eq!(get_paragraph_text(document.paragraph(&paragraph_id).unwrap()), "Updated in Rust");
+
+let saved = document.save()?;
+# Ok::<(), betteroffice_docx::Error>(())
+```
+
+`DocumentModel` exposes the body, sections, headers, footers, notes, styles,
+numbering, relationships, media, and charts. Saving replaces engine-owned DOCX
+parts while retaining the original package as the source for unowned parts.
+
+The high-level paragraph replacement currently accepts plain single-run
+paragraphs. The complete native `EditingDoc` and its typed operation vocabulary
+are re-exported for advanced editing workflows.
+
+Pagination accepts a typed, already-measured `LayoutInput` and returns both the
+typed layout and body display list. Native DOCX-model lowering and measurement
+are not yet exposed by the lower crates, so callers must currently provide that
+projection.
+
+Publishing remains disabled until `docx-parse`, `docx-layout`, and `docx-edit`
+are publishable dependencies. The API is experimental and may change before
+`0.1.0`.

--- a/crates/betteroffice-docx/src/document.rs
+++ b/crates/betteroffice-docx/src/document.rs
@@ -1,0 +1,360 @@
+use docx_edit::{EditCtx, EditingDoc, Receipt, StoryRange};
+use docx_layout::types::Input as LayoutInput;
+use docx_parse::block::BlockContent;
+use docx_parse::document::{DocumentBody, Section, get_paragraph_text};
+use docx_parse::inline::{InlineNode, Run, RunContent, RunType};
+use docx_parse::paragraph::{Paragraph, ParagraphContent};
+use docx_parse::s9::{S9DocumentBodyWire, S9PackageWire, S9ParseOptions, S9SectionWire};
+use docx_parse::serializer::{
+    S13SaveOptions, S13SaveRequest, SerializerDeterminism, write_docx_s13,
+};
+use docx_parse::table::Table;
+use sha2::{Digest, Sha256};
+
+use crate::types::DEFAULT_SERIALIZATION_TIME;
+use crate::{DocumentModel, DocumentStructure, Error, LayoutResult, Result, SaveOptions};
+
+pub struct Document {
+    original: Vec<u8>,
+    seed: String,
+    model: DocumentModel,
+}
+
+impl Document {
+    pub fn open(bytes: &[u8]) -> Result<Self> {
+        let parsed = docx_parse::parse_docx_s9_wire(bytes, S9ParseOptions::default())?;
+        let document = parsed.document;
+        let model = model_from_package(
+            document.package,
+            document.template_variables.unwrap_or_default(),
+            document.warnings.unwrap_or_default(),
+        );
+        Ok(Self {
+            original: bytes.to_vec(),
+            seed: format!("{:x}", Sha256::digest(bytes)),
+            model,
+        })
+    }
+
+    pub fn model(&self) -> &DocumentModel {
+        &self.model
+    }
+
+    pub fn model_mut(&mut self) -> &mut DocumentModel {
+        &mut self.model
+    }
+
+    pub fn into_model(self) -> DocumentModel {
+        self.model
+    }
+
+    pub fn body(&self) -> &DocumentBody {
+        &self.model.body
+    }
+
+    pub fn headers(&self) -> &[(String, docx_parse::HeaderFooter)] {
+        &self.model.headers
+    }
+
+    pub fn footers(&self) -> &[(String, docx_parse::HeaderFooter)] {
+        &self.model.footers
+    }
+
+    pub fn sections(&self) -> &[Section] {
+        self.model.body.sections.as_deref().unwrap_or_default()
+    }
+
+    pub fn paragraphs(&self) -> Vec<&Paragraph> {
+        let mut paragraphs = Vec::new();
+        collect_paragraphs(&self.model.body.content, &mut paragraphs);
+        paragraphs
+    }
+
+    pub fn tables(&self) -> Vec<&Table> {
+        let mut tables = Vec::new();
+        collect_tables(&self.model.body.content, &mut tables);
+        tables
+    }
+
+    pub fn paragraph(&self, para_id: &str) -> Option<&Paragraph> {
+        self.paragraphs()
+            .into_iter()
+            .find(|paragraph| paragraph.para_id.as_deref() == Some(para_id))
+    }
+
+    pub fn structure(&self) -> DocumentStructure {
+        DocumentStructure {
+            body_paragraphs: self.paragraphs().len(),
+            body_tables: self.tables().len(),
+            sections: self.sections().len(),
+            headers: self.model.headers.len(),
+            footers: self.model.footers.len(),
+            footnotes: self.model.footnotes.len(),
+            endnotes: self.model.endnotes.len(),
+        }
+    }
+
+    pub fn replace_paragraph_text(&mut self, para_id: &str, text: &str) -> Result<Receipt> {
+        let context = EditCtx::local("betteroffice-docx", DEFAULT_SERIALIZATION_TIME);
+        self.replace_paragraph_text_with(para_id, text, 1, &context)
+    }
+
+    pub fn replace_paragraph_text_with(
+        &mut self,
+        para_id: &str,
+        text: &str,
+        client_id: u64,
+        context: &EditCtx,
+    ) -> Result<Receipt> {
+        let paragraph = find_paragraph_mut(&mut self.model.body.content, para_id)
+            .ok_or_else(|| Error::ParagraphNotFound(para_id.to_owned()))?;
+        let template = plain_run_template(paragraph)
+            .ok_or_else(|| Error::UnsupportedParagraphEdit(para_id.to_owned()))?;
+        let current = get_paragraph_text(paragraph);
+        let style = paragraph
+            .formatting
+            .as_ref()
+            .and_then(|formatting| formatting.style_id.as_deref())
+            .unwrap_or("Normal");
+        let alignment = paragraph
+            .formatting
+            .as_ref()
+            .and_then(|formatting| formatting.alignment.as_deref())
+            .unwrap_or("left");
+        let editor = EditingDoc::new(client_id);
+        editor.create_story_with_paragraph_id("body", para_id, &current, style, alignment)?;
+        let receipt = editor.replace_range(
+            context,
+            StoryRange::new("body", 0, utf16_len(&current)),
+            text,
+        )?;
+        let edited = editor
+            .paragraphs("body")?
+            .into_iter()
+            .next()
+            .map(|paragraph| paragraph.text)
+            .unwrap_or_default();
+        replace_plain_run(paragraph, edited, template);
+        let replacement = paragraph.clone();
+        if let Some(sections) = &mut self.model.body.sections {
+            for section in sections {
+                if let Some(section_paragraph) = find_paragraph_mut(&mut section.content, para_id) {
+                    *section_paragraph = replacement.clone();
+                }
+            }
+        }
+        Ok(receipt)
+    }
+
+    pub fn layout(&self, mut input: LayoutInput) -> Result<LayoutResult> {
+        let layout = docx_layout::compute_layout_input(&mut input)?;
+        let display_list =
+            docx_layout::build_display_list(&input, &layout).map_err(Error::DisplayList)?;
+        Ok(LayoutResult {
+            layout,
+            display_list,
+        })
+    }
+
+    pub fn save(&self) -> Result<Vec<u8>> {
+        self.save_with_options(SaveOptions::default())
+    }
+
+    pub fn save_with_options(&self, options: SaveOptions) -> Result<Vec<u8>> {
+        let request = S13SaveRequest {
+            determinism: SerializerDeterminism {
+                seed: self.seed.clone(),
+                now: options.now,
+            },
+            document: self.model.body.clone(),
+            header_entries: self.model.headers.clone(),
+            footer_entries: self.model.footers.clone(),
+            footnotes: self.model.footnotes.clone(),
+            endnotes: self.model.endnotes.clone(),
+            footnote_separators: self.model.footnote_separators.clone(),
+            endnote_separators: self.model.endnote_separators.clone(),
+            relationship_entries: self.model.relationships.clone(),
+            numbering: Some(self.model.numbering.clone()),
+            options: S13SaveOptions {
+                update_modified_date: options.update_modified_date,
+                modified_by: options.modified_by,
+            },
+            selective: None,
+        };
+        write_docx_s13(request, &self.original).map_err(Error::from)
+    }
+}
+
+type RunTemplate = Option<(
+    Option<docx_parse::TextFormatting>,
+    Option<Vec<docx_parse::inline::RunPropertyChange>>,
+)>;
+
+fn plain_run_template(paragraph: &Paragraph) -> Option<RunTemplate> {
+    if paragraph.content.is_empty() {
+        return Some(None);
+    }
+    let [ParagraphContent::Inline(InlineNode::Run(run))] = paragraph.content.as_slice() else {
+        return None;
+    };
+    if !run
+        .content
+        .iter()
+        .all(|content| matches!(content, RunContent::Text { .. }))
+    {
+        return None;
+    }
+    Some(Some((run.formatting.clone(), run.property_changes.clone())))
+}
+
+fn replace_plain_run(paragraph: &mut Paragraph, text: String, template: RunTemplate) {
+    if text.is_empty() {
+        paragraph.content.clear();
+        return;
+    }
+    let (formatting, property_changes) = template.unwrap_or_default();
+    paragraph.content = vec![ParagraphContent::Inline(InlineNode::Run(Run {
+        node_type: RunType::Run,
+        formatting,
+        property_changes,
+        content: vec![RunContent::Text {
+            preserve_space: (text.trim() != text).then_some(true),
+            text,
+        }],
+    }))];
+}
+
+fn model_from_package(
+    package: S9PackageWire,
+    template_variables: Vec<String>,
+    warnings: Vec<String>,
+) -> DocumentModel {
+    let S9PackageWire {
+        document,
+        styles,
+        theme,
+        numbering,
+        settings,
+        font_table,
+        header_entries,
+        footer_entries,
+        footnotes,
+        endnotes,
+        footnote_separators,
+        endnote_separators,
+        relationship_entries,
+        media_entries,
+        chart_entries,
+    } = package;
+    DocumentModel {
+        body: body_from_wire(document),
+        styles,
+        theme,
+        numbering,
+        settings,
+        font_table,
+        headers: header_entries.unwrap_or_default(),
+        footers: footer_entries.unwrap_or_default(),
+        footnotes: footnotes.unwrap_or_default(),
+        endnotes: endnotes.unwrap_or_default(),
+        footnote_separators: footnote_separators.unwrap_or_default(),
+        endnote_separators: endnote_separators.unwrap_or_default(),
+        relationships: relationship_entries,
+        media: media_entries,
+        charts: chart_entries,
+        template_variables,
+        warnings,
+    }
+}
+
+fn body_from_wire(wire: S9DocumentBodyWire) -> DocumentBody {
+    let sections = wire.sections.map(|sections| {
+        sections
+            .into_iter()
+            .map(|section| section_from_wire(section, &wire.content))
+            .collect()
+    });
+    DocumentBody {
+        content: wire.content,
+        sections,
+        final_section_properties: wire.final_section_properties,
+        comments: wire.comments,
+    }
+}
+
+fn section_from_wire(section: S9SectionWire, content: &[BlockContent]) -> Section {
+    Section {
+        id: section.id,
+        properties: section.properties,
+        content: content
+            .get(section.content_start..section.content_end)
+            .unwrap_or_default()
+            .to_vec(),
+    }
+}
+
+fn collect_paragraphs<'a>(blocks: &'a [BlockContent], output: &mut Vec<&'a Paragraph>) {
+    for block in blocks {
+        match block {
+            BlockContent::Paragraph(paragraph) => output.push(paragraph),
+            BlockContent::Table(table) => {
+                for row in &table.rows {
+                    for cell in &row.cells {
+                        collect_paragraphs(&cell.content, output);
+                    }
+                }
+            }
+            BlockContent::BlockSdt(sdt) => collect_paragraphs(&sdt.content, output),
+        }
+    }
+}
+
+fn collect_tables<'a>(blocks: &'a [BlockContent], output: &mut Vec<&'a Table>) {
+    for block in blocks {
+        match block {
+            BlockContent::Paragraph(_) => {}
+            BlockContent::Table(table) => {
+                output.push(table);
+                for row in &table.rows {
+                    for cell in &row.cells {
+                        collect_tables(&cell.content, output);
+                    }
+                }
+            }
+            BlockContent::BlockSdt(sdt) => collect_tables(&sdt.content, output),
+        }
+    }
+}
+
+fn find_paragraph_mut<'a>(
+    blocks: &'a mut [BlockContent],
+    para_id: &str,
+) -> Option<&'a mut Paragraph> {
+    for block in blocks {
+        match block {
+            BlockContent::Paragraph(paragraph) if paragraph.para_id.as_deref() == Some(para_id) => {
+                return Some(paragraph);
+            }
+            BlockContent::Paragraph(_) => {}
+            BlockContent::Table(table) => {
+                for row in &mut table.rows {
+                    for cell in &mut row.cells {
+                        if let Some(paragraph) = find_paragraph_mut(&mut cell.content, para_id) {
+                            return Some(paragraph);
+                        }
+                    }
+                }
+            }
+            BlockContent::BlockSdt(sdt) => {
+                if let Some(paragraph) = find_paragraph_mut(&mut sdt.content, para_id) {
+                    return Some(paragraph);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn utf16_len(text: &str) -> u32 {
+    text.encode_utf16().count() as u32
+}

--- a/crates/betteroffice-docx/src/error.rs
+++ b/crates/betteroffice-docx/src/error.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    Parse(docx_parse::ParseError),
+    Edit(docx_edit::EditError),
+    Operation(docx_edit::OpError),
+    Layout(docx_layout::LayoutError),
+    DisplayList(String),
+    ParagraphNotFound(String),
+    UnsupportedParagraphEdit(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(error) => error.fmt(formatter),
+            Self::Edit(error) => error.fmt(formatter),
+            Self::Operation(error) => error.fmt(formatter),
+            Self::Layout(error) => error.fmt(formatter),
+            Self::DisplayList(error) => formatter.write_str(error),
+            Self::ParagraphNotFound(id) => write!(formatter, "paragraph {id:?} was not found"),
+            Self::UnsupportedParagraphEdit(id) => {
+                write!(
+                    formatter,
+                    "paragraph {id:?} is not a plain single-run paragraph"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(error) => Some(error),
+            Self::Edit(error) => Some(error),
+            Self::Operation(error) => Some(error),
+            Self::Layout(error) => Some(error),
+            Self::DisplayList(_)
+            | Self::ParagraphNotFound(_)
+            | Self::UnsupportedParagraphEdit(_) => None,
+        }
+    }
+}
+
+impl From<docx_parse::ParseError> for Error {
+    fn from(error: docx_parse::ParseError) -> Self {
+        Self::Parse(error)
+    }
+}
+
+impl From<docx_edit::EditError> for Error {
+    fn from(error: docx_edit::EditError) -> Self {
+        Self::Edit(error)
+    }
+}
+
+impl From<docx_edit::OpError> for Error {
+    fn from(error: docx_edit::OpError) -> Self {
+        Self::Operation(error)
+    }
+}
+
+impl From<docx_layout::LayoutError> for Error {
+    fn from(error: docx_layout::LayoutError) -> Self {
+        Self::Layout(error)
+    }
+}

--- a/crates/betteroffice-docx/src/lib.rs
+++ b/crates/betteroffice-docx/src/lib.rs
@@ -1,0 +1,22 @@
+//! Typed facade for opening, editing, laying out, and saving DOCX files.
+
+mod document;
+mod error;
+mod types;
+
+pub use document::Document;
+pub use error::Error;
+pub use types::{DocumentModel, DocumentStructure, LayoutResult, SaveOptions};
+
+pub use docx_edit::{
+    EditCtx, EditError, EditOrigin, EditingDoc, FormatPolicy, Loc, LocRange, OpError, Receipt,
+    StoryRange, TextView,
+};
+pub use docx_layout::display_list::{DisplayList, DisplayPage, Primitive};
+pub use docx_layout::types::{Input as LayoutInput, Layout, LayoutOptions, MeasuredBlock, Page};
+pub use docx_parse::{
+    BlockContent, DocumentBody, HeaderFooter, InlineNode, Paragraph, ParagraphContent, Run,
+    RunContent, Section, SectionProperties, Table, TableCell, TableRow, get_paragraph_text,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/betteroffice-docx/src/types.rs
+++ b/crates/betteroffice-docx/src/types.rs
@@ -1,0 +1,70 @@
+use docx_layout::display_list::DisplayList;
+use docx_layout::types::Layout;
+use docx_parse::chart::Chart;
+use docx_parse::document::DocumentBody;
+use docx_parse::fonts::FontTable;
+use docx_parse::header_footer::HeaderFooter;
+use docx_parse::media::MediaFile;
+use docx_parse::notes::Note;
+use docx_parse::numbering::NumberingDefinitions;
+use docx_parse::relationships::Relationship;
+use docx_parse::settings::DocumentSettings;
+use docx_parse::styles::StyleDefinitions;
+use docx_parse::theme::Theme;
+
+pub const DEFAULT_SERIALIZATION_TIME: &str = "1970-01-01T00:00:00.000Z";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DocumentModel {
+    pub body: DocumentBody,
+    pub styles: Option<StyleDefinitions>,
+    pub theme: Theme,
+    pub numbering: NumberingDefinitions,
+    pub settings: DocumentSettings,
+    pub font_table: FontTable,
+    pub headers: Vec<(String, HeaderFooter)>,
+    pub footers: Vec<(String, HeaderFooter)>,
+    pub footnotes: Vec<Note>,
+    pub endnotes: Vec<Note>,
+    pub footnote_separators: Vec<Note>,
+    pub endnote_separators: Vec<Note>,
+    pub relationships: Vec<(String, Relationship)>,
+    pub media: Vec<(String, MediaFile)>,
+    pub charts: Vec<(String, Chart)>,
+    pub template_variables: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DocumentStructure {
+    pub body_paragraphs: usize,
+    pub body_tables: usize,
+    pub sections: usize,
+    pub headers: usize,
+    pub footers: usize,
+    pub footnotes: usize,
+    pub endnotes: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SaveOptions {
+    pub now: String,
+    pub update_modified_date: bool,
+    pub modified_by: Option<String>,
+}
+
+impl Default for SaveOptions {
+    fn default() -> Self {
+        Self {
+            now: DEFAULT_SERIALIZATION_TIME.to_owned(),
+            update_modified_date: false,
+            modified_by: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LayoutResult {
+    pub layout: Layout,
+    pub display_list: DisplayList,
+}

--- a/crates/betteroffice-docx/tests/document.rs
+++ b/crates/betteroffice-docx/tests/document.rs
@@ -1,0 +1,71 @@
+use betteroffice_docx::{Document, LayoutInput, get_paragraph_text};
+
+fn sample_docx() -> Vec<u8> {
+    let parts = vec![
+        (
+            "[Content_Types].xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/></Types>"#.to_vec(),
+        ),
+        (
+            "_rels/.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#.to_vec(),
+        ),
+        (
+            "word/_rels/document.xml.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdHeader" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/></Relationships>"#.to_vec(),
+        ),
+        (
+            "word/document.xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:body><w:p w14:paraId="11111111"><w:pPr><w:sectPr><w:headerReference w:type="default" r:id="rIdHeader"/></w:sectPr></w:pPr><w:r><w:t>Hello DOCX</w:t></w:r></w:p><w:tbl><w:tblGrid><w:gridCol w:w="2400"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr><w:p w14:paraId="22222222"><w:r><w:t>Cell text</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p w14:paraId="33333333"><w:r><w:t>Second section</w:t></w:r></w:p><w:sectPr><w:headerReference w:type="default" r:id="rIdHeader"/><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr></w:body></w:document>"#.to_vec(),
+        ),
+        (
+            "word/header1.xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:p w14:paraId="44444444"><w:r><w:t>Native header</w:t></w:r></w:p></w:hdr>"#.to_vec(),
+        ),
+    ];
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+#[test]
+fn opens_edits_saves_and_reopens_typed_structure() {
+    let mut document = Document::open(&sample_docx()).unwrap();
+    let structure = document.structure();
+    assert_eq!(structure.body_paragraphs, 3);
+    assert_eq!(structure.body_tables, 1);
+    assert_eq!(structure.sections, 2);
+    assert_eq!(structure.headers, 1);
+    assert_eq!(document.headers()[0].1.content.len(), 1);
+    assert_eq!(
+        get_paragraph_text(document.paragraph("11111111").unwrap()),
+        "Hello DOCX"
+    );
+
+    let receipt = document
+        .replace_paragraph_text("11111111", "Edited natively")
+        .unwrap();
+    assert_eq!(receipt.range.unwrap().start.para, "11111111");
+
+    let saved = document.save().unwrap();
+    let reopened = Document::open(&saved).unwrap();
+    assert_eq!(reopened.structure(), structure);
+    assert_eq!(
+        get_paragraph_text(reopened.paragraph("11111111").unwrap()),
+        "Edited natively"
+    );
+    assert_eq!(reopened.tables().len(), 1);
+    assert_eq!(reopened.sections().len(), 2);
+    assert_eq!(reopened.headers().len(), 1);
+}
+
+#[test]
+fn lays_out_typed_input_and_builds_a_display_list() {
+    let document = Document::open(&sample_docx()).unwrap();
+    let input: LayoutInput = serde_json::from_str(include_str!(
+        "../../docx-layout/tests/fixtures/single-page-multi-paragraph.input.json"
+    ))
+    .unwrap();
+    let result = document.layout(input).unwrap();
+    assert_eq!(result.layout.pages.len(), 1);
+    assert_eq!(result.display_list.pages.len(), 1);
+    assert!(!result.display_list.pages[0].primitives.is_empty());
+}

--- a/crates/docx-edit/src/lib.rs
+++ b/crates/docx-edit/src/lib.rs
@@ -328,8 +328,21 @@ impl EditingDoc {
         p_style: &str,
         alignment: &str,
     ) -> EditResult<ParagraphId> {
-        let story_id = story_id.into();
         let para_id = self.next_id();
+        self.create_story_with_paragraph_id(story_id, para_id, initial_text, p_style, alignment)
+    }
+
+    /// Adds a one-paragraph story with a caller-supplied paragraph ID.
+    pub fn create_story_with_paragraph_id(
+        &self,
+        story_id: impl Into<StoryId>,
+        para_id: impl Into<ParagraphId>,
+        initial_text: &str,
+        p_style: &str,
+        alignment: &str,
+    ) -> EditResult<ParagraphId> {
+        let story_id = story_id.into();
+        let para_id = para_id.into();
         let mut txn = self.doc.transact_mut_with(self.client_id);
         let stories = txn
             .get_map(STORIES)

--- a/crates/docx-layout/src/lib.rs
+++ b/crates/docx-layout/src/lib.rs
@@ -104,11 +104,26 @@ impl std::fmt::Display for LayoutError {
     }
 }
 
+impl std::error::Error for LayoutError {}
+
+/// Run pagination from a typed native input.
+pub fn compute_layout_input(input: &mut types::Input) -> Result<types::Layout, LayoutError> {
+    place::layout_document(input)
+}
+
 /// Parse the `{ measured, options }` envelope and run the placement walk.
 pub fn compute_layout(input: &str) -> Result<types::Layout, LayoutError> {
     let mut parsed: types::Input =
         serde_json::from_str(input).map_err(|e| LayoutError::Invalid(format!("parse: {e}")))?;
-    place::layout_document(&mut parsed)
+    compute_layout_input(&mut parsed)
+}
+
+/// Build a body display list from typed pagination state.
+pub fn build_display_list(
+    pagination: &types::Input,
+    layout: &types::Layout,
+) -> Result<display_list::DisplayList, String> {
+    build_display_list_value_from_resident(pagination, layout, "{}")
 }
 
 /// Pure JSON boundary: `{ measured, options }` in, `Layout` JSON out. `Err`


### PR DESCRIPTION
TL;DR:

Summary:
- Add the typed native betteroffice-docx facade for DOCX open, structure inspection, paragraph editing, layout, display lists, and save.
- Re-export the native document model and typed edit/layout vocabulary without exposing JsValue or JSON-string APIs.
- Add typed lower-crate seams for paragraph identity, pagination, and body display-list construction.
- Cover generated-fixture structure, native edit, serialize/reopen, layout, and display-list flows.
- Keep crates.io publishing disabled until the lower-level DOCX dependencies are publishable.

Test plan:
- [ ] Run cargo fmt --all --check.
- [ ] Run cargo clippy --all-targets -- -D warnings.
- [ ] Run cargo test --workspace.