### PR TITLE
fix(relay): reject hostile frames, expire idle rooms, and stop rewriting the log

### DIFF
--- a/.changeset/xlsx-frame-limit.md
+++ b/.changeset/xlsx-frame-limit.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/xlsx": patch
+---
+
+The default collaboration frame limit drops from 64 MiB to 16 MiB to match what the relay accepts and retains, and an oversized frame now raises a protocol error before it is sent instead of closing the socket. Hosts running their own relay can restore the previous ceiling with the `maxFrameBytes` option.

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -1,17 +1,36 @@
 import { DurableObject } from "cloudflare:workers";
 import { MAX_COLLABORATION_FRAME_BYTES } from "../../../shared/collaboration-limits";
-import { classifyFrame, RetainedUpdateLog } from "./retention";
+import {
+  classifyFrame,
+  RetainedUpdateLog,
+  type LogMutation,
+  type RetainedEntry,
+} from "./retention";
 
 interface Env {
   ROOMS: DurableObjectNamespace<CollaborationRoom>;
 }
 
 const MAX_RETAINED_COUNT = 512;
-const LOG_KEY = "updates";
+const UPDATE_PREFIX = "update:";
+const SEQ_DIGITS = 16;
+const LEGACY_LOG_KEY = "updates";
 const ROOM_TTL_MS = 24 * 60 * 60 * 1000;
 const TTL_REFRESH_SLACK_MS = 60 * 60 * 1000;
 
 type PeerMessage = { type: "peers"; count: number };
+
+/** Zero-padded so storage's lexicographic key order is replay order. */
+function updateKey(seq: number): string {
+  return UPDATE_PREFIX + String(seq).padStart(SEQ_DIGITS, "0");
+}
+
+function parseSeq(key: string): number | null {
+  const digits = key.slice(UPDATE_PREFIX.length);
+  if (digits.length !== SEQ_DIGITS || !/^\d+$/.test(digits)) return null;
+  const seq = Number(digits);
+  return Number.isSafeInteger(seq) ? seq : null;
+}
 
 function isWebSocketRequest(request: Request): boolean {
   return request.headers.get("Upgrade")?.toLowerCase() === "websocket";
@@ -36,10 +55,26 @@ export class CollaborationRoom extends DurableObject<Env> {
     super(state, env);
     state.blockConcurrencyWhile(async () => {
       this.expiresAt = await state.storage.getAlarm();
-      const stored = (await state.storage.get<Uint8Array[]>(LOG_KEY)) ?? [];
-      if (this.updates.restore(stored)) {
-        await state.storage.put(LOG_KEY, this.updates.snapshot());
+      const stored = await state.storage.list<Uint8Array>({
+        prefix: UPDATE_PREFIX,
+      });
+      const entries: RetainedEntry[] = [];
+      const unusable: string[] = [];
+      for (const [key, bytes] of stored) {
+        const seq = parseSeq(key);
+        if (seq === null || !(bytes instanceof Uint8Array)) {
+          unusable.push(key);
+          continue;
+        }
+        entries.push({ seq, bytes });
       }
+      if ((await state.storage.get(LEGACY_LOG_KEY)) !== undefined) {
+        unusable.push(LEGACY_LOG_KEY);
+      }
+
+      const repair = this.updates.restore(entries);
+      if (unusable.length > 0) await state.storage.delete(unusable);
+      if (repair) await this.writeMutation(repair);
     });
   }
 
@@ -84,7 +119,10 @@ export class CollaborationRoom extends DurableObject<Env> {
     }
 
     this.refreshExpiry();
-    if (kind === "document" && this.updates.retain(bytes)) this.persistUpdates();
+    if (kind === "document") {
+      const mutation = this.updates.retain(bytes);
+      if (mutation) this.persistUpdates(mutation);
+    }
     for (const peer of this.ctx.getWebSockets()) {
       if (peer !== socket) peer.send(bytes.slice());
     }
@@ -133,10 +171,23 @@ export class CollaborationRoom extends DurableObject<Env> {
     this.ctx.waitUntil(this.persist);
   }
 
-  private persistUpdates(): void {
-    const snapshot = this.updates.snapshot();
-    this.persist = this.persist.then(() => this.ctx.storage.put(LOG_KEY, snapshot));
+  private persistUpdates(mutation: LogMutation): void {
+    this.persist = this.persist.then(() => this.writeMutation(mutation));
     this.ctx.waitUntil(this.persist);
+  }
+
+  private async writeMutation(mutation: LogMutation): Promise<void> {
+    if (mutation.puts.length === 1) {
+      const [entry] = mutation.puts;
+      await this.ctx.storage.put(updateKey(entry.seq), entry.bytes);
+    } else if (mutation.puts.length > 1) {
+      const batch: Record<string, Uint8Array> = {};
+      for (const entry of mutation.puts) batch[updateKey(entry.seq)] = entry.bytes;
+      await this.ctx.storage.put(batch);
+    }
+    if (mutation.deletes.length > 0) {
+      await this.ctx.storage.delete(mutation.deletes.map(updateKey));
+    }
   }
 
   private broadcastPeerCount(): void {

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -1,11 +1,11 @@
 import { DurableObject } from "cloudflare:workers";
+import { MAX_COLLABORATION_FRAME_BYTES } from "../../../shared/collaboration-limits";
 import { classifyFrame, RetainedUpdateLog } from "./retention";
 
 interface Env {
   ROOMS: DurableObjectNamespace<CollaborationRoom>;
 }
 
-const MAX_RETAINED_BYTES = 16 * 1024 * 1024;
 const MAX_RETAINED_COUNT = 512;
 const LOG_KEY = "updates";
 
@@ -25,7 +25,7 @@ function copyBytes(message: ArrayBuffer | ArrayBufferView): Uint8Array {
 export class CollaborationRoom extends DurableObject<Env> {
   private updates = new RetainedUpdateLog(
     MAX_RETAINED_COUNT,
-    MAX_RETAINED_BYTES,
+    MAX_COLLABORATION_FRAME_BYTES,
   );
   private persist = Promise.resolve();
 
@@ -63,8 +63,8 @@ export class CollaborationRoom extends DurableObject<Env> {
     }
 
     const bytes = copyBytes(message);
-    if (bytes.byteLength > MAX_RETAINED_BYTES) {
-      socket.close(1009, "Frame too large");
+    if (bytes.byteLength > MAX_COLLABORATION_FRAME_BYTES) {
+      socket.close(1009, `Frame exceeds ${MAX_COLLABORATION_FRAME_BYTES} bytes`);
       return;
     }
 

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -8,6 +8,8 @@ interface Env {
 
 const MAX_RETAINED_COUNT = 512;
 const LOG_KEY = "updates";
+const ROOM_TTL_MS = 24 * 60 * 60 * 1000;
+const TTL_REFRESH_SLACK_MS = 60 * 60 * 1000;
 
 type PeerMessage = { type: "peers"; count: number };
 
@@ -28,10 +30,12 @@ export class CollaborationRoom extends DurableObject<Env> {
     MAX_COLLABORATION_FRAME_BYTES,
   );
   private persist = Promise.resolve();
+  private expiresAt: number | null = null;
 
   constructor(state: DurableObjectState, env: Env) {
     super(state, env);
     state.blockConcurrencyWhile(async () => {
+      this.expiresAt = await state.storage.getAlarm();
       const stored = (await state.storage.get<Uint8Array[]>(LOG_KEY)) ?? [];
       if (this.updates.restore(stored)) {
         await state.storage.put(LOG_KEY, this.updates.snapshot());
@@ -48,6 +52,7 @@ export class CollaborationRoom extends DurableObject<Env> {
     const client = pair[0];
     const server = pair[1];
     this.ctx.acceptWebSocket(server);
+    this.refreshExpiry();
     this.updates.replay((update) => server.send(update));
     this.broadcastPeerCount();
     return new Response(null, { status: 101, webSocket: client });
@@ -78,6 +83,7 @@ export class CollaborationRoom extends DurableObject<Env> {
       return;
     }
 
+    this.refreshExpiry();
     if (kind === "document" && this.updates.retain(bytes)) this.persistUpdates();
     for (const peer of this.ctx.getWebSockets()) {
       if (peer !== socket) peer.send(bytes.slice());
@@ -97,6 +103,34 @@ export class CollaborationRoom extends DurableObject<Env> {
   webSocketError(socket: WebSocket, _error: unknown): void {
     socket.close(1011, "WebSocket error");
     this.broadcastPeerCount();
+  }
+
+  /** Wipes the room once it has been idle for a full TTL. */
+  async alarm(): Promise<void> {
+    await this.persist;
+    if (this.ctx.getWebSockets().length > 0) {
+      this.expiresAt = Date.now() + ROOM_TTL_MS;
+      await this.ctx.storage.setAlarm(this.expiresAt);
+      return;
+    }
+
+    this.updates.clear();
+    this.expiresAt = null;
+    await this.ctx.storage.deleteAll();
+  }
+
+  /** setAlarm is a storage write, so only rewrite a materially stale deadline. */
+  private refreshExpiry(): void {
+    const deadline = Date.now() + ROOM_TTL_MS;
+    if (
+      this.expiresAt !== null &&
+      deadline - this.expiresAt < TTL_REFRESH_SLACK_MS
+    ) {
+      return;
+    }
+    this.expiresAt = deadline;
+    this.persist = this.persist.then(() => this.ctx.storage.setAlarm(deadline));
+    this.ctx.waitUntil(this.persist);
   }
 
   private persistUpdates(): void {

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { RetainedUpdateLog } from "./retention";
+import { classifyFrame, RetainedUpdateLog } from "./retention";
 
 interface Env {
   ROOMS: DurableObjectNamespace<CollaborationRoom>;
@@ -68,7 +68,17 @@ export class CollaborationRoom extends DurableObject<Env> {
       return;
     }
 
-    if (this.updates.retain(bytes)) this.persistUpdates();
+    const kind = classifyFrame(bytes);
+    if (kind === "invalid") {
+      socket.close(1002, "Malformed collaboration frame");
+      return;
+    }
+    if (kind === "auth") {
+      socket.close(1008, "Auth messages are server-only");
+      return;
+    }
+
+    if (kind === "document" && this.updates.retain(bytes)) this.persistUpdates();
     for (const peer of this.ctx.getWebSockets()) {
       if (peer !== socket) peer.send(bytes.slice());
     }

--- a/apps/relay/src/retention.ts
+++ b/apps/relay/src/retention.ts
@@ -2,6 +2,8 @@ const TOP_LEVEL_SYNC = 0;
 const TOP_LEVEL_AWARENESS = 1;
 const TOP_LEVEL_AUTH = 2;
 const TOP_LEVEL_QUERY_AWARENESS = 3;
+/** A state-vector query: valid to relay, never worth replaying to joiners. */
+const SYNC_STEP_1 = 0;
 const MAX_SYNC_SUBTYPE = 2;
 const AUTH_PERMISSION_DENIED = 0;
 const MAX_MESSAGES_PER_FRAME = 4096;
@@ -110,7 +112,7 @@ function decodeFrame(frame: Uint8Array): DecodedFrame | null {
       ) {
         return null;
       }
-      documents.push({ subtype, payload });
+      if (subtype !== SYNC_STEP_1) documents.push({ subtype, payload });
     } else if (type === TOP_LEVEL_AWARENESS) {
       if (decoder.readVarUint8Array() === null) return null;
     } else if (type === TOP_LEVEL_AUTH) {

--- a/apps/relay/src/retention.ts
+++ b/apps/relay/src/retention.ts
@@ -218,6 +218,11 @@ export class RetainedUpdateLog {
     return this.updates.map((update) => update.slice());
   }
 
+  clear(): void {
+    this.updates = [];
+    this.retainedBytes = 0;
+  }
+
   private trim(): boolean {
     let changed = false;
     while (

--- a/apps/relay/src/retention.ts
+++ b/apps/relay/src/retention.ts
@@ -7,9 +7,17 @@ const AUTH_PERMISSION_DENIED = 0;
 const MAX_MESSAGES_PER_FRAME = 4096;
 const MAX_VAR_UINT = Number.MAX_SAFE_INTEGER;
 
+/** `document` frames carry state worth retaining, `transient` ones do not. */
+export type FrameKind = "document" | "transient" | "auth" | "invalid";
+
 interface DocumentMessage {
   subtype: number;
   payload: Uint8Array;
+}
+
+interface DecodedFrame {
+  documents: DocumentMessage[];
+  hasAuth: boolean;
 }
 
 class FrameDecoder {
@@ -79,12 +87,11 @@ function encodeFrame(parts: readonly Uint8Array[]): Uint8Array {
   return frame;
 }
 
-function decodeDocumentMessages(
-  frame: Uint8Array,
-): DocumentMessage[] | null {
+function decodeFrame(frame: Uint8Array): DecodedFrame | null {
   if (frame.byteLength === 0) return null;
   const decoder = new FrameDecoder(frame);
   const documents: DocumentMessage[] = [];
+  let hasAuth = false;
   let messageCount = 0;
 
   while (!decoder.done) {
@@ -116,12 +123,20 @@ function decodeDocumentMessages(
       ) {
         return null;
       }
+      hasAuth = true;
     } else if (type !== TOP_LEVEL_QUERY_AWARENESS) {
       return null;
     }
   }
 
-  return documents;
+  return { documents, hasAuth };
+}
+
+export function classifyFrame(frame: Uint8Array): FrameKind {
+  const decoded = decodeFrame(frame);
+  if (!decoded) return "invalid";
+  if (decoded.hasAuth) return "auth";
+  return decoded.documents.length > 0 ? "document" : "transient";
 }
 
 function isValidUtf8(bytes: Uint8Array): boolean {
@@ -134,11 +149,11 @@ function isValidUtf8(bytes: Uint8Array): boolean {
 }
 
 function retainDocumentMessages(frame: Uint8Array): Uint8Array | null {
-  const documents = decodeDocumentMessages(frame);
-  if (!documents || documents.length === 0) return null;
+  const decoded = decodeFrame(frame);
+  if (!decoded || decoded.hasAuth || decoded.documents.length === 0) return null;
 
   const parts: Uint8Array[] = [];
-  for (const document of documents) {
+  for (const document of decoded.documents) {
     parts.push(
       encodeVarUint(TOP_LEVEL_SYNC),
       encodeVarUint(document.subtype),
@@ -152,11 +167,6 @@ function retainDocumentMessages(frame: Uint8Array): Uint8Array | null {
 function bytesEqual(first: Uint8Array, second: Uint8Array): boolean {
   if (first.byteLength !== second.byteLength) return false;
   return first.every((byte, index) => byte === second[index]);
-}
-
-export function isDocumentFrame(frame: Uint8Array): boolean {
-  const retained = retainDocumentMessages(frame);
-  return retained !== null && bytesEqual(retained, frame);
 }
 
 export class RetainedUpdateLog {

--- a/apps/relay/src/retention.ts
+++ b/apps/relay/src/retention.ts
@@ -171,68 +171,90 @@ function bytesEqual(first: Uint8Array, second: Uint8Array): boolean {
   return first.every((byte, index) => byte === second[index]);
 }
 
+export interface RetainedEntry {
+  seq: number;
+  bytes: Uint8Array;
+}
+
+/** The storage writes that bring the persisted log back in line with memory. */
+export interface LogMutation {
+  puts: readonly RetainedEntry[];
+  deletes: readonly number[];
+}
+
 export class RetainedUpdateLog {
-  private updates: Uint8Array[] = [];
+  private updates: RetainedEntry[] = [];
   private retainedBytes = 0;
+  private nextSeq = 0;
 
   constructor(
     private readonly maxCount: number,
     private readonly maxBytes: number,
   ) {}
 
-  restore(updates: readonly Uint8Array[]): boolean {
-    this.updates = [];
-    this.retainedBytes = 0;
-    let changed = false;
-    for (const update of updates) {
+  restore(stored: readonly RetainedEntry[]): LogMutation | null {
+    this.clear();
+    const puts: RetainedEntry[] = [];
+    const deletes: number[] = [];
+    for (const entry of [...stored].sort((first, second) => first.seq - second.seq)) {
+      this.nextSeq = Math.max(this.nextSeq, entry.seq + 1);
       const retained =
-        update.byteLength <= this.maxBytes
-          ? retainDocumentMessages(update)
+        entry.bytes.byteLength <= this.maxBytes
+          ? retainDocumentMessages(entry.bytes)
           : null;
       if (!retained || retained.byteLength > this.maxBytes) {
-        changed = true;
+        deletes.push(entry.seq);
         continue;
       }
-      this.updates.push(retained);
+      if (!bytesEqual(retained, entry.bytes)) {
+        puts.push({ seq: entry.seq, bytes: retained });
+      }
+      this.updates.push({ seq: entry.seq, bytes: retained });
       this.retainedBytes += retained.byteLength;
-      changed = this.trim() || !bytesEqual(retained, update) || changed;
+      deletes.push(...this.trim());
     }
-    return changed;
+
+    const evicted = new Set(deletes);
+    const rewrites = puts.filter((entry) => !evicted.has(entry.seq));
+    if (rewrites.length === 0 && deletes.length === 0) return null;
+    return { puts: rewrites, deletes };
   }
 
-  retain(update: Uint8Array): boolean {
-    if (update.byteLength > this.maxBytes) return false;
+  retain(update: Uint8Array): LogMutation | null {
+    if (update.byteLength > this.maxBytes) return null;
     const retained = retainDocumentMessages(update);
-    if (!retained || retained.byteLength > this.maxBytes) return false;
-    this.updates.push(retained);
+    if (!retained || retained.byteLength > this.maxBytes) return null;
+    const entry: RetainedEntry = { seq: this.nextSeq++, bytes: retained };
+    this.updates.push(entry);
     this.retainedBytes += retained.byteLength;
-    this.trim();
-    return true;
+    return { puts: [entry], deletes: this.trim() };
   }
 
   replay(send: (update: Uint8Array) => void): void {
-    for (const update of this.updates) send(update.slice());
+    for (const entry of this.updates) send(entry.bytes.slice());
   }
 
   snapshot(): Uint8Array[] {
-    return this.updates.map((update) => update.slice());
+    return this.updates.map((entry) => entry.bytes.slice());
   }
 
   clear(): void {
     this.updates = [];
     this.retainedBytes = 0;
+    this.nextSeq = 0;
   }
 
-  private trim(): boolean {
-    let changed = false;
+  private trim(): number[] {
+    const evicted: number[] = [];
     while (
       this.updates.length > this.maxCount ||
       this.retainedBytes > this.maxBytes
     ) {
       const removed = this.updates.shift();
-      if (removed) this.retainedBytes -= removed.byteLength;
-      changed = true;
+      if (!removed) break;
+      this.retainedBytes -= removed.bytes.byteLength;
+      evicted.push(removed.seq);
     }
-    return changed;
+    return evicted;
   }
 }

--- a/apps/relay/test/index.test.ts
+++ b/apps/relay/test/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, setSystemTime, test } from "bun:test";
 
 mock.module("cloudflare:workers", () => ({
   DurableObject: class {
@@ -26,20 +26,33 @@ function frame(...parts: readonly Uint8Array[]): Uint8Array {
   return bytes;
 }
 
+function createSocket() {
+  return { send: mock((_: unknown) => {}), close: mock(() => {}) };
+}
+
+type FakeSocket = ReturnType<typeof createSocket>;
+
+(globalThis as { WebSocketPair?: unknown }).WebSocketPair = function () {
+  return { 0: createSocket(), 1: createSocket() };
+};
+
+const UPGRADE = new Request("https://relay.test/room/a", {
+  headers: { Upgrade: "websocket" },
+});
+
 function createRoom() {
-  const sender = {
-    send: mock(() => {}),
-    close: mock(() => {}),
-  };
-  const peer = {
-    send: mock(() => {}),
-    close: mock(() => {}),
-  };
+  const sender = createSocket();
+  const peer = createSocket();
+  const sockets: FakeSocket[] = [sender, peer];
   const storageWrites: Array<{
     key: string;
     value: Uint8Array[];
   }> = [];
   const pending: Promise<unknown>[] = [];
+  const alarms: number[] = [];
+  const deleteAll = mock(async () => {
+    storageWrites.length = 0;
+  });
   let initialization = Promise.resolve();
   const state = {
     storage: {
@@ -47,24 +60,40 @@ function createRoom() {
       put: async (key: string, value: Uint8Array[]) => {
         storageWrites.push({ key, value });
       },
+      getAlarm: async () => null,
+      setAlarm: async (time: number) => {
+        alarms.push(time);
+      },
+      deleteAll,
     },
     blockConcurrencyWhile: (initialize: () => Promise<void>) => {
       initialization = initialize();
     },
-    getWebSockets: () => [sender, peer],
+    acceptWebSocket: (socket: FakeSocket) => {
+      sockets.push(socket);
+    },
+    getWebSockets: () => sockets,
     waitUntil: (promise: Promise<unknown>) => {
       pending.push(promise);
     },
   };
   const room = new CollaborationRoom(state as never, {} as never);
   return {
+    alarms,
+    deleteAll,
     initialization,
     peer,
     pending,
     room,
     sender,
+    sockets,
     storageWrites,
   };
+}
+
+async function join(harness: ReturnType<typeof createRoom>) {
+  await harness.room.fetch(UPGRADE);
+  return harness.sockets[harness.sockets.length - 1];
 }
 
 describe("CollaborationRoom.webSocketMessage", () => {
@@ -157,5 +186,87 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.peer.send).toHaveBeenCalledTimes(1);
     expect(harness.peer.send.mock.calls[0][0]).toEqual(query);
     expect(harness.storageWrites).toEqual([]);
+  });
+});
+
+describe("CollaborationRoom expiry", () => {
+  const HOUR_MS = 60 * 60 * 1000;
+  const DAY_MS = 24 * HOUR_MS;
+  const START_MS = Date.UTC(2026, 0, 1);
+  const document = Uint8Array.of(0, 2, 2, 10, 11);
+
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  function send(harness: ReturnType<typeof createRoom>): void {
+    harness.room.webSocketMessage(
+      harness.sender as never,
+      document.buffer as ArrayBuffer,
+    );
+  }
+
+  test("throttles deadline rewrites but extends on later activity", async () => {
+    setSystemTime(new Date(START_MS));
+    const harness = createRoom();
+    await harness.initialization;
+
+    send(harness);
+    send(harness);
+    await Promise.all(harness.pending);
+    expect(harness.alarms).toEqual([START_MS + DAY_MS]);
+
+    setSystemTime(new Date(START_MS + 2 * HOUR_MS));
+    send(harness);
+    await Promise.all(harness.pending);
+    expect(harness.alarms).toEqual([
+      START_MS + DAY_MS,
+      START_MS + 2 * HOUR_MS + DAY_MS,
+    ]);
+  });
+
+  test("replays retained frames to a joining socket", async () => {
+    const harness = createRoom();
+    await harness.initialization;
+    send(harness);
+    await Promise.all(harness.pending);
+
+    const joiner = await join(harness);
+    expect(joiner.send.mock.calls[0][0]).toEqual(document);
+  });
+
+  test("wipes an idle room when the alarm fires", async () => {
+    const harness = createRoom();
+    await harness.initialization;
+    send(harness);
+    await Promise.all(harness.pending);
+    expect(harness.storageWrites).toHaveLength(1);
+
+    harness.sockets.length = 0;
+    await harness.room.alarm();
+
+    expect(harness.deleteAll).toHaveBeenCalledTimes(1);
+    expect(harness.storageWrites).toEqual([]);
+
+    const joiner = await join(harness);
+    expect(joiner.send).toHaveBeenCalledTimes(1);
+    expect(joiner.send.mock.calls[0][0]).toBe(
+      JSON.stringify({ type: "peers", count: 1 }),
+    );
+  });
+
+  test("reschedules instead of wiping while a socket is connected", async () => {
+    setSystemTime(new Date(START_MS));
+    const harness = createRoom();
+    await harness.initialization;
+    send(harness);
+    await Promise.all(harness.pending);
+
+    setSystemTime(new Date(START_MS + DAY_MS));
+    await harness.room.alarm();
+
+    expect(harness.deleteAll).not.toHaveBeenCalled();
+    expect(harness.storageWrites).toHaveLength(1);
+    expect(harness.alarms).toEqual([START_MS + DAY_MS, START_MS + 2 * DAY_MS]);
   });
 });

--- a/apps/relay/test/index.test.ts
+++ b/apps/relay/test/index.test.ts
@@ -40,25 +40,51 @@ const UPGRADE = new Request("https://relay.test/room/a", {
   headers: { Upgrade: "websocket" },
 });
 
-function createRoom() {
+function updateKey(seq: number): string {
+  return `update:${String(seq).padStart(16, "0")}`;
+}
+
+function createRoom(seed: Iterable<[string, unknown]> = []) {
   const sender = createSocket();
   const peer = createSocket();
   const sockets: FakeSocket[] = [sender, peer];
-  const storageWrites: Array<{
-    key: string;
-    value: Uint8Array[];
-  }> = [];
+  const rows = new Map<string, unknown>(seed);
+  const putKeys: string[][] = [];
+  const deletedKeys: string[][] = [];
   const pending: Promise<unknown>[] = [];
   const alarms: number[] = [];
   const deleteAll = mock(async () => {
-    storageWrites.length = 0;
+    rows.clear();
   });
   let initialization = Promise.resolve();
   const state = {
     storage: {
-      get: async () => [],
-      put: async (key: string, value: Uint8Array[]) => {
-        storageWrites.push({ key, value });
+      get: async (key: string) => rows.get(key),
+      list: async ({ prefix }: { prefix: string }) =>
+        new Map(
+          [...rows]
+            .filter(([key]) => key.startsWith(prefix))
+            .sort(([first], [second]) => (first < second ? -1 : 1)),
+        ),
+      put: async (
+        keyOrBatch: string | Record<string, Uint8Array>,
+        value?: Uint8Array,
+      ) => {
+        if (typeof keyOrBatch === "string") {
+          rows.set(keyOrBatch, value);
+          putKeys.push([keyOrBatch]);
+          return;
+        }
+        for (const [key, bytes] of Object.entries(keyOrBatch)) {
+          rows.set(key, bytes);
+        }
+        putKeys.push(Object.keys(keyOrBatch));
+      },
+      delete: async (keys: string | readonly string[]) => {
+        const batch = typeof keys === "string" ? [keys] : [...keys];
+        for (const key of batch) rows.delete(key);
+        deletedKeys.push(batch);
+        return batch.length;
       },
       getAlarm: async () => null,
       setAlarm: async (time: number) => {
@@ -81,13 +107,15 @@ function createRoom() {
   return {
     alarms,
     deleteAll,
+    deletedKeys,
     initialization,
     peer,
     pending,
+    putKeys,
     room,
+    rows,
     sender,
     sockets,
-    storageWrites,
   };
 }
 
@@ -113,9 +141,8 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.peer.send).toHaveBeenCalledTimes(1);
     expect(harness.peer.send.mock.calls[0][0]).toEqual(mixed);
     expect(harness.sender.send).not.toHaveBeenCalled();
-    expect(harness.storageWrites).toEqual([
-      { key: "updates", value: [document] },
-    ]);
+    expect(harness.putKeys).toEqual([[updateKey(0)]]);
+    expect(harness.rows.get(updateKey(0))).toEqual(document);
   });
 
   test("closes only the sender on a malformed frame and broadcasts nothing", async () => {
@@ -136,7 +163,7 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.peer.send).not.toHaveBeenCalled();
     expect(harness.peer.close).not.toHaveBeenCalled();
     expect(harness.pending).toEqual([]);
-    expect(harness.storageWrites).toEqual([]);
+    expect(harness.rows.size).toBe(0);
   });
 
   test("closes only the sender on a client-origin auth denial", async () => {
@@ -153,7 +180,7 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.sender.close.mock.calls[0][0]).toBe(1008);
     expect(harness.peer.send).not.toHaveBeenCalled();
     expect(harness.peer.close).not.toHaveBeenCalled();
-    expect(harness.storageWrites).toEqual([]);
+    expect(harness.rows.size).toBe(0);
   });
 
   test("broadcasts awareness-only frames without retaining them", async () => {
@@ -169,7 +196,7 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.sender.close).not.toHaveBeenCalled();
     expect(harness.peer.send).toHaveBeenCalledTimes(1);
     expect(harness.peer.send.mock.calls[0][0]).toEqual(awareness);
-    expect(harness.storageWrites).toEqual([]);
+    expect(harness.rows.size).toBe(0);
   });
 
   test("broadcasts sync-step-1 so live peers answer it, without retaining it", async () => {
@@ -185,7 +212,7 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.sender.close).not.toHaveBeenCalled();
     expect(harness.peer.send).toHaveBeenCalledTimes(1);
     expect(harness.peer.send.mock.calls[0][0]).toEqual(query);
-    expect(harness.storageWrites).toEqual([]);
+    expect(harness.rows.size).toBe(0);
   });
 });
 
@@ -240,13 +267,13 @@ describe("CollaborationRoom expiry", () => {
     await harness.initialization;
     send(harness);
     await Promise.all(harness.pending);
-    expect(harness.storageWrites).toHaveLength(1);
+    expect(harness.rows.size).toBe(1);
 
     harness.sockets.length = 0;
     await harness.room.alarm();
 
     expect(harness.deleteAll).toHaveBeenCalledTimes(1);
-    expect(harness.storageWrites).toEqual([]);
+    expect(harness.rows.size).toBe(0);
 
     const joiner = await join(harness);
     expect(joiner.send).toHaveBeenCalledTimes(1);
@@ -266,7 +293,101 @@ describe("CollaborationRoom expiry", () => {
     await harness.room.alarm();
 
     expect(harness.deleteAll).not.toHaveBeenCalled();
-    expect(harness.storageWrites).toHaveLength(1);
+    expect(harness.rows.size).toBe(1);
     expect(harness.alarms).toEqual([START_MS + DAY_MS, START_MS + 2 * DAY_MS]);
+  });
+});
+
+describe("CollaborationRoom persistence", () => {
+  function documentAt(payload: number): Uint8Array {
+    return Uint8Array.of(0, 2, 1, payload);
+  }
+
+  function send(
+    harness: ReturnType<typeof createRoom>,
+    document: Uint8Array,
+  ): void {
+    harness.room.webSocketMessage(
+      harness.sender as never,
+      document.buffer as ArrayBuffer,
+    );
+  }
+
+  function replayed(socket: FakeSocket, count: number): unknown[] {
+    return socket.send.mock.calls.slice(0, count).map(([value]) => value);
+  }
+
+  test("writes one key per retained frame and rewrites nothing", async () => {
+    const harness = createRoom();
+    await harness.initialization;
+
+    for (const payload of [1, 2, 3]) send(harness, documentAt(payload));
+    await Promise.all(harness.pending);
+
+    expect(harness.putKeys).toEqual([
+      [updateKey(0)],
+      [updateKey(1)],
+      [updateKey(2)],
+    ]);
+    expect(harness.deletedKeys).toEqual([]);
+    expect(harness.rows.size).toBe(3);
+  });
+
+  test("evicts only the oldest key once the entry cap is reached", async () => {
+    const harness = createRoom();
+    await harness.initialization;
+
+    for (let index = 0; index <= 512; index += 1) {
+      send(harness, documentAt(index & 0xff));
+    }
+    await Promise.all(harness.pending);
+
+    expect(harness.rows.size).toBe(512);
+    expect(harness.deletedKeys).toEqual([[updateKey(0)]]);
+    expect(harness.rows.has(updateKey(512))).toBe(true);
+  });
+
+  test("rehydrates in sequence order and appends above the highest seq", async () => {
+    const first = documentAt(4);
+    const second = documentAt(5);
+    const harness = createRoom([
+      [updateKey(9), second],
+      [updateKey(2), first],
+    ]);
+    await harness.initialization;
+
+    expect(harness.putKeys).toEqual([]);
+    expect(harness.deletedKeys).toEqual([]);
+    expect(replayed(await join(harness), 2)).toEqual([first, second]);
+
+    send(harness, documentAt(6));
+    await Promise.all(harness.pending);
+    expect(harness.putKeys).toEqual([[updateKey(10)]]);
+  });
+
+  test("repairs a non-canonical entry and drops unreadable ones", async () => {
+    const document = documentAt(7);
+    const survivor = documentAt(9);
+    const harness = createRoom([
+      [updateKey(0), frame(document, Uint8Array.of(1, 1, 8))],
+      [updateKey(1), Uint8Array.of(0x80)],
+      ["update:nope", document],
+      [updateKey(2), survivor],
+    ]);
+    await harness.initialization;
+
+    expect(harness.deletedKeys).toEqual([["update:nope"], [updateKey(1)]]);
+    expect(harness.putKeys).toEqual([[updateKey(0)]]);
+    expect(harness.rows.get(updateKey(0))).toEqual(document);
+    expect(replayed(await join(harness), 2)).toEqual([document, survivor]);
+  });
+
+  test("discards the legacy single-blob log on rehydrate", async () => {
+    const harness = createRoom([["updates", [documentAt(10)]]]);
+    await harness.initialization;
+
+    expect(harness.deletedKeys).toEqual([["updates"]]);
+    expect(harness.rows.size).toBe(0);
+    expect((await join(harness)).send).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/relay/test/index.test.ts
+++ b/apps/relay/test/index.test.ts
@@ -142,4 +142,20 @@ describe("CollaborationRoom.webSocketMessage", () => {
     expect(harness.peer.send.mock.calls[0][0]).toEqual(awareness);
     expect(harness.storageWrites).toEqual([]);
   });
+
+  test("broadcasts sync-step-1 so live peers answer it, without retaining it", async () => {
+    const query = Uint8Array.of(0, 0, 1, 15);
+    const harness = createRoom();
+    await harness.initialization;
+
+    harness.room.webSocketMessage(
+      harness.sender as never,
+      query.buffer as ArrayBuffer,
+    );
+
+    expect(harness.sender.close).not.toHaveBeenCalled();
+    expect(harness.peer.send).toHaveBeenCalledTimes(1);
+    expect(harness.peer.send.mock.calls[0][0]).toEqual(query);
+    expect(harness.storageWrites).toEqual([]);
+  });
 });

--- a/apps/relay/test/index.test.ts
+++ b/apps/relay/test/index.test.ts
@@ -89,7 +89,7 @@ describe("CollaborationRoom.webSocketMessage", () => {
     ]);
   });
 
-  test("broadcasts malformed bytes without throwing or persisting", async () => {
+  test("closes only the sender on a malformed frame and broadcasts nothing", async () => {
     const document = Uint8Array.of(0, 2, 1, 13);
     const malformed = frame(document, Uint8Array.of(1, 2, 14));
     const harness = createRoom();
@@ -102,10 +102,44 @@ describe("CollaborationRoom.webSocketMessage", () => {
       ),
     ).not.toThrow();
 
-    expect(harness.peer.send).toHaveBeenCalledTimes(1);
-    expect(harness.peer.send.mock.calls[0][0]).toEqual(malformed);
-    expect(harness.sender.send).not.toHaveBeenCalled();
+    expect(harness.sender.close).toHaveBeenCalledTimes(1);
+    expect(harness.sender.close.mock.calls[0][0]).toBe(1002);
+    expect(harness.peer.send).not.toHaveBeenCalled();
+    expect(harness.peer.close).not.toHaveBeenCalled();
     expect(harness.pending).toEqual([]);
+    expect(harness.storageWrites).toEqual([]);
+  });
+
+  test("closes only the sender on a client-origin auth denial", async () => {
+    const auth = Uint8Array.of(2, 0, 2, 104, 105);
+    const harness = createRoom();
+    await harness.initialization;
+
+    harness.room.webSocketMessage(
+      harness.sender as never,
+      auth.buffer as ArrayBuffer,
+    );
+
+    expect(harness.sender.close).toHaveBeenCalledTimes(1);
+    expect(harness.sender.close.mock.calls[0][0]).toBe(1008);
+    expect(harness.peer.send).not.toHaveBeenCalled();
+    expect(harness.peer.close).not.toHaveBeenCalled();
+    expect(harness.storageWrites).toEqual([]);
+  });
+
+  test("broadcasts awareness-only frames without retaining them", async () => {
+    const awareness = Uint8Array.of(1, 1, 12);
+    const harness = createRoom();
+    await harness.initialization;
+
+    harness.room.webSocketMessage(
+      harness.sender as never,
+      awareness.buffer as ArrayBuffer,
+    );
+
+    expect(harness.sender.close).not.toHaveBeenCalled();
+    expect(harness.peer.send).toHaveBeenCalledTimes(1);
+    expect(harness.peer.send.mock.calls[0][0]).toEqual(awareness);
     expect(harness.storageWrites).toEqual([]);
   });
 });

--- a/apps/relay/test/limits.test.ts
+++ b/apps/relay/test/limits.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { MAX_COLLABORATION_FRAME_BYTES } from "../../../shared/collaboration-limits";
+import { DEFAULT_MAX_FRAME_BYTES as DOCX_MAX_FRAME_BYTES } from "../../../packages/docx/src/collaboration/protocol";
+import { DEFAULT_MAX_FRAME_BYTES as PPTX_MAX_FRAME_BYTES } from "../../../packages/pptx/src/collaboration/protocol";
+import { DEFAULT_MAX_FRAME_BYTES as XLSX_MAX_FRAME_BYTES } from "../../../packages/xlsx/src/collaboration/protocol";
+
+test("every client caps frames at the relay's ingress limit", () => {
+  expect(DOCX_MAX_FRAME_BYTES).toBe(MAX_COLLABORATION_FRAME_BYTES);
+  expect(PPTX_MAX_FRAME_BYTES).toBe(MAX_COLLABORATION_FRAME_BYTES);
+  expect(XLSX_MAX_FRAME_BYTES).toBe(MAX_COLLABORATION_FRAME_BYTES);
+});

--- a/apps/relay/test/retention.test.ts
+++ b/apps/relay/test/retention.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { decodeMessages } from "../../../packages/docx/src/collaboration/protocol";
-import { RetainedUpdateLog, isDocumentFrame } from "../src/retention";
+import { RetainedUpdateLog, classifyFrame } from "../src/retention";
 
 function encodeVarUint(value: number): Uint8Array {
   const bytes: number[] = [];
@@ -39,6 +39,15 @@ function awarenessFrame(payload: Uint8Array): Uint8Array {
     encodeVarUint(1),
     encodeVarUint(payload.byteLength),
     payload,
+  );
+}
+
+function authFrame(reason: Uint8Array): Uint8Array {
+  return frame(
+    encodeVarUint(2),
+    encodeVarUint(0),
+    encodeVarUint(reason.byteLength),
+    reason,
   );
 }
 
@@ -135,6 +144,17 @@ describe("RetainedUpdateLog", () => {
     expect(log.snapshot()).toEqual([]);
   });
 
+  test("does not retain frames carrying an auth message", () => {
+    const log = new RetainedUpdateLog(512, 1024);
+    const mixed = frame(
+      syncFrame(2, Uint8Array.of(24)),
+      authFrame(Uint8Array.of(105)),
+    );
+
+    expect(log.retain(mixed)).toBe(false);
+    expect(log.snapshot()).toEqual([]);
+  });
+
   test("normalizes mixed stored frames and removes invalid entries", () => {
     const document = syncFrame(0, Uint8Array.of(22));
     const awareness = awarenessFrame(Uint8Array.of(23));
@@ -148,18 +168,35 @@ describe("RetainedUpdateLog", () => {
   });
 });
 
-describe("isDocumentFrame", () => {
-  test("accepts only complete, canonical sync messages", () => {
+describe("classifyFrame", () => {
+  test("reports frames carrying document state as document", () => {
     const document = syncFrame(2, Uint8Array.of(1));
-    expect(isDocumentFrame(document)).toBe(true);
+    expect(classifyFrame(document)).toBe("document");
     expect(
-      isDocumentFrame(frame(document, awarenessFrame(Uint8Array.of(2)))),
-    ).toBe(false);
-    expect(isDocumentFrame(new Uint8Array())).toBe(false);
-    expect(isDocumentFrame(Uint8Array.of(0))).toBe(false);
-    expect(isDocumentFrame(Uint8Array.of(0x80))).toBe(false);
-    expect(isDocumentFrame(Uint8Array.of(0x80, 0))).toBe(false);
-    expect(isDocumentFrame(Uint8Array.of(0, 3, 0))).toBe(false);
-    expect(isDocumentFrame(encodeVarUint(128))).toBe(false);
+      classifyFrame(frame(document, awarenessFrame(Uint8Array.of(2)))),
+    ).toBe("document");
+  });
+
+  test("reports valid but unretained frames as transient", () => {
+    expect(classifyFrame(awarenessFrame(Uint8Array.of(2)))).toBe("transient");
+    expect(classifyFrame(encodeVarUint(3))).toBe("transient");
+  });
+
+  test("reports auth-bearing frames as auth even alongside sync", () => {
+    const denial = authFrame(Uint8Array.of(104, 105));
+    expect(classifyFrame(denial)).toBe("auth");
+    expect(classifyFrame(frame(syncFrame(2, Uint8Array.of(1)), denial))).toBe(
+      "auth",
+    );
+  });
+
+  test("reports truncated or unknown frames as invalid", () => {
+    expect(classifyFrame(new Uint8Array())).toBe("invalid");
+    expect(classifyFrame(Uint8Array.of(0))).toBe("invalid");
+    expect(classifyFrame(Uint8Array.of(0x80))).toBe("invalid");
+    expect(classifyFrame(Uint8Array.of(0x80, 0))).toBe("invalid");
+    expect(classifyFrame(Uint8Array.of(0, 3, 0))).toBe("invalid");
+    expect(classifyFrame(encodeVarUint(128))).toBe("invalid");
+    expect(classifyFrame(authFrame(Uint8Array.of(0xff)))).toBe("invalid");
   });
 });

--- a/apps/relay/test/retention.test.ts
+++ b/apps/relay/test/retention.test.ts
@@ -63,7 +63,7 @@ describe("RetainedUpdateLog", () => {
     const mixed = frame(document, awarenessFrame(Uint8Array.of(12)));
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(mixed)).toBe(true);
+    expect(log.retain(mixed)).not.toBeNull();
     const [retained] = log.snapshot();
     expect(retained).toEqual(document);
     expect(decodeMessages(retained)).toEqual(documentMessages(mixed));
@@ -79,7 +79,7 @@ describe("RetainedUpdateLog", () => {
   test("does not retain awareness-only frames", () => {
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(awarenessFrame(Uint8Array.of(13)))).toBe(false);
+    expect(log.retain(awarenessFrame(Uint8Array.of(13)))).toBeNull();
     expect(log.snapshot()).toEqual([]);
   });
 
@@ -87,7 +87,7 @@ describe("RetainedUpdateLog", () => {
     const document = syncFrame(1, new Uint8Array(130).fill(14));
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(document)).toBe(true);
+    expect(log.retain(document)).not.toBeNull();
     const [retained] = log.snapshot();
     expect(retained).toEqual(document);
     expect(retained).not.toBe(document);
@@ -99,7 +99,7 @@ describe("RetainedUpdateLog", () => {
     const mixed = frame(encodeVarUint(3), document);
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(mixed)).toBe(true);
+    expect(log.retain(mixed)).not.toBeNull();
     const [retained] = log.snapshot();
     expect(retained).toEqual(document);
     expect(decodeMessages(retained)).toEqual(documentMessages(mixed));
@@ -109,10 +109,10 @@ describe("RetainedUpdateLog", () => {
     const query = syncFrame(0, Uint8Array.of(15));
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(query)).toBe(false);
-    expect(log.retain(frame(query, awarenessFrame(Uint8Array.of(16))))).toBe(
-      false,
-    );
+    expect(log.retain(query)).toBeNull();
+    expect(
+      log.retain(frame(query, awarenessFrame(Uint8Array.of(16)))),
+    ).toBeNull();
     expect(log.snapshot()).toEqual([]);
   });
 
@@ -121,7 +121,7 @@ describe("RetainedUpdateLog", () => {
     const mixed = frame(syncFrame(0, Uint8Array.of(16)), update);
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(mixed)).toBe(true);
+    expect(log.retain(mixed)).not.toBeNull();
     expect(log.snapshot()).toEqual([update]);
   });
 
@@ -136,7 +136,7 @@ describe("RetainedUpdateLog", () => {
     const expected = frame(first, second);
     const log = new RetainedUpdateLog(512, 1024);
 
-    expect(log.retain(mixed)).toBe(true);
+    expect(log.retain(mixed)).not.toBeNull();
     const [retained] = log.snapshot();
     expect(retained).toEqual(expected);
     expect(decodeMessages(retained)).toEqual(documentMessages(mixed));
@@ -152,11 +152,11 @@ describe("RetainedUpdateLog", () => {
     const log = new RetainedUpdateLog(512, 1024);
 
     for (const malformed of frames) {
-      let retained = true;
+      let retained: unknown = "unset";
       expect(() => {
         retained = log.retain(malformed);
       }).not.toThrow();
-      expect(retained).toBe(false);
+      expect(retained).toBeNull();
     }
     expect(log.snapshot()).toEqual([]);
   });
@@ -168,7 +168,7 @@ describe("RetainedUpdateLog", () => {
       authFrame(Uint8Array.of(105)),
     );
 
-    expect(log.retain(mixed)).toBe(false);
+    expect(log.retain(mixed)).toBeNull();
     expect(log.snapshot()).toEqual([]);
   });
 
@@ -179,9 +179,72 @@ describe("RetainedUpdateLog", () => {
     const log = new RetainedUpdateLog(512, 1024);
 
     expect(
-      log.restore([awareness, Uint8Array.of(0x80), mixed]),
-    ).toBe(true);
+      log.restore([
+        { seq: 0, bytes: awareness },
+        { seq: 1, bytes: Uint8Array.of(0x80) },
+        { seq: 2, bytes: mixed },
+      ]),
+    ).toEqual({ puts: [{ seq: 2, bytes: document }], deletes: [0, 1] });
     expect(log.snapshot()).toEqual([document]);
+  });
+
+  test("reports nothing to write when the stored log is canonical", () => {
+    const log = new RetainedUpdateLog(512, 1024);
+    const stored = [
+      { seq: 4, bytes: syncFrame(1, Uint8Array.of(25)) },
+      { seq: 9, bytes: syncFrame(2, Uint8Array.of(26)) },
+    ];
+
+    expect(log.restore(stored)).toBeNull();
+    expect(log.snapshot()).toEqual(stored.map((entry) => entry.bytes));
+  });
+
+  test("restores in sequence order and appends above the highest seq", () => {
+    const first = syncFrame(2, Uint8Array.of(27));
+    const second = syncFrame(2, Uint8Array.of(28));
+    const third = syncFrame(2, Uint8Array.of(29));
+    const log = new RetainedUpdateLog(512, 1024);
+
+    log.restore([
+      { seq: 9, bytes: second },
+      { seq: 2, bytes: first },
+    ]);
+    expect(log.snapshot()).toEqual([first, second]);
+    expect(log.retain(third)).toEqual({
+      puts: [{ seq: 10, bytes: third }],
+      deletes: [],
+    });
+    expect(log.snapshot()).toEqual([first, second, third]);
+  });
+
+  test("reports the appended entry and the seqs it evicted", () => {
+    const first = syncFrame(2, Uint8Array.of(30));
+    const second = syncFrame(2, Uint8Array.of(31));
+    const third = syncFrame(2, Uint8Array.of(32));
+    const log = new RetainedUpdateLog(2, 1024);
+
+    expect(log.retain(first)).toEqual({
+      puts: [{ seq: 0, bytes: first }],
+      deletes: [],
+    });
+    expect(log.retain(second)?.deletes).toEqual([]);
+    expect(log.retain(third)).toEqual({
+      puts: [{ seq: 2, bytes: third }],
+      deletes: [0],
+    });
+    expect(log.snapshot()).toEqual([second, third]);
+  });
+
+  test("replays nothing after clear and restarts sequence numbers", () => {
+    const document = syncFrame(2, Uint8Array.of(33));
+    const log = new RetainedUpdateLog(512, 1024);
+    log.retain(document);
+
+    log.clear();
+    const replayed: Uint8Array[] = [];
+    log.replay((update) => replayed.push(update));
+    expect(replayed).toEqual([]);
+    expect(log.retain(document)?.puts).toEqual([{ seq: 0, bytes: document }]);
   });
 });
 

--- a/apps/relay/test/retention.test.ts
+++ b/apps/relay/test/retention.test.ts
@@ -53,10 +53,7 @@ function authFrame(reason: Uint8Array): Uint8Array {
 
 function documentMessages(protocolFrame: Uint8Array) {
   return decodeMessages(protocolFrame).filter(
-    ({ type }) =>
-      type === "sync-step-1" ||
-      type === "sync-step-2" ||
-      type === "update",
+    ({ type }) => type === "sync-step-2" || type === "update",
   );
 }
 
@@ -98,7 +95,7 @@ describe("RetainedUpdateLog", () => {
   });
 
   test("retains sync from a mixed query-awareness frame", () => {
-    const document = syncFrame(0, Uint8Array.of(15));
+    const document = syncFrame(1, Uint8Array.of(15));
     const mixed = frame(encodeVarUint(3), document);
     const log = new RetainedUpdateLog(512, 1024);
 
@@ -108,8 +105,28 @@ describe("RetainedUpdateLog", () => {
     expect(decodeMessages(retained)).toEqual(documentMessages(mixed));
   });
 
+  test("does not retain sync-step-1 state-vector queries", () => {
+    const query = syncFrame(0, Uint8Array.of(15));
+    const log = new RetainedUpdateLog(512, 1024);
+
+    expect(log.retain(query)).toBe(false);
+    expect(log.retain(frame(query, awarenessFrame(Uint8Array.of(16))))).toBe(
+      false,
+    );
+    expect(log.snapshot()).toEqual([]);
+  });
+
+  test("drops sync-step-1 from a frame that also carries an update", () => {
+    const update = syncFrame(2, Uint8Array.of(17));
+    const mixed = frame(syncFrame(0, Uint8Array.of(16)), update);
+    const log = new RetainedUpdateLog(512, 1024);
+
+    expect(log.retain(mixed)).toBe(true);
+    expect(log.snapshot()).toEqual([update]);
+  });
+
   test("retains multiple sync messages in their original order", () => {
-    const first = syncFrame(0, Uint8Array.of(16));
+    const first = syncFrame(1, Uint8Array.of(16));
     const second = syncFrame(2, Uint8Array.of(17, 18));
     const mixed = frame(
       first,
@@ -156,7 +173,7 @@ describe("RetainedUpdateLog", () => {
   });
 
   test("normalizes mixed stored frames and removes invalid entries", () => {
-    const document = syncFrame(0, Uint8Array.of(22));
+    const document = syncFrame(1, Uint8Array.of(22));
     const awareness = awarenessFrame(Uint8Array.of(23));
     const mixed = frame(document, awareness);
     const log = new RetainedUpdateLog(512, 1024);
@@ -180,6 +197,7 @@ describe("classifyFrame", () => {
   test("reports valid but unretained frames as transient", () => {
     expect(classifyFrame(awarenessFrame(Uint8Array.of(2)))).toBe("transient");
     expect(classifyFrame(encodeVarUint(3))).toBe("transient");
+    expect(classifyFrame(syncFrame(0, Uint8Array.of(3)))).toBe("transient");
   });
 
   test("reports auth-bearing frames as auth even alongside sync", () => {

--- a/packages/docx/src/collaboration/protocol.ts
+++ b/packages/docx/src/collaboration/protocol.ts
@@ -1,3 +1,4 @@
+import { MAX_COLLABORATION_FRAME_BYTES } from '../../../../shared/collaboration-limits';
 import {
   MAX_AWARENESS_CURSOR_BYTES,
   MAX_AWARENESS_ENTRIES_PER_UPDATE,
@@ -7,7 +8,7 @@ import {
   type AwarenessUpdateEntry,
 } from './awareness';
 
-export const DEFAULT_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+export const DEFAULT_MAX_FRAME_BYTES = MAX_COLLABORATION_FRAME_BYTES;
 export const DEFAULT_MAX_MESSAGES_PER_FRAME = 4096;
 
 const TOP_LEVEL_SYNC = 0;

--- a/packages/pptx/src/collaboration/protocol.ts
+++ b/packages/pptx/src/collaboration/protocol.ts
@@ -1,3 +1,4 @@
+import { MAX_COLLABORATION_FRAME_BYTES } from '../../../../shared/collaboration-limits';
 import {
   MAX_AWARENESS_STRING_LENGTH,
   sanitizePresenceColor,
@@ -5,7 +6,7 @@ import {
 } from './presence';
 import type { PptxPresenceCursor, PptxPresenceState } from './types';
 
-export const DEFAULT_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+export const DEFAULT_MAX_FRAME_BYTES = MAX_COLLABORATION_FRAME_BYTES;
 export const DEFAULT_MAX_MESSAGES_PER_FRAME = 4096;
 
 const TOP_LEVEL_SYNC = 0;

--- a/packages/xlsx/src/collaboration/protocol.ts
+++ b/packages/xlsx/src/collaboration/protocol.ts
@@ -1,3 +1,4 @@
+import { MAX_COLLABORATION_FRAME_BYTES } from '../../../../shared/collaboration-limits';
 import type { AwarenessPayload, AwarenessUpdate } from './types';
 import {
   MAX_AWARENESS_NAME_LENGTH,
@@ -5,7 +6,7 @@ import {
   normalizeAwarenessColor,
 } from './awareness';
 
-export const DEFAULT_MAX_FRAME_BYTES = 64 * 1024 * 1024 + 16;
+export const DEFAULT_MAX_FRAME_BYTES = MAX_COLLABORATION_FRAME_BYTES;
 export const DEFAULT_MAX_MESSAGES_PER_FRAME = 4096;
 export const DEFAULT_MAX_AWARENESS_STATES = 1024;
 

--- a/shared/collaboration-limits.ts
+++ b/shared/collaboration-limits.ts
@@ -1,0 +1,5 @@
+/**
+ * Largest collaboration frame the relay accepts, broadcasts and retains.
+ * Clients must not exceed it: the relay cannot replay what it cannot retain.
+ */
+export const MAX_COLLABORATION_FRAME_BYTES = 16 * 1024 * 1024;


### PR DESCRIPTION
TL;DR:

Summary:
- Invalid frames and client-origin auth denials are rejected before the fan-out, closing only the sender; previously any room participant could send one handcrafted frame and terminate document sync for every other peer, and a test actually asserted that malformed bytes were broadcast
- sync-step-1 state-vector queries are broadcast but no longer retained: one frame may carry up to 4096 messages while counting as a single log entry, so replaying them to every future joiner amplified into thousands of full-document diffs
- The frame limit is now one shared constant used by the relay and all three clients; xlsx drops from 64 MiB to 16 MiB (what the relay actually accepts and retains) and raises a protocol error before sending rather than eating a socket close
- Rooms idle for 24 hours have their state wiped by a Durable Object alarm, with the deadline refreshed at most hourly so a busy room writes the alarm ~24 times a day instead of once per frame
- Retained frames are stored as append-only `update:<seq>` keys: a retained frame costs one put of its own bytes (plus one batched delete once the cap is reached) instead of rewriting the entire log, which was up to 512 entries / 16 MiB per edit batch

Test plan:
- [ ] Malformed frame from one peer: only that peer disconnects, others keep syncing
- [ ] Two windows still converge, including a peer joining mid-session
- [ ] Room rejoinable within 24h; wiped afterwards, and a joiner to a wiped room still reaches correct state from its seed
- [ ] Sustained editing does not grow storage writes with log size
- [ ] Relay deploys (depends on #108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5Bk9ACXaUCGeFvwSzsviG