### PR TITLE
chore(packages): sharper npm descriptions and aligned keywords

### DIFF
--- a/packages/docx-i18n/package.json
+++ b/packages/docx-i18n/package.json
@@ -67,7 +67,9 @@
   },
   "keywords": [
     "docx",
+    "ooxml",
     "editor",
+    "react",
     "i18n",
     "locales",
     "translations"

--- a/packages/docx-react/package.json
+++ b/packages/docx-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@betteroffice/docx-react",
   "version": "0.0.1",
-  "description": "React DOCX editor adapter for @betteroffice/docx.",
+  "description": "Word-faithful React DOCX editor and viewer — full OOXML fidelity, real-time human + AI agent collaboration.",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -44,11 +44,15 @@
   },
   "keywords": [
     "docx",
-    "editor",
-    "template",
     "word",
     "document",
-    "react"
+    "ooxml",
+    "editor",
+    "viewer",
+    "react",
+    "collaborative",
+    "real-time",
+    "ai-agent"
   ],
   "author": "OpenOOXML",
   "license": "Apache-2.0",

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -4,7 +4,7 @@
   "sideEffects": [
     "**/residentEngineWorker.*"
   ],
-  "description": "Framework-agnostic core for DOCX parsing, editing, and rendering",
+  "description": "Word-faithful DOCX editor and viewer core — full OOXML fidelity, real-time human + AI agent collaboration. Framework-agnostic (Rust/Wasm).",
   "main": "./dist/core.mjs",
   "module": "./dist/core.mjs",
   "types": "./dist/core.d.mts",
@@ -217,9 +217,16 @@
   },
   "keywords": [
     "docx",
-    "editor",
     "word",
-    "document"
+    "document",
+    "ooxml",
+    "office",
+    "editor",
+    "viewer",
+    "collaborative",
+    "real-time",
+    "ai-agent",
+    "wasm"
   ],
   "author": "OpenOOXML",
   "license": "Apache-2.0",

--- a/packages/pptx-react/package.json
+++ b/packages/pptx-react/package.json
@@ -1,7 +1,20 @@
 {
   "name": "@betteroffice/pptx-react",
   "version": "0.0.1",
-  "description": "React chrome for the BetterOffice PPTX editor.",
+  "description": "PowerPoint-faithful React PPTX editor and viewer — full OOXML fidelity, real-time human + AI agent collaboration.",
+  "keywords": [
+    "pptx",
+    "powerpoint",
+    "presentation",
+    "slides",
+    "ooxml",
+    "editor",
+    "viewer",
+    "react",
+    "collaborative",
+    "real-time",
+    "ai-agent"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/pptx/package.json
+++ b/packages/pptx/package.json
@@ -1,7 +1,21 @@
 {
   "name": "@betteroffice/pptx",
   "version": "0.0.1",
-  "description": "Framework-free core for the BetterOffice PPTX editor: Rust/Wasm deck model, layout, and canvas replay.",
+  "description": "PowerPoint-faithful PPTX editor and viewer core — full OOXML fidelity, real-time human + AI agent collaboration. Framework-free (Rust/Wasm).",
+  "keywords": [
+    "pptx",
+    "powerpoint",
+    "presentation",
+    "slides",
+    "ooxml",
+    "office",
+    "editor",
+    "viewer",
+    "collaborative",
+    "real-time",
+    "ai-agent",
+    "wasm"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/xlsx-react/package.json
+++ b/packages/xlsx-react/package.json
@@ -1,7 +1,19 @@
 {
   "name": "@betteroffice/xlsx-react",
   "version": "0.0.5",
-  "description": "React chrome for the BetterOffice xlsx editor.",
+  "description": "Excel-faithful React XLSX spreadsheet editor and viewer — full OOXML fidelity, real-time human + AI agent collaboration.",
+  "keywords": [
+    "xlsx",
+    "excel",
+    "spreadsheet",
+    "ooxml",
+    "editor",
+    "viewer",
+    "react",
+    "collaborative",
+    "real-time",
+    "ai-agent"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/xlsx/package.json
+++ b/packages/xlsx/package.json
@@ -1,7 +1,20 @@
 {
   "name": "@betteroffice/xlsx",
   "version": "0.0.5",
-  "description": "Framework-free core for the BetterOffice xlsx editor: display list, viewport math, wasm loader.",
+  "description": "Excel-faithful XLSX spreadsheet editor and viewer core — full OOXML fidelity, real-time human + AI agent collaboration. Framework-free (Rust/Wasm).",
+  "keywords": [
+    "xlsx",
+    "excel",
+    "spreadsheet",
+    "ooxml",
+    "office",
+    "editor",
+    "viewer",
+    "collaborative",
+    "real-time",
+    "ai-agent",
+    "wasm"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",


### PR DESCRIPTION
npm-facing metadata was thin: xlsx/pptx cores and all three React shims shipped no keywords, and the descriptions ("React chrome for…") said nothing a searcher cares about.

Now every editor package leads with the same three things a reader should grasp instantly — **editor/viewer**, **OOXML fidelity**, **real-time human + AI agent collaboration** — and shares an aligned keyword set across the docx/xlsx/pptx cores and their React shims.

Metadata only; no code or public API change. docx-i18n's description is left to #73 (React-only rewrite there); this only aligns its keywords.