### PR TITLE
fix(deps): unbreak the web deploy under the brace-expansion patch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -266,6 +266,7 @@
     "brace-expansion": "5.0.8",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
+    "minimatch": "^10.2.5",
     "postcss": "8.5.23",
     "sharp": "^0.35.0",
   },
@@ -2401,8 +2402,6 @@
     "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
-
-    "@node-minify/core/glob/minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
 
     "@node-minify/core/glob/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
     "sharp": "^0.35.0",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.8",
+    "minimatch": "^10.2.5"
   },
   "scripts": {
     "dev": "bun run --filter './apps/web' dev",


### PR DESCRIPTION
TL;DR:

Summary:
- The `brace-expansion@5.0.8` override added for GHSA-mh99-v99m-4gvg broke `bun run --filter './apps/web' deploy`: 5.x is ESM-only with named exports, and `minimatch@8` imports it as a default, so `opennextjs-cloudflare` crashed at module load with `does not provide an export named 'default'`
- The offending path is `@opennextjs/aws -> @node-minify/core -> glob@9.3.5 -> minimatch@8.0.7`; the toolchain is not removable
- `minimatch@10` uses the named import, so overriding minimatch to `^10.2.5` keeps the advisory patched and restores the deploy
- Verified rather than assumed: `@node-minify/core` imports cleanly, `glob@9` still resolves patterns correctly under minimatch 10, `bun audit` reports no vulnerabilities, and `bun run --filter './apps/web' build` exits 0

Test plan:
- [ ] `bun run --filter './apps/web' deploy` gets past module load in CI
- [ ] Security audit stays green
- [ ] Package gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5Bk9ACXaUCGeFvwSzsviG