### PR TITLE
docs: React-only docx-i18n readme + collaboration in the shim readmes

### DIFF
--- a/packages/docx-i18n/README.md
+++ b/packages/docx-i18n/README.md
@@ -1,117 +1,70 @@
 # @betteroffice/docx-i18n
 
-Shared locale strings, types, and runtime helpers for the [OpenOOXML DOCX editor](https://betteroffice.dev) adapters. One source of truth for translations consumed by `@betteroffice/docx-react` and `@betteroffice/docx-vue`.
+UI locale strings, types, and runtime helpers for the
+[`@betteroffice/docx-react`](https://www.npmjs.com/package/@betteroffice/docx-react)
+editor. `en` is the source of truth; community locales mirror its shape and fall
+back to English for any untranslated key.
 
-## Quick Start
+> **Experimental (`0.0.x`).** The API is unstable and may change in any release.
 
 ```bash
-npm install @betteroffice/docx-i18n
+bun add @betteroffice/docx-i18n
 ```
+
+## Usage
 
 Pass a typed locale to the editor's `i18n` prop:
 
 ```tsx
-// React
 import { de } from '@betteroffice/docx-i18n';
-<DocxEditor documentBuffer={file} i18n={de} />
 
-// Vue
-import { de } from '@betteroffice/docx-i18n';
-<DocxEditor :document-buffer="file" :i18n="de" />
+<DocxEditor documentBuffer={file} i18n={de} />;
 ```
 
-Mix a community locale with custom overrides:
+Override individual strings by spreading a locale:
 
 ```ts
 import { de } from '@betteroffice/docx-i18n';
 
-const myLocale = {
-  ...de,
-  toolbar: { ...de.toolbar, bold: 'Fettdruck' },
-};
+const myLocale = { ...de, toolbar: { ...de.toolbar, bold: 'Fettdruck' } };
 ```
 
 Keys set to `null` in any locale fall back to English.
 
-## Packages
+## Locales
 
-| Package                                                                          | Description                                                                                                                                |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`@betteroffice/docx-react`](https://www.npmjs.com/package/@betteroffice/docx-react)   | <img src="https://cdn.simpleicons.org/react/61DAFB" width="20" align="middle" /> &nbsp; React adapter. Toolbar, paged editor, plugins.     |
-| [`@betteroffice/docx-vue`](https://www.npmjs.com/package/@betteroffice/docx-vue)       | <img src="https://cdn.simpleicons.org/vuedotjs/4FC08D" width="20" align="middle" /> &nbsp; Vue 3 adapter. Toolbar, paged editor, plugins.  |
-| [`@betteroffice/docx`](https://www.npmjs.com/package/@betteroffice/docx)               | Framework-agnostic core: OOXML parser, serializer, layout engine, ProseMirror schema. Depend on this if you fork the React or Vue adapter. |
-| [`@betteroffice/docx-i18n`](https://www.npmjs.com/package/@betteroffice/docx-i18n)     | Shared locale strings and types consumed by both adapters.                                                                                 |
+`en` (source), `de`, `he`, `pl`, `pt-BR`, `tr`, `zh-CN`. BCP-47 tags use
+camelCase identifiers (`ptBR`, `zhCN`).
 
-> **Forking the adapter?** Keep your fork thin. Depend on `@betteroffice/docx` directly so parser, serializer, and rendering fixes land in your build automatically, without backporting each upstream change by hand.
-
-## Available locales
-
-| Code    | Export | Language            |
-| ------- | ------ | ------------------- |
-| `en`    | `en`   | English (source)    |
-| `de`    | `de`   | German              |
-| `he`    | `he`   | Hebrew              |
-| `pl`    | `pl`   | Polish              |
-| `pt-BR` | `ptBR` | Portuguese (Brazil) |
-| `tr`    | `tr`   | Turkish             |
-| `zh-CN` | `zhCN` | Simplified Chinese  |
-
-BCP-47 codes (`pt-BR`, `zh-CN`) use camelCase JS identifiers (`ptBR`, `zhCN`). For runtime lookup by tag:
-
-```ts
-import { locales } from '@betteroffice/docx-i18n';
-<DocxEditor i18n={locales[userPreferredLocale]} />
-```
-
-> Importing `locales` pulls every locale into your bundle. For a smaller bundle, import only the ones you need by name; `sideEffects: false` lets the rest tree-shake.
-
-## Per-locale subpaths
-
-For apps that pick the locale at runtime, the named exports above don't tree-shake — the bundler can't know which locale wins, so it ships them all. Use the per-locale subpaths instead. Each one bundles a single locale (~30KB) and code-splits cleanly:
-
-```ts
-// Static — bundler ships only this locale's strings
-import pl from '@betteroffice/docx-i18n/pl';
-
-// Dynamic — splits into its own chunk, loaded on demand
-const pl = (await import('@betteroffice/docx-i18n/pl')).default;
-```
-
-Subpaths ship for every locale: `/en`, `/de`, `/he`, `/pl`, `/pt-BR`, `/tr`, `/zh-CN`. Each also exports its locale as a named binding (`import { pl } from '@betteroffice/docx-i18n/pl'`) for callers that prefer non-default imports.
+Each locale also ships as its own subpath (`@betteroffice/docx-i18n/pl`) so an
+app that picks the locale at runtime can code-split rather than bundle them all.
+For lookup by tag, `import { locales } from '@betteroffice/docx-i18n'` (pulls
+every locale into the bundle).
 
 ## Types
 
 ```ts
 import type {
   LocaleStrings, // shape of `en`, the full source of truth
-  PartialLocaleStrings, // shape of a community partial (null falls back)
-  Translations, // alias for PartialLocaleStrings
+  PartialLocaleStrings, // a community partial (null falls back)
   TranslationKey, // 'toolbar.bold' | 'dialogs.findReplace.title' | ...
   LocaleCode, // 'en' | 'de' | 'pt-BR' | ...
-  TFunction, // signature of the `t()` callback
+  TFunction,
 } from '@betteroffice/docx-i18n';
 ```
 
-## Non-React/Vue hosts
+## Non-React hosts
 
-Build a typed `t()` outside the adapter packages:
+Build a typed `t()` directly:
 
 ```ts
 import { createT, deepMerge, en, de, type LocaleStrings } from '@betteroffice/docx-i18n';
 
-const merged = deepMerge(en, de) as LocaleStrings;
-const t = createT(merged, 'de');
+const t = createT(deepMerge(en, de) as LocaleStrings, 'de');
 t('toolbar.bold'); // 'Fett'
-t('dialogs.findReplace.matchCount', { current: 3, total: 15 }); // ICU plurals
 ```
 
-`en.json` is the source of truth. Add keys there, then run `bun run i18n:fix` from the repo root to sync community locales (new keys land as `null`). Full guide: [docs/i18n.md](https://github.com/openooxml/betteroffice/blob/main/docs/i18n.md).
+Add keys to `en.json`, then `bun run i18n:fix` from the repo root to sync the
+community locales (new keys land as `null`).
 
-## Contributing
-
-Contributions welcome. See [CONTRIBUTING.md](https://github.com/openooxml/betteroffice/blob/main/CONTRIBUTING.md) for setup, tests, and the one-time CLA signature.
-
-## Commercial Support
-
-> [!TIP]
-> Questions or feature requests? Open an issue at **[github.com/openooxml/betteroffice](https://github.com/openooxml/betteroffice/issues)**.
+Docs: https://betteroffice.dev · Apache-2.0.

--- a/packages/docx-i18n/package.json
+++ b/packages/docx-i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@betteroffice/docx-i18n",
   "version": "0.0.1",
-  "description": "Shared UI locale strings and types for the @betteroffice/docx editor adapters (React and Vue).",
+  "description": "UI locale strings and types for the @betteroffice/docx-react editor.",
   "sideEffects": false,
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/docx-react/README.md
+++ b/packages/docx-react/README.md
@@ -58,4 +58,29 @@ Key props: `documentBuffer` (or a parsed `document`), `onSave`, `onChange`,
 `showRuler`, `showZoomControl`, `measurementFontProvider`. The `ref` exposes
 the full editor API (selection, formatting, find/replace, comments, revisions).
 
+## Collaboration
+
+The document is a CRDT — pass a `collaboration` prop and wire a transport to
+co-edit with other people or an agent. `onReplica` hands you the session as a
+`CollaborationReplica`; drive it with a `CollaborationProvider` over any
+transport (a WebSocket relay, etc.). Every window must boot from the same shared
+state, so pass identical `initialUpdate` bytes to each peer.
+
+```tsx
+import { CollaborationProvider } from '@betteroffice/docx/collaboration';
+
+<DocxEditor
+  documentBuffer={file}
+  collaboration={{
+    clientId,
+    initialUpdate: sharedSeed, // identical bytes for every peer
+    onReplica: (replica) => {
+      if (!replica) return;
+      const provider = new CollaborationProvider(replica, transport);
+      provider.connect();
+    },
+  }}
+/>;
+```
+
 Docs: https://betteroffice.dev · Apache-2.0.

--- a/packages/pptx-react/README.md
+++ b/packages/pptx-react/README.md
@@ -36,6 +36,29 @@ export function Presentation({ file, fontBytes }: {
 Click text to place the Rust-computed caret, type to edit the yrs story and
 trigger Rust reflow, or use the toolbar for bold, italic, size, color, slides,
 and text boxes. `onReady` exposes the core handle and a `refresh` callback for
-collaboration transports or host-driven edits.
+host-driven edits.
+
+## Collaboration
+
+Pass a `collaboration` prop to co-edit a deck live. `onReplica` hands you the
+session; drive it with a `CollaborationProvider` over any transport. Every peer
+must boot from the same `initialUpdate` seed.
+
+```tsx
+import { CollaborationProvider } from '@betteroffice/pptx/collaboration';
+
+<PptxEditor
+  file={file}
+  collaboration={{
+    clientId,
+    initialUpdate: sharedSeed,
+    onReplica: (replica) => {
+      if (!replica) return;
+      const provider = new CollaborationProvider(replica, transport);
+      provider.connect();
+    },
+  }}
+/>;
+```
 
 Docs: https://betteroffice.dev · Apache-2.0.


### PR DESCRIPTION
TL;DR:


Summary:
- docx-i18n readme was the eigenpal-era copy (Vue, a non-existent docx-vue, ProseMirror references); trimmed to the React-only reality and shortened. Description dropped 'and Vue'.
- Adds a CollaborationProvider section to docx-react and pptx-react (xlsx-react already documented it).

Test plan:
- [ ] readmes render