### PR TITLE
docs(drawingml): changeset for the shared chart module

### DIFF
--- a/.changeset/drawingml-chart-module.md
+++ b/.changeset/drawingml-chart-module.md
@@ -1,0 +1,7 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Chart parsing and plot geometry now live in `betteroffice-drawingml` behind a `chart` cargo feature, shared by the docx, xlsx and pptx engines instead of being duplicated per format.
+
+Breaking, for Rust consumers of `betteroffice-drawingml` only. `ChartAxes`, `ChartAxis`, `ChartLegend`, `ChartMarker`, `ChartPoint`, `ChartPlotGroup` and `ChartSeries` were re-exported at the crate root in 0.0.4 and are no longer. Enable the `chart` feature and import them from `ooxml_drawingml::chart`. The feature is off by default, so a crate that does not draw charts no longer compiles the geometry engine.


### PR DESCRIPTION
TL;DR:


Summary:
- Adds the changeset #112 landed without, so the shared chart module reaches the changelog.
- Documents a breaking change for Rust consumers of `betteroffice-drawingml`: `ChartAxes`, `ChartAxis`, `ChartLegend`, `ChartMarker`, `ChartPoint`, `ChartPlotGroup` and `ChartSeries` were re-exported at the crate root in the published 0.0.4 and now sit behind the non-default `chart` feature at `ooxml_drawingml::chart`.

Test plan:
- [ ] `bun run version-packages` produces a changelog entry naming the moved types
- [ ] no code change, so CI green is the whole gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)