### PR TITLE
fix(redact): release workflow (path-only sibling dep)

### DIFF
--- a/crates/ooxml-redact-cli/Cargo.toml
+++ b/crates/ooxml-redact-cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "betteroffice-redact"
 path = "src/main.rs"
 
 [dependencies]
-ooxml-redact = { package = "betteroffice-redact", path = "../ooxml-redact", version = "0.0.1" }
+ooxml-redact = { package = "betteroffice-redact", path = "../ooxml-redact" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = { version = "3", default-features = false, features = ["rustls"] }


### PR DESCRIPTION
TL;DR:


Summary:
- The Release workflow on main failed at version-packages: cargo metadata could not resolve betteroffice-redact = "^0.0.1". The redact CLI pinned an inline version on betteroffice-redact, which uses version.workspace = true and is publish=false; the release version bump moved the crate past the pinned requirement.
- Fixed by depending on betteroffice-redact by path only (no version). Both crates are publish=false, so a path-only dep is correct and immune to the version bump. Verified by simulating the synchronized release bump (workspace.package + workspace.dependencies to 0.0.2) — cargo metadata now resolves cleanly.

Test plan:
- [ ] Rust gate green
- [ ] Release workflow succeeds on next run
