### PR TITLE
docs(legal): CLA and CCLA refinements

### DIFF
--- a/CCLA.md
+++ b/CCLA.md
@@ -1,7 +1,7 @@
 # OpenOOXML Corporate Contributor License Agreement
 
 Thank you for your organization's interest in contributing to software
-projects maintained by the OpenOOXML project and its maintainers
+projects maintained by Elia Hilse, the OpenOOXML project and its maintainers
 ("Us"). This Agreement clarifies the intellectual property license
 granted with Contributions from any legal entity. This license is for
 Your protection as a Contributor as well as the protection of Us and

--- a/CCLA.md
+++ b/CCLA.md
@@ -30,18 +30,22 @@ contract or otherwise, or (ii) ownership of fifty percent (50%) or
 more of the outstanding shares, or (iii) beneficial ownership of
 such entity.
 
+"Project" shall mean any software project owned or managed by Us,
+including BetterOffice and the other repositories of the OpenOOXML
+organization.
+
 "Contribution" shall mean any original work of authorship, including
 any modifications or additions to an existing work, that is
 intentionally submitted by You to Us for inclusion in, or
-documentation of, any of the products owned or managed by Us
-(the "Work"). For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication
-sent to Us or our representatives, including but not limited to
-communication on electronic mailing lists, source code control
-systems, and issue tracking systems that are managed by, or on
-behalf of, Us for the purpose of discussing and improving the
-Work, but excluding communication that is conspicuously marked or
-otherwise designated in writing by You as "Not a Contribution."
+documentation of, any Project (the "Work"). For the purposes of
+this definition, "submitted" means any form of electronic, verbal,
+or written communication sent to Us or our representatives,
+including but not limited to communication on electronic mailing
+lists, source code control systems, and issue tracking systems
+that are managed by, or on behalf of, Us for the purpose of
+discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
 
 "Designated Employees" shall mean the employees and contractors
 identified by You, by GitHub username, as authorized to submit
@@ -134,4 +138,4 @@ By having an authorized representative sign this Agreement — as
 instructed by the project's CLA assistant, or in writing to the
 maintainers — and identifying You and Your initial Designated
 Employees, You accept and agree to these terms for Contributions
-submitted by Your Designated Employees to OpenOOXML projects.
+submitted by Your Designated Employees to the Projects.

--- a/CLA.md
+++ b/CLA.md
@@ -1,7 +1,7 @@
 # OpenOOXML Individual Contributor License Agreement
 
 Thank you for your interest in contributing to software projects
-maintained by the OpenOOXML project and its maintainers ("Us"). This Agreement clarifies the
+maintained by Elia Hilse, the OpenOOXML project and its maintainers ("Us"). This Agreement clarifies the
 intellectual property license granted with Contributions from any
 person or entity. This license is for Your protection as a
 Contributor as well as the protection of Us and recipients of

--- a/CLA.md
+++ b/CLA.md
@@ -20,18 +20,22 @@ Contributions.
 authorized by the copyright owner that is making this Agreement
 with Us.
 
+"Project" shall mean any software project owned or managed by Us,
+including BetterOffice and the other repositories of the OpenOOXML
+organization.
+
 "Contribution" shall mean any original work of authorship, including
 any modifications or additions to an existing work, that is
 intentionally submitted by You to Us for inclusion in, or
-documentation of, any of the products owned or managed by Us
-(the "Work"). For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication
-sent to Us or our representatives, including but not limited to
-communication on electronic mailing lists, source code control
-systems, and issue tracking systems that are managed by, or on
-behalf of, Us for the purpose of discussing and improving the
-Work, but excluding communication that is conspicuously marked or
-otherwise designated in writing by You as "Not a Contribution."
+documentation of, any Project (the "Work"). For the purposes of
+this definition, "submitted" means any form of electronic, verbal,
+or written communication sent to Us or our representatives,
+including but not limited to communication on electronic mailing
+lists, source code control systems, and issue tracking systems
+that are managed by, or on behalf of, Us for the purpose of
+discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
 
 ## 2. Grant of Copyright License
 
@@ -111,4 +115,4 @@ personally aware, and conspicuously marking the work as
 
 By signing this Agreement on a pull request as instructed by the
 project's CLA assistant, You accept and agree to these terms for
-Your present and future Contributions to OpenOOXML projects.
+Your present and future Contributions to the Projects.


### PR DESCRIPTION
TL;DR:


Summary:

Two changes to `CLA.md` and `CCLA.md`, in separate commits so each can be read on its own.

**Name the party** (`d59fb20`) — both agreements defined `"Us"` as "the OpenOOXML project and its maintainers", leaving the individual who holds the copyright unnamed. Both now read "Elia Hilse, the OpenOOXML project and its maintainers". `"Us"` is defined once per document and referenced throughout, so this is one line per file. Matches `NOTICE`, which already reads "Copyright 2026 Elia Hilse, The OpenOOXML Project".

**Define the scope** (`480afc6`) — the grant clause covered "any of the products owned or managed by Us" while the acceptance clause narrowed to "OpenOOXML projects", a term never defined anywhere in either document. Naming Elia Hilse separately from the project made the gap visible: a project maintained personally, outside the OpenOOXML organization, sat inside the first phrase and arguably outside the second. Both now use one defined term:

> "Project" shall mean any software project owned or managed by Us, including BetterOffice and the other repositories of the OpenOOXML organization.

BetterOffice is named as an **example, not an enumeration**. Listing projects by name would invite the argument that unlisted ones are not covered, which gets worse with every repository added; "including" keeps it open-ended while still naming the flagship explicitly.

After this, `"OpenOOXML projects"` and `"products owned or managed by Us"` appear nowhere — the grant, the definition and the acceptance clause all say `Project`.

Worth knowing before merging:

- **Nobody has signed yet.** `signatures/v1/cla.json` is `{"signedContributors":[]}`, so no contributor agreed to the previous wording and `v1` can be amended in place. If signatures existed this should be a `v2`, because amending text does not retroactively change what a past signer agreed to.
- The CLA bot links to these files by URL and tracks signers by GitHub user ID; it does not hash or pin the agreement text, so no tooling change is needed. `.github/cla/cla.test.sh` passes 53/53.
- The Contribution sentence is reflowed in the second commit. That is not cleanup: shortening the clause to "any Project" left an orphan line mid-sentence, and a reflow cannot be contained without cascading. Nothing else was rewrapped.
- This is substantive rather than editorial. Worth your read-through, and a lawyer's if outside contributions ever matter at scale.

Test plan:

- [ ] Read `d59fb20` on its own — two lines, party only
- [ ] Read `480afc6` on its own — confirm the `Project` definition says what you want and that "including" reads as non-limiting
- [ ] Confirm naming BetterOffice as an example rather than enumerating every repository is the intent
- [ ] `bash .github/cla/cla.test.sh`
- [ ] Confirm `signatures/v1/cla.json` is still empty at merge time — if anyone signs first, this should become `v2`
- [ ] Decide whether the document titles should stay "OpenOOXML Individual/Corporate Contributor License Agreement"

🤖 Generated with [Claude Code](https://claude.com/claude-code)