### PR TITLE
docs(pptx): list pptx packages and mark slides available

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 | [`betteroffice-xlsx`](https://crates.io/crates/betteroffice-xlsx) | typed Rust API for opening, editing, calculating, rendering, and saving XLSX workbooks |
 | [`@betteroffice/xlsx`](https://www.npmjs.com/package/@betteroffice/xlsx) | framework-free spreadsheet core powered by the Rust engine through WebAssembly |
 | [`@betteroffice/xlsx-react`](https://www.npmjs.com/package/@betteroffice/xlsx-react) | drop-in React spreadsheet editor |
+| [`@betteroffice/xlsx-i18n`](https://www.npmjs.com/package/@betteroffice/xlsx-i18n) | locale strings for the spreadsheet editor |
+| [`@betteroffice/pptx`](https://www.npmjs.com/package/@betteroffice/pptx) | framework-free .pptx editor core — slide model, masters, and rendering in Rust through WebAssembly |
+| [`@betteroffice/pptx-react`](https://www.npmjs.com/package/@betteroffice/pptx-react) | drop-in React .pptx editor |
+| [`@betteroffice/pptx-i18n`](https://www.npmjs.com/package/@betteroffice/pptx-i18n) | locale strings for the pptx editor |
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@
 |---|---|
 | [`@betteroffice/docx`](https://www.npmjs.com/package/@betteroffice/docx) | framework-free .docx editor core — parsing, CRDT editing, and page layout in Rust through WebAssembly |
 | [`@betteroffice/docx-react`](https://www.npmjs.com/package/@betteroffice/docx-react) | drop-in React .docx editor |
-| [`@betteroffice/docx-i18n`](https://www.npmjs.com/package/@betteroffice/docx-i18n) | locale strings for the docx editor |
 | [`betteroffice-xlsx`](https://crates.io/crates/betteroffice-xlsx) | typed Rust API for opening, editing, calculating, rendering, and saving XLSX workbooks |
 | [`@betteroffice/xlsx`](https://www.npmjs.com/package/@betteroffice/xlsx) | framework-free spreadsheet core powered by the Rust engine through WebAssembly |
 | [`@betteroffice/xlsx-react`](https://www.npmjs.com/package/@betteroffice/xlsx-react) | drop-in React spreadsheet editor |
-| [`@betteroffice/xlsx-i18n`](https://www.npmjs.com/package/@betteroffice/xlsx-i18n) | locale strings for the spreadsheet editor |
+| [`betteroffice-pptx`](https://crates.io/crates/betteroffice-pptx) | typed Rust API for opening, editing, rendering, and saving PPTX presentations |
 | [`@betteroffice/pptx`](https://www.npmjs.com/package/@betteroffice/pptx) | framework-free .pptx editor core — slide model, masters, and rendering in Rust through WebAssembly |
 | [`@betteroffice/pptx-react`](https://www.npmjs.com/package/@betteroffice/pptx-react) | drop-in React .pptx editor |
-| [`@betteroffice/pptx-i18n`](https://www.npmjs.com/package/@betteroffice/pptx-i18n) | locale strings for the pptx editor |
 
 ## Structure
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -46,8 +46,8 @@ const EDITORS = [
   {
     name: "Slides",
     format: "pptx",
-    desc: "Slide model and masters on the same shared core — in development.",
-    live: false,
+    desc: "Slide model, masters and shape editing on the same shared core.",
+    live: true,
   },
 ];
 
@@ -67,6 +67,14 @@ const PACKAGES = [
   {
     name: "@betteroffice/xlsx-react",
     desc: "The spreadsheet editor as a drop-in React component.",
+  },
+  {
+    name: "@betteroffice/pptx",
+    desc: "Framework-free slides core — parsing, editing and rendering on the Rust engine.",
+  },
+  {
+    name: "@betteroffice/pptx-react",
+    desc: "The slides editor as a drop-in React component.",
   },
 ];
 
@@ -183,8 +191,8 @@ export default function Home() {
           </h2>
           <p className={`${secP} mb-6`}>
             BetterOffice packages the OpenOOXML engines as ready-to-use
-            editors. Documents and spreadsheets are live today; slides follow
-            on the same foundation.
+            editors. Documents, spreadsheets and slides are all live today on
+            the same foundation.
           </p>
         </Reveal>
         <Reveal delay={0.1}>


### PR DESCRIPTION
TL;DR:

Summary:
- Adds `betteroffice-pptx` (crates.io), `@betteroffice/pptx`, and `@betteroffice/pptx-react` to the root README package table; drops the i18n package rows
- Marks the Slides editor as available on the landing page, updates its description, and adds the pptx packages to the packages section

Test plan:
- [ ] Landing page renders Slides with the "available" badge and correct copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj5sPZs3GXb4t2uWJ4QM8D