### PR TITLE
fix(docx-react): release with resolved dependency ranges

### DIFF
--- a/.changeset/heavy-doors-open.md
+++ b/.changeset/heavy-doors-open.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/docx-react": patch
+---
+
+Fix the published dependency ranges: 0.0.1 shipped the unresolved `workspace:*` protocol for `@betteroffice/docx` and `@betteroffice/docx-i18n`, which made `npm install @betteroffice/docx-react` fail. Ranges are now pinned to concrete versions at publish time.


### PR DESCRIPTION
The manually bootstrapped `@betteroffice/docx-react@0.0.1` shipped raw `workspace:*` ranges for `@betteroffice/docx` and `@betteroffice/docx-i18n` (published with npm, which doesn't resolve the workspace protocol), so `npm install @betteroffice/docx-react` fails with `EUNSUPPORTEDPROTOCOL`.

Changeset-only: the next release publishes the docx group at 0.0.2 through the train, whose pin step resolves the ranges (verified against xlsx-react@0.0.5, which shipped correctly that way). After it's out, 0.0.1 should be npm-deprecated.