### PR TITLE
chore(xlsx): changeset for toolbar and formatting release

### DIFF
--- a/.changeset/wired-toolbars.md
+++ b/.changeset/wired-toolbars.md
@@ -1,0 +1,15 @@
+---
+"@betteroffice/rust-crates": patch
+"@betteroffice/xlsx": patch
+"@betteroffice/xlsx-react": patch
+"@betteroffice/xlsx-i18n": patch
+---
+
+Add a Google Sheets-style toolbar to the XLSX editor backed by new engine
+APIs for range styling, number formats, selection-format aggregation, format
+painting, merge queries, and history state. Formatting is fully collaborative
+through a content-addressed style catalog (collaboration schema v3; v2 state
+does not migrate). Merging replaces intersecting ranges like Excel, parsing
+repairs overlapping merges in third-party files, and display-list font fields
+now serialize correctly so styled text renders with its real font, size, and
+weight.


### PR DESCRIPTION
TL;DR:

Summary:
- Adds the changeset that #81 merged without: patch bumps for `@betteroffice/xlsx`, `@betteroffice/xlsx-react`, `@betteroffice/xlsx-i18n`, and `@betteroffice/rust-crates` (lockstep crates.io republish)

Test plan:
- [ ] `chore: release` PR opens/updates after merge with the four bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj5sPZs3GXb4t2uWJ4QM8D