### PR TITLE
chore(crates): publish the docx and pptx crate trees to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,73 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "betteroffice-docx"
 version = "0.0.1"
 dependencies = [
+ "betteroffice-docx-edit",
+ "betteroffice-docx-layout",
+ "betteroffice-docx-parse",
  "betteroffice-opc",
- "docx-edit",
- "docx-layout",
- "docx-parse",
  "serde_json",
  "sha2",
+]
+
+[[package]]
+name = "betteroffice-docx-edit"
+version = "0.0.1"
+dependencies = [
+ "betteroffice-docx-layout",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "yrs",
+]
+
+[[package]]
+name = "betteroffice-docx-layout"
+version = "0.0.1"
+dependencies = [
+ "betteroffice-drawingml",
+ "betteroffice-ooxml-text",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "betteroffice-docx-parse"
+version = "0.0.1"
+dependencies = [
+ "base64",
+ "betteroffice-drawingml",
+ "betteroffice-opc",
+ "indexmap",
+ "quick-xml",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "betteroffice-drawingml"
+version = "0.0.1"
+dependencies = [
+ "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "betteroffice-ooxml-text"
+version = "0.0.1"
+dependencies = [
+ "rustybuzz",
+ "serde",
+ "serde_json",
+ "skrifa",
+ "unicode-bidi",
+ "unicode-linebreak",
 ]
 
 [[package]]
@@ -90,20 +151,59 @@ dependencies = [
 name = "betteroffice-pptx"
 version = "0.0.1"
 dependencies = [
- "pptx-edit",
- "pptx-parse",
- "pptx-render",
+ "betteroffice-pptx-edit",
+ "betteroffice-pptx-parse",
+ "betteroffice-pptx-render",
+]
+
+[[package]]
+name = "betteroffice-pptx-edit"
+version = "0.0.1"
+dependencies = [
+ "betteroffice-drawingml",
+ "betteroffice-pptx-parse",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "wasm-bindgen",
+ "yrs",
+]
+
+[[package]]
+name = "betteroffice-pptx-parse"
+version = "0.0.1"
+dependencies = [
+ "betteroffice-drawingml",
+ "betteroffice-opc",
+ "quick-xml",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "betteroffice-pptx-render"
+version = "0.0.1"
+dependencies = [
+ "betteroffice-drawingml",
+ "betteroffice-ooxml-text",
+ "betteroffice-pptx-edit",
+ "betteroffice-pptx-parse",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "betteroffice-redact"
 version = "0.0.1"
 dependencies = [
+ "betteroffice-docx-parse",
  "betteroffice-opc",
+ "betteroffice-pptx-parse",
  "betteroffice-xlsx-parse",
- "docx-parse",
  "image",
- "pptx-parse",
  "quick-xml",
  "thiserror",
 ]
@@ -351,47 +451,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "docx-edit"
-version = "0.0.0"
-dependencies = [
- "docx-layout",
- "js-sys",
- "serde",
- "serde_json",
- "unicode-segmentation",
- "wasm-bindgen",
- "yrs",
-]
-
-[[package]]
-name = "docx-layout"
-version = "0.0.0"
-dependencies = [
- "ooxml-drawingml",
- "ooxml-text",
- "serde",
- "serde_json",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "docx-parse"
-version = "0.0.0"
-dependencies = [
- "base64",
- "betteroffice-opc",
- "indexmap",
- "ooxml-drawingml",
- "quick-xml",
- "ryu-js",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -730,26 +789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "ooxml-drawingml"
-version = "0.0.0"
-dependencies = [
- "indexmap",
- "serde",
-]
-
-[[package]]
-name = "ooxml-text"
-version = "0.0.0"
-dependencies = [
- "rustybuzz",
- "serde",
- "serde_json",
- "skrifa",
- "unicode-bidi",
- "unicode-linebreak",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,51 +846,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pptx-edit"
-version = "0.0.0"
-dependencies = [
- "js-sys",
- "ooxml-drawingml",
- "pptx-parse",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "wasm-bindgen",
- "yrs",
-]
-
-[[package]]
-name = "pptx-parse"
-version = "0.0.0"
-dependencies = [
- "betteroffice-opc",
- "ooxml-drawingml",
- "quick-xml",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "pptx-render"
-version = "0.0.0"
-dependencies = [
- "ooxml-drawingml",
- "ooxml-text",
- "pptx-edit",
- "pptx-parse",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "pptx-wasm"
 version = "0.0.0"
 dependencies = [
- "pptx-edit",
- "pptx-parse",
- "pptx-render",
+ "betteroffice-pptx-edit",
+ "betteroffice-pptx-parse",
+ "betteroffice-pptx-render",
  "serde_json",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,23 @@ xlsx-calc = { package = "betteroffice-xlsx-calc", path = "crates/xlsx-calc", ver
 xlsx-ops = { package = "betteroffice-xlsx-ops", path = "crates/xlsx-ops", version = "0.0.1" }
 xlsx-render = { package = "betteroffice-xlsx-render", path = "crates/xlsx-render", version = "0.0.1" }
 xlsx-raster = { package = "betteroffice-xlsx-raster", path = "crates/xlsx-raster", version = "0.0.1" }
+ooxml-text = { package = "betteroffice-ooxml-text", path = "crates/ooxml-text", version = "0.0.1" }
+ooxml-drawingml = { package = "betteroffice-drawingml", path = "crates/ooxml-drawingml", version = "0.0.1" }
+docx-parse = { package = "betteroffice-docx-parse", path = "crates/docx-parse", version = "0.0.1" }
+docx-layout = { package = "betteroffice-docx-layout", path = "crates/docx-layout", version = "0.0.1" }
+docx-edit = { package = "betteroffice-docx-edit", path = "crates/docx-edit", version = "0.0.1" }
+betteroffice-docx = { path = "crates/betteroffice-docx", version = "0.0.1" }
+pptx-parse = { package = "betteroffice-pptx-parse", path = "crates/pptx-parse", version = "0.0.1" }
+pptx-edit = { package = "betteroffice-pptx-edit", path = "crates/pptx-edit", version = "0.0.1" }
+pptx-render = { package = "betteroffice-pptx-render", path = "crates/pptx-render", version = "0.0.1" }
+betteroffice-pptx = { path = "crates/betteroffice-pptx", version = "0.0.1" }
 
 [profile.release]
 opt-level = "s"
 lto = true
 
-[profile.release.package.docx-layout]
+[profile.release.package.betteroffice-docx-layout]
 opt-level = 3
 
-[profile.release.package.docx-parse]
+[profile.release.package.betteroffice-docx-parse]
 opt-level = 3

--- a/crates/betteroffice-docx/Cargo.toml
+++ b/crates/betteroffice-docx/Cargo.toml
@@ -5,19 +5,18 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-# Publishing is gated on the lower-level DOCX crates becoming publishable.
-publish = false
+publish = ["crates-io"]
 description = "Typed native Rust facade for DOCX parsing, editing, layout, and serialization."
 readme = "README.md"
 keywords = ["docx", "word", "ooxml", "wordprocessingml"]
 categories = ["parser-implementations", "rendering"]
 
 [dependencies]
-docx-edit = { path = "../docx-edit" }
-docx-layout = { path = "../docx-layout" }
-docx-parse = { path = "../docx-parse" }
+docx-edit.workspace = true
+docx-layout.workspace = true
+docx-parse.workspace = true
 sha2 = "0.10"
 
 [dev-dependencies]
-ooxml-opc = { package = "betteroffice-opc", path = "../ooxml-opc" }
+ooxml-opc.workspace = true
 serde_json = "1"

--- a/crates/betteroffice-pptx/Cargo.toml
+++ b/crates/betteroffice-pptx/Cargo.toml
@@ -5,14 +5,13 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-# Publishing is gated on the lower-level PPTX crates being published.
-publish = false
+publish = ["crates-io"]
 description = "Typed native Rust facade for parsing, editing, rendering, and saving PPTX presentations."
 readme = "README.md"
 keywords = ["pptx", "powerpoint", "ooxml", "presentationml"]
 categories = ["parser-implementations", "rendering"]
 
 [dependencies]
-pptx-edit = { path = "../pptx-edit" }
-pptx-parse = { path = "../pptx-parse" }
-pptx-render = { path = "../pptx-render" }
+pptx-edit.workspace = true
+pptx-parse.workspace = true
+pptx-render.workspace = true

--- a/crates/docx-edit/Cargo.toml
+++ b/crates/docx-edit/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "docx-edit"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-docx-edit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Pilcrow-stream yrs editing foundation for collaborative DOCX documents."
+keywords = ["docx", "word", "ooxml", "collaboration"]
+categories = ["text-processing", "data-structures"]
 
 [lib]
+name = "docx_edit"
 # cdylib feeds the wasm-bindgen boundary (feature = "wasm"); rlib keeps the
 # native unit tests and in-workspace crate consumers unchanged.
 crate-type = ["cdylib", "rlib"]
@@ -20,7 +25,7 @@ wasm = ["dep:wasm-bindgen", "dep:js-sys"]
 [dependencies]
 # 0.27.3 is the newest crates.io release. The repository's minimumReleaseAge is a Bun/npm
 # policy; there is no Cargo deny/release-age policy, and the existing lockfile already pins it.
-docx-layout = { path = "../docx-layout" }
+docx-layout.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 yrs = "0.27.3"

--- a/crates/docx-layout/Cargo.toml
+++ b/crates/docx-layout/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "docx-layout"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-docx-layout"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "The pure layout-core (pagination) in Rust, compiled to WASM. A twin of the TypeScript layoutCore behind the same MeasuredBlock[] -> Layout contract; ports incrementally, one block kind at a time, gated by the golden corpus."
+keywords = ["docx", "word", "ooxml", "layout"]
+categories = ["rendering", "text-processing"]
 
 [lib]
+name = "docx_layout"
 crate-type = ["cdylib", "rlib"]
 
 # wasm-pack runs a wasm-opt post-pass after rustc/LLVM codegen. Pin it to -O3
@@ -18,8 +23,8 @@ crate-type = ["cdylib", "rlib"]
 wasm-opt = ['-O3']
 
 [dependencies]
-ooxml-drawingml = { path = "../ooxml-drawingml", version = "=0.0.0" }
-ooxml-text = { path = "../ooxml-text" }
+ooxml-drawingml.workspace = true
+ooxml-text.workspace = true
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -27,4 +32,4 @@ serde_json = "1"
 [dev-dependencies]
 # the glyph-run emission tests build an explicit FontStore (register the
 # Liberation fixture) and drive build_display_list_json_with_fonts directly
-ooxml-text = { path = "../ooxml-text" }
+ooxml-text.workspace = true

--- a/crates/docx-parse/Cargo.toml
+++ b/crates/docx-parse/Cargo.toml
@@ -1,19 +1,24 @@
 [package]
-name = "docx-parse"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-docx-parse"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Safe DOCX XML parsing, typed relationship models, and the versioned Rust/TypeScript equivalence contract."
+keywords = ["docx", "word", "ooxml", "wordprocessingml"]
+categories = ["parser-implementations", "encoding"]
 
 [lib]
+name = "docx_parse"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 base64 = "0.22"
 ooxml-opc.workspace = true
 indexmap = { version = "2", features = ["serde"] }
-ooxml-drawingml = { path = "../ooxml-drawingml", version = "=0.0.0" }
+ooxml-drawingml.workspace = true
 quick-xml = { version = "0.41", features = ["encoding"] }
 ryu-js = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/ooxml-drawingml/Cargo.toml
+++ b/crates/ooxml-drawingml/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
-name = "ooxml-drawingml"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-drawingml"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Shared DrawingML colors, themes, shape models, and preset geometry."
+keywords = ["ooxml", "drawingml", "graphics", "office"]
+categories = ["graphics", "rendering", "data-structures"]
+
+[lib]
+name = "ooxml_drawingml"
 
 [dependencies]
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/ooxml-redact/Cargo.toml
+++ b/crates/ooxml-redact/Cargo.toml
@@ -18,6 +18,6 @@ quick-xml = "0.41"
 thiserror = "2"
 
 [dev-dependencies]
-docx-parse = { path = "../docx-parse", version = "=0.0.0" }
-pptx-parse = { path = "../pptx-parse", version = "=0.0.0" }
+docx-parse.workspace = true
+pptx-parse.workspace = true
 xlsx-parse.workspace = true

--- a/crates/ooxml-text/Cargo.toml
+++ b/crates/ooxml-text/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "ooxml-text"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-ooxml-text"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Shared OOXML text shaping, measurement, line breaking, and bidirectional text support."
+keywords = ["ooxml", "text", "typography", "fonts"]
+categories = ["text-processing", "rendering"]
 
 [lib]
+name = "ooxml_text"
 crate-type = ["rlib"]
 
 [dependencies]

--- a/crates/pptx-edit/Cargo.toml
+++ b/crates/pptx-edit/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
-name = "pptx-edit"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-pptx-edit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Collaborative yrs-backed editing core for PPTX decks."
+keywords = ["pptx", "powerpoint", "ooxml", "collaboration"]
+categories = ["text-processing", "data-structures"]
 
 [lib]
+name = "pptx_edit"
 crate-type = ["cdylib", "rlib"]
 
 [features]
@@ -14,8 +19,8 @@ wasm = ["dep:js-sys", "dep:wasm-bindgen"]
 
 [dependencies]
 js-sys = { version = "0.3", optional = true }
-ooxml-drawingml = { path = "../ooxml-drawingml", version = "=0.0.0" }
-pptx-parse = { path = "../pptx-parse", version = "=0.0.0" }
+ooxml-drawingml.workspace = true
+pptx-parse.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/pptx-parse/Cargo.toml
+++ b/crates/pptx-parse/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
-name = "pptx-parse"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-pptx-parse"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Bounded PresentationML parsing and byte-preserving PPTX package serialization."
+keywords = ["pptx", "powerpoint", "ooxml", "presentationml"]
+categories = ["parser-implementations", "encoding"]
+
+[lib]
+name = "pptx_parse"
 
 [dependencies]
-ooxml-drawingml = { path = "../ooxml-drawingml", version = "=0.0.0" }
+ooxml-drawingml.workspace = true
 ooxml-opc.workspace = true
 quick-xml = { version = "0.41", features = ["encoding"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/pptx-render/Cargo.toml
+++ b/crates/pptx-render/Cargo.toml
@@ -1,16 +1,23 @@
 [package]
-name = "pptx-render"
-version = "0.0.0"
-edition = "2024"
-license = "Apache-2.0"
-publish = false
+name = "betteroffice-pptx-render"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = ["crates-io"]
 description = "Rust-owned PPTX slide layout and display-list compiler."
+keywords = ["pptx", "powerpoint", "ooxml", "rendering"]
+categories = ["rendering", "graphics"]
+
+[lib]
+name = "pptx_render"
 
 [dependencies]
-ooxml-drawingml = { path = "../ooxml-drawingml", version = "=0.0.0" }
-ooxml-text = { path = "../ooxml-text", version = "=0.0.0" }
-pptx-edit = { path = "../pptx-edit", version = "=0.0.0" }
-pptx-parse = { path = "../pptx-parse", version = "=0.0.0" }
+ooxml-drawingml.workspace = true
+ooxml-text.workspace = true
+pptx-edit.workspace = true
+pptx-parse.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/pptx-wasm/Cargo.toml
+++ b/crates/pptx-wasm/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 wasm-opt = ["-O3"]
 
 [dependencies]
-pptx-edit = { path = "../pptx-edit", version = "=0.0.0", features = ["wasm"] }
-pptx-parse = { path = "../pptx-parse", version = "=0.0.0" }
-pptx-render = { path = "../pptx-render", version = "=0.0.0" }
+pptx-edit = { workspace = true, features = ["wasm"] }
+pptx-parse.workspace = true
+pptx-render.workspace = true
 serde_json = "1"
 wasm-bindgen = "0.2"

--- a/scripts/rust-crates.mjs
+++ b/scripts/rust-crates.mjs
@@ -12,7 +12,17 @@ export const RUST_CRATES = [
   { name: 'betteroffice-xlsx-render', dependency: 'xlsx-render' },
   { name: 'betteroffice-xlsx-ops', dependency: 'xlsx-ops' },
   { name: 'betteroffice-xlsx-raster', dependency: 'xlsx-raster' },
-  { name: 'betteroffice-xlsx', dependency: 'betteroffice-xlsx' }
+  { name: 'betteroffice-xlsx', dependency: 'betteroffice-xlsx' },
+  { name: 'betteroffice-ooxml-text', dependency: 'ooxml-text' },
+  { name: 'betteroffice-drawingml', dependency: 'ooxml-drawingml' },
+  { name: 'betteroffice-docx-parse', dependency: 'docx-parse' },
+  { name: 'betteroffice-docx-layout', dependency: 'docx-layout' },
+  { name: 'betteroffice-docx-edit', dependency: 'docx-edit' },
+  { name: 'betteroffice-docx', dependency: 'betteroffice-docx' },
+  { name: 'betteroffice-pptx-parse', dependency: 'pptx-parse' },
+  { name: 'betteroffice-pptx-edit', dependency: 'pptx-edit' },
+  { name: 'betteroffice-pptx-render', dependency: 'pptx-render' },
+  { name: 'betteroffice-pptx', dependency: 'betteroffice-pptx' }
 ];
 
 export function rustReleaseVersion() {


### PR DESCRIPTION
TL;DR:

Summary:
- Publish the shared OOXML text and DrawingML crates.
- Publish the DOCX and PPTX lower-level crates and umbrella facades.
- Synchronize internal crate versions through workspace dependencies.
- Extend the Rust release train in dependency order while keeping wasm and redaction boundaries private.

Test plan:
- [x] cargo build --workspace
- [x] cargo test --workspace
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt --check
- [x] cargo deny check bans licenses advisories sources
- [x] bun run build:docx-wasm
- [x] bun run build:pptx-wasm
- [x] Simulate the 0.0.2 Rust release-train bump and restore 0.0.1
- [x] bun run build:packages
- [x] bun scripts/publish-crates.mjs --dry-run