### PR TITLE
chore(docx): changeset for the perf and caret release

### DIFF
--- a/.changeset/docx-perf-caret.md
+++ b/.changeset/docx-perf-caret.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Docx typing hot path is 7x faster (resident region fast path, memoized font parsing, direct frame-delta encoding, incremental worker sync); pages no longer remount and flash on remote or structural edits; page bitmaps are windowed to the viewport on long documents; the caret is painted by the renderer in the same frame as the glyphs while typing and blinks in the DOM at idle.


### PR DESCRIPTION
TL;DR:

Summary:
- Adds the changeset for #80 (merged without one): patch bumps for the docx package trio and the Rust crate train

Test plan:
- [ ] Release PR picks up the docx and rust-crates bumps after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dqs53ZFqDrTv2FzAS2aa9W