### PR TITLE
ci(deploy): deploy the collaboration relay

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [web, demo, docs]
+        app: [web, demo, docs, relay]
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
TL;DR:

Summary:
- Adds `relay` to the deploy matrix in `deploy.yml`, which the release workflow dispatches after a successful publish
- The relay had a `deploy` script and its own wrangler config but was never in the matrix, so relay changes shipped to npm without ever reaching production, while the demo defaults to the production relay origin
- No build step is needed: the existing `matrix.app == 'demo'` guards already skip the Rust toolchain, wasm-pack and package builds, so the relay runs checkout, install, then `wrangler deploy`

Test plan:
- [ ] Manual `workflow_dispatch` of Deploy succeeds for the relay entry
- [ ] Relay responds at its production origin after the run
- [ ] Two demo windows still sync against the deployed relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5Bk9ACXaUCGeFvwSzsviG