### PR TITLE
chore(deps): clear the brace-expansion advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -272,6 +272,7 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.10",
+    "brace-expansion": "5.0.8",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
@@ -1150,7 +1151,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -2454,8 +2455,6 @@
 
     "@betteroffice/docx-react/tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
-    "@node-minify/core/glob/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
-
     "@node-minify/core/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@node-minify/core/glob/path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
@@ -2479,7 +2478,5 @@
     "shadcn/@dotenvx/dotenvx/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
     "@betteroffice/docx-react/tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "@node-minify/core/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 minimumReleaseAge = 604800
 # Per-advisory exemptions; remove each after its pinned version clears the release-age window.
-minimumReleaseAgeExcludes = ["fast-uri", "next", "postcss"]
+minimumReleaseAgeExcludes = ["fast-uri", "next", "postcss", "brace-expansion"]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "brace-expansion": "5.0.8"
   },
   "scripts": {
     "dev": "bun run --filter './apps/web' dev",


### PR DESCRIPTION
TL;DR:

Summary:
- Overrides brace-expansion to 5.0.8 (GHSA-mh99-v99m-4gvg, DoS via unbounded expansion length); it reaches the tree only through demo build tooling (@opennextjs/cloudflare and shadcn)
- Pinned exactly and added to the release-age exemptions, following the convention set for patches newer than the 7-day quarantine window
- `bun audit` reports no vulnerabilities at any level; the advisory currently reddens the Security audit on main and every open PR

Test plan:
- [ ] Security audit green on this PR
- [ ] Package gate green (demo build tooling still resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5Bk9ACXaUCGeFvwSzsviG