### PR TITLE
docs(docx): document the layout, measurement and editing internals

### DIFF
--- a/crates/docx-edit/Cargo.toml
+++ b/crates/docx-edit/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # The JS/wasm session boundary (src/wasm.rs). Off by default so native builds
 # and `cargo test` never pull the wasm-bindgen stack; wasm-pack builds pass
-# `--features wasm` (driven by scripts/embed-edit-wasm.mjs).
+# `--features wasm` (driven by scripts/build-docx-wasm.ts).
 wasm = ["dep:wasm-bindgen", "dep:js-sys"]
 
 [dependencies]

--- a/crates/docx-edit/src/bridge/mod.rs
+++ b/crates/docx-edit/src/bridge/mod.rs
@@ -1,4 +1,37 @@
-//! Read-only lowering from editing stories to layout blocks.
+//! Read-only lowering from the pilcrow-stream editing model to the layout
+//! engine's [`LayoutBlock`] vocabulary.
+//!
+//! One yrs story in, one flat block list out. The walk goes in UTF-16 units,
+//! every embed (pilcrows included) counting as one, and turns:
+//!
+//! - a run of identically formatted text into one paragraph run, cut further
+//!   at tabs and at comment-interval boundaries so each run carries a single
+//!   comment set;
+//! - a pilcrow into the end of a paragraph block, lowering its authored OOXML
+//!   properties (spacing, indents, borders, tabs, list numbering, section
+//!   properties) into the block's attributes;
+//! - a table embed into a table block whose cells recurse into their own
+//!   stories, and other embeds into image, break, field or shape runs.
+//!
+//! Nothing here mutates the document, and the whole lowering runs inside one
+//! read transaction, so the result is a consistent snapshot.
+//!
+//! Two things cross the walk rather than sitting on a single item. Section
+//! properties CASCADE: a section that overrides one margin emits a full
+//! margins record whose unset sides inherit from the previous section instead
+//! of resetting to the OOXML default. List counters advance per numbering id
+//! across the whole story, so a marker depends on every earlier list paragraph.
+//!
+//! Positions come out in two coordinate systems. Story offsets are the UTF-16
+//! indices above; the `pm_*` fields carry the paragraph-node positions that
+//! [`pm_position`] derives, in which every paragraph adds two positions for
+//! its own open and close. They usually track each other, and diverge where
+//! one story unit displays as several characters — a `noteRef` embed occupies
+//! one unit but shows a multi-digit number.
+//!
+//! Values the story cannot supply — theme colors, the default tab stop, the
+//! page content height, and the mapping from yrs ids to the numeric ids the
+//! layout contract uses — arrive in [`RenderEnv`].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -24,13 +57,24 @@ mod shapes;
 
 const AUTO_PARAGRAPH_SPACING_PX: f64 = 14.0;
 
-/// Preflattened values and ID mappings used during story lowering.
+/// Document-level values lowering cannot read off a story. Every field
+/// defaults, so an empty env lowers a story with built-in fallbacks.
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct RenderEnv {
+    /// Six-digit RGB values keyed by OOXML theme slot. A missing slot falls
+    /// back to the default Office palette.
     pub theme_colors: BTreeMap<String, String>,
+    /// Interval between implicit tab stops, passed through to each paragraph.
+    /// `None` leaves the layout engine's own default in effect.
     pub default_tab_stop_twips: Option<f64>,
+    /// Usable page height in px. Images taller than this are scaled down to
+    /// fit; `None` or a non-positive value clamps nothing.
     pub page_content_height: Option<f64>,
+    /// Maps a yrs `{client}:{counter}` revision or comment id to the number
+    /// the layout contract carries. An unmapped id is hashed into the
+    /// safe-integer range instead, which is stable but not shared with a peer
+    /// that numbers the same document differently.
     pub numeric_ids: BTreeMap<String, f64>,
 }
 
@@ -41,21 +85,26 @@ impl RenderEnv {
     }
 }
 
-/// A malformed story or a model/bridge configuration mismatch.
+/// Why a story could not be lowered. Every variant means the input is wrong,
+/// not that lowering is incomplete.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BridgeError {
+    /// The story or a comment anchor could not be read.
     Edit(EditError),
+    /// The document counts in code points rather than UTF-16 units, so every
+    /// offset in the block output would be wrong.
     WrongOffsetKind,
+    /// The story does not end in a pilcrow, so its last paragraph has no mark.
     UnterminatedStory(String),
-    UnsupportedEmbed {
-        story: String,
-        index: u32,
-    },
+    /// An embed kind lowering does not know how to render.
+    UnsupportedEmbed { story: String, index: u32 },
+    /// A table embed whose rows, grid or spans do not describe a rectangle.
     MalformedTable {
         story: String,
         index: u32,
         detail: String,
     },
+    /// A table cell refers back to a story already being lowered.
     RecursiveStory(String),
 }
 
@@ -93,12 +142,18 @@ impl From<EditError> for BridgeError {
     }
 }
 
-/// Maps UTF-16 story offsets to paragraph-node positions.
+/// Maps a UTF-16 story offset to its paragraph-node position.
+///
+/// A paragraph node occupies its content plus two positions, one for each of
+/// its boundaries, while a story counts one unit per pilcrow. Each pilcrow
+/// already crossed therefore contributes the one extra position the story
+/// index does not have, and the leading `+ 1` opens the first paragraph.
 pub const fn pm_position(story_index: u32, pilcrows_before: u32) -> u64 {
     story_index as u64 + 1 + pilcrows_before as u64
 }
 
-/// Lowers one story from an [`EditingDoc`] to the unchanged renderer vocabulary.
+/// Lowers one story to the layout engine's block vocabulary. Table cells
+/// recurse, so a body story yields the blocks of every cell it contains.
 pub fn yrs_doc_to_layout_blocks(
     doc: &EditingDoc,
     story_id: &str,
@@ -139,7 +194,8 @@ fn lower_story<T: ReadTxn>(
         let mut paragraph_pm_units = 0_u32;
         let mut pm_cursor = pm_base;
         let mut at_block_boundary = true;
-        // Section-break margins cascade per story.
+        // Sections are body-level, so the cascade is per story; cell and
+        // header/footer stories simply never carry section properties.
         let mut section_margins = SectionMarginsTwips::default();
 
         for diff in story.diff(txn, YChange::identity) {
@@ -176,7 +232,8 @@ fn lower_story<T: ReadTxn>(
                     );
                     pm_cursor = paragraph_pm_start + u64::from(paragraph_pm_units) + 2;
                     blocks.extend(paragraph_blocks);
-                    // Section properties emit a break after the paragraph.
+                    // A pilcrow carrying section properties ENDS its section,
+                    // so the break block follows its paragraph.
                     let values = pilcrow_values(&pilcrow, txn);
                     if let Some(section_break) = section_break_block(&values, &mut section_margins)
                     {
@@ -420,7 +477,8 @@ fn lower_story<T: ReadTxn>(
                         formatting: RunFormatting {
                             italic: Some(true),
                             font_family: Some("Cambria Math".to_owned()),
-                            // Sentinel for math fallback without logical order.
+                            // Sentinel consumed by `stamp_logical_order`: a
+                            // math fallback run gets no logical order.
                             logical_order: Some(u64::MAX),
                             ..RunFormatting::default()
                         },
@@ -520,7 +578,8 @@ fn lower_story<T: ReadTxn>(
     result
 }
 
-/// CamelCase alias for story lowering.
+/// CamelCase alias of [`yrs_doc_to_layout_blocks`] for callers spelling the
+/// entry point the way the boundary names it.
 #[allow(non_snake_case)]
 pub fn yrsDocToLayoutBlocks(
     doc: &EditingDoc,
@@ -1436,7 +1495,8 @@ fn lower_inline_sdt_values(
                     runs,
                 )
             }),
-            // Nested shapes and charts are omitted; other leaves occupy one position.
+            // A shape or chart nested in an inline SDT produces no run; every
+            // other leaf still occupies one position even without one.
             _ => 1,
         };
         content_size += child_size;
@@ -1576,27 +1636,37 @@ enum RawRunKind {
     },
 }
 
+/// One run before coalescing and before its position is made absolute.
 #[derive(Clone, Debug)]
 struct RawRun {
     kind: RawRunKind,
     formatting: RunFormatting,
+    /// Story-global UTF-16 bounds of the source content.
     story_start: u32,
     story_end: u32,
-    /// Offsets relative to the paragraph content start. Usually identical
-    /// to story offsets; a one-unit `noteRef` displays its possibly multi-digit id.
+    /// Rendered bounds relative to the paragraph's content start. Usually the
+    /// same width as the story bounds; they diverge where one story unit
+    /// displays as several characters, as a `noteRef` does when its id has
+    /// more than one digit.
     pm_start: u32,
     pm_end: u32,
     /// Checkbox chrome inherited from the nearest editable inline SDT.
     inline_sdt_widget: Option<Value>,
 }
 
+/// A shape or chart child that splits its paragraph, held with the position it
+/// occupied so the surrounding runs keep their original offsets.
 #[derive(Clone, Debug)]
 struct DrawingMarker {
-    /// Offset relative to the original paragraph content start.
     pm_offset: u32,
     block: LayoutBlock,
 }
 
+/// Resolves every comment anchored in `story_id` to sorted, story-global
+/// UTF-16 intervals with the numeric ids the layout contract carries. Anchors
+/// in other stories are skipped and an empty range contributes nothing; an
+/// anchor that no longer resolves is an error, because the run cuts derived
+/// from these intervals would silently misplace the comment.
 fn resolve_comment_intervals<T: ReadTxn>(
     txn: &T,
     story_id: &str,
@@ -1645,6 +1715,9 @@ fn resolve_comment_intervals<T: ReadTxn>(
     Ok(intervals)
 }
 
+/// Splits one formatted text chunk into runs. Cuts land at every comment
+/// interval boundary inside the chunk, so a run's comment set is uniform, and
+/// around each tab, which becomes a run of its own.
 fn push_text_chunks(
     runs: &mut Vec<RawRun>,
     text: &str,
@@ -1710,6 +1783,10 @@ fn push_text_chunks(
     }
 }
 
+/// Emits the blocks one paragraph contributes: normally a single paragraph
+/// block, but a paragraph holding shape or chart children breaks into the text
+/// segments around them, each carrying the same pilcrow properties. Empty
+/// segments are dropped, and every surviving run keeps its original position.
 #[allow(clippy::too_many_arguments)]
 fn flush_paragraph_parts<T: ReadTxn>(
     mut raw_runs: Vec<RawRun>,
@@ -1737,7 +1814,6 @@ fn flush_paragraph_parts<T: ReadTxn>(
         ))];
     }
 
-    // Direct shape and chart children split paragraphs without empty slices.
     let mut blocks = Vec::new();
     let mut segment_start = 0_u32;
     for drawing in drawings {
@@ -1845,13 +1921,18 @@ fn pilcrow_values<T: ReadTxn>(pilcrow: &MapRef, txn: &T) -> BTreeMap<String, Any
         .collect()
 }
 
-/// OOXML page geometry defaults in twips.
+/// OOXML page-geometry defaults in twips — US Letter, one-inch margins,
+/// half-inch column gap — used when a `sectPr` overrides only part of the
+/// geometry.
 const DEFAULT_PAGE_WIDTH_TWIPS: f64 = 12240.0;
 const DEFAULT_PAGE_HEIGHT_TWIPS: f64 = 15840.0;
 const DEFAULT_SECTION_MARGIN_TWIPS: f64 = 1440.0;
 const DEFAULT_COLUMN_GAP_TWIPS: f64 = 720.0;
 
-/// Running per-side margin cascade across section breaks.
+/// The running per-side margin cascade across section breaks, in twips. A
+/// section that overrides ANY margin emits a full margins record; its unset
+/// sides inherit from the prior section rather than resetting to the OOXML
+/// default.
 #[derive(Clone, Copy, Debug)]
 struct SectionMarginsTwips {
     top: f64,
@@ -1882,7 +1963,11 @@ fn section_break_type(value: &str) -> Option<SectionBreakType> {
     }
 }
 
-/// Lowers section properties to a layout break.
+/// Lowers a boundary pilcrow's `sectPr` sub-map and `sectionBreakType` to the
+/// [`SectionBreakBlock`] the layout engine consumes, or `None` when the
+/// pilcrow carries no section properties. Geometry converts twips to px; page
+/// size is emitted only when a dimension is overridden, margins follow the
+/// `cascade`, and columns only when the count exceeds one.
 fn section_break_block(
     values: &BTreeMap<String, Any>,
     cascade: &mut SectionMarginsTwips,
@@ -1973,6 +2058,9 @@ fn section_break_block(
     Some(block)
 }
 
+/// Merges neighbouring text runs that are adjacent in BOTH coordinate systems
+/// and agree on formatting and inline-SDT chrome. Only text merges, so tabs,
+/// images and fields always stay separate runs.
 fn coalesce_runs(runs: Vec<RawRun>) -> Vec<RawRun> {
     let mut result: Vec<RawRun> = Vec::with_capacity(runs.len());
     for run in runs {
@@ -2047,6 +2135,8 @@ fn raw_run_to_layout(raw: RawRun, paragraph_pm_start: u64) -> Run {
     }
 }
 
+/// Numbers the runs of one paragraph in reading order. A run already carrying
+/// the [`u64::MAX`] sentinel is left without a logical order instead.
 fn stamp_logical_order(runs: &mut [Run]) {
     for (index, run) in runs.iter_mut().enumerate() {
         match run {
@@ -2061,9 +2151,13 @@ fn stamp_logical_order(runs: &mut [Run]) {
     }
 }
 
+/// List numbering carried across the whole story.
 #[derive(Default)]
 struct ListState {
+    /// Live counter stack per abstract numbering id, indexed by level.
     counters: BTreeMap<String, Vec<i64>>,
+    /// The `{numId}:{level}` pairs already numbered, so a `listStartOverride`
+    /// applies once rather than on every paragraph at that level.
     seen_num_ids: BTreeSet<String>,
 }
 
@@ -2176,6 +2270,11 @@ fn resolve_list_template(template: &str, counters: &[i64], formats: &[String]) -
     result
 }
 
+/// The rendered list marker for one paragraph, advancing `state`. Bullets and
+/// authored literal markers pass through; a marker containing `%` is a
+/// template resolved against the counter stack, and a paragraph with no marker
+/// at all gets the dotted counter path (`"1.2."`). Numbering a level resets
+/// every deeper level.
 fn compute_list_marker(values: &BTreeMap<String, Any>, state: &mut ListState) -> Option<String> {
     let marker = value_string(values.get("listMarker"));
     let Some(Any::Map(num_pr)) = values.get("numPr") else {
@@ -2393,7 +2492,9 @@ fn lower_font_size(attributes: Option<&Attrs>, result: &mut RunFormatting) {
         return;
     };
     match value {
-        // Scalar marks hold `w:sz`; object marks preserve independent `w:sz` and `w:szCs`.
+        // A scalar mark is the authored `w:sz`; the object form additionally
+        // preserves an independent `w:szCs`. Both stay in half-points until
+        // this conversion.
         Any::Number(half_points) => result.font_size = Some(*half_points / 2.0),
         Any::BigInt(half_points) => result.font_size = Some(*half_points as f64 / 2.0),
         Any::Map(map) => {
@@ -3048,6 +3149,10 @@ fn hex_byte(value: &str) -> Option<u8> {
     u8::from_str_radix(value, 16).ok()
 }
 
+/// The number the layout contract carries for a yrs `{client}:{counter}` id:
+/// the explicit [`RenderEnv::numeric_ids`] mapping when there is one,
+/// otherwise a hash of the id folded into the JavaScript safe-integer range.
+/// The fallback is stable within a document but cannot round-trip the string.
 fn numeric_id(id: &str, env: &RenderEnv) -> f64 {
     if let Some(value) = env.numeric_ids.get(id) {
         return *value;
@@ -3057,7 +3162,6 @@ fn numeric_id(id: &str, env: &RenderEnv) -> f64 {
     {
         return value;
     }
-    // Hash unmapped IDs into the safe-integer range.
     let hash = id.bytes().fold(0xcbf29ce484222325_u64, |hash, byte| {
         (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
     });

--- a/crates/docx-edit/src/canonical.rs
+++ b/crates/docx-edit/src/canonical.rs
@@ -1,4 +1,44 @@
-//! Deterministic `canonical-stream-v1` projection.
+//! Deterministic `canonical-stream-v1` projection: one story's semantic
+//! content rendered to bytes that any implementation can reproduce exactly.
+//!
+//! Byte format:
+//!
+//! 1. UTF-8 `canonical-stream-v1`, then LF (`0x0a`).
+//! 2. One compact JSON object per item, each followed by LF (the final item
+//!    included). Items are externally tagged:
+//!    `{"CharItem":{"ch":"x","marks":{…}}}`, `{"ParaMark":{"ppr":{…}}}`,
+//!    `{"Table":{"tblPr":{…},"grid":[…],"rows":[…]}}`,
+//!    `{"Embed":{"kind":"break","payload":{…}}}`, `{"OpaqueBlk":{"blob":…}}`.
+//! 3. Object keys at every depth are in Rust `str`/`BTreeMap` lexicographic
+//!    order; arrays keep their input order. JSON is compact and uses
+//!    `serde_json`'s escaping and number formatting.
+//! 4. `null` (including yrs `Any::Undefined`) is stripped from objects at every
+//!    depth. A null ARRAY slot survives, because removing it would shift the
+//!    positions after it; an opaque blob may itself be `null`, because that
+//!    field cannot be made absent.
+//!
+//! Text projects one [`CanonicalItem::CharItem`] per Unicode scalar (Rust
+//! `char`) — never per UTF-16 code unit and never coalesced into runs; a tab is
+//! an ordinary `"\t"` item. [`CanonicalItem::ParaMark`] excludes the pilcrow's
+//! `_kind` discriminator and its volatile `paraId`, so two documents that
+//! differ only in freshly minted paragraph ids project identical bytes. Every
+//! other atom — hard breaks, native `noteRef` anchors — is an
+//! [`CanonicalItem::Embed`] whose `_kind` becomes `kind` and whose remaining
+//! entries become `payload`.
+//!
+//! Comments project as presence and grouping, never identity: a char item
+//! fully covered by a comment's resolved anchors carries a sorted `commentIds`
+//! array of per-story ORDINALS. Ordinals rank the covering comments by their
+//! covered story units (UTF-16 units, every embed counting one) compared
+//! lexicographically, so volatile comment keys never reach the stream — the
+//! same rule as the excluded `paraId`. The field is omitted when empty, so an
+//! uncommented story projects exactly as if comments did not exist. Anchors
+//! that no longer resolve, resolve empty, or belong to another story are
+//! skipped.
+//!
+//! [`CanonicalItem::OpaqueBlk`] is part of the byte vocabulary, but the editing
+//! schema carries no opaque-block discriminator, so [`project_story`] never
+//! emits one.
 
 use std::collections::BTreeMap;
 
@@ -36,11 +76,13 @@ pub enum CanonicalItem {
         kind: String,
         payload: BTreeMap<String, Value>,
     },
-    /// Sealed block JSON.
+    /// Sealed block JSON, projected verbatim apart from the shared null strip.
     OpaqueBlk { blob: Value },
 }
 
-/// Projects one yrs story into canonical semantic units.
+/// Projects one yrs story into canonical semantic units, in story order.
+///
+/// Errors only when `story_id` is not a story of `doc`.
 pub fn project_story(doc: &EditingDoc, story_id: &str) -> Result<Vec<CanonicalItem>, OpError> {
     let txn = doc.yrs_doc().transact();
     let story = story_ref(&txn, story_id)?;
@@ -154,7 +196,10 @@ fn exclude_cell_story_ids(rows: &mut Value) {
     }
 }
 
-/// Resolves comments to ordinal-ordered UTF-16 intervals.
+/// Resolves the comments anchored in `story_id` to ordinal-ordered interval
+/// lists: the index is the comment's per-story ordinal, the value its merged,
+/// sorted `[start, end)` UTF-16 story-unit intervals. Ordinals come from
+/// comparing covered story units lexicographically, never from comment keys.
 fn story_comment_groups<T: ReadTxn>(txn: &T, story_id: &str) -> Vec<Vec<(u32, u32)>> {
     let Some(comments) = txn.get_map(crate::COMMENTS) else {
         return Vec::new();
@@ -227,7 +272,8 @@ fn covering_ordinals(groups: &[Vec<(u32, u32)>], unit: u32, width: u32) -> Vec<u
         .collect()
 }
 
-/// Serializes canonical items to the exact `canonical-stream-v1` bytes documented above.
+/// Serializes canonical items to the exact `canonical-stream-v1` bytes
+/// documented at the top of this module.
 pub fn to_canonical_bytes(items: &[CanonicalItem]) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(VERSION.as_bytes());

--- a/crates/docx-edit/src/frame_delta/typed_page.rs
+++ b/crates/docx-edit/src/frame_delta/typed_page.rs
@@ -1,4 +1,35 @@
-//! Streaming typed-page serialization for frame deltas.
+//! Streaming typed-page serialization for the FrameDelta encoder.
+//!
+//! Three `serde::Serializer` implementations walk a typed [`DisplayPage`]
+//! directly, so a rebuilt page costs three allocation-free passes instead of
+//! materializing an intermediate value tree:
+//!
+//! - [`hash_page`] — the structural and visual fingerprints, in one pass;
+//! - [`collect_page_strings`] — string-table population, for upsert pages;
+//! - [`encode_page`] — the typed value stream, for upsert pages.
+//!
+//! The two fingerprints answer different questions, so each excludes what it
+//! must not notice. The structural one ignores the root `pageIndex`, since a
+//! page that only moved is still the same page. The visual one additionally
+//! ignores `docStart`, `docEnd`, `fragmentDocStart`, `fragmentDocEnd` and an
+//! `inlineSdtWidget`'s `pos`: those shift as text is edited elsewhere without
+//! changing a pixel, and a page whose visual fingerprint holds can ship a
+//! position patch rather than a full re-encode. Fingerprints are only ever
+//! compared against others from the same session.
+//!
+//! Emission rules the browser decoder depends on:
+//!
+//! - object field order is declaration order — the decoder materializes
+//!   fields one by one and does not care;
+//! - a duplicate key, which a named field colliding with a `serde(flatten)`
+//!   member produces, is compacted to its LAST write, because the decoder
+//!   rejects duplicate object keys outright;
+//! - an unsigned value that fits in `i64` emits `VALUE_I64`, so a number has
+//!   one canonical encoding;
+//! - a non-finite float emits `VALUE_NULL`, JSON having no spelling for it;
+//! - an array under `"glyphs"` whose entries all carry the expected numeric
+//!   fields emits the compact `VALUE_GLYPH_ARRAY` payload instead of a
+//!   generic array.
 
 use std::collections::{BTreeSet, HashMap};
 use std::fmt;
@@ -14,7 +45,10 @@ use super::{
 };
 
 pub(super) struct PageHashes {
+    /// Changes whenever the page's content changes, ignoring only its index.
     pub fingerprint: u64,
+    /// Changes only when the page's appearance changes; equal fingerprints
+    /// mean a position patch suffices.
     pub visual_fingerprint: u64,
 }
 
@@ -84,7 +118,9 @@ fn unsupported<T>(what: &str) -> Result<T, SerError> {
     )))
 }
 
-/// Key classifications the exclusion / compaction rules depend on.
+/// The parent key a value sits under, where that changes how it is treated:
+/// glyph arrays compact, and an inline SDT widget's `pos` leaves the visual
+/// fingerprint. Array elements inherit their array's slot.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Slot {
     None,
@@ -100,6 +136,8 @@ fn classify(key: &str) -> Slot {
     }
 }
 
+/// Keys the visual fingerprint ignores: they move with edits elsewhere in the
+/// document without changing what the page looks like.
 fn is_position_key(key: &str) -> bool {
     matches!(
         key,
@@ -321,8 +359,8 @@ impl HashContainer<'_> {
             fp_on: self.fp_on,
             vfp_on: self.vfp_on,
             root: false,
-            // array elements inherit the array's slot (glyph objects sit
-            // under "glyphs"), matching the Value-walk's parent_key rule
+            // Array elements inherit the array's slot, so a glyph object
+            // still counts as sitting under "glyphs".
             slot: self.slot,
         })
     }
@@ -368,7 +406,7 @@ impl<'a> Serializer for HashSer<'a> {
         self.serialize_u64(value.into())
     }
     fn serialize_u64(mut self, value: u64) -> Result<(), SerError> {
-        // mirrors the old Value introspection: as_i64() first
+        // One canonical encoding per number: prefer VALUE_I64.
         if let Ok(signed) = i64::try_from(value) {
             self.write(&[VALUE_I64]);
             self.write(&signed.to_le_bytes());
@@ -382,7 +420,7 @@ impl<'a> Serializer for HashSer<'a> {
         self.serialize_f64(value.into())
     }
     fn serialize_f64(mut self, value: f64) -> Result<(), SerError> {
-        // serde_json::to_value maps non-finite floats to null
+        // JSON cannot spell a non-finite float; emit null.
         if value.is_finite() {
             self.write(&[VALUE_F64]);
             self.write(&value.to_bits().to_le_bytes());
@@ -899,7 +937,10 @@ struct EmitContainer<'a> {
     payload_at: usize,
     count: u32,
     key_buf: String,
-    /// Object entries used to compact duplicate flattened keys to the last write.
+    /// One `(key id, byte offset of that entry)` per object entry, so
+    /// [`EmitContainer::compact_duplicate_keys`] can splice out a superseded
+    /// key — which a named field colliding with a `serde(flatten)` member
+    /// produces.
     entries: Vec<(u32, usize)>,
 }
 
@@ -935,10 +976,12 @@ impl<'a> EmitContainer<'a> {
         Ok(())
     }
 
-    /// Drop every non-final occurrence of a repeated object key (last write
-    /// wins). Duplicate-free objects — the overwhelming majority — pay one
-    /// linear scan and nothing else; typed value payloads only carry relative
-    /// lengths, so splicing bytes out never invalidates inner containers.
+    /// Drops every non-final occurrence of a repeated object key, so the last
+    /// write wins — a correctness rule, not a size optimization, because the
+    /// decoder rejects duplicate keys outright. Duplicate-free objects, the
+    /// overwhelming majority, pay one linear scan and nothing else; container
+    /// payloads carry only relative lengths, so splicing bytes out can never
+    /// invalidate an inner container.
     fn compact_duplicate_keys(&mut self) {
         let has_duplicate = self.entries.iter().enumerate().any(|(index, (key, _))| {
             self.entries[index + 1..]
@@ -1039,7 +1082,7 @@ impl<'a> Serializer for EmitSer<'a> {
         self.serialize_u64(value.into())
     }
     fn serialize_u64(self, value: u64) -> Result<(), SerError> {
-        // mirrors the old Value introspection: as_i64() first
+        // One canonical encoding per number: prefer VALUE_I64.
         if let Ok(signed) = i64::try_from(value) {
             self.out.push(VALUE_I64);
             write_i64(self.out, signed);
@@ -1053,7 +1096,7 @@ impl<'a> Serializer for EmitSer<'a> {
         self.serialize_f64(value.into())
     }
     fn serialize_f64(self, value: f64) -> Result<(), SerError> {
-        // serde_json::to_value maps non-finite floats to null
+        // JSON cannot spell a non-finite float; emit null.
         if value.is_finite() {
             self.out.push(VALUE_F64);
             write_f64(self.out, value);
@@ -1263,9 +1306,10 @@ impl ser::SerializeStructVariant for EmitContainer<'_> {
 // compact glyph probe (shared by the strings and emit passes)
 // ---------------------------------------------------------------------------
 
-/// One glyph eligible for the fixed-field wire payload. Range checks beyond
-/// eligibility (id/cluster into u32) happen at emission, exactly like the
-/// `Value`-based encoder: an out-of-range id is a hard error, not a fallback.
+/// One glyph eligible for the fixed-field wire payload. Eligibility only
+/// checks that the expected fields are present and numeric; narrowing the id
+/// and cluster to `u32` happens at emission, where an out-of-range value is a
+/// hard error rather than a fall back to the generic array encoding.
 struct CompactGlyph {
     id: u64,
     x: f64,
@@ -1282,6 +1326,9 @@ fn probe_glyphs<T: Serialize + ?Sized>(value: &T) -> Option<Vec<CompactGlyph>> {
     value.serialize(GlyphSeqProbe).ok()
 }
 
+/// Emits `VALUE_GLYPH_ARRAY`: a byte length and count, then a fixed-width
+/// record per glyph. `logicalOrder` and `bidiLevel` are optional, so each
+/// record carries a flag byte saying which of them follow.
 fn emit_glyph_array(glyphs: &[CompactGlyph], out: &mut Vec<u8>) -> Result<(), SerError> {
     out.push(VALUE_GLYPH_ARRAY);
     let length_at = out.len();
@@ -1330,6 +1377,9 @@ fn emit_glyph_array(glyphs: &[CompactGlyph], out: &mut Vec<u8>) -> Result<(), Se
     Ok(())
 }
 
+/// Signals "not a compact glyph array" out of the probe. The error never
+/// reaches a caller: [`probe_glyphs`] turns it into `None`, which selects the
+/// generic array encoding.
 fn ineligible<T>() -> Result<T, SerError> {
     Err(SerError("glyph array is not compact-eligible".to_owned()))
 }
@@ -1343,7 +1393,7 @@ enum GlyphNum {
 }
 
 impl GlyphNum {
-    /// `Value::as_u64` equivalence.
+    /// The value as `u64`, refusing a float even when it is whole.
     fn as_u64(self) -> Option<u64> {
         match self {
             GlyphNum::Uint(value) => Some(value),
@@ -1352,7 +1402,7 @@ impl GlyphNum {
         }
     }
 
-    /// `Value::as_f64` equivalence.
+    /// The value as `f64`, widening either integer form.
     fn as_f64(self) -> Option<f64> {
         match self {
             GlyphNum::Uint(value) => Some(value as f64),

--- a/crates/docx-edit/src/ops/paragraph.rs
+++ b/crates/docx-edit/src/ops/paragraph.rs
@@ -1,4 +1,25 @@
-//! Paragraph editing operations.
+//! Paragraph structure and properties: split, merge, attribute deltas, tab
+//! stops, indent steps, style application, and paraId maintenance.
+//!
+//! A paragraph is not a container here. Its text is a plain run of story
+//! units, and its identity and properties live on the pilcrow embed that
+//! TERMINATES it — so splitting a paragraph is inserting one pilcrow, merging
+//! two is removing one, and every property op writes to a pilcrow's map.
+//!
+//! Two consequences follow. First, splitting has to decide which half keeps
+//! the original paraId: the new pilcrow takes it and terminates the FIRST
+//! half, while the original pilcrow — now ending the second half — is
+//! re-minted. Second, merging has to decide whose properties survive; a plain
+//! merge lets the deleted mark's properties and paraId win, so the earlier
+//! paragraph's identity carries over. Tracked-change resolution uses the
+//! opposite rule, for the reasons its own module docs give.
+//!
+//! Style resolution stays outside the CRDT. Ops that apply a style take a
+//! host-supplied [`ResolvedStyleProjection`] rather than reading `styles.xml`,
+//! and reject an unknown style before touching the document.
+//!
+//! Spacing, indent and tab values are authored OOXML units — twips and
+//! line-spacing units — never pixels.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
@@ -17,7 +38,9 @@ use crate::{
     Position, StoryRange, check_position, insertion_attrs, next_pilcrow, revision_value, story_ref,
 };
 
-/// Paragraph attributes controlled by style application.
+/// The paragraph attributes a style definition owns. Applying a style resets
+/// every one of them to the style's value, or clears it when the style has
+/// none — an attribute here is never left over from the previous style.
 pub const STYLE_CONTROLLED_PARA_ATTRS: [&str; 15] = [
     "alignment",
     "spaceBefore",
@@ -36,7 +59,9 @@ pub const STYLE_CONTROLLED_PARA_ATTRS: [&str; 15] = [
     "defaultTextFormatting",
 ];
 
-/// Marks cleared before applying style run formatting.
+/// The run marks swept from a paragraph's text before the new style's own run
+/// formatting is written, so direct formatting from the old style cannot
+/// survive the switch.
 pub const STYLE_CONTROLLED_MARKS: [&str; 7] = [
     "bold",
     "italic",
@@ -47,7 +72,9 @@ pub const STYLE_CONTROLLED_MARKS: [&str; 7] = [
     "strike",
 ];
 
-/// Paragraph properties inherited by an empty split half.
+/// The only paragraph properties an EMPTY second half inherits on split —
+/// pressing Enter at the end of a paragraph starts a clean one that keeps the
+/// style and vertical rhythm but nothing else.
 const INHERITED_PARA_ATTRS: [&str; 7] = [
     "defaultTextFormatting",
     "pStyle",
@@ -58,7 +85,8 @@ const INHERITED_PARA_ATTRS: [&str; 7] = [
     "contextualSpacing",
 ];
 
-/// Default text-formatting keys carried across a split.
+/// The `defaultTextFormatting` keys that cross a split: font, size and color
+/// only. Bold, italic, underline and the rest deliberately do not carry.
 const STYLE_CARRY_DTF_KEYS: [&str; 4] = ["fontFamily", "fontSize", "fontSizeCs", "color"];
 
 const BORDERS: &str = "borders";
@@ -77,10 +105,12 @@ pub enum MergeDirection {
     Backward,
 }
 
-/// Paragraphs targeted by an operation.
+/// Which paragraphs an op targets. Every variant is resolved and validated
+/// before any mutation, so an unknown id never leaves a partial edit.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParaSelector {
     One(ParagraphId),
+    /// Resolved in the order given; an unknown id in the list is an error.
     Many(Vec<ParagraphId>),
     /// Every paragraph whose content or mark intersects the range.
     Range(StoryRange),
@@ -108,7 +138,9 @@ impl TabStop {
     }
 }
 
-/// Tri-state paragraph attributes in authored OOXML units.
+/// A tri-state paragraph-property delta: [`Patch::Keep`] leaves the current
+/// value, [`Patch::Clear`] removes the property, [`Patch::Set`] writes it.
+/// Spacing and indent values are authored OOXML units, never pixels.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ParaAttrDelta {
     pub alignment: Patch<String>,
@@ -124,17 +156,25 @@ pub struct ParaAttrDelta {
     pub tabs: Patch<Vec<TabStop>>,
     /// The paragraph-mark run defaults (`defaultTextFormatting`), as an opaque attr map.
     pub default_text_formatting: Patch<BTreeMap<String, Any>>,
-    /// The +30 opaque paragraph properties; `None` clears the key.
+    /// Every paragraph property without a typed field above, written as given;
+    /// `None` clears the key. Schema-managed identity keys are rejected.
     pub other: BTreeMap<String, Option<Any>>,
 }
 
-/// Host-resolved paragraph and run style attributes.
+/// A style definition already resolved by the host, injected because the
+/// `styles.xml` cascade lives outside the CRDT.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ResolvedStyleProjection {
     pub style_id: String,
-    /// Host-verified existence. `false` → [`OpError::UnknownStyle`] before any mutation.
+    /// Host-verified existence. `false` yields [`OpError::UnknownStyle`]
+    /// before any mutation.
     pub known: bool,
+    /// Values for the [`STYLE_CONTROLLED_PARA_ATTRS`] keys — a missing or null
+    /// entry clears that attribute — plus any list attributes when the style
+    /// defines numbering.
     pub paragraph_attrs: BTreeMap<String, Any>,
+    /// The style's run formatting as story attribute values (`bold`,
+    /// `fontSize`, …), applied after the [`STYLE_CONTROLLED_MARKS`] sweep.
     pub run_marks: BTreeMap<String, Any>,
 }
 
@@ -229,7 +269,10 @@ fn set_or_remove(txn: &mut TransactionMut<'_>, map: &MapRef, key: &str, value: O
     }
 }
 
-/// Writes style-controlled and extra paragraph attributes.
+/// Writes a style's paragraph-attribute projection: each
+/// [`STYLE_CONTROLLED_PARA_ATTRS`] key is reset to the projection's value or
+/// cleared when it has none, and any extra key (list attributes) is applied as
+/// given. Errors on a schema-managed identity key.
 fn apply_paragraph_attr_projection(
     txn: &mut TransactionMut<'_>,
     map: &MapRef,
@@ -268,7 +311,27 @@ fn style_carry_dtf(value: &Any) -> Option<Any> {
 }
 
 impl EditingDoc {
-    /// Splits a paragraph with one pilcrow and inherited properties.
+    /// Splits a paragraph by inserting exactly ONE pilcrow at `at`.
+    ///
+    /// The new pilcrow terminates the FIRST half, carrying the source
+    /// paragraph's full properties and its ORIGINAL paraId; the original
+    /// pilcrow is re-minted with a fresh paraId and becomes the second half's
+    /// mark. What the second half then keeps depends on where the split fell:
+    ///
+    /// - mid-paragraph: it keeps its own properties;
+    /// - at the paragraph end, so the second half is empty: only
+    ///   the `INHERITED_PARA_ATTRS` subset survives, with
+    ///   `defaultTextFormatting` reduced to the font/size/color carry keys;
+    /// - at the end WITH a `next_style`: it switches to that style's
+    ///   projection outright instead.
+    ///
+    /// Paragraph borders are cleared in every case, because Word never
+    /// propagates `w:pBdr` across a split. Suggesting mode stamps the inserted
+    /// pilcrow `ins` and `pPrIns`, reusing an adjacent revision by the same
+    /// author when there is one.
+    ///
+    /// Errors when `next_style` is not known, before any mutation, and when
+    /// `at` does not address a position inside a story.
     pub fn split_paragraph(
         &self,
         ctx: &EditCtx,
@@ -327,7 +390,8 @@ impl EditingDoc {
         orig_map.insert(&mut txn, PARA_ID, second_para_id.as_str());
         if second_half_empty {
             if let Some(next) = next_style {
-                // A `w:next` switch uses fresh projected attributes.
+                // A `w:next` switch starts from nothing: drop the source
+                // properties before writing the projection.
                 for (key, _) in &props {
                     orig_map.remove(&mut txn, key);
                 }
@@ -361,9 +425,18 @@ impl EditingDoc {
         })
     }
 
-    /// Merges the paragraph with its neighbor by deleting the boundary pilcrow; the survivor
-    /// adopts the deleted mark's pPr + paraId (the earlier paragraph's identity wins — R6).
-    /// Suggesting mode retains the mark with `del` + `pPrDel` instead.
+    /// Merges the paragraph with its neighbour by deleting the boundary
+    /// pilcrow. The survivor adopts the deleted mark's properties and paraId,
+    /// so the EARLIER paragraph's identity wins.
+    ///
+    /// Suggesting mode normally retains the mark, stamping it `del` and
+    /// `pPrDel`. The exception is backspacing over this same author's still
+    /// pending split: that retracts the suggestion, physically removing the
+    /// pilcrow rather than authoring a second, contradictory revision.
+    ///
+    /// The receipt's range is the caret position after the merge. Errors when
+    /// the paragraph is unknown, when merging forward from a story's last
+    /// paragraph, and when merging backward from its first.
     pub fn merge_paragraphs(
         &self,
         ctx: &EditCtx,
@@ -443,8 +516,12 @@ impl EditingDoc {
         })
     }
 
-    /// Applies a tri-state paragraph attribute delta to the selected paragraphs in one
-    /// transaction.
+    /// Applies a tri-state paragraph attribute delta to the selected
+    /// paragraphs in one transaction. In suggesting mode a `pPrChange` record
+    /// capturing the before and after property maps is appended to every
+    /// paragraph the delta actually changed, and the receipt carries its
+    /// revision id; a delta that changes nothing stamps nothing. Errors when
+    /// the delta names a schema-managed identity key, before any mutation.
     pub fn set_paragraph_attrs(
         &self,
         ctx: &EditCtx,
@@ -497,7 +574,8 @@ impl EditingDoc {
         })
     }
 
-    /// Adds (or replaces, by position) a tab stop on the selected paragraphs.
+    /// Adds a tab stop to the selected paragraphs, replacing any existing stop
+    /// at the same position. Stops stay sorted by position.
     pub fn add_tab_stop(
         &self,
         ctx: &EditCtx,
@@ -522,7 +600,8 @@ impl EditingDoc {
         Ok(Receipt::default())
     }
 
-    /// Removes the tab stop at `pos` (twips) from the selected paragraphs.
+    /// Removes the tab stop at `pos` twips from the selected paragraphs,
+    /// dropping the `tabs` attribute entirely once none are left.
     pub fn remove_tab_stop(
         &self,
         ctx: &EditCtx,
@@ -545,7 +624,8 @@ impl EditingDoc {
         Ok(Receipt::default())
     }
 
-    /// Increases left indent by a default half-inch step.
+    /// Increases `indentLeft` by `step` twips, defaulting to
+    /// [`INDENT_STEP_TWIPS`].
     pub fn increase_indent(
         &self,
         ctx: &EditCtx,
@@ -564,7 +644,9 @@ impl EditingDoc {
         Ok(Receipt::default())
     }
 
-    /// Decreases left indent and clears it at zero.
+    /// Decreases `indentLeft` by `step` twips, defaulting to
+    /// [`INDENT_STEP_TWIPS`] and clamping at zero. Reaching zero removes the
+    /// attribute rather than storing it.
     pub fn decrease_indent(
         &self,
         ctx: &EditCtx,
@@ -612,7 +694,14 @@ impl EditingDoc {
         Ok(Receipt::default())
     }
 
-    /// Applies a host-resolved paragraph style atomically.
+    /// Applies a host-resolved paragraph style in ONE transaction: writes the
+    /// style id, resets every [`STYLE_CONTROLLED_PARA_ATTRS`] entry to the
+    /// projection's value or clears it, sweeps the [`STYLE_CONTROLLED_MARKS`]
+    /// from the paragraph's text, and writes the style's run formats over it.
+    ///
+    /// Errors before any mutation when the style is not known, and when the
+    /// projection's run marks include a protected attribute such as a
+    /// hyperlink or a tracked-change stamp.
     pub fn apply_paragraph_style(
         &self,
         ctx: &EditCtx,
@@ -653,8 +742,10 @@ impl EditingDoc {
         Ok(Receipt::default())
     }
 
-    /// R5 maintenance: re-mints duplicate paraIds (first occurrence keeps its id), under
-    /// `Origin::System` so the pass never enters undo history. Returns `(old, new)` pairs.
+    /// Restores paraId uniqueness after a merge of divergent replicas: every
+    /// duplicate is re-minted, with the first occurrence in document order
+    /// keeping its id. Runs under a system origin so the pass never enters
+    /// undo history. Returns the `(old, new)` pairs.
     pub fn dedupe_para_ids(&self, now_iso: &str) -> OpResult<Vec<(ParagraphId, ParagraphId)>> {
         let ctx = EditCtx::system(now_iso);
         let mut renames = Vec::new();
@@ -778,6 +869,9 @@ fn paragraph_formatting<T: ReadTxn>(map: &MapRef, txn: &T) -> HashMap<String, An
         .collect()
 }
 
+/// Appends one `paragraphPropertyChange` record to the pilcrow's `pPrChange`
+/// array, holding the revision info plus the complete property maps from
+/// before and after — what rejection needs to rewind the paragraph.
 fn append_paragraph_property_change(
     txn: &mut TransactionMut<'_>,
     map: &MapRef,

--- a/crates/docx-edit/src/ops/resolve.rs
+++ b/crates/docx-edit/src/ops/resolve.rs
@@ -1,4 +1,35 @@
-//! Tracked-change acceptance and rejection operations.
+//! Tracked-change resolution: `accept_change` and `reject_change`.
+//!
+//! Each stamp class resolves two ways:
+//!
+//! | stamp    | accept                           | reject                           |
+//! |----------|----------------------------------|----------------------------------|
+//! | `ins`    | drop the stamp, text stays       | remove the text                  |
+//! | `del`    | remove the text                  | drop the stamp, text stays       |
+//! | `pPrIns` | clear the marker, split stays    | remove the pilcrow, paragraphs join |
+//! | `pPrDel` | remove the pilcrow, paragraphs join | clear the marker, split stays |
+//!
+//! A unit carrying BOTH `ins` and `del` — one author suggesting over another's
+//! suggestion — is removed either way: the remove class wins over the keep
+//! class on the same content.
+//!
+//! Removing a boundary pilcrow joins two paragraphs, and it is the FOLLOWING
+//! paragraph's mark that survives, so the merged paragraph keeps the SECOND
+//! paragraph's properties and paraId. That is the OOXML rule — the surviving
+//! `w:p` owns the properties — and it deliberately differs from a plain
+//! delete, which models a user removing a paragraph mark rather than a
+//! revision being applied. A story's FINAL pilcrow is never removed, because a
+//! document always keeps its last paragraph mark; a join that would remove it
+//! clears the markers instead.
+//!
+//! Resolving APPLIES a revision, it does not author one: no new revision is
+//! ever stamped and the context's suggesting mode is ignored.
+//!
+//! Structural table-row revisions (`trIns`/`trDel`) live in each row's `trPr`
+//! bag and resolve in the same transaction as story-unit revisions; removing a
+//! row also removes the cell stories it made unreachable. Paragraph-property
+//! revisions (`pPrChange`) resolve alongside them: accepting drops the record,
+//! rejecting restores the properties it captured.
 
 use std::sync::Arc;
 
@@ -14,7 +45,7 @@ use crate::{
     StoryRange, check_range, story_ref,
 };
 
-/// Resolve target by story range or coalesced revision ID.
+/// What a resolve op targets.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ChangeTarget {
     /// Resolve every tracked change overlapping the range (no id filtering).
@@ -82,6 +113,10 @@ fn property_map<'a>(
     }
 }
 
+/// Rewinds a pilcrow to the `previousFormatting` a `pPrChange` captured:
+/// properties the change introduced are removed, then the previous values are
+/// written back. Introducing `numPr` also clears the derived list attributes.
+/// Schema-managed keys are never touched.
 fn restore_paragraph_properties(txn: &mut TransactionMut<'_>, map: &MapRef, change: &Any) {
     let previous = property_map(change, "previousFormatting");
     let current = property_map(change, "currentFormatting");
@@ -123,6 +158,9 @@ fn restore_paragraph_properties(txn: &mut TransactionMut<'_>, map: &MapRef, chan
     }
 }
 
+/// Resolves the `pPrChange` records on one pilcrow. Matching records are
+/// consumed — rejecting restores their captured properties, accepting only
+/// drops them — and non-matching records stay for a later resolve.
 fn resolve_paragraph_property_changes(
     txn: &mut TransactionMut<'_>,
     map: &MapRef,
@@ -236,7 +274,8 @@ fn resolve_story(
             ChunkKind::Text(_) | ChunkKind::Embed(_) => {
                 let ins = active_stamp(chunk.attrs.get(INS).cloned(), filter);
                 let del = active_stamp(chunk.attrs.get(DEL).cloned(), filter);
-                // Units carrying both stamps are removed in either mode.
+                // A unit carrying BOTH stamps is removed in either mode: the
+                // remove class wins over the keep class on the same content.
                 let remove = match mode {
                     ResolveMode::Accept => del.is_some(),
                     ResolveMode::Reject => ins.is_some(),
@@ -268,13 +307,21 @@ fn resolve_story(
 }
 
 impl EditingDoc {
-    /// Accepts insertions and applies deletions for the targeted changes.
+    /// Accepts the targeted changes: pending insertions become plain content
+    /// and pending deletions are carried out. See the module docs for the full
+    /// matrix and the join rule.
+    ///
+    /// The receipt's `revision_ids` lists the ids resolved, deduplicated and
+    /// in resolution order; a range target also echoes the surviving range.
+    /// A [`ChangeTarget::Range`] errors when empty, a
+    /// [`ChangeTarget::Revision`] when the id matches nothing.
     pub fn accept_change(&self, ctx: &EditCtx, target: &ChangeTarget) -> OpResult<Receipt> {
         self.resolve_change(ctx, target, ResolveMode::Accept)
     }
 
-    /// Rejects tracked changes — the inverse of [`EditingDoc::accept_change`]: pending
-    /// insertions are rolled back, pending deletions are restored to plain content.
+    /// Rejects the targeted changes — the inverse of
+    /// [`EditingDoc::accept_change`]: pending insertions are rolled back and
+    /// pending deletions restored to plain content. Same receipt and errors.
     pub fn reject_change(&self, ctx: &EditCtx, target: &ChangeTarget) -> OpResult<Receipt> {
         self.resolve_change(ctx, target, ResolveMode::Reject)
     }

--- a/crates/docx-edit/src/wasm.rs
+++ b/crates/docx-edit/src/wasm.rs
@@ -1,4 +1,40 @@
-//! wasm-bindgen session boundary over [`EditingDoc`].
+//! wasm-bindgen session boundary over [`EditingDoc`] — the only JS-visible
+//! surface of this crate, compiled behind `--features wasm`.
+//!
+//! Conventions every entry point below obeys, so its own docs need only state
+//! what is specific to it:
+//!
+//! - **Values cross as JSON strings or raw bytes.** Arguments named `*_json`
+//!   are JSON text; a method returning `Result<String, _>` returns JSON text.
+//!   Yrs updates and binary display frames cross as byte slices / `Vec<u8>`
+//!   (wasm-bindgen exposes the latter as a transferable `Uint8Array`).
+//! - **Errors cross as `Err(JsValue)` carrying a display string** and nothing
+//!   else — there is no error code or structured payload. Every entry point
+//!   taking JSON fails that way on malformed JSON or a wrong value type, and
+//!   every entry point addressing content fails that way on an unknown story,
+//!   an unknown paragraph, or an out-of-range offset. A failed call leaves the
+//!   document untouched: arguments are fully validated before any mutation,
+//!   and each op commits in a single yrs transaction.
+//! - **Content is addressed as `Loc { story, paraId, offset }`.** `offset`
+//!   counts UTF-16 units within ONE paragraph and lives in `[0, para_len]`,
+//!   where `para_len` excludes the paragraph's own pilcrow; `offset ==
+//!   para_len` addresses the paragraph mark. A paragraph id is resolved
+//!   story-scoped, so an id living in another story reads as "not found".
+//!   Story-global indices exist only transiently inside a call and are never
+//!   returned.
+//! - **A range is two Locs in one story** and is half-open, `[start, end)`.
+//!   Because pilcrows occupy a unit, a range whose ends sit in different
+//!   paragraphs spans the boundary marks.
+//! - **Suggesting mode is the optional `(author_name, author_date)` pair.**
+//!   Pass both to record the edit as a tracked change stamped with that author
+//!   and ISO date, or neither for a plain local edit; passing one alone is an
+//!   error. Ops without the pair are always plain and local.
+//! - **Receipts are JSON objects.** An op that can stamp a tracked change
+//!   reports `{"revisionId": string|null}` — null outside suggesting mode.
+//!   Ops with no receipt content return `()`.
+//!
+//! Story lengths, selection indices and every other unit count in this module
+//! are UTF-16 units in which each embed, pilcrows included, counts as one.
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -173,7 +209,8 @@ fn apply_mark(doc: &EditingDoc, range: StoryRange, mark_json: &str) -> Result<()
         .get("type")
         .and_then(Value::as_str)
         .ok_or_else(|| js_err("mark JSON requires a string \"type\""))?;
-    // Formatting uses a plain local context.
+    // Formatting is never itself a tracked change, so the caret's suggest mode
+    // is irrelevant here.
     let ctx = EditCtx::local(String::new(), String::new());
     let simple = match kind {
         "bold" => Some(SimpleFormat::Bold),
@@ -1021,8 +1058,9 @@ impl EditSession {
 
 #[wasm_bindgen]
 impl EditSession {
-    /// Creates a replica. `client_id` must be a non-negative safe integer —
-    /// the host allocates it (yjs-style random 32-bit ids are fine).
+    /// Creates a replica. The host allocates `client_id` (a random 32-bit id
+    /// is fine) and must keep it unique across the replicas that will merge.
+    /// Errors unless it is a non-negative safe integer.
     #[wasm_bindgen(constructor)]
     pub fn new(client_id: f64) -> Result<EditSession, JsValue> {
         const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
@@ -1046,57 +1084,73 @@ impl EditSession {
         })
     }
 
+    /// This replica's client id, as passed to the constructor.
     pub fn client_id(&self) -> f64 {
         self.engine.doc().client_id() as f64
     }
 
-    /// Register font bytes in this editing wasm's resident measurement store.
-    /// Returned ids are valid for measurement and display work in this module.
+    /// Registers raw sfnt bytes in this session's resident measurement store
+    /// and returns the font id that measurement and display inputs reference.
+    /// Errors on bytes the font parser rejects.
     pub fn register_measure_font(&self, bytes: &[u8]) -> Result<u32, JsValue> {
         docx_layout::register_measure_font(bytes)
     }
 
-    /// Clear this editing wasm's resident measurement fonts.
+    /// Drops every registered measurement font (ids restart at zero) and
+    /// invalidates the retained paragraph measurement templates, so the next
+    /// edit must pass back through the full layout path.
     pub fn clear_measure_fonts(&self) {
         docx_layout::clear_measure_fonts();
         self.engine.clear_measurement_templates();
     }
 
-    /// Paragraph-measure compatibility export on the resident engine module.
+    /// Measurement input JSON in, `ParagraphExtent` JSON out. Also records the
+    /// paragraph's immutable width/font envelope under its stable block id, so
+    /// a later resident edit re-measures only the changed block. Errors with
+    /// the engine's message for input it cannot measure.
     pub fn measure_paragraph_json(&self, input: &str) -> Result<String, JsValue> {
         self.engine.measure_paragraph_json(input).map_err(js_err)
     }
 
-    /// Paginates and retains measured input and layout.
+    /// `{ measured, options }` JSON in, `Layout` JSON out. Both the measured
+    /// input and the resulting layout are retained for the resident edit path.
+    /// Errors on unparseable input or on layout failure.
     pub fn layout_document_json(&self, input: &str) -> Result<String, JsValue> {
         self.engine
             .layout_document_json(input)
             .map_err(|error| JsValue::from_str(&error))
     }
 
+    /// Region-layout input JSON in, the font families and sizes that input
+    /// needs as JSON out, so the host can register fonts before laying out.
     pub fn layout_font_requirements_json(&self, input: &str) -> Result<String, JsValue> {
         self.engine
             .layout_font_requirements_json(input)
             .map_err(|error| JsValue::from_str(&error))
     }
 
-    /// Paginate and compose section/page regions inside the resident engine.
+    /// Region-layout input JSON in, a paginated envelope with section and page
+    /// regions already composed as JSON out — ready for the display builder
+    /// with no host-side layout mutation. Retains the pass for resident edits.
     pub fn layout_document_with_regions_json(&self, input: &str) -> Result<String, JsValue> {
         self.engine
             .layout_document_with_regions_json(input)
             .map_err(|error| JsValue::from_str(&error))
     }
 
-    /// Build display primitives against the same resident font store used by
-    /// this session's measurement path.
+    /// `{ measured, options, layout }` JSON in, `DisplayList` JSON out, built
+    /// against the same resident font store this session measures with.
     pub fn build_display_list_json(&self, input: &str) -> Result<String, JsValue> {
         self.engine
             .build_display_list_json(input)
             .map_err(|error| JsValue::from_str(&error))
     }
 
-    /// Binary FrameDelta v1 display output. The returned `Vec<u8>` is exposed
-    /// by wasm-bindgen as a transferable-friendly `Uint8Array`.
+    /// Display-only input JSON in, one binary `FrameDelta` v1 out (exposed as
+    /// a transferable `Uint8Array`). `expected_frame_epoch` is the epoch of the
+    /// frame the caller currently holds; pass `0` for the first frame. A
+    /// mismatch makes the engine emit a full frame instead of a delta. Errors
+    /// unless the epoch is a non-negative safe integer, and on build failure.
     pub fn build_display_list_frame(
         &self,
         input: &str,
@@ -1117,6 +1171,10 @@ impl EditSession {
             .map_err(|error| JsValue::from_str(&error))
     }
 
+    /// `{"frameEpoch", "caretRect": {…}|null}` for the session's own collapsed
+    /// body selection. `caretRect` is null whenever there is no selection, the
+    /// selection is not a collapsed body caret, or the retained layout has no
+    /// geometry for it. `frameEpoch` identifies the frame the rect belongs to.
     pub fn resident_caret_snapshot_json(&self) -> Result<String, JsValue> {
         let paragraph = {
             let selection = self.selection.borrow();
@@ -1154,9 +1212,17 @@ impl EditSession {
         serde_json::to_string(&snapshot).map_err(js_err)
     }
 
-    /// Apply one ordinary collapsed body-text insertion and return the
-    /// resulting FrameDelta. Selection, measurement inputs, pagination
-    /// checkpoints, and display state all remain resident in this session.
+    /// Applies one ordinary insertion at this session's collapsed selection
+    /// and returns the resulting binary `FrameDelta`. The inserted text
+    /// inherits the formatting at the caret; selection, measurement inputs,
+    /// pagination checkpoints and display state all stay resident, so nothing
+    /// but the frame crosses the boundary.
+    ///
+    /// Errors when `text` is empty or contains `\r`/`\n`, when
+    /// `expected_frame_epoch` is not a non-negative safe integer, when there is
+    /// no resident selection or it no longer resolves, when the selection is
+    /// not collapsed, or when the resident layout state cannot absorb an edit
+    /// in that paragraph. The caller must then run the full layout path.
     pub fn apply_input(&self, text: &str, expected_frame_epoch: f64) -> Result<Vec<u8>, JsValue> {
         const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
         if text.is_empty() || text.contains(['\r', '\n']) {
@@ -1217,8 +1283,10 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Instrumented twin of `apply_input`, used only by opt-in browser perf
-    /// traces. Keeping this separate leaves the production hot path timer-free.
+    /// Instrumented twin of [`EditSession::apply_input`]: identical arguments,
+    /// result and error contract, but it also records stage timings for
+    /// [`EditSession::apply_input_profile_json`]. Separate so the ordinary
+    /// input path pays no timer calls.
     pub fn apply_input_profiled(
         &self,
         text: &str,
@@ -1303,8 +1371,15 @@ impl EditSession {
         Ok(frame)
     }
 
-    /// Apply one ordinary collapsed character deletion (or adjacent paragraph
-    /// merge at a boundary) and return the resulting resident FrameDelta.
+    /// Deletes one character at this session's collapsed selection and returns
+    /// the resulting binary `FrameDelta`. `direction` is `"backward"` or
+    /// `"forward"`; a surrogate pair is removed whole. At a paragraph boundary
+    /// this merges with the neighbouring paragraph instead.
+    ///
+    /// Errors on an unknown `direction`, when `expected_frame_epoch` is not a
+    /// non-negative safe integer, under the same selection and readiness
+    /// conditions as [`EditSession::apply_input`], and when there is no
+    /// character to delete in that direction (document start or end).
     pub fn apply_delete(
         &self,
         direction: &str,
@@ -1327,8 +1402,9 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Instrumented twin of `apply_delete`, used only by opt-in browser perf
-    /// traces. Keeping this separate leaves the production hot path timer-free.
+    /// Instrumented twin of [`EditSession::apply_delete`]: identical arguments,
+    /// result and error contract, but it also records stage timings for
+    /// [`EditSession::apply_input_profile_json`].
     pub fn apply_delete_profiled(
         &self,
         direction: &str,
@@ -1373,12 +1449,19 @@ impl EditSession {
         Ok(frame)
     }
 
-    /// Last opt-in `apply_input_profiled` stage timings as a compact JSON object.
+    /// Stage timings of the last profiled apply, in milliseconds:
+    /// `{"selectionMs","editMs","lowerMs","measureMs","paginateMs",
+    /// "displayInputMs","displayBuildMs","displayFinalizeMs","displayMs",
+    /// "encodeMs"}`. `{}` before the first profiled call.
     pub fn apply_input_profile_json(&self) -> String {
         self.last_apply_profile_json.borrow().clone()
     }
 
-    /// Hit-test without re-serializing the resident display list through JS.
+    /// Region-aware hit test against the resident display list, so no
+    /// display-list JSON crosses the boundary. `x`/`y` are page-local px.
+    /// Returns `{"region":"body"|"header"|"footer","rId"?,"pos":n|null}`, or
+    /// `"null"` for a page index outside the frame. A header/footer `pos`
+    /// refers to that header/footer's own document, not the body.
     pub fn display_hit_test_regions_json(
         &self,
         page_index: u32,
@@ -1390,6 +1473,12 @@ impl EditSession {
             .map_err(|error| JsValue::from_str(&error))
     }
 
+    /// Nearest caret position on the adjacent visual line. `direction` is
+    /// `"up"` or `"down"`; `goal_x` is the page-local x the caret is trying to
+    /// hold across successive moves (a non-finite value falls back to the
+    /// caret's own x). Returns `{"position","goalX"}`, or `"null"` when there
+    /// is no line in that direction. Errors on an unknown `direction` and when
+    /// no display list is resident.
     pub fn display_vertical_move_json(
         &self,
         position: f64,
@@ -1401,14 +1490,23 @@ impl EditSession {
             .map_err(|error| JsValue::from_str(&error))
     }
 
-    /// Body range geometry without a display-list JSON round trip.
+    /// Highlight rectangles for a body document range against the resident
+    /// display list: a JSON array of `{pageIndex,x,y,width,height}` in
+    /// page-local px, one entry per page the range touches. Body positions
+    /// only. Errors when no display list is resident.
     pub fn display_range_rects_json(&self, from: f64, to: f64) -> Result<String, JsValue> {
         self.engine
             .display_range_rects_json(from as i64, to as i64)
             .map_err(|error| JsValue::from_str(&error))
     }
 
-    /// Region-scoped range geometry without a display-list JSON round trip.
+    /// Same rectangles as [`EditSession::display_range_rects_json`], scoped to
+    /// a region. `region` is `"body"`, `"header"` or `"footer"`; `r_id` names
+    /// one header/footer part, and an empty string matches any. `from`/`to`
+    /// are positions in THAT region's document, and a header/footer part
+    /// paints on every page carrying it, so the result holds one rect set per
+    /// such page, each tagged with its `pageIndex`. Errors on an unknown
+    /// `region` and when no display list is resident.
     pub fn display_range_rects_region_json(
         &self,
         region: &str,
@@ -1421,28 +1519,47 @@ impl EditSession {
             .map_err(|error| JsValue::from_str(&error))
     }
 
-    /// Resolve one glyph outline from the session's resident font store.
+    /// One glyph outline from this session's resident font store:
+    /// `{"upem":n,"cmds":[{"t":"M"|"L"|"Q"|"C"|"Z", …}]}` — commands in font
+    /// units, y-up. `font_id` comes from
+    /// [`EditSession::register_measure_font`] and `glyph_id` from shaping.
+    /// Errors when the glyph cannot be extracted.
     pub fn outline_glyph_json(&self, font_id: u32, glyph_id: u32) -> Result<String, JsValue> {
         docx_layout::outline_glyph_json(font_id, glyph_id)
     }
 
-    /// Hydrates this replica from an encoded yrs update (the bytes form of
-    /// `load` — typically another replica's `encode_state()` output).
+    /// Hydrates this replica from an encoded yrs v1 update, typically another
+    /// replica's [`EditSession::encode_state`] output. Identical to
+    /// [`EditSession::apply_update`]; the separate name marks the initial-load
+    /// call site. Errors on a malformed update.
     pub fn load(&self, update: &[u8]) -> Result<(), JsValue> {
         self.engine.doc().apply_update_v1(update).map_err(js_err)
     }
 
-    /// Parses a DOCX, seeds its stories, and returns thin host metadata.
+    /// [`EditSession::open_docx`] with seeding always on.
     pub fn seed_from_docx(&self, bytes: &[u8]) -> Result<String, JsValue> {
         self.open_docx_inner(bytes, true)
     }
 
-    /// Parses a DOCX and optionally seeds its editable stories.
+    /// Parses a DOCX package, optionally seeds its editable stories into this
+    /// replica, and retains the source bytes for
+    /// [`EditSession::materialize_docx`].
+    ///
+    /// Returns `{"envelope","referencedFonts":[string, …]}`. The envelope is
+    /// the parsed package with the parts the host does not need stripped —
+    /// body content, header/footer and note content, numbering, media and
+    /// charts are emptied, section entries keep only their properties — so
+    /// styles, theme, settings, fonts and relationships still cross while the
+    /// bulk of the document stays in Rust. Errors on bytes that are not a
+    /// readable DOCX.
     pub fn open_docx(&self, bytes: &[u8], seed_stories: bool) -> Result<String, JsValue> {
         self.open_docx_inner(bytes, seed_stories)
     }
 
-    /// Materializes the retained canonical package for compatibility APIs.
+    /// Re-parses the DOCX bytes retained by the last
+    /// [`EditSession::open_docx`] and returns the COMPLETE package envelope as
+    /// JSON, or `None` when no DOCX has been opened. Unlike `open_docx` this
+    /// keeps every part; it reflects the source file, not later edits.
     pub fn materialize_docx(&self) -> Result<Option<String>, JsValue> {
         let source = self.docx_source.borrow();
         let Some(source) = source.as_ref() else {
@@ -1455,8 +1572,11 @@ impl EditSession {
 
     /// Seeds stories from JSON:
     /// `[{"storyId","paragraphs":[{"text","pStyle"?,"alignment"?}, …]}, …]`.
-    /// Paragraph text must not contain paragraph breaks. Returns
-    /// `{storyId: [paraId, …]}` in document order.
+    /// `pStyle` defaults to `"Normal"` and `alignment` to `"left"`; paragraph
+    /// text must not contain paragraph breaks. Receipt:
+    /// `{storyId: [paraId, …]}` with each story's paragraphs in document
+    /// order. Errors when a story entry has no `storyId`, no `paragraphs`
+    /// array, or an empty one, and when a story id already exists.
     pub fn load_json(&self, stories_json: &str) -> Result<String, JsValue> {
         let value: Value = serde_json::from_str(stories_json).map_err(js_err)?;
         let entries = value
@@ -1486,7 +1606,9 @@ impl EditSession {
             let seed_ctx = EditCtx::local(String::new(), String::new());
             for paragraph in &paragraphs[1..] {
                 let (text, p_style, alignment) = seed_paragraph(paragraph);
-                // The first split half keeps its ID and the second receives a new ID.
+                // Splitting at the final pilcrow appends: the first half keeps
+                // the original paraId, so the appended paragraph — whose
+                // properties this seeds — is the SECOND half.
                 let boundary = self.engine.doc().story_len(story_id).map_err(js_err)? - 1;
                 if !text.is_empty() {
                     self.engine
@@ -1535,15 +1657,21 @@ impl EditSession {
         serde_json::to_string(&Value::Object(receipt)).map_err(js_err)
     }
 
-    /// Full document state as one yrs v1 update (Yjs wire format).
+    /// The full document state as one yrs v1 update. Hand it to
+    /// [`EditSession::load`] on a fresh replica to reproduce this document.
     pub fn encode_state(&self) -> Vec<u8> {
         self.engine.doc().encode_state_as_update_v1()
     }
 
+    /// This replica's yrs v1 state vector — what a peer sends so
+    /// [`EditSession::encode_diff`] can compute the update it is missing.
     pub fn encode_state_vector(&self) -> Vec<u8> {
         self.engine.doc().encode_state_vector_v1()
     }
 
+    /// The yrs v1 update carrying everything this replica has that the peer
+    /// described by `remote_state_vector` does not. Errors on a malformed
+    /// state vector.
     pub fn encode_diff(&self, remote_state_vector: &[u8]) -> Result<Vec<u8>, JsValue> {
         self.engine
             .doc()
@@ -1551,11 +1679,19 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Applies a remote/incremental yrs v1 update.
+    /// Applies a remote or incremental yrs v1 update. It commits without a
+    /// local origin, so this replica's undo manager never claims it. Errors on
+    /// a malformed update.
     pub fn apply_update(&self, update: &[u8]) -> Result<(), JsValue> {
         self.engine.doc().apply_update_v1(update).map_err(js_err)
     }
 
+    /// [`EditSession::apply_update`] plus an inference about where the peer
+    /// that authored it is typing, for caret presence. Returns
+    /// `{"clientId","story","paraId","endOffset"}` for the end of that peer's
+    /// last text insertion, or `"null"` when the update carries work from more
+    /// than one client, ends in a non-text insertion, or inserts nothing.
+    /// Errors on a malformed update.
     pub fn apply_update_with_inference(&self, update: &[u8]) -> Result<String, JsValue> {
         let inference =
             apply_update_with_typing_inference(self.engine.doc(), update).map_err(js_err)?;
@@ -1580,10 +1716,12 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Subscribes `callback(update: Uint8Array)` to every committed
-    /// transaction (v1 encoding — feed it straight to `apply_update` on a
-    /// peer). One observer per session; a second call replaces the first.
-    /// The facade fans out to multiple JS listeners over this single hook.
+    /// Subscribes `callback(update: Uint8Array, isRemote: 0|1)` to every
+    /// committed transaction. `update` is v1-encoded — feed it straight to
+    /// [`EditSession::apply_update`] on a peer — and is copied out of wasm
+    /// memory, so JS may hold it across later edits. The second argument is
+    /// `1` when the transaction had no local origin. One observer per session;
+    /// a second call replaces the first, and a throwing callback is ignored.
     pub fn set_update_observer(&mut self, callback: &Function) -> Result<(), JsValue> {
         let callback = callback.clone();
         let subscription = self
@@ -1607,6 +1745,9 @@ impl EditSession {
         self.update_observer = None;
     }
 
+    /// Starts queueing committed transactions for
+    /// [`EditSession::drain_update_event`] instead of pushing them through a
+    /// callback. Idempotent while observation is running.
     pub fn start_update_event_observation(&mut self) -> Result<(), JsValue> {
         if self.update_event_observer.is_some() {
             return Ok(());
@@ -1631,6 +1772,10 @@ impl EditSession {
         Ok(())
     }
 
+    /// Pops the oldest queued transaction, in arrival order. Byte 0 is `1`
+    /// when the transaction had no local origin and `0` otherwise; the rest is
+    /// the v1 update. Empty when the queue is drained or observation never
+    /// started.
     pub fn drain_update_event(&self) -> Vec<u8> {
         self.update_event_observer
             .as_ref()
@@ -1638,15 +1783,18 @@ impl EditSession {
             .unwrap_or_default()
     }
 
+    /// Stops queueing and discards anything not yet drained.
     pub fn clear_update_event_observation(&mut self) {
         self.update_event_observer = None;
     }
 
     // -- local input state (undo + awareness selection) --
 
-    /// Starts local-origin undo tracking for one story. Hosts call this lazily
-    /// after import/seeding but before the first direct input operation, so the
-    /// initial document is not an undo step.
+    /// Starts local-origin undo tracking for one story, replacing any scope
+    /// already tracked (and its history). Call this after import or seeding but
+    /// before the first edit, so the initial document is not an undo step.
+    /// Re-tracking the same story is a no-op that preserves the history.
+    /// Errors on an unknown story.
     pub fn track_undo(&self, story: &str) -> Result<(), JsValue> {
         if self.undo_story.borrow().as_deref() == Some(story) {
             return Ok(());
@@ -1657,9 +1805,12 @@ impl EditSession {
         Ok(())
     }
 
-    /// Starts local undo tracking for a structural table transaction. Besides
-    /// the parent story (which owns the table embed), the stories root must be
-    /// in scope so undo/redo also removes/restores cell-story map entries.
+    /// Starts local undo tracking for a structural table edit in `story`.
+    /// Besides the parent story, which owns the table embed, this widens the
+    /// scope to the stories root so undo and redo also remove and restore the
+    /// cell stories the edit created or destroyed. Tracked separately from
+    /// [`EditSession::track_undo`] on the same story, so switching between
+    /// them starts a fresh history. Errors on an unknown story.
     pub fn track_table_undo(&self, story: &str) -> Result<(), JsValue> {
         let scope_key = format!("table:{story}");
         if self.undo_story.borrow().as_deref() == Some(scope_key.as_str()) {
@@ -1679,8 +1830,9 @@ impl EditSession {
         Ok(())
     }
 
-    /// Reverts the latest local-origin transaction. Remote/system mirror
-    /// transactions are excluded by `DocUndoManager`'s tracked-origin policy.
+    /// Reverts the latest local-origin transaction and reports whether
+    /// anything was reverted. Remote and system transactions are excluded by
+    /// the manager's tracked-origin policy; `false` before a story is tracked.
     pub fn undo(&self) -> bool {
         self.undo
             .borrow_mut()
@@ -1688,7 +1840,8 @@ impl EditSession {
             .is_some_and(DocUndoManager::undo)
     }
 
-    /// Reapplies the latest locally undone transaction.
+    /// Reapplies the latest locally undone transaction and reports whether
+    /// anything was reapplied.
     pub fn redo(&self) -> bool {
         self.undo
             .borrow_mut()
@@ -1696,6 +1849,7 @@ impl EditSession {
             .is_some_and(DocUndoManager::redo)
     }
 
+    /// Whether [`EditSession::undo`] would revert something.
     pub fn can_undo(&self) -> bool {
         self.undo
             .borrow()
@@ -1703,6 +1857,7 @@ impl EditSession {
             .is_some_and(DocUndoManager::can_undo)
     }
 
+    /// Whether [`EditSession::redo`] would reapply something.
     pub fn can_redo(&self) -> bool {
         self.undo
             .borrow()
@@ -1726,8 +1881,11 @@ impl EditSession {
             .map_or(0, |undo| undo.redo_depth() as u32)
     }
 
-    /// Stores this peer's anchor/head as sticky positions. `Assoc::After`
-    /// makes a collapsed caret advance with text inserted at the caret.
+    /// Stores this peer's anchor and head as sticky positions, replacing any
+    /// previous selection. Both endpoints must lie in `story`. The positions
+    /// live outside the yrs document, so they are never serialized as content
+    /// or carried in an update. `Assoc::After` makes a collapsed caret advance
+    /// with text inserted at it.
     #[allow(clippy::too_many_arguments)]
     pub fn set_selection(
         &self,
@@ -1756,7 +1914,10 @@ impl EditSession {
         Ok(())
     }
 
-    /// Encodes one paragraph location as a sticky position.
+    /// Encodes one Loc as opaque sticky-position bytes that keep pointing at
+    /// the same content as the story is edited. Publish them over an awareness
+    /// transport and resolve them with
+    /// [`EditSession::resolve_sticky_position`].
     pub fn encode_sticky_position(
         &self,
         story: &str,
@@ -1772,7 +1933,9 @@ impl EditSession {
         Ok(encode_sticky(&position))
     }
 
-    /// Resolves one encoded sticky position to a paragraph location.
+    /// Resolves sticky bytes from [`EditSession::encode_sticky_position`] back
+    /// to `{"story","paraId","offset"}`. Errors when the bytes are malformed
+    /// or the position no longer resolves in `story`.
     pub fn resolve_sticky_position(&self, story: &str, position: &[u8]) -> Result<String, JsValue> {
         let (index, _) = resolve_sticky_selection(self.engine.doc(), story, position, position)
             .map_err(js_err)?;
@@ -1785,8 +1948,9 @@ impl EditSession {
         .to_string())
     }
 
-    /// Resolves this peer's current sticky selection as two public Locs, or
-    /// `null` before the host establishes an initial selection.
+    /// This peer's current selection as `{"anchor":{"story","paraId","offset"},
+    /// "head":{…}}`, or `"null"` before [`EditSession::set_selection`] is
+    /// called. Errors when an endpoint no longer resolves.
     pub fn selection(&self) -> Result<String, JsValue> {
         let selection = self.selection.borrow();
         let Some(selection) = selection.as_ref() else {
@@ -1822,6 +1986,10 @@ impl EditSession {
         .to_string())
     }
 
+    /// This peer's selection in transportable form:
+    /// `{"story","anchor":[byte, …],"head":[byte, …]}` with sticky-encoded
+    /// endpoints, or `"null"` before a selection is set. A peer resolves it
+    /// with [`EditSession::resolve_encoded_selection`].
     pub fn encoded_selection(&self) -> Result<String, JsValue> {
         let selection = self.selection.borrow();
         let Some(selection) = selection.as_ref() else {
@@ -1835,6 +2003,9 @@ impl EditSession {
         .to_string())
     }
 
+    /// Resolves another peer's encoded selection against this replica's
+    /// current state: `{"anchor":{"story","paraId","offset"},"head":{…}}`.
+    /// Errors on malformed bytes or an endpoint that no longer resolves.
     pub fn resolve_encoded_selection(
         &self,
         story: &str,
@@ -1860,9 +2031,13 @@ impl EditSession {
         .to_string())
     }
 
-    /// Stores a rectangular anchor-cell → head-cell selection outside the yrs
-    /// document. `range_json` is a [`TableRange`]. The table embed is held by a
-    /// sticky index and the endpoints by stable cell-story identity.
+    /// Stores a rectangular anchor-cell to head-cell selection outside the yrs
+    /// document. `range_json` is a [`TableRange`]:
+    /// `{"anchor":{"story","tableIndex","row","column"},"head":{…}}`. The table
+    /// embed is held by a sticky index and each endpoint by its cell story's
+    /// stable identity, so the selection survives unrelated edits and follows
+    /// inserted or deleted rows and columns. Errors when the two endpoints are
+    /// not in the same table, or when either cell does not resolve.
     pub fn set_cell_selection(&self, range_json: &str) -> Result<(), JsValue> {
         let range: TableRange = serde_json::from_str(range_json).map_err(js_err)?;
         if range.anchor.story != range.head.story
@@ -1909,8 +2084,9 @@ impl EditSession {
         Ok(())
     }
 
-    /// Resolves the current local cell selection, or `null` before the host
-    /// establishes one. Deleted endpoints clamp to a surviving nearby cell.
+    /// The current local cell selection as a [`TableRange`], or `"null"`
+    /// before one is set. An endpoint whose cell was deleted clamps to a
+    /// surviving nearby cell. Errors when the table itself no longer resolves.
     pub fn cell_selection(&self) -> Result<String, JsValue> {
         let selection = self.cell_selection.borrow();
         let Some(selection) = selection.as_ref() else {
@@ -1951,8 +2127,10 @@ impl EditSession {
         serde_json::to_string(&TableRange { anchor, head }).map_err(js_err)
     }
 
-    /// Adds a story with one paragraph. Receipt: `{"paraId"}` (the final
-    /// pilcrow's paragraph).
+    /// Adds a story holding one paragraph with `initial_text` (which must not
+    /// contain paragraph breaks), `p_style` and `alignment`. Receipt:
+    /// `{"paraId"}` — the paragraph ending at the story's pilcrow. Errors when
+    /// the story id already exists.
     pub fn create_story(
         &self,
         story_id: &str,
@@ -1968,14 +2146,31 @@ impl EditSession {
         Ok(json!({ "paraId": para_id }).to_string())
     }
 
-    /// Removes one complete story (used for unreachable table-cell stories).
+    /// Removes one complete story and its content. Errors on an unknown story.
     pub fn delete_story(&self, story_id: &str) -> Result<(), JsValue> {
         self.engine.doc().delete_story(story_id).map_err(js_err)
     }
 
-    // -- native table ops (cell-grid addressing; JSON receipts) --
+    // -- native table ops --
+    //
+    // Tables are addressed in the resolved rectangular grid, not by OOXML row
+    // and cell order: `TableLocator` is `{"story","tableIndex"}` with the
+    // zero-based ordinal of the table embed in its story, `CellLoc` adds
+    // `{"row","column"}`, and `TableRange` is `{"anchor":CellLoc,"head":
+    // CellLoc}` covering the rectangle they span. Each cell's content lives in
+    // its own story, so structural edits create and destroy stories.
+    //
+    // Every op below returns the same receipt:
+    // `{"table":TableLocator,"rows","columns","createdStoryIds":[string, …],
+    // "deletedStoryIds":[string, …],"newParaIds":[string, …],
+    // "deletedTable":bool,"revisionIds":[string, …]}` — `rows`/`columns` are
+    // the grid AFTER the op, the story lists let the host follow cell content
+    // in and out of existence, and `revisionIds` is non-empty only for the ops
+    // that accept a suggesting author. All of them additionally error on an
+    // unknown table or a cell outside the grid.
 
-    /// Inserts a rectangular structural table at a paragraph-keyed location.
+    /// Inserts a `rows` x `columns` table at `(story, para_id, offset)`,
+    /// creating one story per cell. Errors when either dimension is zero.
     #[allow(clippy::too_many_arguments)]
     pub fn insert_table(
         &self,
@@ -1997,7 +2192,8 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Inserts a row above (`after = false`) or below (`after = true`) a cell.
+    /// Inserts a row above (`after = false`) or below (`after = true`) the
+    /// cell `at_json` names. `at_json` is a [`CellLoc`].
     pub fn insert_row(
         &self,
         at_json: &str,
@@ -2015,7 +2211,8 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Inserts a column left (`after = false`) or right (`after = true`) of a cell.
+    /// Inserts a column left (`after = false`) or right (`after = true`) of
+    /// the cell `at_json` ([`CellLoc`]) names. Always a plain local edit.
     pub fn insert_column(&self, at_json: &str, after: bool) -> Result<String, JsValue> {
         let at: CellLoc = serde_json::from_str(at_json).map_err(js_err)?;
         let receipt = self
@@ -2026,7 +2223,8 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Deletes every row covered by an explicit cell range.
+    /// Deletes every row the [`TableRange`] `range_json` covers. In suggesting
+    /// mode the rows are marked `trDel` instead of removed.
     pub fn delete_row(
         &self,
         range_json: &str,
@@ -2039,7 +2237,8 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Deletes every column covered by an explicit cell range.
+    /// Deletes every column the [`TableRange`] `range_json` covers, along with
+    /// the stories of the cells removed. Always a plain local edit.
     pub fn delete_column(&self, range_json: &str) -> Result<String, JsValue> {
         let range: TableRange = serde_json::from_str(range_json).map_err(js_err)?;
         let receipt = self
@@ -2050,7 +2249,9 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Removes one complete table plus all of its reachable cell stories.
+    /// Removes the table `table_json` ([`TableLocator`]) names plus every one
+    /// of its reachable cell stories. Always a plain local edit; the receipt
+    /// has `deletedTable: true`.
     pub fn delete_table(&self, table_json: &str) -> Result<String, JsValue> {
         let table: TableLocator = serde_json::from_str(table_json).map_err(js_err)?;
         let receipt = self
@@ -2061,7 +2262,10 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Merges a rectangular cell range into its top-left cell.
+    /// Merges the rectangle the [`TableRange`] `range_json` covers into its
+    /// top-left cell, whose story survives; the other cells' stories are
+    /// deleted. Always a plain local edit. Errors when the range covers fewer
+    /// than two cells or has no top-left anchor cell.
     pub fn merge_cells(&self, range_json: &str) -> Result<String, JsValue> {
         let range: TableRange = serde_json::from_str(range_json).map_err(js_err)?;
         let receipt = self
@@ -2072,8 +2276,12 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Splits the cell covering `at` into the requested grid. Omitted
-    /// dimensions unmerge the cell into its existing covered slots.
+    /// Splits the cell `at_json` ([`CellLoc`]) covers into a `rows` x
+    /// `columns` grid; the original story stays in the top-left slot and every
+    /// other slot gets a fresh one-paragraph cell story. Omitting both
+    /// dimensions unmerges the cell into the slots it already covers, which
+    /// then requires a merged cell. Always a plain local edit. Errors on a
+    /// zero dimension or a grid smaller than the cell already covers.
     pub fn split_cell(
         &self,
         at_json: &str,
@@ -2089,7 +2297,9 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Sets/clears selected cells' background color (hex without or with `#`).
+    /// Sets every selected cell's background to `color` (hex, with or without
+    /// a leading `#`), or clears it when `color` is absent. `range_json` is a
+    /// [`TableRange`]. Always a plain local edit.
     pub fn set_cell_shading(
         &self,
         range_json: &str,
@@ -2104,7 +2314,10 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Merges a JSON cell-format patch into every selected cell's `tcPr`.
+    /// Merges the JSON object `patch_json` into every selected cell's `tcPr`;
+    /// a `null` value removes that key. `range_json` is a [`TableRange`].
+    /// Always a plain local edit. Errors when the patch touches `rowspan`,
+    /// `colspan`, `gridSpan` or `vMerge`, which only merge and split may set.
     pub fn set_cell_text_format(
         &self,
         range_json: &str,
@@ -2120,7 +2333,9 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Replaces the selected cells' complete border property object.
+    /// Replaces every selected cell's complete `tcPr.borders` object with the
+    /// JSON object `borders_json`. `range_json` is a [`TableRange`]. Always a
+    /// plain local edit.
     pub fn set_cell_borders(
         &self,
         range_json: &str,
@@ -2136,7 +2351,9 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Sets one grid-column width in twips.
+    /// Sets the grid width, in twips, of the column holding the cell `at_json`
+    /// ([`CellLoc`]) names. Always a plain local edit. Errors unless
+    /// `width_twips` is finite and positive.
     pub fn set_column_width(&self, at_json: &str, width_twips: f64) -> Result<String, JsValue> {
         let at: CellLoc = serde_json::from_str(at_json).map_err(js_err)?;
         let receipt = self
@@ -2147,7 +2364,9 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Sets the table-wide preferred width in twips.
+    /// Sets the preferred width, in twips, of the table `table_json`
+    /// ([`TableLocator`]) names. Always a plain local edit. Errors unless
+    /// `width_twips` is finite and positive.
     pub fn set_table_width(&self, table_json: &str, width_twips: f64) -> Result<String, JsValue> {
         let table: TableLocator = serde_json::from_str(table_json).map_err(js_err)?;
         let receipt = self
@@ -2158,8 +2377,12 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Inserts paragraph-break-free text at `(story, para_id, offset)`.
-    /// Receipt: `{"revisionId": string|null}` (non-null in suggesting mode).
+    /// Inserts `text` at `(story, para_id, offset)`. It must contain no
+    /// paragraph or line breaks, and it inherits the formatting at the
+    /// insertion point. Receipt: `{"revisionId": string|null}` — non-null in
+    /// suggesting mode, where the text is stamped `ins` and coalesces into an
+    /// adjacent insertion by the same author rather than opening a second
+    /// revision.
     pub fn insert_text(
         &self,
         story: &str,
@@ -2179,11 +2402,10 @@ impl EditSession {
         Ok(json!({ "revisionId": receipt.revision_ids.into_iter().next() }).to_string())
     }
 
-    /// Deletes `[start, end)` given as two Locs in one story. A range whose
-    /// ends sit in different paragraphs spans the boundary pilcrows, so the
-    /// plain delete also merges (the pilcrow-as-character dividend).
-    /// Suggesting mode retains the content with a `del` revision instead.
-    /// Receipt: `{"revisionId": string|null}`.
+    /// Deletes `[start, end)`. Because a range crossing a paragraph boundary
+    /// includes the boundary pilcrow, a plain delete also merges those
+    /// paragraphs. Suggesting mode removes nothing and stamps the content
+    /// `del` instead. Receipt: `{"revisionId": string|null}`.
     #[allow(clippy::too_many_arguments)]
     pub fn delete_range(
         &self,
@@ -2206,9 +2428,10 @@ impl EditSession {
         Ok(json!({ "revisionId": receipt.revision_ids.into_iter().next() }).to_string())
     }
 
-    /// Replaces `[start, end)` with text in one transaction. The inserted text
-    /// adopts the first replaced unit's formatting; in suggesting mode the
-    /// deletion and insertion share one revision id.
+    /// Replaces `[start, end)` with `text` in one transaction. The inserted
+    /// text adopts the first replaced unit's formatting; in suggesting mode
+    /// the deletion and the insertion share one revision id. Receipt:
+    /// `{"revisionId": string|null}`.
     #[allow(clippy::too_many_arguments)]
     pub fn replace_range(
         &self,
@@ -2233,8 +2456,11 @@ impl EditSession {
     }
 
     /// Splits a paragraph at `(story, para_id, offset)` by inserting one
-    /// pilcrow. The first half keeps the original paraId, the second is
-    /// re-minted. Receipt:
+    /// pilcrow. The FIRST half keeps the original paraId and the second is
+    /// re-minted. A split at the paragraph end leaves the empty second half
+    /// with only the inherited property subset; a mid-paragraph split keeps
+    /// its properties. Paragraph borders are cleared either way. Suggesting
+    /// mode stamps the new pilcrow `ins` and `pPrIns`. Receipt:
     /// `{"firstParaId","secondParaId","revisionId": string|null}`.
     pub fn split_paragraph(
         &self,
@@ -2260,8 +2486,11 @@ impl EditSession {
     }
 
     /// Merges `para_id` with the FOLLOWING paragraph by deleting (plain) or
-    /// `del`-marking (suggesting) its pilcrow. Errors on the story's final
-    /// paragraph. Receipt: `{"revisionId": string|null}`.
+    /// `del`- and `pPrDel`-marking (suggesting) its pilcrow. On a plain merge
+    /// the survivor adopts the deleted mark's properties and paraId, so the
+    /// earlier paragraph's identity wins. Receipt:
+    /// `{"revisionId": string|null}`. Errors on the story's final paragraph,
+    /// which has no following paragraph to merge with.
     pub fn merge_paragraphs(
         &self,
         story: &str,
@@ -2280,11 +2509,14 @@ impl EditSession {
         Ok(json!({ "revisionId": receipt.revision_ids.into_iter().next() }).to_string())
     }
 
-    /// Applies one run mark over `[start, end)` (two Locs in one story). Simple
-    /// marks toggle; font/size/color set (see [`apply_mark`]). `mark_json`:
+    /// Applies one run mark over `[start, end)`. `mark_json`:
     /// `{"type":"bold"|"italic"|"underline"|"strike"|"superscript"|"subscript"} |
     /// {"type":"fontFamily"|"color","value":string} |
-    /// {"type":"fontSize","value":number}`.
+    /// {"type":"fontSize","value":number}`. The six boolean types TOGGLE —
+    /// they turn on unless the whole range already carries the mark — while
+    /// font family, size and color SET. Formatting is always a plain local
+    /// edit, never a tracked change, so there is no receipt. Errors on an
+    /// unknown `"type"` or a missing/mistyped `"value"`.
     #[allow(clippy::too_many_arguments)]
     pub fn toggle_mark(
         &self,
@@ -2305,8 +2537,26 @@ impl EditSession {
     }
 
     /// Applies a set-valued, tri-state inline formatting delta over
-    /// `[start, end)` in one transaction. Omitted fields are kept and `null`
-    /// fields are cleared.
+    /// `[start, end)` in one transaction. An omitted key keeps the current
+    /// value, `null` clears it, and any other value sets it. `delta_json`:
+    ///
+    /// ```json
+    /// {
+    ///   "bold": true, "italic": true,
+    ///   "underline": true | {"style"?: string, "color"?: string},
+    ///   "strike": true | {"double"?: boolean},
+    ///   "color": {"rgb": string} | {"themeColor": string},
+    ///   "highlight": string,
+    ///   "fontSize": 12,
+    ///   "fontFamily": {"ascii": string, "hAnsi"?: string},
+    ///   "other": {"anyAttr": value}
+    /// }
+    /// ```
+    ///
+    /// `false` clears `bold`, `italic`, `underline` and `strike`. `color`
+    /// takes exactly one of `rgb` or `themeColor`. `other` writes arbitrary
+    /// run attributes, with `null` removing one. Always a plain local edit, so
+    /// there is no receipt. Errors when a key carries a type not listed here.
     #[allow(clippy::too_many_arguments)]
     pub fn format_range(
         &self,
@@ -2328,8 +2578,11 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Sets or clears the protected hyperlink attribute over `[start, end)`.
-    /// `hyperlink_json` is an object (`{href, tooltip?, rId?}`) or `null`.
+    /// Sets or clears the hyperlink attribute over `[start, end)`.
+    /// `hyperlink_json` is `{"href", "tooltip"?, "rId"?}` or `null` to unlink.
+    /// The attribute is protected: ordinary formatting ops cannot write or
+    /// erase it, only this one. Errors when the JSON is neither an object nor
+    /// `null`.
     #[allow(clippy::too_many_arguments)]
     pub fn set_hyperlink(
         &self,
@@ -2358,8 +2611,9 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Clears every direct formatting attribute over `[start, end)`, while
-    /// retaining hyperlinks and tracked-change stamps.
+    /// Clears every direct run-formatting attribute over `[start, end)`.
+    /// Protected attributes — hyperlinks and tracked-change stamps — survive,
+    /// as do paragraph properties.
     #[allow(clippy::too_many_arguments)]
     pub fn clear_formatting(
         &self,
@@ -2379,9 +2633,11 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Applies a paragraph style id to every paragraph intersecting
-    /// `[start, end)`, writing `pStyle` without fabricating a resolved
-    /// paragraph or run formatting projection.
+    /// Writes `style_id` as the `pStyle` of every paragraph intersecting
+    /// `[start, end)`. Only that key changes: this boundary has no style
+    /// resolver, so it never fabricates the paragraph attributes or run marks
+    /// the style definition would imply. In suggesting mode the property
+    /// change is recorded as a `pPrChange` revision.
     #[allow(clippy::too_many_arguments)]
     pub fn apply_paragraph_style(
         &self,
@@ -2410,7 +2666,19 @@ impl EditSession {
     }
 
     /// Applies a tri-state paragraph-property delta to every paragraph
-    /// intersecting `[start, end)` in one transaction.
+    /// intersecting `[start, end)` in one transaction. An omitted key keeps
+    /// the current value and `null` clears it. `attrs_json` recognises
+    /// `alignment`, `lineSpacing`, `lineSpacingRule`, `spaceBefore`,
+    /// `spaceAfter`, `indentLeft`, `indentRight`, `indentFirstLine`,
+    /// `hangingIndent`, `bidi`, `tabs`
+    /// (`[{"position":number,"alignment":string,"leader"?:string}, …]`) and
+    /// `defaultTextFormatting` (an object of run defaults). Any other key —
+    /// whether written at the top level or nested under `"other"` — is stored
+    /// as an opaque paragraph property. Spacing and indents are authored OOXML
+    /// units (twips, line-spacing units), never pixels. In suggesting mode a
+    /// change is recorded as a `pPrChange` revision. Errors when a recognised
+    /// key carries the wrong type, and when a key names schema-managed
+    /// identity such as `paraId`.
     #[allow(clippy::too_many_arguments)]
     pub fn set_paragraph_attrs(
         &self,
@@ -2435,7 +2703,11 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Inserts one native inline image embed at a paragraph-keyed location.
+    /// Inserts one inline image embed at `(story, para_id, offset)`.
+    /// `payload_json` is the image's authored payload object, stored as given.
+    /// The embed occupies one story unit. Receipt:
+    /// `{"revisionId": string|null}`. Errors when the payload is not an
+    /// object.
     #[allow(clippy::too_many_arguments)]
     pub fn insert_image(
         &self,
@@ -2467,7 +2739,9 @@ impl EditSession {
         Ok(json!({ "revisionId": receipt.revision_ids.into_iter().next() }).to_string())
     }
 
-    /// Sets the authored `value` on a stable-id content-control embed.
+    /// Sets the authored `value` (any JSON) on the content-control embed
+    /// carrying `embed_id`, searching every story. Errors when no embed has
+    /// that id.
     pub fn set_content_control_value(
         &self,
         embed_id: &str,
@@ -2482,9 +2756,11 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Sets the authored `value` on a content-control embed at a paragraph-keyed
-    /// position. This is the fallback for valid controls that have no authored
-    /// `w:id`/tag and therefore cannot be addressed by stable payload identity.
+    /// Sets the authored `value` on the content-control embed at
+    /// `(story, para_id, offset)` — the way to reach a control with no
+    /// authored `w:id` or tag, which
+    /// [`EditSession::set_content_control_value`] cannot address. Errors when
+    /// that position holds no embed.
     pub fn set_content_control_value_at(
         &self,
         story: &str,
@@ -2506,7 +2782,9 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Clears the authored `value` from a stable-id content-control embed.
+    /// Removes the authored `value` from the content-control embed carrying
+    /// `embed_id`, leaving the control itself in place. Errors when no embed
+    /// has that id.
     pub fn clear_content_control_value(&self, embed_id: &str) -> Result<(), JsValue> {
         let ctx = EditCtx::local(String::new(), String::new());
         self.engine
@@ -2516,8 +2794,12 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Commits image geometry fields to a stable-id image embed in one
-    /// transaction. `null` fields clear; `other` is flattened into the payload.
+    /// Writes geometry fields onto the image embed carrying `embed_id` in one
+    /// transaction. Every key of the `geometry_json` object becomes a payload
+    /// entry, with `null` clearing it; the entries of a nested `"other"`
+    /// object are flattened into the payload alongside them. Errors when
+    /// `geometry_json` or its `"other"` is not an object, and when no embed
+    /// has that id.
     pub fn set_image_geometry(&self, embed_id: &str, geometry_json: &str) -> Result<(), JsValue> {
         let value: Value = serde_json::from_str(geometry_json).map_err(js_err)?;
         let object = value
@@ -2544,7 +2826,8 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Inserts a native page-break embed at a Loc.
+    /// Inserts a page-break embed at `(story, para_id, offset)`, occupying one
+    /// story unit. Always a plain local edit.
     pub fn insert_page_break(
         &self,
         story: &str,
@@ -2560,7 +2843,9 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Inserts a native section-break embed at a Loc.
+    /// Inserts a section-break embed at `(story, para_id, offset)`.
+    /// `break_type` must be `"nextPage"`, `"continuous"`, `"oddPage"` or
+    /// `"evenPage"`; anything else errors. Always a plain local edit.
     pub fn insert_section_break(
         &self,
         story: &str,
@@ -2588,7 +2873,9 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Inserts a typed watermark embed at a Loc.
+    /// Inserts a watermark embed at `(story, para_id, offset)`, its payload
+    /// taken verbatim from the `watermark_json` object. Always a plain local
+    /// edit. Errors when the JSON is not an object.
     pub fn insert_watermark(
         &self,
         story: &str,
@@ -2610,8 +2897,11 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Sets one paragraph property (any JSON value) on `para_id`'s pilcrow.
-    /// `paraId` / the embed discriminator are reserved.
+    /// Sets one paragraph property to any JSON value on `para_id`'s pilcrow,
+    /// searching every story. Unlike
+    /// [`EditSession::set_paragraph_attrs`] this writes a single key and never
+    /// records a revision. Errors when the paragraph is unknown and when `key`
+    /// names schema-managed identity (`paraId` or the embed discriminator).
     pub fn set_paragraph_attr(
         &self,
         para_id: &str,
@@ -2625,9 +2915,13 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    /// Adds a sticky-anchored comment. `ranges_json`:
+    /// Adds a comment anchored to one or more ranges. `ranges_json`:
     /// `[{"story","startPara","startOffset","endPara","endOffset"}, …]`;
-    /// `body_json` is any JSON value. Receipt: `{"commentId"}`.
+    /// `body_json` is any JSON value, stored as given. The anchors are sticky,
+    /// so they follow the text they cover, and the comment lives outside the
+    /// story rather than as an attribute on it. Receipt: `{"commentId"}` — a
+    /// freshly minted id. Errors when `ranges_json` is not an array of
+    /// well-formed ranges, or is empty.
     pub fn add_comment(
         &self,
         ranges_json: &str,
@@ -2681,13 +2975,19 @@ impl EditSession {
     }
 
     /// Accepts tracked changes: pending insertions become plain content,
-    /// pending deletions are carried out; `pPrIns` marks clear (the split
-    /// stays), `pPrDel` marks join with the following paragraph (its pPr
-    /// survives). `target_json`: `{"revisionId": string}` for one coalesced
-    /// revision, or
-    /// `{"story","startPara","startOffset","endPara","endOffset"}` for a Loc
-    /// range. Receipt: `{"revisionIds": [string, …]}`. Never stamps a new
-    /// revision.
+    /// pending deletions are carried out; `pPrIns` marks clear so the split
+    /// stays, `pPrDel` marks join with the following paragraph, whose own
+    /// properties survive.
+    ///
+    /// `target_json` is either `{"revisionId": string}`, resolving that one
+    /// coalesced revision wherever it appears in any story, or
+    /// `{"story","startPara","startOffset","endPara","endOffset"}`, resolving
+    /// every tracked change overlapping that range regardless of revision id.
+    /// Receipt: `{"revisionIds": [string, …]}` — the ids actually resolved, in
+    /// resolution order and deduplicated. Resolving applies a revision rather
+    /// than authoring one, so it never stamps a new revision and ignores
+    /// suggesting mode. Errors on an empty range and on a `revisionId` that
+    /// matches nothing.
     pub fn accept_change(&self, target_json: &str) -> Result<String, JsValue> {
         let target = parse_change_target(self.engine.doc(), target_json)?;
         let ctx = EditCtx::local(String::new(), String::new());
@@ -2699,10 +2999,12 @@ impl EditSession {
         Ok(json!({ "revisionIds": receipt.revision_ids }).to_string())
     }
 
-    /// Rejects tracked changes — the inverse of [`EditSession::accept_change`]:
-    /// pending insertions roll back, pending deletions restore their text;
-    /// `pPrIns` marks join back with the following paragraph, `pPrDel` marks
-    /// clear (the split stays). Same target and receipt shapes.
+    /// Rejects tracked changes — the inverse of
+    /// [`EditSession::accept_change`]: pending insertions roll back, pending
+    /// deletions restore their text; `pPrIns` marks join back with the
+    /// following paragraph, `pPrDel` marks clear so the split stays, and a
+    /// `pPrChange` restores the paragraph's previous properties. Same target,
+    /// receipt and error contract.
     pub fn reject_change(&self, target_json: &str) -> Result<String, JsValue> {
         let target = parse_change_target(self.engine.doc(), target_json)?;
         let ctx = EditCtx::local(String::new(), String::new());
@@ -2714,12 +3016,26 @@ impl EditSession {
         Ok(json!({ "revisionIds": receipt.revision_ids }).to_string())
     }
 
-    /// Applies a batch of raw story mutations in one transaction. `ops_json`
-    /// is `[{ "op":"insert"|"delete"|"format"|"insertEmbed"|"setEmbedAttr"
-    /// |"setComment"|"removeComment", "index", … }, …]`. Each op's index, and
-    /// each `setComment` `[start, end)` range, is read against the story state
-    /// after all prior ops in the batch. Tracked-change stamps arrive inside
-    /// `attrs`; comments are keyed by comment id and anchored sticky.
+    /// Applies a batch of raw story mutations in ONE transaction. Unlike every
+    /// other op here these carry no user intent: indices are story-global
+    /// UTF-16 units, not Locs, and nothing is inferred or stamped on the
+    /// caller's behalf. `ops_json` is an array of:
+    ///
+    /// - `{"op":"insert","index","text"?,"attrs"?}`
+    /// - `{"op":"delete","index","len"}`
+    /// - `{"op":"format","index","len","attrs"?}`
+    /// - `{"op":"insertEmbed","index","kind"?,"payload"?,"attrs"?}`
+    /// - `{"op":"setEmbedAttr","index","key","value"?}`
+    /// - `{"op":"setComment","id","ranges":[[start,end], …],"author"?,"date"?,"body"?}`
+    /// - `{"op":"removeComment","id"}`
+    ///
+    /// Each op's `index`, and each `setComment` range, is read against the
+    /// story state AFTER every preceding op in the batch. `attrs` and
+    /// `payload` are JSON objects written verbatim, so tracked-change stamps
+    /// travel inside `attrs`; comments are keyed by the given id and anchored
+    /// sticky. Errors on an unknown `"op"`, a missing or negative `"index"`,
+    /// or a missing required field, and leaves the story untouched — parsing
+    /// completes before the transaction opens.
     pub fn apply_raw_ops(&self, story: &str, ops_json: &str) -> Result<(), JsValue> {
         let value: Value = serde_json::from_str(ops_json).map_err(js_err)?;
         let entries = value
@@ -2736,11 +3052,31 @@ impl EditSession {
             .map_err(js_err)
     }
 
-    // -- read queries (pure snapshots; JSON out) --
+    // -- read queries --
+    //
+    // Every query below is a pure snapshot of the document as it stands: it
+    // mutates nothing, commits no transaction, and its JSON is fully
+    // materialized before it returns.
 
-    /// Aggregated toolbar/a11y state over one paragraph-addressed story
-    /// range. Toggle marks are `true`, `false`, or `"mixed"`; value marks
-    /// are their uniform value or `null` when absent/mixed.
+    /// Aggregated toolbar and accessibility state over `[start, end)`:
+    ///
+    /// ```json
+    /// {
+    ///   "bold": true | false | "mixed", "italic": …, "underline": …, "strike": …,
+    ///   "fontFamily": string|null, "fontSize": number|null, "color": string|null,
+    ///   "paraId": string, "styleId": string|null, "alignment": string|null,
+    ///   "paragraphProperties": {…},
+    ///   "hasSelection": bool, "isMultiParagraph": bool, "inTable": bool,
+    ///   "isSingleEmbed": bool, "embedKind": string|null, "isImage": bool,
+    ///   "inInsertion": bool, "inDeletion": bool
+    /// }
+    /// ```
+    ///
+    /// A toggle mark is `"mixed"` when the range disagrees about it; a value
+    /// mark is `null` when it is absent OR not uniform, so the two cases are
+    /// not distinguished. `isImage` is `embedKind == "image"`, and
+    /// `inInsertion`/`inDeletion` report whether the range sits inside a
+    /// pending tracked change.
     #[allow(clippy::too_many_arguments)]
     pub fn selection_context(
         &self,
@@ -2783,8 +3119,14 @@ impl EditSession {
         .to_string())
     }
 
-    /// Every tracked-change run/paragraph-mark revision across all stories,
-    /// in deterministic story/position order.
+    /// Every pending tracked change across all stories, in deterministic
+    /// story-then-position order:
+    /// `[{"revisionId","author","date","kind","story","preview",
+    /// "range":{"story","start":{"paraId","offset"},"end":{…}}}, …]`. `kind`
+    /// is one of `"insertion"`, `"deletion"`, `"pPrIns"`, `"pPrDel"`,
+    /// `"pPrChange"`, `"trIns"`, `"trDel"`, `"tableIns"` or `"tableDel"`.
+    /// `preview` holds the first few characters of the affected text, and is
+    /// empty for every structural kind, which covers no text.
     pub fn list_revisions(&self) -> Result<String, JsValue> {
         let revisions = self.engine.doc().list_revisions().map_err(js_err)?;
         let items: Vec<Value> = revisions
@@ -2825,7 +3167,8 @@ impl EditSession {
         serde_json::to_string(&items).map_err(js_err)
     }
 
-    /// Story ids currently in the document, sorted for determinism.
+    /// Every story id in the document, sorted so the order is stable across
+    /// replicas.
     pub fn story_ids(&self) -> Vec<String> {
         let txn = self.engine.doc().yrs_doc().transact();
         let Some(stories) = txn.get_map(STORIES) else {
@@ -2836,29 +3179,40 @@ impl EditSession {
         ids
     }
 
-    /// Story length in UTF-16 units (every embed, pilcrows included, = 1).
+    /// Story length in UTF-16 units, every embed (pilcrows included) counting
+    /// as one. Errors on an unknown story.
     pub fn story_len(&self, story: &str) -> Result<u32, JsValue> {
         self.engine.doc().story_len(story).map_err(js_err)
     }
 
-    /// The story's `canonical-stream-v1` FNV-1a checksum, as a decimal
-    /// string because u64 exceeds the JS safe-integer range.
+    /// The story's `canonical-stream-v1` FNV-1a checksum (see
+    /// [`crate::canonical`]) as a DECIMAL STRING, because a u64 exceeds the
+    /// JavaScript safe-integer range. Two stories with the same authored
+    /// content share a checksum even when their paragraph and comment ids
+    /// differ. Errors on an unknown story.
     pub fn story_checksum(&self, story: &str) -> Result<String, JsValue> {
         crate::story_checksum(self.engine.doc(), story)
             .map(|checksum| checksum.to_string())
             .map_err(js_err)
     }
 
-    /// Lowers a story for layout. Errors with an unsupported-embed message on
-    /// any non-native content. `env_json` carries theme colors, the default tab
-    /// stop and list numeric ids (see [`parse_render_env`]).
+    /// Lowers one story to a `LayoutBlock[]` JSON array — the block, run and
+    /// table vocabulary the layout engine consumes. `env_json` supplies the
+    /// document-level values lowering cannot read off the story:
+    /// `{"themeColors":{slot: hex},"defaultTabStopTwips":number|null,
+    /// "pageContentHeight":number|null,"numericIds":{yrsId: number}}`, all
+    /// optional. Errors when the story does not end in a pilcrow, holds a
+    /// malformed table, references itself through a cell story, or contains an
+    /// embed lowering does not support.
     pub fn yrs_blocks_for_story(&self, story: &str, env_json: &str) -> Result<String, JsValue> {
         let env = parse_render_env(env_json)?;
         self.engine.lower_story_json(story, &env).map_err(js_err)
     }
 
-    /// `[{"paraId","text","properties"}]` in document order. `properties`
-    /// carries pStyle/alignment plus any op-set extras.
+    /// `[{"paraId","text","properties"}, …]` in document order. `text` is the
+    /// paragraph's plain text without its pilcrow; `properties` is the
+    /// pilcrow's authored property map (`pStyle`, `alignment` and whatever
+    /// else has been set on it). Errors on an unknown story.
     pub fn paragraphs(&self, story: &str) -> Result<String, JsValue> {
         let paragraphs = self.engine.doc().paragraphs(story).map_err(js_err)?;
         let items = paragraphs
@@ -2874,10 +3228,11 @@ impl EditSession {
         serde_json::to_string(&items).map_err(js_err)
     }
 
-    /// Compact paragraph-position projection in one story traversal:
-    /// `[{"paraId","length"}]`. Length counts UTF-16 text and inline embed
-    /// units before each paragraph's pilcrow. The JS input shim uses this
-    /// instead of crossing the wasm boundary once per paragraph.
+    /// Compact paragraph-position projection built in one story traversal:
+    /// `[{"paraId","length"}, …]` in document order, where `length` counts the
+    /// UTF-16 text and inline embed units before that paragraph's pilcrow —
+    /// exactly the `offset` domain of a Loc in it. One call replaces crossing
+    /// the boundary once per paragraph. Errors on an unknown story.
     pub fn paragraph_spans(&self, story: &str) -> Result<String, JsValue> {
         let mut items = Vec::new();
         let mut cursor = 0_u32;
@@ -2901,10 +3256,17 @@ impl EditSession {
         serde_json::to_string(&items).map_err(js_err)
     }
 
-    /// The raw formatted-segment view (the render bridge's input):
-    /// `[{"kind":"text","text",…} | {"kind":"pilcrow","paraId","properties",…}
-    /// | {"kind":"embed",…}]`, each with `"attributes"` (run marks plus
-    /// `ins`/`del` revision values).
+    /// The story as an ordered run of formatted segments — the same view
+    /// lowering reads:
+    ///
+    /// - `{"kind":"text","text","attributes"}`
+    /// - `{"kind":"pilcrow","paraId","properties","attributes"}`
+    /// - `{"kind":"embed","embedKind","payload","attributes"}`
+    ///
+    /// A text segment covers one maximal run of identically formatted
+    /// characters; each pilcrow and embed is its own segment worth one unit.
+    /// `attributes` holds the segment's run marks together with any `ins`/`del`
+    /// tracked-change stamps. Errors on an unknown story.
     pub fn story_segments(&self, story: &str) -> Result<String, JsValue> {
         let segments = self.engine.doc().story_segments(story).map_err(js_err)?;
         let items = segments
@@ -2935,15 +3297,19 @@ impl EditSession {
         serde_json::to_string(&items).map_err(js_err)
     }
 
-    /// `{"start","end"}` — the paragraph's story span; `end` is its pilcrow's
-    /// index, so `end - start` is the paragraph length (`offset` domain).
+    /// `{"start","end"}` — the paragraph's span in story-global UTF-16 units.
+    /// `end` is the index of its own pilcrow, so `end - start` is the
+    /// paragraph length and the upper bound of a Loc `offset` in it. Errors
+    /// when the paragraph is not in `story`.
     pub fn locate_paragraph(&self, story: &str, para_id: &str) -> Result<String, JsValue> {
         let span = find_para_span(self.engine.doc(), story, para_id)?;
         Ok(json!({ "start": span.start, "end": span.pilcrow }).to_string())
     }
 
-    /// Current offsets of a comment's sticky anchors:
-    /// `[{"story","start","end"}]`. Errors when an anchor no longer resolves.
+    /// Where a comment's sticky anchors currently sit:
+    /// `[{"story","start","end"}, …]`, one entry per anchored range, in
+    /// story-global UTF-16 units. Errors on an unknown comment id and when an
+    /// anchor no longer resolves.
     pub fn resolve_comment(&self, comment_id: &str) -> Result<String, JsValue> {
         let anchors = self
             .engine

--- a/crates/docx-layout/src/cell_layout.rs
+++ b/crates/docx-layout/src/cell_layout.rs
@@ -66,7 +66,7 @@ pub fn layout_cell_content(
         }
     }
 
-    // The painter renders the final block's trailing space-after as paddingBottom.
+    // The final block's trailing space-after becomes the cell's bottom padding.
     CellContentLayout {
         line_tops,
         flat_bottoms,
@@ -128,7 +128,7 @@ mod tests {
                 SP + LINE + SP + LINE + SP + LINE,
             ]
         );
-        // content height includes the trailing after (painter paddingBottom)
+        // content height includes the trailing after-spacing
         assert_eq!(
             layout.content_height,
             SP + LINE + SP + LINE + SP + LINE + SP

--- a/crates/docx-layout/src/column_balancing.rs
+++ b/crates/docx-layout/src/column_balancing.rs
@@ -1,4 +1,24 @@
-//! Terminal continuous-section column balancing.
+//! Column balancing for a document's final continuous multi-column section.
+//!
+//! Word leaves the last continuous section's columns ragged unless it can even
+//! them out. Balancing works by *shortening the region*: the content limit
+//! drops so each column fills to roughly the same depth instead of the first
+//! column running to the page bottom.
+//!
+//! The target is `ceil(total / columnCount)`, then snapped forward to the first
+//! legal break at or past it, so a column boundary never lands mid-line. Legal
+//! breaks are:
+//!
+//! - inside a paragraph, after a line that is neither the first nor within two
+//!   lines of the last, and only when the paragraph does not set `w:keepLines`;
+//! - at a paragraph's end, unless it sets `w:keepNext`;
+//! - after every table row, and after an image or text box.
+//!
+//! Balancing is abandoned — leaving the region at full height — when the
+//! section has no content, when the range holds any block kind other than those
+//! above (section breaks are simply skipped), when there is a single column,
+//! when the content cannot fit the region even across all columns, or when the
+//! snapped height is not actually shorter than the region.
 
 use crate::paragraph_spacing::{get_spacing_after, get_spacing_before};
 use crate::types::{BlockExtent, ColumnLayout, LayoutBlock, MeasuredBlock};
@@ -11,11 +31,15 @@ pub trait ColumnBalancePaginator {
     fn set_content_limit(&mut self, value: f64);
 }
 
+/// Stacked height of the balanced range and the offsets a column may end at,
+/// both measured from the top of the range.
 struct SectionBalance {
     total_height: f64,
     legal_breaks: Vec<f64>,
 }
 
+/// Stacks the range and collects its legal breaks, or `None` when the range
+/// holds nothing to balance or a block kind balancing cannot reason about.
 fn get_balanced_section_height(
     measured: &[MeasuredBlock],
     start: usize,
@@ -89,6 +113,8 @@ fn get_balanced_section_height(
     }
 }
 
+/// Lowers the current region's content limit to the balanced depth, or leaves
+/// it alone when any of the module's bail-out conditions holds.
 fn balance_current_column_region<P: ColumnBalancePaginator>(
     paginator: &mut P,
     total_content_height: f64,
@@ -118,7 +144,8 @@ fn balance_current_column_region<P: ColumnBalancePaginator>(
     paginator.set_content_limit(column_region_top + balanced_height);
 }
 
-/// Balances a terminal continuous text section across columns.
+/// Balances the measured blocks in `start..end` across the current region's
+/// columns. Called with the range that follows the terminal continuous break.
 pub fn balance_terminal_continuous_text_columns<P: ColumnBalancePaginator>(
     measured: &[MeasuredBlock],
     paginator: &mut P,

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -11,10 +11,16 @@
 //!
 //! # Paint order
 //!
-//! Within a page: background and page borders, watermark, behind-document
-//! floating images, the layout's fragments in order, front floating images, and
-//! finally the header/footer bands ([`crate::hf_bands`]) and note areas. Inside
-//! a fragment the order is shading, borders, then line content.
+//! A page's `primitives` are emitted back to front: watermark, behind-document
+//! floating images, the layout's fragments in order, in-front floating images,
+//! then column separators. Inside a fragment the order is shading, borders,
+//! then line content.
+//!
+//! `background`, `page_borders`, `header`, `footer` and `note_areas` are
+//! separate fields rather than entries in that stream, so the consumer places
+//! them. Page borders are not one layer: each carries a `z_order` of `back` or
+//! `front` taken from `w:pgBorders/@zOrder` (anything but `back` is `front`),
+//! so a border may sit behind page content or over it.
 //!
 //! # Text
 //!

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -1,4 +1,75 @@
-//! Display-list construction from measured layout state.
+//! Display-list builder: `{ measured, options } + Layout -> DisplayList`.
+//!
+//! Takes the same measured/options envelope pagination consumes plus the
+//! finished [`crate::types::Layout`], and compiles one [`DisplayPage`] of
+//! renderer-agnostic paint primitives per laid-out page. A display list is
+//! always derived from a `Layout`; nothing here decides where content goes.
+//!
+//! Every text-bearing primitive carries `docStart` / `docEnd` and its block
+//! identity. That is what hit testing, selection and the accessibility mirror
+//! resolve against, so a primitive without those is invisible to interaction.
+//!
+//! # Paint order
+//!
+//! Within a page: background and page borders, watermark, behind-document
+//! floating images, the layout's fragments in order, front floating images, and
+//! finally the header/footer bands ([`crate::hf_bands`]) and note areas. Inside
+//! a fragment the order is shading, borders, then line content.
+//!
+//! # Text
+//!
+//! Run positions come from resolved line segments, and decorations — underline,
+//! strike, highlight, comment range, revision washes — ride with the run they
+//! belong to. A run becomes a [`GlyphRunPrimitive`] when the input supplies
+//! font chains and the run's chain resolves against the measurement font store;
+//! any miss (no fonts, no chain, empty text, a shaping failure) falls back to a
+//! [`TextRunPrimitive`] carrying a CSS font shorthand. A glyph run is
+//! single-font by contract, so a run spanning fallback fonts splits into one
+//! glyph run per maximal same-font subrange.
+//!
+//! Rows measured with authoritative run, cluster and bidi metadata use it
+//! directly. Rows without it fall back to a deterministic proportional split:
+//! fixed-width items (tabs, inline images) claim their width first, and the
+//! line's remaining measured width is distributed across the text-ish segments
+//! by character count.
+//!
+//! PAGE and NUMPAGES fields whose per-page resolved widths the input supplies
+//! leave that pool and become fixed-width at the page's own width, with the
+//! fallback width they contributed to the measure subtracted from the pool
+//! baseline — which is what lets a centred or right-aligned field line
+//! re-centre per page instead of tracking the once-measured fallback. DATE and
+//! TIME fields always render their stored fallback text rather than the current
+//! clock, so a display list is reproducible. A field's instruction is carried
+//! for announcement only and is never evaluated.
+//!
+//! Justified lines (`jc` of `both` or `distribute`) spread the line's slack
+//! evenly across U+0020 clusters. Glyph positions already fold that stretch in,
+//! so the emitted `wordSpacing` is an interchange hint, not something a
+//! renderer re-applies. On the first line the hanging or first-line indent
+//! shifts the text; when a visible list marker is present it occupies the hang,
+//! and body text starts at the text indent instead of being pulled left.
+//!
+//! # Tables
+//!
+//! A table fragment paints the row window its page shows, stacking a repeated
+//! header band above it. Vertically merged cells are re-emitted as continuation
+//! slices on later pages: those are re-paints, so they carry no document
+//! positions and are not selectable. Repeated header rows are literal re-paints
+//! and are deliberately *not* flagged as continuations. Shared cell edges
+//! collapse to a single border, and a fragment cut by a page break is closed
+//! with its own cut edges.
+//!
+//! Inside a cell, paragraph spacing collapses as it does in body flow, drawn
+//! border widths and padding inset the content box, and `w:vAlign` offsets the
+//! leftover slack — except that content which fills or overflows the box stays
+//! top-aligned, matching where the paginator broke it. Text boxes nested inside
+//! table cells emit nothing.
+//!
+//! # Numbers
+//!
+//! Coordinates round to three decimals, and integral floats are canonicalized
+//! to integers so the fields typed as integers survive a round trip through a
+//! host with a single number type.
 
 use ooxml_drawingml::GeometryPathCommand;
 use ooxml_drawingml::chart::{
@@ -10,6 +81,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 use std::collections::{HashMap, HashSet};
 
+/// A compiled document: one entry per laid-out page, in document order.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DisplayList {
@@ -84,9 +156,9 @@ pub struct NoteRegion {
     pub primitives: Vec<Primitive>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub note_ids: Vec<i64>,
-    /// per-note backlink metadata: body-doc anchor range + formatted
-    /// label per note, so the a11y mirror can wire note ↔ reference links.
-    /// Additive; legacy regions omit it and serialize byte-identically.
+    /// Per-note backlink metadata: the body-document anchor range and the
+    /// formatted label, so a note can be linked back to its reference mark.
+    /// Emitted only for notes that carry anchor or label data.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub notes: Vec<NoteRegionNote>,
 }
@@ -127,6 +199,8 @@ pub enum HfKind {
     Footer,
 }
 
+/// One paint operation. A renderer walks these in order and needs no knowledge
+/// of DOCX to draw them.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "kind")]
 pub enum Primitive {
@@ -146,8 +220,11 @@ pub enum Primitive {
     Decoration(DecorationPrimitive),
 }
 
-/// attrs shared by primitives that map back to document content; replaces the
-/// painted-DOM dataset contract (data-doc-start/end, data-block-id, ...)
+/// Everything a primitive carries about the document content it came from:
+/// its position range, block and paragraph identity, enclosing table cell,
+/// content-control ancestry, revision and comment state, and the per-class
+/// paint metadata flattened alongside. This is the only channel through which
+/// a painted primitive can be mapped back to the document.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DocAttrs {
@@ -163,9 +240,10 @@ pub struct DocAttrs {
     /// whenever the primitive has block identity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_key: Option<String>,
-    /// Exact document range of the owning paragraph fragment. Primitive doc ranges
-    /// describe inline content (normally beginning at paragraph pmStart+1),
-    /// while painter-compatible paragraph wrappers begin at fragment pmStart.
+    /// Exact document range of the owning paragraph fragment. A primitive's own
+    /// range describes inline content and normally starts at the paragraph's
+    /// `pmStart + 1`, whereas a paragraph wrapper starts at the fragment's
+    /// `pmStart`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fragment_doc_start: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -173,12 +251,11 @@ pub struct DocAttrs {
     /// Stable Word `w14:paraId` of the enclosing paragraph.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub para_id: Option<String>,
-    /// measured line window `[from_line, to_line)` of the paragraph fragment
-    /// this primitive belongs to — the display-list analogue of the painter's
-    /// `data-from-line` / `data-to-line`. Stamped only on paragraph fragments
-    /// the a11y mirror surfaces as a paragraph wrapper (body, header/footer,
-    /// text box); table-cell paragraphs are omitted because the mirror renders
-    /// them as ARIA cells, which have no fragment element to hang the range on.
+    /// Measured line window `[from_line, to_line)` of the paragraph fragment
+    /// this primitive belongs to. Stamped only where a fragment surfaces as a
+    /// paragraph wrapper — body, header/footer and text-box content. Table-cell
+    /// paragraphs are omitted, because they surface as ARIA cells and have no
+    /// fragment of their own to carry the window.
     /// Omitted when no stamped range exists.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from_line: Option<u64>,
@@ -269,9 +346,8 @@ pub struct DocAttrs {
     pub highlight_slice: Option<HighlightSliceMetadata>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub style: Option<DisplayBorderStyle>,
-    /// Primitive-class-specific additive fields are flattened through the
-    /// shared attrs so legacy constructors in the HF compositor remain source
-    /// compatible.
+    /// Fields belonging to one primitive class are flattened through the shared
+    /// attrs, so a constructor that fills only the common fields stays valid.
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "opacity")]
     pub primitive_opacity: Option<Number>,
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "flipH")]
@@ -286,8 +362,8 @@ pub struct DocAttrs {
     pub border: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fill_paint: Option<Value>,
-    /// Lossless DrawingML stroke details beyond the legacy color/width/dash
-    /// triple (compound/alignment/caps/joins/arrows/custom dash).
+    /// Lossless DrawingML stroke details beyond the plain colour/width/dash
+    /// triple: compound, alignment, caps, joins, arrows and custom dashes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stroke_paint: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -375,7 +451,7 @@ pub struct CommentReplyMetadata {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldMetadata {
-    /// painter-resolved category (PAGE, NUMPAGES, DATE, TIME, OTHER)
+    /// resolved category: PAGE, NUMPAGES, DATE, TIME or OTHER
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     /// raw Word field type token (e.g. TOC, PAGEREF, REF)
@@ -466,7 +542,14 @@ pub struct ChartA11yAttrs {
     pub label: String,
 }
 
-/// Resolved anchor-grid coordinates for a table cell.
+/// The grid position of the cell a primitive paints inside.
+///
+/// `row` and `col` are 0-based anchor-grid coordinates with vertical merges and
+/// column spans already resolved, so a merged cell keeps its anchor row, and
+/// spans are always at least 1. `continuation` marks the synthetic slice of a
+/// vertically merged cell re-painted on a later page: not selectable, and with
+/// document positions stripped. A repeated header row is a literal re-paint and
+/// is deliberately not flagged.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TableCellRef {
@@ -610,6 +693,8 @@ pub enum StructuralRevisionKind {
     Merge,
 }
 
+/// A run of text painted from a font shorthand and a measured advance, used
+/// wherever shaping is unavailable for the run.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TextRunPrimitive {
@@ -624,11 +709,10 @@ pub struct TextRunPrimitive {
     pub color: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub letter_spacing: Option<Number>,
-    /// extra advance added after each U+0020 space cluster (px) — the canvas
-    /// backend replays it as `ctx.wordSpacing`. Set only on justified lines
-    /// (`jc=both/distribute`), where the DOM painter stretches spaces via CSS
-    /// `text-align: justify`; the primitive `width` already includes the same
-    /// stretch so the mirror geometry matches. Absent = 0 (no stretch).
+    /// Extra advance added after each U+0020 cluster (px), set only on
+    /// justified lines (`jc` of `both` or `distribute`). The primitive's
+    /// `width` already includes the same stretch, so this is an interchange
+    /// hint. Absent means no stretch.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub word_spacing: Option<Number>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -657,7 +741,13 @@ pub struct TextRunPrimitive {
     pub attrs: DocAttrs,
 }
 
-/// Single-font shaped glyph run with source text for accessibility.
+/// A shaped run of positioned glyphs, single-font by contract.
+///
+/// A renderer paints each glyph as an outline from `font_id`'s bytes, while
+/// `text` keeps the real characters for accessibility and copying. Emitted only
+/// when the measurement font store is populated and the run's font chain
+/// resolves; otherwise the builder emits a [`TextRunPrimitive`]. A run spanning
+/// several fallback fonts becomes one glyph run per maximal same-font subrange.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GlyphRunPrimitive {
@@ -1007,9 +1097,8 @@ pub struct DecorationPrimitive {
     pub w: Number,
     pub h: Number,
     pub color: String,
-    /// dashed rule instead of a solid one — set for the tracked-change
-    /// insertion underline (the painter's `border-bottom: 2px dashed`).
-    /// omitted for a plain solid decoration.
+    /// Dashed rule instead of a solid one, used for the tracked-change
+    /// insertion underline. Omitted for a plain solid decoration.
     #[serde(default, skip_serializing_if = "is_false")]
     pub dashed: bool,
     /// dotted rule instead of a solid one — set for hidden-run dotted underline.
@@ -1019,8 +1108,7 @@ pub struct DecorationPrimitive {
     pub attrs: DocAttrs,
 }
 
-/// serde `skip_serializing_if` predicate: omit `false` bools from the wire
-/// form so solid decorations keep their historical shape.
+/// serde `skip_serializing_if` predicate: omit `false` bools from the wire form.
 fn is_false(b: &bool) -> bool {
     !*b
 }
@@ -1039,24 +1127,29 @@ pub enum DecoKind {
     Spell,
 }
 
+/// The parsed build envelope: the measured blocks and options pagination also
+/// saw, the `Layout` it produced, and the display-only extras.
 pub struct BuildInput {
     contract_version: Option<u32>,
     measured: Vec<MeasuredBlockIn>,
     options: Value,
     layout: LayoutIn,
-    /// Optional header/footer payload.
+    /// Optional header/footer payload; see [`crate::hf_bands`] for its shape.
+    /// Absent means the pages carry no bands.
     headers_footers: Option<crate::hf_bands::HeadersFootersIn>,
     headers_footers_content: Option<HeadersFootersContentIn>,
-    /// Font fallback chains keyed by family, bold, and italic state.
+    /// Font fallback chains keyed `"<family lowercase>|<bold>|<italic>"`, the
+    /// same map measurement used. Resolving these against a populated font
+    /// store is what gates glyph-run emission.
     font_chains: HashMap<String, Vec<u32>>,
     resolved_comment_ids: Vec<i64>,
     comment_authors: Vec<CommentAuthorIn>,
     comment_threads: Vec<CommentThreadIn>,
 }
 
-/// Parsed display input retained by the editing engine. Its fields stay
-/// private to this module so the legacy display-input contract can evolve
-/// without becoming a second public layout model.
+/// Parsed display input retained by the editing engine across edits. Its fields
+/// stay private so the display-input contract can evolve without becoming a
+/// second public layout model.
 pub struct ResidentDisplayInput {
     input: BuildInput,
 }
@@ -1814,8 +1907,8 @@ pub(crate) struct TableBlockIn {
     caption: Option<String>,
     #[serde(default)]
     description: Option<String>,
-    /// `<w:tblpPr>` placement; floating tables do not advance the HF flow cursor,
-    /// like the DOM painter.
+    /// `<w:tblpPr>` placement. A floating table does not advance the
+    /// header/footer flow cursor.
     #[serde(default)]
     pub(crate) floating: Option<FloatingTablePositionIn>,
 }
@@ -2590,8 +2683,8 @@ pub(crate) struct SizeIn {
     pub(crate) h: f64,
 }
 
-/// page margins as serialized in the Layout (`Page.margins`); `header` /
-/// `footer` are the `w:headerReference` distances the painter falls back to
+/// Page margins as serialized in the `Layout`. `header` and `footer` are the
+/// band distances header/footer composition falls back to.
 #[derive(Deserialize, Default, Clone, Copy)]
 pub(crate) struct MarginsIn {
     #[serde(default)]
@@ -2872,8 +2965,8 @@ fn effective_font_px_of(fmt: &RunFormattingIn) -> f64 {
     font_px_of(fmt) * script_scale_of(fmt)
 }
 
-/// Paint-only baseline offset. Positive `positionPx` raises text in the DOM
-/// painter, which means a smaller canvas y coordinate.
+/// Paint-only baseline offset. A positive `positionPx` raises the text, which
+/// is a smaller y coordinate.
 fn baseline_y_of(fmt: &RunFormattingIn, baseline: f64) -> f64 {
     let mut y = baseline - fmt.position_px.unwrap_or(0.0);
     let script_font = effective_font_px_of(fmt);
@@ -3203,8 +3296,8 @@ pub(crate) fn rotation_degrees(transform: Option<&str>) -> f64 {
 /// the display list (a11y mirror DOM, canvas hosts, serialized snapshots)
 pub const MAX_ALT_TEXT_CHARS: usize = 2048;
 
-/// alt text for an image primitive: empty values drop (the DOM painter only
-/// sets `alt` when truthy), oversized values truncate on a char boundary
+/// Alt text for an image primitive: an empty value is dropped rather than
+/// emitted, and an oversized one truncates on a character boundary.
 pub(crate) fn capped_alt_text(alt: Option<&str>) -> Option<String> {
     let alt = alt?;
     if alt.is_empty() {
@@ -3774,7 +3867,9 @@ fn push_bidi_text_items<'a>(
 // builder
 // ---------------------------------------------------------------------------
 
-/// Per-page resolved widths for one PAGE/NUMPAGES field run.
+/// Per-page resolved widths for one PAGE/NUMPAGES field run. `fallback` is the
+/// width the measure baked into the line (from the field's fallback text);
+/// `per_page[i]` is the width of its resolved text on layout page `i`.
 pub(crate) struct FieldWidthEntry {
     pub(crate) fallback: f64,
     pub(crate) per_page: Vec<f64>,
@@ -3783,6 +3878,9 @@ pub(crate) struct FieldWidthEntry {
 /// field document position → per-page widths (see [`FieldWidthEntry`]).
 pub(crate) type FieldWidthMap = HashMap<i64, FieldWidthEntry>;
 
+/// Everything emission needs that varies per page or per band: the numbers
+/// PAGE and NUMPAGES resolve to, the shaping fonts, and the field widths scoped
+/// to the header/footer variant being composed.
 pub(crate) struct RenderCtx<'a> {
     pub(crate) page_number: u64,
     /// Zero-based key into per-page field-width arrays.
@@ -4264,9 +4362,7 @@ fn emit_note_regions(page: &PageIn, ctx: &RenderCtx<'_>) -> Vec<NoteRegion> {
             separator_primitives,
             primitives,
             note_ids: area.notes.iter().filter_map(|note| note.id).collect(),
-            // backlink metadata: emitted only for notes that actually
-            // carry anchor/label data, so anchor-less legacy inputs keep the
-            // region serialization byte-identical
+            // Only notes carrying anchor or label data get backlink metadata.
             notes: area
                 .notes
                 .iter()
@@ -4543,8 +4639,7 @@ fn build_display_list_selected(
     fonts: &ooxml_text::FontStore,
     selected_pages: Option<&HashSet<usize>>,
 ) -> DisplayList {
-    // shaping context: present only under Rust measurement (input carries
-    // fontChains). None ⇒ every text run takes the v0 TextRunPrimitive path.
+    // Without font chains every text run stays a TextRunPrimitive.
     let shape_fonts = ShapeFonts::build(input, fonts);
     let render_options =
         serde_json::from_value::<RenderOptionsIn>(input.options.clone()).unwrap_or_default();
@@ -5027,7 +5122,15 @@ fn apply_review_metadata(
     }
 }
 
-/// Emits one paragraph fragment in page coordinates.
+/// Paints one paragraph fragment: shading rect, grouped borders, then each
+/// measured line's runs with indent padding, per-line float offsets and the
+/// alignment shift.
+///
+/// `origin_*` are the fragment's page coordinates; cell content passes its own
+/// origin and suppresses border grouping. `stamp_line_range` records the
+/// fragment's `[from_line, to_line)` on every primitive it emits — table-cell
+/// callers pass `false`, since a cell paragraph has no fragment of its own for
+/// the range to describe.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_paragraph_fragment(
     prims: &mut Vec<Primitive>,
@@ -5183,9 +5286,8 @@ pub(crate) fn emit_paragraph_fragment(
         line_top += line.line_height;
     }
 
-    // Paragraph-mark tracked-change pilcrow. The DOM painter appends it to the
-    // final line element only; split fragments that carry to the next page get
-    // the margin bar above but not the terminating glyph.
+    // The tracked-change pilcrow marks the paragraph's end, so only the final
+    // fragment gets it; earlier fragments get the margin bar alone.
     if let (Some(rev), Some(line)) = (pmark_revision, last_line)
         && frag.carried_to_next != Some(true)
     {
@@ -5267,6 +5369,9 @@ pub(crate) fn emit_paragraph_fragment(
     }
 }
 
+/// Everything one line needs beyond its own measure: the fragment box it sits
+/// in, the paragraph's indents, its position within the paragraph, and the
+/// direction and alignment that place its content.
 struct LineGeom<'a> {
     frag_x: f64,
     frag_width: f64,
@@ -5516,7 +5621,7 @@ fn emit_line(
     let effective_line_width =
         authoritative_width.unwrap_or(pool_width + fixed_width + field_fixed);
 
-    // alignment shift for the line (justify paints at natural width in v0)
+    // Justified lines already fill the width, so they take no alignment shift.
     let align_shift = match geom.alignment {
         Some("center") => ((usable_width - effective_line_width) / 2.0).max(0.0),
         Some("right") => (usable_width - effective_line_width).max(0.0),
@@ -5707,8 +5812,7 @@ fn emit_line(
                     });
                 }
                 RunIn::Image(imr) => {
-                    // floating images never paint inline (page/cell float layers own
-                    // them); v0 omits those layers, so they are skipped entirely
+                    // The page and cell float layers own these, not the line.
                     if is_floating_image_run(imr) {
                         continue;
                     }
@@ -5867,16 +5971,12 @@ fn emit_line(
         }
     }
 
-    // a line with no positioned text still needs a doc position for hit-testing
-    // (the painter's zero-width marker / empty-run rule): a blank row from a
-    // line break carries the break's own (inline) position; an empty paragraph
-    // line carries the paragraph's CONTENT position — fragment pmStart is the
-    // paragraph NODE boundary, and the DOM resolvers' empty-run rule was
-    // `paragraph.docStart + 1` (a caret cannot sit on the node boundary; the
-    // query layer's anchorRect likewise documents the blank-paragraph marker
-    // at pos+1). Emitting the node position made hit-tests and ArrowUp/Down
-    // land the selection BEFORE the paragraph, breaking every empty-paragraph
-    // consumer (toolbar state, stored-mark re-derivation).
+    // A line with no positioned text still needs a doc position for hit
+    // testing. A blank row from a line break carries the break's own inline
+    // position; an empty paragraph line carries the paragraph's CONTENT
+    // position, which is `pmStart + 1`. The fragment's own pmStart is the
+    // paragraph boundary, and a caret cannot sit there — emitting it would land
+    // every click and vertical move BEFORE the paragraph.
     if !emitted_positioned_text {
         let pos = line_break_pos.or(geom.frag_pm_start.map(|p| p + 1));
         if let Some(p) = pos {
@@ -6167,7 +6267,7 @@ fn emit_text_segment(
             attrs: highlight_attrs,
         }));
     }
-    // comment-range tint behind the glyphs (painter: rgba(255,212,0,0.15) wash)
+    // Comment ranges tint behind the glyphs.
     if comment_ids.is_some() {
         prims.push(Primitive::Decoration(DecorationPrimitive {
             deco: DecoKind::CommentRange,
@@ -6195,9 +6295,8 @@ fn emit_text_segment(
             attrs: attrs.clone(),
         }));
     }
-    // suggested deletion: red wash behind the glyphs (painter:
-    // `background-color: rgba(211,47,47,0.08)`). The red text comes from
-    // run_color and the strike-through from the Strike decoration below.
+    // Suggested deletion: a red wash behind the glyphs. The red text itself
+    // comes from run_color and the strike from the Strike decoration below.
     if fmt.is_deletion == Some(true) {
         prims.push(Primitive::Decoration(DecorationPrimitive {
             deco: DecoKind::Highlight,
@@ -6301,9 +6400,9 @@ fn emit_text_segment(
             attrs: underline_attrs,
         }));
     } else if fmt.is_insertion == Some(true) {
-        // suggested insertion: green dashed rule under the run (painter:
-        // `border-bottom: 2px dashed #2e7d32`). Reuses the underline offset and
-        // thickness of an explicit underline; the dashed flag drives the canvas
+        // Suggested insertion: a green dashed rule under the run, reusing the
+        // offset and thickness of an explicit underline; the dashed flag drives
+        // the canvas
         // rule. `else if` so an already-underlined inserted run keeps a single
         // rule rather than stacking two lines at the same baseline offset.
         prims.push(Primitive::Decoration(DecorationPrimitive {
@@ -6330,7 +6429,7 @@ fn emit_text_segment(
             attrs: attrs.clone(),
         }));
     }
-    // deletions strike through in the revision color, like the DOM painter
+    // Deletions strike through in the revision colour.
     if fmt.strike == Some(true) || fmt.is_deletion == Some(true) {
         prims.push(Primitive::Decoration(DecorationPrimitive {
             deco: DecoKind::Strike,
@@ -6347,7 +6446,7 @@ fn emit_text_segment(
 }
 
 /// Shape one styled text slice into [`GlyphRunPrimitive`]s and push them, or
-/// return `false` to signal the caller to emit the v0 [`TextRunPrimitive`]
+/// return `false` to signal the caller to emit a [`TextRunPrimitive`]
 /// instead. Returns `false` (touching nothing) when the run has no text, its
 /// font family has no chain, or any subrange fails to shape — so the fallback
 /// is always a clean whole-segment TextRunPrimitive, never a partial mix.
@@ -6594,8 +6693,8 @@ fn field_text(f: &FieldRunIn, ctx: &RenderCtx<'_>) -> String {
 /// field instruction cap — announcement identity, not a full field-code view
 pub const MAX_FIELD_INSTRUCTION_CHARS: usize = 1024;
 
-/// inert a11y identity of a field run: painter category, raw type token, and
-/// the (bounded) instruction. The instruction is file-derived and
+/// Inert accessibility identity of a field run: its resolved category, raw type
+/// token, and bounded instruction. The instruction is file-derived and
 /// attacker-controlled; it is carried for announcement ONLY — nothing here or
 /// downstream evaluates it (field codes render inert; see the repo security guidelines).
 fn field_metadata(f: &FieldRunIn) -> FieldMetadata {
@@ -6982,7 +7081,13 @@ fn vertical_anchor_band(
     }
 }
 
-/// Resolves a floating image anchor to a content-relative origin.
+/// Resolves a floating image run's OOXML anchor to a content-relative origin.
+///
+/// Each axis reads its `relativeFrom` band, then applies either an explicit
+/// offset or an alignment inside that band. `fragment_y` is the anchoring
+/// paragraph fragment's content-relative top, which is the base for the
+/// `paragraph` and `line` bands. Anchors are resolved here rather than read off
+/// the fragment, because the layout does not store them.
 fn resolve_anchored_position(
     imr: &ImageRunIn,
     fragment_y: f64,
@@ -7059,7 +7164,9 @@ fn resolve_anchored_position(
     (x, y)
 }
 
-/// Emits paragraph floating images at their resolved page rectangles.
+/// Emits a paragraph's floating image runs at their resolved page rectangles.
+/// `want_behind` selects the pass: behind-document floats paint before body
+/// content, the rest after.
 fn emit_paragraph_floating_images(
     prims: &mut Vec<Primitive>,
     block: &ParagraphBlockIn,
@@ -7068,7 +7175,7 @@ fn emit_paragraph_floating_images(
     want_behind: bool,
 ) {
     let block_ref = BlockRef::of(&block.id);
-    // fragment top relative to the content area (painter: fragment.y - margins.top)
+    // Float anchors resolve against the content area, not the page.
     let fragment_content_y = frag_y - geom.margin_top;
     for run in &block.runs {
         let RunIn::Image(imr) = run else { continue };
@@ -7080,8 +7187,7 @@ fn emit_paragraph_floating_images(
             continue;
         }
         let (x, y) = resolve_anchored_position(imr, fragment_content_y, geom);
-        // content-relative → page-local (the painter's float layer sits inside
-        // the content area at margins.left / margins.top)
+        // Content-relative back to page-local.
         let page_x = geom.margin_left + x;
         let page_y = geom.margin_top + y;
         let rot = imr
@@ -7672,7 +7778,10 @@ fn shape_path_command(command: GeometryPathCommand) -> ShapePathCommand {
     }
 }
 
-/// Paints one text-box fragment.
+/// Paints one text-box fragment: the container's fill and border edges at the
+/// box's page rect, then the inner paragraphs at the content origin. The box
+/// behaves like a border-box, so border and padding sit inside the fragment
+/// rect and content starts at `x + borderWidth + margin`.
 fn emit_text_box_fragment(
     prims: &mut Vec<Primitive>,
     frag: &TextBoxFragmentIn,
@@ -7683,8 +7792,8 @@ fn emit_text_box_fragment(
     let stamp_from = prims.len();
     let block_ref = BlockRef::of(&frag.block_id);
 
-    // container fill: a fragment-sized rect behind the content, carrying the
-    // text box's doc range (the painter stamps the container with pmStart/pmEnd)
+    // Container fill: a fragment-sized rect behind the content, carrying the
+    // text box's own doc range.
     if let Some(fill) = &block.fill_color {
         let mut fill_attrs = block_ref.attrs();
         fill_attrs.doc_start = frag.pm_start;
@@ -7782,6 +7891,8 @@ struct GridCell {
     width: f64,
 }
 
+/// Resolves every cell onto the column grid and gives it a pixel `x` and width
+/// from `column_widths`.
 fn compute_cell_grid(block: &TableBlockIn, column_widths: &[f64]) -> Vec<GridCell> {
     // rtl tables (`w:bidiVisual`) mirror x so logical column 0 lands rightmost
     let bidi = block.bidi == Some(true);
@@ -7836,7 +7947,8 @@ fn compute_cell_grid(block: &TableBlockIn, column_widths: &[f64]) -> Vec<GridCel
     out
 }
 
-/// Returns whole-pixel cumulative row offsets.
+/// Cumulative row offsets, each rounded to a whole pixel so shared borders land
+/// on the same device line. Length is `rows + 1`.
 fn row_y_positions(rows: &[TableRowExtentIn]) -> Vec<f64> {
     let mut out = Vec::with_capacity(rows.len() + 1);
     let mut y: f64 = 0.0;
@@ -7917,7 +8029,9 @@ fn table_metadata(
     }
 }
 
-/// Emits a windowed table fragment with merged cells and cut-edge borders.
+/// Paints the row window this page shows of a table: the repeated header band,
+/// the visible rows, re-emitted vertical merges, collapsed shared borders, and
+/// the cut edges that close the fragment where a page break sliced it.
 pub(crate) fn emit_table_fragment(
     prims: &mut Vec<Primitive>,
     frag: &TableFragmentIn,
@@ -7956,8 +8070,8 @@ pub(crate) fn emit_table_fragment(
         to_frag_y(row_tops.get(frag.row_end).copied().unwrap_or(0.0))
     };
 
-    // clip band in page coordinates; every emitted rect/text clips to it (the
-    // DOM painter gets this for free from the fragment's overflow:hidden)
+    // Clip band in page coordinates; every emitted rect and text clips to it,
+    // so a row sliced by the page break cannot paint past the fragment.
     let clip_top_y = frag.y;
     let clip_bottom_y = frag.y + visible_height;
 
@@ -8109,9 +8223,9 @@ pub(crate) fn emit_table_fragment(
         } else {
             p.g.column_index == 0
         };
-        // grid position carried on every DocAttrs-bearing primitive painted
-        // inside this cell; a vmerge continuation slice keeps the anchor
-        // cell's row/col and flags itself (data-vmerge-continuation analogue)
+        // Grid position stamped on every primitive inside this cell. A vertical
+        // merge continuation keeps the anchor cell's row and column and flags
+        // itself so consumers know it is a re-paint.
         let is_header = p.g.row_index < semantic_header_count
             || block.rows[p.g.row_index].is_header == Some(true);
         let cell_id = format!("{table_id}-r{}-c{}", p.g.row_index, p.g.column_index);
@@ -8411,7 +8525,14 @@ pub(crate) fn emit_table_fragment(
     stamp_sdt_range(&mut prims[stamp_from..], &block.sdt_groups, false);
 }
 
-/// Paints stacked cell content with collapsed paragraph spacing.
+/// Stacks a cell's paragraphs and nested tables with Word's spacing collapse.
+///
+/// Adjacent paragraphs collapse `spacing.after` against the next
+/// `spacing.before`, a nested table flows after the previous paragraph's
+/// after-spacing, and a trailing after-spacing acts as the content box's bottom
+/// padding. Drawn border widths and padding inset the box on the sides this
+/// cell actually paints, and the resulting box is what `w:vAlign` measures its
+/// slack against.
 #[allow(clippy::too_many_arguments)]
 fn emit_cell_content(
     prims: &mut Vec<Primitive>,
@@ -8764,7 +8885,12 @@ fn postprocess_cell_primitives(
     }
 }
 
-/// Resolves a cell-anchored image to a cell-content-relative origin.
+/// Resolves a cell-anchored floating image to a cell-content-relative origin.
+///
+/// `paragraph_y` is the anchoring paragraph's top within the cell content box;
+/// the caller offsets the result into page space. Unlike the page float path
+/// there are no `relativeFrom` bands here — the cell content box is the only
+/// frame — and the image is clamped inside it.
 fn resolve_cell_float_position(
     imr: &ImageRunIn,
     paragraph_y: f64,
@@ -8805,7 +8931,14 @@ fn resolve_cell_float_position(
     (x, y)
 }
 
-/// Emits a table cell's floating image runs.
+/// Emits a cell's floating image runs, `want_behind` choosing the layer painted
+/// under the cell content or the one over it.
+///
+/// The anchoring `paragraph_y` accumulates the cell's measured block heights
+/// with no spacing collapse. Each image clips to the fragment window, carries
+/// the cell's grid reference, and keeps its document positions only on a
+/// selectable slice — a vertical-merge continuation is a re-paint and carries
+/// none.
 #[allow(clippy::too_many_arguments)]
 fn emit_cell_floating_images(
     prims: &mut Vec<Primitive>,
@@ -8824,8 +8957,7 @@ fn emit_cell_floating_images(
     let mut paragraph_y = 0.0_f64;
     for (i, blk) in cell.blocks.iter().enumerate() {
         let BlockIn::Paragraph(pb) = blk else {
-            // non-paragraph blocks (nested tables) advance the anchor cursor by
-            // their measured height, matching the painter's extractor
+            // Nested tables advance the anchor cursor by their measured height.
             match cell_measure.blocks.get(i) {
                 Some(MeasureIn::Table(tm)) => paragraph_y += tm.total_height,
                 Some(MeasureIn::Shape(sm)) | Some(MeasureIn::Chart(sm)) => paragraph_y += sm.height,
@@ -8872,7 +9004,7 @@ fn emit_cell_floating_images(
                 alt_text: capped_alt_text(imr.alt.as_deref()),
                 attrs,
             });
-            // clip to the fragment window (the DOM cell's overflow:hidden)
+            // Clip to the fragment window.
             let (top, bottom) = primitive_v_extent(&prim);
             if bottom < clip_top_y || top > clip_bottom_y {
                 continue;
@@ -8951,8 +9083,8 @@ fn strip_doc_positions(p: &mut Primitive) {
     if let Some(attrs) = doc_attrs_mut(p) {
         attrs.doc_start = None;
         attrs.doc_end = None;
-        // a re-painted slice is not a paraId target either — drop it so the
-        // mirror does not expose a duplicate data-para-id for the anchor cell
+        // A re-painted slice is not a paragraph-id target either; keeping it
+        // would expose a duplicate id for the anchor cell.
         attrs.para_id = None;
     }
 }
@@ -8969,10 +9101,10 @@ fn set_cell_ref(p: &mut Primitive, cell: &TableCellRef) {
 // JSON boundary
 // ---------------------------------------------------------------------------
 
-/// pure JSON boundary: `{ measured, options, layout }` in, `DisplayList` JSON
-/// out, with NO shaping fonts — every text run emits `TextRunPrimitive`, the
-/// browser-measured v0 path. Native-testable (no JsValue). The fonts-aware wasm
-/// entry is [`build_display_list_json_with_fonts`].
+/// Pure JSON boundary: `{ measured, options, layout }` in, `DisplayList` JSON
+/// out, with no shaping fonts — so every text run emits a
+/// [`TextRunPrimitive`]. Native-testable (no `JsValue`); the fonts-aware entry
+/// is [`build_display_list_json_with_fonts`].
 pub fn build_display_list_json(input: &str) -> Result<String, String> {
     build_display_list_json_with_fonts(input, &ooxml_text::FontStore::new())
 }
@@ -9364,7 +9496,12 @@ fn shift_page_body_positions(page: &mut DisplayPage, deltas: &HashMap<String, i6
     }
 }
 
-/// Canonicalizes lossless integral JSON floats for integer-valued fields.
+/// Rewrites losslessly-integral JSON floats as integers.
+///
+/// Several established display-input fields deserialize as `i64`, but the same
+/// values reach this builder as `f64` when they come from typed Rust state
+/// rather than through a host with a single number type. Canonicalizing here
+/// makes both paths parse identically.
 fn normalize_integral_json_numbers(value: &mut Value) {
     match value {
         Value::Array(values) => {

--- a/crates/docx-layout/src/floating_objects.rs
+++ b/crates/docx-layout/src/floating_objects.rs
@@ -1,9 +1,34 @@
-//! Floating-object exclusion geometry.
+//! Registry of the page-space exclusion zones anchored floats claim.
+//!
+//! Anchored images, floating tables and floating text boxes carve horizontal
+//! room out of the lines they overlap. Line breaking itself happens during
+//! measurement, upstream of this crate, so the measured lines arriving here
+//! already have float effects folded into their widths and offsets — no zone
+//! data crosses the input envelope. What pagination still needs is each
+//! float's claim in page coordinates, which callers register as a
+//! [`BlockedRegion`] and query per line through
+//! [`FloatRegionRegistry::resolve_free_span`].
+//!
+//! Coordinate spaces differ between input and output: a region's `rect` is in
+//! page coordinates, while [`FreeSpan`] is content-area relative, so a shift of
+//! `0.0` means the line starts at the left margin.
+//!
+//! A float participates in a line only when it is on the same page, its
+//! [`WrapSide`] is not `None`, and its clearance-padded box overlaps the line's
+//! vertical band. Each participating float then squeezes the writable interval
+//! from one side: `Left` or `Both` pulls the right edge back to the float's
+//! cleared left edge, `Right` or `Both` pushes the left edge past its cleared
+//! right edge. The resulting span is clamped at zero, so a line fully covered
+//! by floats reports no room rather than a negative width.
+//!
+//! Comparisons use NaN-propagating, signed-zero-aware minimum and maximum so
+//! the numbers reaching the canonical JSON match the host's semantics.
 
 use serde::{Deserialize, Serialize};
 
 /// A text segment beside a float narrower than this (px) is not worth
-/// wrapping into.
+/// wrapping into. Measurement applies the threshold; this registry reports raw
+/// spans and leaves the decision to its caller.
 pub const MIN_WRAP_SEGMENT_WIDTH: f64 = 24.0;
 
 /// NaN-propagating minimum that preserves negative zero.
@@ -66,6 +91,8 @@ pub enum WrapSide {
     None,
 }
 
+/// One float's claim on a page: its box, the wrap gap around it, and which
+/// side text may run down.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockedRegion {
@@ -78,6 +105,7 @@ pub struct BlockedRegion {
     pub wrap_side: WrapSide,
 }
 
+/// Room left for one line, in content-area coordinates.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FreeSpan {

--- a/crates/docx-layout/src/hf_bands.rs
+++ b/crates/docx-layout/src/hf_bands.rs
@@ -1,4 +1,60 @@
-//! Header/footer band composition.
+//! Header/footer band composition for the display list.
+//!
+//! A page gains `header` / `footer` regions only when the build envelope
+//! carries a `headersFooters` payload. Band content reuses the body paragraph
+//! and table emitters, so runs, decorations and PAGE/NUMPAGES fields behave the
+//! same as in the body — but the `docStart` / `docEnd` on those primitives
+//! address the header/footer document named by the region's `rId`, never the
+//! body document. Hit testing and selection must therefore scope by region.
+//!
+//! # Envelope
+//!
+//! The payload carries the section flags `titlePg` (`w:titlePg`) and
+//! `evenAndOddHeaders` (`w:evenAndOddHeaders`), each optionally narrowed to
+//! individual sections via `titlePageSections` / `evenAndOddSections`; optional
+//! `headerDistance` / `footerDistance` overrides (`w:pgMar` `w:header` /
+//! `w:footer`); an optional watermark; and one `variants` entry per part in
+//! play. A variant names its `rId`, `kind`, `type`, optional `sectionIndex`,
+//! its own `measured` blocks in the body schema, its heights, and optional
+//! per-page `fieldWidths`.
+//!
+//! # Variant selection
+//!
+//! A page's own `headerFooterRefs` wins when present: the relationship id for
+//! the selected type resolves the variant directly, and a `first` selection
+//! that names no relationship leaves the band blank. Otherwise, by 1-based page
+//! number:
+//!
+//! 1. the section's first page (`sectionPageIndex == 0`) under `titlePg`
+//!    selects `first`. An absent `first` variant means a deliberately blank
+//!    band; it must not fall through to `default`.
+//! 2. an even page number under `evenAndOddHeaders` selects `even` when that
+//!    variant exists;
+//! 3. otherwise `default`.
+//!
+//! Where several variants match a (kind, type, section), the last one wins.
+//!
+//! # Band geometry
+//!
+//! The distance resolves as the envelope override, then the page's
+//! `margins.header` / `margins.footer`, then [`DEFAULT_HF_DISTANCE_PX`]. Both
+//! kinds take the interactive height `max(flowHeight - min(0, visualTop), 24)`.
+//! A header band sits at `distance + visualTop` and flows content from
+//! `distance`. A footer band is bottom-anchored: it sits at
+//! `pageHeight - distance - bandHeight`, flows content from
+//! `pageHeight - distance - max(visualBottom - visualTop, 24) - visualTop`, and
+//! anchors floating tables against `pageHeight - distance - height`. Content
+//! starts at `margins.left` horizontally in both cases.
+//!
+//! # Stacking inside a band
+//!
+//! A band-local cursor starts at zero. A paragraph paints at
+//! `cursor + spacing.before` as a single unsplit fragment and advances the
+//! cursor by its measured total height, which already accounts for its own
+//! spacing. An inline table paints whole at the cursor and advances by its
+//! total height; a `w:tblpPr` floating table paints at its resolved anchor and
+//! does not advance. An image paints at the cursor and advances by its measured
+//! height. Every other block kind emits nothing and leaves the cursor alone.
 
 use serde::Deserialize;
 
@@ -13,9 +69,10 @@ use crate::display_list::{Crop, ImagePrimitive};
 /// Word's default header/footer distance: 0.5 inches at 96 DPI.
 const DEFAULT_HF_DISTANCE_PX: f64 = 48.0;
 
-/// Minimum interactive band height.
+/// Minimum interactive band height, so a near-empty band stays clickable.
 const MIN_BAND_HEIGHT_PX: f64 = 24.0;
 
+/// The optional `headersFooters` envelope field.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HeadersFootersIn {
@@ -37,6 +94,9 @@ pub struct HeadersFootersIn {
     variants: Vec<HfVariantIn>,
 }
 
+/// One header/footer part, with the four heights the band geometry needs.
+/// `visualTop` and `visualBottom` describe the painted extent, which may sit
+/// outside the in-flow stack when content is negatively offset.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct HfVariantIn {
@@ -255,9 +315,11 @@ fn stacked_height(measured: &[MeasuredBlockIn]) -> f64 {
         .sum()
 }
 
-/// resolve both regions for one page. `page_number` follows the layout's own
-/// 1-based `Page.number` (fallback index+1), the value the DOM painter feeds
-/// its per-page selection and PAGE fields.
+/// Resolves both bands for one page.
+///
+/// `page_number` is the layout's own 1-based `Page.number` (falling back to
+/// `page_index + 1`) and drives both variant selection and PAGE field text, so
+/// it restarts wherever a section restarts numbering.
 pub(crate) fn compose_page_regions<'a>(
     hf: &HeadersFootersIn,
     page: &PageIn,
@@ -314,7 +376,11 @@ fn field_width_map(v: &HfVariantIn) -> Option<FieldWidthMap> {
     )
 }
 
-/// Resolves floating-table offsets relative to the band flow origin.
+/// Resolves a `w:tblpPr` anchor into offsets from the band's flow origin.
+///
+/// `page` and `margin` anchors are expressed against the page or the body
+/// margin box, so both are rebased onto the band; any other anchor is already
+/// band-relative. The caller adds the returned offsets to the region origin.
 fn resolve_hf_floating_table_position(
     floating: &FloatingTablePositionIn,
     page: &PageIn,
@@ -338,7 +404,7 @@ fn resolve_hf_floating_table_position(
     (left, top)
 }
 
-/// Composes one resolved header or footer region.
+/// Builds one band: geometry first, then the block stack, per the module rules.
 #[allow(clippy::too_many_arguments)]
 fn compose_region(
     v: &HfVariantIn,

--- a/crates/docx-layout/src/hit.rs
+++ b/crates/docx-layout/src/hit.rs
@@ -1,4 +1,43 @@
 //! Display-list hit testing and selection geometry.
+//!
+//! Two directions, both reading the display list alone and both working in
+//! page-local coordinates: a point resolves to a document position, and a
+//! document range resolves to highlight rectangles.
+//!
+//! A point is resolved in a fixed order. A direct hit inside a text or glyph
+//! primitive's box wins first (its vertical band is padded by
+//! [`BAND_SLACK`] so a click just above or below the glyphs still lands). Next
+//! comes a direct hit on an image that carries a document position, where the
+//! caret parks at its start. Failing both, the nearest line by vertical-centre
+//! distance is chosen, then the nearest primitive on that line — inside a run
+//! the position interpolates between caret stops, outside it snaps to the
+//! closer edge.
+//!
+//! A run's vertical band is derived from its font size: the top sits one font
+//! size above the baseline and the bottom a quarter of one below. A glyph run
+//! additionally takes its horizontal extent from the real glyph geometry —
+//! leftmost `x` to the trailing glyph's `x + advance` — so mixed-font lines do
+//! not drift. Combining marks sit above the baseline, so the largest glyph `y`
+//! is the base baseline.
+//!
+//! Caret stops are grapheme boundaries spread across the run's width for text
+//! primitives and shaped cluster bounds for glyph runs. In an RTL run visual
+//! order is inverted against logical order, so the physical left and right
+//! edges map to the logical end and start respectively.
+//!
+//! Two primitives share a visual line when they agree on the enclosing table
+//! and cell, on the paragraph's line index, and then on paragraph id, block key
+//! or block id — whichever identity is present. With no identity at all,
+//! adjacency of document positions decides.
+//!
+//! Region scoping matters because a page carries three independent documents.
+//! [`hit_test_regions`] tests the page's header and footer bands first (simple
+//! vertical containment against the band box) and resolves inside the winning
+//! band, returning the region kind and its `rId`; the position then addresses
+//! that header/footer document, never the body. [`range_rects_in_region`] is
+//! the selection-geometry twin, and [`range_rects`] the body-only wrapper. The
+//! same header/footer part paints on every page that uses it, so a scoped range
+//! query emits one rect set per such page, each stamped with its own page index.
 
 use crate::display_list::{DisplayList, DocAttrs, HfRegion, Primitive, TableCellRef};
 use serde::Serialize;
@@ -13,13 +52,15 @@ thread_local! {
     static LINE_OWNER_COMPARE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
-/// vertical slack when matching a pointer to a span's band, mirrors the ±4px
-/// tolerance in the DOM HF fallback resolver
+/// Vertical slack (px) added on each side of a run's band when testing a
+/// pointer, so a click in the leading still hits the line.
 const BAND_SLACK: f64 = 4.0;
 
-/// width of the selection sliver drawn for a blank line (BLANK_LINE_SELECTION_WIDTH_PX)
+/// Width (px) of the selection sliver drawn for a blank line, which has no
+/// glyphs of its own to highlight.
 const BLANK_LINE_SELECTION_WIDTH: f64 = 4.0;
 
+/// Tolerance (px) within which two band centres count as the same line.
 const LINE_CENTER_EPSILON: f64 = 0.5;
 
 /// parse the px size out of a CSS font shorthand ("700 16px Calibri, ...")
@@ -67,6 +108,8 @@ fn doc_position_at_utf16(doc_start: i64, doc_end: i64, utf16_offset: i64, utf16_
     }
 }
 
+/// Caret stops spread evenly across a run's width, one per grapheme boundary.
+/// In an RTL run the visual index counts down the logical boundaries.
 fn text_caret_stops(
     text: &str,
     x: f64,
@@ -109,6 +152,8 @@ fn text_caret_stops(
         .collect()
 }
 
+/// Caret stops taken from shaped cluster bounds, so ligatures and reordered
+/// clusters land on real boundaries rather than an even split.
 fn glyph_caret_stops(
     text: &str,
     glyphs: &[crate::display_list::PlacedGlyph],
@@ -306,6 +351,8 @@ where
     best.map(|(_, position)| position)
 }
 
+/// Whether two runs belong to the same visual line, checked from strongest to
+/// weakest identity and ending at document adjacency.
 fn same_line_owner(left: &TextHit<'_>, right: &TextHit<'_>) -> bool {
     #[cfg(test)]
     LINE_OWNER_COMPARE_COUNT.with(|count| count.set(count.get() + 1));
@@ -592,6 +639,7 @@ impl VerticalDirection {
     }
 }
 
+/// Where a vertical caret move lands, plus the sticky x it should keep.
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VerticalMove {
@@ -599,6 +647,15 @@ pub struct VerticalMove {
     pub goal_x: f64,
 }
 
+/// Moves the caret one visual line up or down, holding `goal_x` so a run of
+/// moves through short lines does not creep inwards.
+///
+/// Only the caret's page and its immediate neighbours are scanned, so a move
+/// can cross a page boundary without walking the whole document. Table cells
+/// are traversed cell-first: the next line in the same cell wins, lines in
+/// sibling cells of the same row are skipped over, and leaving the cell targets
+/// the nearest line of the adjoining row by `goal_x`. When no line lies in the
+/// requested direction the position is returned unchanged.
 pub fn vertical_move(
     dl: &DisplayList,
     position: i64,
@@ -628,18 +685,19 @@ pub fn vertical_move(
     })
 }
 
-/// Resolves a body position through direct, image, then nearest-line hits.
+/// Body-only point resolution, in the order described on the module.
+/// Region-aware callers use [`hit_test_regions`].
 pub fn hit_test(dl: &DisplayList, page_index: usize, x: f64, y: f64) -> Option<i64> {
     let page = dl.pages.get(page_index)?;
     resolve_point(&page.primitives, x, y)
 }
 
-/// the shared point resolver over one primitive list (a page body or one
-/// HF region — both use page coordinates)
+/// The shared point resolver over one primitive list — a page body or a single
+/// header/footer band, both of which use page coordinates.
 fn resolve_point(prims: &[Primitive], x: f64, y: f64) -> Option<i64> {
     let hits = text_hits(prims);
 
-    // 1. direct hit on a text primitive's box (paint order = DOM order)
+    // 1. direct hit on a text primitive's box, in paint order
     for h in &hits {
         if h.width <= 0.0 {
             continue;
@@ -689,11 +747,10 @@ fn resolve_point(prims: &[Primitive], x: f64, y: f64) -> Option<i64> {
     position_for_hits(line.iter().copied(), x)
 }
 
-/// region-aware hit result: which part of the page owns the point, and the
-/// resolved position inside that part's doc. For `header`/`footer` the
-/// position refers to the HF doc identified by `rId`, NOT the
-/// body doc (the caller must route the selection to that HF editor, the way
-/// `usePagesPointer` scopes clicks to `.layout-page-header|footer`).
+/// Which part of the page owns a point, and the position inside that part's
+/// document. For `header` / `footer` the position addresses the header/footer
+/// document identified by `rId`, never the body document, so the caller must
+/// route the resulting selection to that editor.
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RegionHit {
@@ -725,12 +782,13 @@ pub(crate) fn parse_region(region: &str) -> Result<HitRegion, String> {
     }
 }
 
-/// a point inside an HF band's box resolves within that band (`pos` may be
-/// None when the band has no positioned content — the region identification
-/// alone is what routes the click into HF editing); everything else falls
-/// through to the body resolver. Band membership is the vertical
-/// `[y, y+height]` test on the region's box, the display-list analogue of the
-/// painted `.layout-page-header` / `.layout-page-footer` hosts.
+/// Resolves a point against the page's header and footer bands before falling
+/// through to the body.
+///
+/// Band membership is the vertical `[y, y + height]` test on the region's box.
+/// A point inside a band always identifies that region even when `pos` is
+/// `None` — an empty band still owns the click, and the region alone is what
+/// routes editing into that header or footer.
 pub fn hit_test_regions(dl: &DisplayList, page_index: usize, x: f64, y: f64) -> Option<RegionHit> {
     let page = dl.pages.get(page_index)?;
 
@@ -852,6 +910,9 @@ pub fn range_rects(dl: &DisplayList, from: i64, to: i64) -> Vec<RangeRect> {
     range_rects_in_region(dl, HitRegion::Body, None, from, to)
 }
 
+/// Caret box for a body-document position: the first primitive on the earliest
+/// page whose half-open range covers it, or that is an empty run sitting
+/// exactly at it.
 pub fn caret_rect(dl: &DisplayList, pos: i64) -> Option<CaretRect> {
     for (page_index, page) in dl.pages.iter().enumerate() {
         if let Some(hit) = page.primitives.iter().find_map(|primitive| {
@@ -922,22 +983,19 @@ pub fn caret_rect(dl: &DisplayList, pos: i64) -> Option<CaretRect> {
     None
 }
 
-/// highlight rectangles for a document range resolved inside a specific page region —
-/// the selection-geometry twin of [`hit_test_regions`]'s scoping.
+/// Highlight rectangles for a document range inside one page region — the
+/// selection-geometry twin of [`hit_test_regions`]'s scoping.
 ///
-/// For [`HitRegion::Body`] this is exactly [`range_rects`] (`r_id` is ignored —
-/// the body has one doc). For [`HitRegion::Header`] / [`HitRegion::Footer`]
-/// the `from`/`to` refer to the header/footer doc identified by
-/// `r_id`, so only bands whose `rId` matches are consulted — the display-list
-/// analogue of scoping selection to `.layout-page-header` /
-/// `.layout-page-footer` for the active HF part. The SAME HF doc is painted on
-/// every page carrying the part, so a match emits one rect-set per such page
-/// (each stamped with its own `page_index`); the caller renders the page it is
-/// editing, exactly as the DOM HF overlay picks the nearest painted host.
+/// [`HitRegion::Body`] behaves exactly like [`range_rects`] and ignores `r_id`,
+/// since the body is a single document. For [`HitRegion::Header`] and
+/// [`HitRegion::Footer`], `from` and `to` address the header/footer document
+/// named by `r_id`, and only bands whose `rId` matches contribute. Because that
+/// part paints on every page using it, a match yields one rect set per such
+/// page, each stamped with its own `page_index`.
 ///
-/// `r_id = None` matches any band of the region kind — reserved for callers that
-/// don't disambiguate variants; passing the active part's rId is preferred so a
-/// first-page vs default variant on another page never contributes stray rects.
+/// `r_id = None` matches any band of the kind. Passing the active part's `rId`
+/// is preferred, so a first-page variant on another page cannot contribute
+/// stray rectangles.
 pub fn range_rects_in_region(
     dl: &DisplayList,
     region: HitRegion,

--- a/crates/docx-layout/src/hooks.rs
+++ b/crates/docx-layout/src/hooks.rs
@@ -1,4 +1,10 @@
-//! Pagination feature hooks.
+//! Feature seams the placement walk calls for per-block pagination decisions.
+//!
+//! Break policy, keep-with-next, section breaks and column balancing delegate
+//! to their owning modules; table placement lives here because it is driven
+//! entirely by paginator state. Every entry point returns a `Result` so a
+//! feature the engine cannot paginate surfaces `LayoutError::Unsupported` to
+//! the caller rather than producing wrong geometry.
 
 use crate::LayoutError;
 use crate::page_flow::Paginator;
@@ -68,6 +74,8 @@ pub fn balance_terminal_continuous_text_columns(
     Ok(())
 }
 
+/// Length of the leading run of `w:tblHeader` rows, the band that repeats on
+/// continuation fragments. Header rows after a non-header row do not count.
 fn tally_header_rows(block: &TableBlock) -> usize {
     let mut count = 0usize;
     for row in &block.rows {
@@ -80,6 +88,7 @@ fn tally_header_rows(block: &TableBlock) -> usize {
     count
 }
 
+/// Vertical cost a continuation fragment pays to repeat the header band.
 fn get_header_rows_height(measure: &TableExtent, header_row_count: usize) -> f64 {
     let mut height = 0.0f64;
     let mut i = 0usize;
@@ -90,7 +99,21 @@ fn get_header_rows_height(measure: &TableExtent, header_row_count: usize) -> f64
     height
 }
 
-/// Places table rows, splitting at the deepest whole-line boundary that fits.
+/// Places an in-flow table, emitting one fragment per page or column it spans.
+///
+/// The cursor is `(row_index, consumed)`, where `consumed` is how many pixels
+/// of `row_index` a previous fragment already placed. Rows go in order; a row
+/// that overruns the remaining space breaks at the deepest whole-line boundary
+/// that fits (Word's "allow row to break across pages"), which keeps the row's
+/// other columns on the page where they start and lets a tall vertically merged
+/// cell flow across the boundary. `w:cantSplit` rows (§17.4.6) never break
+/// unless they cannot fit a whole column even alone. A fresh fragment where not
+/// one line fits places the row's remainder with overflow instead of looping.
+///
+/// A continuation fragment repeats the leading header band, but only when the
+/// band plus the smallest legal body slice still fits the column; otherwise it
+/// pays no header overhead. Deferred spacing from the preceding block is
+/// consumed by the first fragment only.
 pub fn layout_table(
     block: &TableBlock,
     measure: &TableExtent,
@@ -294,6 +317,16 @@ pub fn layout_table(
     Ok(())
 }
 
+/// Places a `w:tblpPr` table as an overlay that normally leaves the pen alone.
+///
+/// A table taller than one column cannot float and falls back to
+/// [`layout_table`]. Otherwise `w:horzAnchor` / `w:vertAnchor` pick the
+/// page, margin or text band, an explicit `w:tblpX` / `w:tblpY` offsets from
+/// that band's start, and an alignment spec resolves against it — `inside` and
+/// `outside` flip with page parity. Only when the wrap gutters on both sides of
+/// the table fall below the minimum wrap segment (24px) does the pen advance
+/// past the table plus its `w:bottomFromText` distance, since no line could
+/// wrap beside it.
 pub fn layout_floating_table(
     block: &TableBlock,
     measure: &TableExtent,

--- a/crates/docx-layout/src/keep_together.rs
+++ b/crates/docx-layout/src/keep_together.rs
@@ -1,4 +1,20 @@
-//! Keep-with-next grouping and measurement.
+//! Keep-with-next grouping (`w:keepNext`, ECMA-376 §17.3.1.15).
+//!
+//! A run of consecutive keepNext paragraphs must share a page with the *start*
+//! of whatever follows it. [`analyze_keep_with_next`] walks the measured blocks
+//! once and returns each run keyed by its head, plus the interior members, so
+//! the placement walk can skip blocks a group already accounted for.
+//!
+//! [`measure_keep_with_next_group`] turns a group into the height the contract
+//! actually demands: every member paragraph in full (spacing before, measured
+//! height, spacing after) plus one witness slice of the follower — never the
+//! follower in full, since the binding is only to where it begins. The witness
+//! is a paragraph's first line, a table's first row, the whole height of an
+//! image or text box, and nothing at all for any other follower kind.
+//!
+//! Spacing is read through the shared paragraph-spacing helpers, which suppress
+//! style-inherited spacing on empty paragraphs, so a chain of blank paragraphs
+//! does not inflate the budget with spacing that never paints.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -19,7 +35,9 @@ pub struct KeepWithNextGroup {
     pub follower: Option<usize>,
 }
 
-/// Group lookup and ascending interior membership indexes.
+/// The two indexes placement needs: groups by head block, and every non-head
+/// member so the walk does not re-evaluate them. Both iterate in ascending
+/// block order.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct KeepWithNextScan {
     /// Groups keyed by their leading block index.
@@ -102,7 +120,8 @@ pub fn analyze_keep_with_next(measured: &[MeasuredBlock]) -> KeepWithNextScan {
     }
 }
 
-/// Returns the group height plus its follower's first unbreakable slice.
+/// Vertical space (px) the group needs for its keepNext contract to hold on a
+/// single page: the members in full plus the follower's witness slice.
 pub fn measure_keep_with_next_group(group: &KeepWithNextGroup, measured: &[MeasuredBlock]) -> f64 {
     // follower's witness line first: zero when there is no follower, or when
     // it is not a laid-out paragraph

--- a/crates/docx-layout/src/lib.rs
+++ b/crates/docx-layout/src/lib.rs
@@ -28,6 +28,34 @@
 )]
 
 //! DOCX pagination and display-list construction.
+//!
+//! Two stages, in order:
+//!
+//! 1. **Pagination** — [`compute_layout`] takes `{ measured, options }` and
+//!    walks the measured blocks into a [`types::Layout`]: pages of positioned
+//!    fragments, with spacing collapse, page and column splits, section
+//!    geometry, floats and per-page footnote reservations resolved. The
+//!    walk lives in [`place`], the cursor in [`page_flow`], and the per-feature
+//!    decisions in [`hooks`].
+//! 2. **Display compilation** — the `build_display_list*` family turns a
+//!    finished `Layout` plus the same measured input into a
+//!    [`display_list::DisplayList`]: renderer-agnostic paint primitives per
+//!    page, each carrying the document positions and block identity that
+//!    interaction needs. Compilation only ever reads a `Layout`; the paginator
+//!    never builds primitives itself.
+//!
+//! [`hit`] answers point and range queries over a finished display list, and
+//! [`session`] does the same by handle so an interactive path parses the list
+//! once instead of per event.
+//!
+//! An input engaging a feature the engine does not cover raises
+//! [`LayoutError::Unsupported`], which crosses the JSON boundary as the string
+//! `"UNSUPPORTED"` so the host can fall back rather than paint wrong geometry.
+//!
+//! This crate is the workspace's only `wasm_bindgen` site, so the `ooxml-text`
+//! measurement surface is re-exported here as well and the wasm-visible font
+//! registry lives in this file. Everything below the wrappers is pure and
+//! native-testable.
 
 pub mod canonical;
 pub mod hooks;
@@ -119,7 +147,9 @@ pub fn build_display_list(
     build_display_list_value_from_resident(pagination, layout, "{}")
 }
 
-/// Converts a JSON layout request into JSON layout output.
+/// `{ measured, options }` JSON in, `Layout` JSON out. An `Err` of
+/// `"UNSUPPORTED"` means the input needs a host fallback; any other `Err`
+/// describes a malformed envelope.
 pub fn layout_to_json(input: &str) -> Result<String, String> {
     let layout = compute_layout(input).map_err(|e| match e {
         LayoutError::Unsupported(_) => "UNSUPPORTED".to_string(),
@@ -148,7 +178,10 @@ pub fn layout_document_json(input: &str) -> Result<String, JsValue> {
     layout_to_json(input).map_err(|e| JsValue::from_str(&e))
 }
 
-/// Builds a display list using the module-global measurement fonts.
+/// Builds a display list from a `{ measured, options, layout }` JSON envelope,
+/// threading the module-global measurement fonts. With fonts registered, runs
+/// whose font chains resolve are shaped into glyph runs; with none registered
+/// every run stays a text primitive.
 pub fn build_display_list_value(input: &str) -> Result<display_list::DisplayList, String> {
     MEASURE_FONTS
         .with(|store| display_list::build_display_list_value_with_fonts(input, &store.borrow()))
@@ -359,7 +392,7 @@ pub fn range_rects_json(display_list: &str, from: f64, to: f64) -> Result<String
 /// wasm wrapper over [`hit::range_rects_region_json`]: region-aware range rects.
 /// `region` is `"body" | "header" | "footer"`; `r_id` scopes a header/footer to
 /// one HF part (empty for body / match-any). The `from`/`to` refer to that
-/// region's doc. The legacy `range_rects_json` export stays body-only.
+/// region's doc. The plain `range_rects_json` export stays body-only.
 #[wasm_bindgen]
 pub fn range_rects_region_json(
     display_list: &str,
@@ -374,7 +407,7 @@ pub fn range_rects_region_json(
 
 /// wasm wrapper over [`hit::hit_test_regions_json`]: region-aware hit test —
 /// `{"region":"body"|"header"|"footer","rId"?,"pos":n|null}` (or `"null"` for
-/// an out-of-range page). The legacy `hit_test_json` export stays body-only.
+/// an out-of-range page). The plain `hit_test_json` export stays body-only.
 #[wasm_bindgen]
 pub fn hit_test_regions_json(
     display_list: &str,

--- a/crates/docx-layout/src/page_flow.rs
+++ b/crates/docx-layout/src/page_flow.rs
@@ -1,4 +1,31 @@
-//! Page and column flow state.
+//! Page and column flow state: where the pen is, what room is left, and when
+//! to open the next column or page.
+//!
+//! [`Paginator`] owns the growing `pages` output and one [`FlowState`] per page
+//! created; the last state is the current one. No page exists until something
+//! asks for the current state, so an empty document produces no pages. Page
+//! numbers run `start_page_number + pages.len()`.
+//!
+//! Vertical room is `content_limit - pen_y`. `content_limit` is the content
+//! bottom already reduced by the page's footnote reservation, so reserved note
+//! space is simply invisible to body flow. [`Paginator::ensure_fits`] walks to
+//! the next column, then the next page, until the height fits; a fragment
+//! taller than a whole column is placed with overflow — after moving off a
+//! partly used column — rather than looping forever.
+//!
+//! Word collapses adjacent vertical spacing to the larger of the two instead of
+//! summing, so [`Paginator::add_fragment`] takes `max(space_before,
+//! deferred_spacing)` and leaves `space_after` deferred for the next fragment.
+//! The deferred value is read before fitting can advance the state, and a new
+//! page or column resets it to zero, which is what lets an explicit `w:before`
+//! still apply at the top of a page.
+//!
+//! Columns live in a *region* starting at `column_region_top`. A new page
+//! resets that to the content top; [`Paginator::update_columns`] sets it to the
+//! current pen and returns to column zero, so a continuous section break stacks
+//! its new column band below content already on the page. Page geometry a
+//! continuous break defers is held as pending and applied when the next page is
+//! created.
 
 use crate::LayoutError;
 use crate::types::{ColumnLayout, Fragment, Page, PageMargins, Size};
@@ -32,6 +59,7 @@ pub struct FlowState {
     pub deferred_spacing: f64,
 }
 
+/// Splits the content width evenly after subtracting the inter-column gaps.
 fn calculate_column_width(
     page_width: f64,
     left_margin: f64,
@@ -43,6 +71,7 @@ fn calculate_column_width(
     (content_width - total_gaps) / columns.count
 }
 
+/// The page/column cursor and the pages it has produced so far.
 pub struct Paginator {
     pub pages: Vec<Page>,
     states: Vec<FlowState>,
@@ -174,6 +203,8 @@ impl Paginator {
         self.margins.left + column_index as f64 * (self.column_width + self.columns.gap)
     }
 
+    /// Opens the next page, promoting any deferred geometry first, and returns
+    /// its state index.
     fn create_new_page(&mut self) -> usize {
         // apply any geometry queued by a continuous section break before
         // computing the new page's size / margins
@@ -290,6 +321,8 @@ impl Paginator {
         self.available_height_of(idx) >= height
     }
 
+    /// Moves to the next column of the current region, or opens a new page once
+    /// the region's columns are spent.
     fn advance_column(&mut self, idx: usize) -> usize {
         if (self.states[idx].column_index as f64) < self.columns.count - 1.0 {
             let region_top = self.column_region_top;
@@ -327,7 +360,8 @@ impl Paginator {
         idx
     }
 
-    /// Places a fragment at the cursor and collapses adjacent spacing.
+    /// Places a fragment at the cursor, collapsing adjacent spacing, and
+    /// returns its resolved `(x, y)`.
     pub fn add_fragment(
         &mut self,
         mut fragment: Fragment,
@@ -379,6 +413,7 @@ impl Paginator {
         self.create_new_page()
     }
 
+    /// Moves to the next column, or the next page from the last column.
     pub fn force_column_break(&mut self) -> usize {
         let idx = self.get_current();
         self.advance_column(idx)

--- a/crates/docx-layout/src/place.rs
+++ b/crates/docx-layout/src/place.rs
@@ -1,4 +1,33 @@
-//! Placement of measured blocks into pages and columns.
+//! The placement walk: measured blocks in, pages of positioned fragments out.
+//!
+//! One pass over the measured list, a per-kind placer for each block, the
+//! paginator holding page and column state, and every look-ahead answered from
+//! the prescan plan rather than by re-scanning. Contextual spacing
+//! (`w:contextualSpacing`, ECMA-376 §17.3.1.9) is folded into adjacent
+//! same-style paragraphs before the walk starts, recursing through table cells.
+//!
+//! Each block is processed in a fixed order: record a checkpoint if placement
+//! stands at a pristine page start; force a page when the block carries
+//! `w:pageBreakBefore`; at the head of a keep-with-next group, force a page when
+//! the group would otherwise straddle the boundary; then dispatch to the placer.
+//! A section break reads the *next* section's configuration and break type,
+//! falling back to the current break's when the plan has no successor. Column
+//! balancing runs over the range up to the next section break, both at the start
+//! of the document and after each break that opens multi-column geometry.
+//!
+//! Unknown block and run kinds raise `Unsupported` rather than being silently
+//! dropped, and a measure whose kind disagrees with its block raises `Invalid`.
+//!
+//! Anchored images and floating text boxes overlay the page and never move the
+//! pen; inline images, shapes, charts and inline text boxes consume their
+//! measured bbox in flow. Paragraph placement is described on
+//! [`layout_paragraph`].
+//!
+//! Checkpoints are resume bookmarks at pristine page starts. They stay resident
+//! and never appear in a serialized `Layout`. [`layout_document_incremental`]
+//! restarts from the last checkpoint before the edit and stops as soon as
+//! page-start geometry and the measured suffix converge with the retained
+//! layout, so an edit late in a document does not re-place everything above it.
 
 use crate::LayoutError;
 use crate::hooks;
@@ -92,6 +121,13 @@ fn run_boundary_pm_pos(run: Option<&Run>, char_offset: usize, edge: Edge) -> Opt
     run.pm_start()
 }
 
+/// Document range covered by lines `[from_line, to_line)`.
+///
+/// The paragraph's own bounds win at its true first and last line, so a
+/// single-fragment paragraph keeps the range it declared; interior fragment
+/// edges come from the head and tail runs of their boundary lines. Any edge
+/// that stays unresolved falls back to the paragraph, and an end that would not
+/// exceed its start is nudged forward by one so the range is never empty.
 fn get_paragraph_fragment_pm_range(
     block: &ParagraphBlock,
     measure: &ParagraphExtent,
@@ -146,6 +182,8 @@ fn is_floating_wrap_type(wrap_type: Option<&str>) -> bool {
     )
 }
 
+/// A text box floats when it declares float display, a floating wrap type, or
+/// `topAndBottom` wrapping.
 fn is_floating_text_box_block(block: &TextBoxBlock) -> bool {
     block.display_mode.as_deref() == Some("float")
         || is_floating_wrap_type(block.wrap_type.as_deref())
@@ -217,7 +255,7 @@ fn apply_contextual_spacing_measured(measured: &mut [MeasuredBlock]) {
     }
 }
 
-/// Converts measured blocks into positioned pages.
+/// Converts measured blocks into positioned pages, discarding checkpoints.
 pub fn layout_document(input: &mut Input) -> Result<Layout, LayoutError> {
     Ok(layout_document_checkpointed(input)?.layout)
 }
@@ -445,6 +483,9 @@ struct PlacementOutcome {
     converged: Option<(LayoutCheckpoint, LayoutCheckpoint)>,
 }
 
+/// The block walk itself, per the module's ordering rules. Returns early once
+/// a checkpoint matches the retained layout, which is how incremental placement
+/// detects convergence.
 fn place(
     measured: &[MeasuredBlock],
     plan: &LayoutPlan,
@@ -741,7 +782,25 @@ fn build_resolved_lines(
     resolved
 }
 
-/// Places measured paragraph lines across pages and columns.
+/// Places a paragraph's measured lines, splitting into carried fragments
+/// whenever the page or column runs out of room.
+///
+/// Lines are fitted greedily, and a fragment always takes at least one line so
+/// an oversized line cannot stall the walk. A line's `floatSkipBefore` counts
+/// toward the fragment height, which is what makes following blocks flow below
+/// the float instead of over it. A paragraph with no measured lines still emits
+/// a zero-height fragment, because its spacing must still advance the pen.
+///
+/// Two rules can move lines before they are placed. `w:keepLines` advances to a
+/// fresh column when the whole paragraph fits a column but not the space left
+/// here. Widow and orphan control applies to paragraphs of at least four lines:
+/// a lone opening line moves the paragraph on when two lines would fit there,
+/// and a lone trailing line is avoided by pushing one more line down, provided
+/// the fragment keeps more than two.
+///
+/// Spacing before is charged to the first fragment only and spacing after to
+/// the last, and each fragment carries its own document range and resolved run
+/// slices.
 fn layout_paragraph(
     block: &ParagraphBlock,
     measure: &ParagraphExtent,
@@ -935,9 +994,7 @@ fn layout_image(block: &ImageBlock, measure: &ImageExtent, paginator: &mut Pagin
     paginator.add_fragment(fragment, measure.height, 0.0, 0.0);
 }
 
-/// Common DrawingML shapes consume their measured bbox in normal flow. The
-/// bridge currently emits the host path's in-flow shape contract; exotic anchor
-/// scenes remain eligible for the host fallback before they reach pagination.
+/// Places a DrawingML shape by consuming its measured bbox in normal flow.
 fn layout_shape(block: &ShapeBlock, measure: &ShapeExtent, paginator: &mut Paginator) {
     let state_idx = paginator.ensure_fits(measure.height);
     let column_index = paginator.state(state_idx).column_index;
@@ -977,6 +1034,13 @@ fn layout_chart(block: &ChartBlock, measure: &ChartExtent, paginator: &mut Pagin
     paginator.add_fragment(fragment, measure.height, 0.0, 0.0);
 }
 
+/// Resolves a DrawingML anchor to a page-coordinate origin.
+///
+/// A simple position is taken verbatim. Otherwise each axis picks a band from
+/// its `relativeFrom` — page, margin box, an individual margin strip, or the
+/// current column horizontally and the flow region vertically — and then
+/// applies either an explicit offset or an alignment within that band. The
+/// `insideMargin` and `outsideMargin` bands swap sides with page parity.
 fn resolve_object_position(
     position: Option<&ImageRunPosition>,
     width: f64,
@@ -1053,7 +1117,8 @@ fn resolve_object_position(
     )
 }
 
-/// Places an anchored image without moving the flow position.
+/// Places an anchored image at its resolved anchor without moving the pen.
+/// `behindDoc` decides whether it paints under or over body content.
 fn layout_anchored_image(block: &ImageBlock, measure: &ImageExtent, paginator: &mut Paginator) {
     let anchor = block.anchor.as_ref().expect("anchored image has anchor");
 

--- a/crates/docx-layout/src/section_breaks.rs
+++ b/crates/docx-layout/src/section_breaks.rs
@@ -1,4 +1,31 @@
 //! Section geometry across section breaks.
+//!
+//! ECMA-376 §17.6.22: a section break's `w:type` says how the *next* section
+//! starts relative to this one, and an absent `w:type` means `nextPage`.
+//! [`handle_section_break`] is the entry point the placement walk uses; it
+//! drives the paginator directly:
+//!
+//! - `nextPage` applies the next section's page size and margins immediately,
+//!   then forces a page.
+//! - `evenPage` / `oddPage` do the same and then insert one blank page if the
+//!   forced break landed on the wrong parity.
+//! - `continuous` keeps the current sheet and defers the new geometry to the
+//!   next natural page break — unless the page size changes, which Word and
+//!   LibreOffice promote to a page break because two page sizes cannot share
+//!   one physical sheet. Sizes are compared after rounding.
+//!
+//! Column layout is applied for every break kind, defaulting to a single
+//! full-width column when the section declares none.
+//!
+//! The tracker half ([`SectionLayoutTracker`] and the `apply` / `promote` /
+//! `resolve_next_*` functions) models the same rules as a two-stage schedule:
+//! a break writes into `queued`, and a page or region boundary folds `queued`
+//! onto `in_force`. Every queued field is optional, and an omitted field
+//! inherits the in-force value at the boundary — that is how a `w:sectPr` that
+//! overrides only some geometry keeps the rest.
+//!
+//! Rounding uses ties-toward-`+∞` and NaN-propagating maximum so the values
+//! reaching the canonical JSON match the host's numeric semantics.
 #![allow(dead_code)]
 
 use crate::LayoutError;
@@ -13,7 +40,8 @@ const SINGLE_COLUMN: ColumnLayout = ColumnLayout {
     columns: None,
 };
 
-/// Margin fields scheduled by a section break.
+/// Margin fields scheduled by a section break. `None` means "not scheduled",
+/// so the in-force value carries forward at the boundary.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct PartialPageMargins {
     pub top: Option<f64>,
@@ -42,7 +70,7 @@ pub struct QueuedGeometry {
     pub orientation: Option<String>,
 }
 
-/// In-force and queued section geometry.
+/// Geometry the current page uses, plus what the next boundary will adopt.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SectionLayoutTracker {
     pub in_force: SectionGeometry,
@@ -167,7 +195,13 @@ pub fn create_section_layout_tracker(
     }
 }
 
-/// Schedules section geometry and returns the required pagination action.
+/// Schedules a break's geometry and reports what the paginator must do now.
+///
+/// The tracker is never mutated in place, so a caller can discard the result.
+/// `nextPage` / `evenPage` / `oddPage` always break and queue their columns.
+/// A `continuous` break opens a new column region on the current page only
+/// when its column count or gap differs from the columns in force; a section
+/// declaring no columns resolves to a single full-width column.
 pub fn apply_section_break(
     block: &SectionBreakBlock,
     tracker: &SectionLayoutTracker,
@@ -296,7 +330,8 @@ pub fn resolve_next_columns(tracker: &SectionLayoutTracker) -> ColumnLayout {
 // One inch at 96 DPI.
 const DEFAULT_MARGIN_PX: f64 = 96.0;
 
-/// Resolves body and header/footer margins.
+/// Fills missing body margins with one inch and defaults the header/footer
+/// distances to the resolved top/bottom body margins.
 pub fn resolve_page_margins(requested: Option<&PageMargins>) -> PageMargins {
     let top = requested.map_or(DEFAULT_MARGIN_PX, |m| m.top);
     let right = requested.map_or(DEFAULT_MARGIN_PX, |m| m.right);
@@ -312,7 +347,11 @@ pub fn resolve_page_margins(requested: Option<&PageMargins>) -> PageMargins {
     }
 }
 
-/// Applies a section break to the paginator.
+/// Drives the paginator through a section break, per the module rules.
+///
+/// `next_section_config` and `next_section_type` describe the section being
+/// entered, not the one ending; the block itself carries no geometry the
+/// paginator needs at this point.
 pub fn handle_section_break<P: SectionBreakPaginator>(
     _block: &SectionBreakBlock,
     paginator: &mut P,

--- a/crates/docx-layout/src/table_grid.rs
+++ b/crates/docx-layout/src/table_grid.rs
@@ -1,4 +1,29 @@
-//! DOCX table-grid geometry and width resolution.
+//! DOCX table-grid geometry and column-width resolution.
+//!
+//! [`resolve_cell_grid`] is the single source of truth for which grid column a
+//! cell occupies: measurement, painting and the row-break paginator all read it,
+//! so they cannot disagree. It is deliberately width-free — callers multiply a
+//! column index by their own (possibly scaled) widths.
+//!
+//! Column widths come from one of three algorithms, chosen by
+//! `w:tblLayout`/the block's width algorithm:
+//!
+//! - **fixed** — normalize the declared grid, then raise columns so the first
+//!   row's preferred cell widths fit, sharing a spanning cell's deficit evenly
+//!   across the columns it covers, and finally grow to any explicit table
+//!   width.
+//! - **autofit** — accumulate per-column minimum and maximum content widths
+//!   from every cell (`w:noWrap` pins the minimum to the maximum), target
+//!   `max(minTotal, min(contentWidth, explicitOrMaxTotal))`, and hand out the
+//!   room above the minimums in proportion to each column's flex
+//!   (`max - min`); with no flex anywhere the target is spread evenly.
+//! - otherwise — normalize the declared grid and uniformly scale it to an
+//!   explicit table width when the two differ by more than a pixel.
+//!
+//! A width pair resolves through the preferred-width element, then the flat
+//! value/type pair, then a raw pixel width. `pct` units are 50ths of a percent
+//! (ECMA-376 §17.18.111, so 5000 means 100%); `dxa`, `auto` and an absent type
+//! are twips at 96 DPI. Zero, negative and NaN widths never resolve.
 
 use std::collections::{HashMap, HashSet};
 
@@ -52,12 +77,13 @@ pub struct ResolvedGridCell {
     pub row_span: usize,
 }
 
-/// Resolve every cell's grid column index, accounting for `colSpan` and the
-/// columns occupied by vertically-merged (`rowSpan`) cells from earlier rows.
+/// Resolve every cell's grid column index.
 ///
-/// Single source of truth for table grid geometry — width-free on purpose:
-/// callers multiply `column_index` by their own (possibly scaled) column
-/// widths to get an x offset.
+/// A row starts at its `w:gridBefore` offset and skips any column a
+/// vertically-merged cell from an earlier row still occupies; each cell then
+/// claims `w:gridSpan` columns, or starts at its explicit grid position when
+/// one is given. Spans are truncated and clamped (columns to 16384 rows to
+/// 32768), so malformed input cannot blow up the grid.
 pub fn resolve_cell_grid(table_block: &TableBlock) -> Vec<ResolvedGridCell> {
     let mut occupied: HashMap<usize, HashSet<usize>> = HashMap::new();
     let mut out: Vec<ResolvedGridCell> = Vec::new();
@@ -103,7 +129,8 @@ pub fn resolve_cell_grid(table_block: &TableBlock) -> Vec<ResolvedGridCell> {
     out
 }
 
-/// Total grid columns, derived from the widest row's accumulated colSpans.
+/// Total grid columns: the furthest column any cell reaches, and every row's
+/// own end plus its `w:gridAfter` skip.
 pub fn count_table_columns(table_block: &TableBlock) -> usize {
     let resolved = resolve_cell_grid(table_block);
     let mut count = 1usize;
@@ -121,6 +148,8 @@ pub fn count_table_columns(table_block: &TableBlock) -> usize {
     count.min(16_384)
 }
 
+/// Resolves a width through the preferred element, then the flat value/type
+/// pair, then a raw pixel width.
 fn preferred_width_px(
     preferred: Option<&crate::types::PreferredWidth>,
     legacy_value: Option<f64>,
@@ -136,6 +165,8 @@ fn preferred_width_px(
         .or_else(|| legacy_px.filter(|value| *value > 0.0))
 }
 
+/// Raises a span's columns until they total `required`, sharing the shortfall
+/// evenly. Columns already wide enough are left alone.
 fn add_span_constraint(widths: &mut [f64], start: usize, span: usize, required: f64) {
     if !(required > 0.0) || start >= widths.len() {
         return;
@@ -152,6 +183,7 @@ fn add_span_constraint(widths: &mut [f64], start: usize, span: usize, required: 
     }
 }
 
+/// Grows every column equally up to `target`. Never shrinks.
 fn distribute_to_target(mut widths: Vec<f64>, target: f64) -> Vec<f64> {
     let current: f64 = widths.iter().sum();
     if target > current && !widths.is_empty() {
@@ -163,6 +195,7 @@ fn distribute_to_target(mut widths: Vec<f64>, target: f64) -> Vec<f64> {
     widths
 }
 
+/// Fixed layout: only the first row's cells constrain the grid.
 fn resolve_fixed_column_widths(
     table_block: &TableBlock,
     content_width: f64,
@@ -206,6 +239,8 @@ fn resolve_fixed_column_widths(
     })
 }
 
+/// Autofit layout: every cell contributes a minimum and a maximum, and the
+/// slack between them is what the target width is distributed across.
 fn resolve_autofit_column_widths(
     table_block: &TableBlock,
     content_width: f64,
@@ -367,7 +402,8 @@ pub fn normalize_table_column_widths(
         .collect()
 }
 
-/// Resolves table column widths without measuring cell content.
+/// Resolves per-column pixel widths from the table's grid metadata and width
+/// budget, per the module's three algorithms. Measures no cell content.
 pub fn resolve_table_column_widths(table_block: &TableBlock, content_width: f64) -> Vec<f64> {
     let mut column_widths: Vec<f64> = table_block.column_widths.clone().unwrap_or_default();
     let explicit_width_px = preferred_width_px(
@@ -420,7 +456,8 @@ pub fn resolve_table_column_widths(table_block: &TableBlock, content_width: f64)
     column_widths
 }
 
-/// Resolves total table width from columns, explicit width, or content width.
+/// Total pixel width: the resolved columns, else the explicit table width,
+/// else the whole content-width budget.
 pub fn resolve_table_total_width_px(table_block: &TableBlock, content_width: f64) -> f64 {
     let column_widths = resolve_table_column_widths(table_block, content_width);
     let explicit_width_px = preferred_width_px(

--- a/crates/docx-layout/src/table_row_break.rs
+++ b/crates/docx-layout/src/table_row_break.rs
@@ -83,8 +83,8 @@ pub fn build_table_row_break_info(block: &TableBlock, measure: &TableExtent) -> 
     }
     row_tops.push(acc);
 
-    // Use the shared grid resolution so "which cells cover row r" matches the
-    // measurer and painter. A cell starting in row `sr` with rowSpan covers
+    // Use the shared grid resolution so "which cells cover row r" agrees with
+    // measurement and paint. A cell starting in row `sr` with rowSpan covers
     // rows [sr, sr + rowSpan); a merged cell spills its line bottoms into the
     // rows below its restart row.
     let resolved = resolve_cell_grid(block);

--- a/crates/docx-layout/src/types.rs
+++ b/crates/docx-layout/src/types.rs
@@ -1,4 +1,26 @@
-//! Pagination and display-list data contracts.
+//! The data contracts pagination reads and writes.
+//!
+//! Three families live here. *Blocks* ([`LayoutBlock`]) describe document
+//! content; *extents* ([`BlockExtent`]) are the measurement results paired with
+//! them in a [`MeasuredBlock`]; *fragments* ([`Fragment`]) and [`Page`] are what
+//! placement produces. [`Input`] is the `{ measured, options }` envelope; the
+//! result is a [`Layout`].
+//!
+//! Serialization conventions hold across the whole module and are load-bearing
+//! for the JSON boundary: every field is camelCase, an absent `Option` is
+//! omitted rather than emitted as null, and unknown incoming fields are
+//! ignored so a producer may send more than pagination reads. An unrecognized
+//! `kind` tag on a block, run or extent deserializes to that union's
+//! `Unsupported` variant, which lets the engine refuse a document deliberately
+//! instead of failing to parse it.
+//!
+//! Fields pagination never inspects — revision markers, content-control
+//! payloads, chart models, DrawingML scene data — are typed as
+//! [`serde_json::Value`] so they survive a round trip untouched.
+//!
+//! Numeric fields are `f64` even where a count would do, because the values
+//! arrive from and return to a JavaScript host that has a single number type,
+//! and intermediate arithmetic must agree with it.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -8,6 +30,7 @@ use std::collections::BTreeMap;
 // shared scalars
 // ---------------------------------------------------------------------------
 
+/// A block's identity, numeric or string, passed through to fragments verbatim.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockId {
@@ -22,6 +45,8 @@ pub struct Size {
     pub h: f64,
 }
 
+/// Body margins, plus the `w:header` / `w:footer` band distances. Only the two
+/// distances are optional.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PageMargins {
     pub top: f64,
@@ -43,6 +68,7 @@ pub struct ColumnDefinition {
     pub space: Option<f64>,
 }
 
+/// `w:cols`. `count` is `f64` because column width divides by it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ColumnLayout {
@@ -56,6 +82,7 @@ pub struct ColumnLayout {
     pub columns: Option<Vec<ColumnDefinition>>,
 }
 
+/// `w:type` on a section break: how the *next* section starts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SectionBreakType {
@@ -370,8 +397,8 @@ pub struct FieldRun {
     #[serde(flatten)]
     pub fmt: RunFormatting,
     pub field_type: String,
-    /// raw Word field type token when `field_type` collapsed it to a painter
-    /// category — inert a11y identity, never evaluated
+    /// Raw Word field type token, kept when `field_type` collapsed it to a
+    /// coarse category. Inert identity for announcement; never evaluated.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_type: Option<String>,
     /// raw field instruction text carried INERT for a11y announcement only
@@ -385,6 +412,8 @@ pub struct FieldRun {
     pub pm_end: Option<f64>,
 }
 
+/// Inline content of a paragraph. An unknown `kind` becomes `Unsupported`, and
+/// a paragraph containing one cannot be placed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Run {
@@ -1033,6 +1062,8 @@ pub struct TextBoxBlock {
 }
 
 #[allow(clippy::large_enum_variant)]
+/// A document block. An unknown `kind` becomes `Unsupported`, which placement
+/// refuses rather than dropping the content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum LayoutBlock {
@@ -1127,6 +1158,10 @@ pub struct TypesetBidiSlice {
     pub logical_order: Option<u64>,
 }
 
+/// One measured line. `head_*` / `tail_*` bound the line's run and character
+/// range, `float_skip_before` is vertical room the line had to skip past a
+/// float, and `left_offset` / `right_offset` are the exclusions measurement
+/// already applied.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRow {
@@ -1217,6 +1252,8 @@ pub struct TextBoxExtent {
     pub inner_measures: Vec<ParagraphExtent>,
 }
 
+/// A block's measurement result. Break blocks measure to a bare placeholder
+/// because they occupy no space of their own.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum BlockExtent {
@@ -1242,6 +1279,8 @@ pub enum BlockExtent {
     Unsupported,
 }
 
+/// A block paired with its measure. Placement requires the two kinds to agree;
+/// a mismatch is a contract violation, not a recoverable input.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MeasuredBlock {
     pub block: LayoutBlock,
@@ -1252,6 +1291,9 @@ pub struct MeasuredBlock {
 // layout options
 // ---------------------------------------------------------------------------
 
+/// Document-level pagination inputs. `footnote_reserved_heights` is keyed by
+/// decimal page number, and the paginator subtracts each entry from that page's
+/// content limit before body flow sees it.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct LayoutOptions {
@@ -1297,7 +1339,7 @@ pub struct SectionLayoutContract {
     pub note_settings: Option<Value>,
 }
 
-/// JSON layout input.
+/// The `{ measured, options }` envelope the engine paginates.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Input {
     pub measured: Vec<MeasuredBlock>,
@@ -1311,6 +1353,9 @@ pub struct Input {
 
 use crate::resolve_lines::ResolvedLine;
 
+/// One page's slice of a paragraph: the measured line window
+/// `[from_line, to_line)`, its own document range, and the run slices those
+/// lines resolve to. `carried_from_prev` / `carried_to_next` mark a split.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ParagraphFragment {
@@ -1333,6 +1378,10 @@ pub struct ParagraphFragment {
     pub resolved_lines: Option<Vec<ResolvedLine>>,
 }
 
+/// One page's slice of a table: rows `[row_start, row_end)`, plus
+/// `clip_top` / `clip_bottom` when the boundary cuts through a row that broke
+/// mid-content, and `header_row_count` when this fragment repeats the header
+/// band.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TableFragment {
@@ -1441,6 +1490,7 @@ pub struct TextBoxFragment {
     pub z_index: Option<f64>,
 }
 
+/// A positioned piece of a block on one page. Break blocks produce none.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum Fragment {
@@ -1501,6 +1551,9 @@ pub struct HeaderFooterRefs {
     pub footer_even: Option<String>,
 }
 
+/// One paginated page: its geometry, the fragments placed on it in paint order,
+/// and the section-derived metadata a renderer needs for page numbering, header
+/// and footer selection, borders and note areas.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page {
@@ -1554,6 +1607,7 @@ pub struct HeaderFooterLayout {
     pub fragments: Vec<Fragment>,
 }
 
+/// The paginator's complete result.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Layout {

--- a/crates/docx-layout/tests/display_list.rs
+++ b/crates/docx-layout/tests/display_list.rs
@@ -1,4 +1,25 @@
 //! Display-list contract, determinism, and interaction gates.
+//!
+//! Three kinds of test live here.
+//!
+//! **Contract** — the demo fixture must round-trip through the serde types
+//! without losing or renaming a field, and parse-then-serialize must be
+//! idempotent. A new output field that is not wired into the types shows up
+//! here first.
+//!
+//! **Determinism and snapshots** — every fixture is built twice and the two
+//! JSON strings must be byte-identical, then compared against a committed
+//! snapshot. Fixtures pinning only `{ measured, options }` have their golden
+//! canonical layout spliced in as the `layout` the builder consumes; fixtures
+//! that already carry one are used verbatim. A fixture the builder cannot
+//! handle is reported as a gap rather than a failure, so coverage can grow
+//! without the suite going red. Snapshots regenerate only under
+//! `DL_SNAPSHOT_UPDATE=1`, which keeps drift a deliberate act.
+//!
+//! **Behaviour** — the remaining tests pin individual emission rules against
+//! hand-computed geometry: hit testing and caret movement, table cell identity
+//! and vertical-merge continuations, indents and justification, tracked-change
+//! decorations, watermarks, floats, charts, shapes and text boxes.
 
 use docx_layout::display_list::{
     DecoKind, DecorationPrimitive, DisplayList, DocAttrs, MAX_ALT_TEXT_CHARS, Primitive,
@@ -1173,7 +1194,10 @@ fn image_alt_text_threads_and_caps() {
     );
 
     let empty = images.iter().find(|i| i.rel_id == "rId11").unwrap();
-    assert_eq!(empty.alt_text, None, "empty alt drops like the DOM painter");
+    assert_eq!(
+        empty.alt_text, None,
+        "an empty alt attribute resolves to None"
+    );
 }
 
 #[test]
@@ -1650,7 +1674,7 @@ fn hanging_list_first_line_body_sits_at_the_text_indent() {
     );
 
     // no marker: a plain hanging paragraph pulls the first line left by the hang
-    // (100 + 40 - 20 = 120), body lines still at 140 — unchanged v0 behavior
+    // (100 + 40 - 20 = 120), body lines still at 140
     let dl2 = build_dl(&with_marker(serde_json::Value::Null));
     let xs2: Vec<f64> = text_prims(&dl2.pages[0].primitives)
         .iter()

--- a/crates/docx-layout/tests/glyph_run.rs
+++ b/crates/docx-layout/tests/glyph_run.rs
@@ -222,8 +222,8 @@ fn emits_glyph_runs_when_fonts_resolve() {
 
 #[test]
 fn falls_back_to_text_run_without_fonts() {
-    // fontChains present, but the store is empty ⇒ every run fails to shape and
-    // takes the v0 TextRunPrimitive path
+    // fontChains present, but the store is empty, so every run fails to shape
+    // and falls back to a TextRunPrimitive
     let empty = FontStore::new();
     let with_chains = build_input("Hello world", 60.0, None, false, Some(&[0]));
     let out_fallback = build_display_list_json_with_fonts(&with_chains, &empty).expect("builds");
@@ -460,8 +460,8 @@ fn glyph_run_extent_uses_real_trailing_advance() {
         );
     }
 
-    // expected extent = the shaped natural advance sum (what the DOM painter lays
-    // out); reshape the same run in an isolated store to learn it
+    // expected extent = the shaped natural advance sum; reshape the same run in
+    // an isolated store to learn it
     let mut probe = FontStore::new();
     let id = probe.register(LIBERATION.to_vec()).unwrap();
     let shaped = shape(&probe, id, text, 16.0, &[]).unwrap();
@@ -491,7 +491,7 @@ fn glyph_run_extent_uses_real_trailing_advance() {
     );
     assert!(
         (r.width - shaped_width).abs() < 0.5,
-        "range-rect width {} matches the shaped extent {} (F3: real trailing advance)",
+        "range-rect width {} matches the shaped extent {}, including trailing advance",
         r.width,
         shaped_width
     );

--- a/crates/docx-layout/tests/hf_bands.rs
+++ b/crates/docx-layout/tests/hf_bands.rs
@@ -141,7 +141,7 @@ fn hit_test_regions_resolves_bands_and_body() {
         .expect("footer band with content resolves a position");
     assert!((1..=15).contains(&pos), "footer pos out of HF span: {pos}");
 
-    // body click resolves like the legacy body-only hit test
+    // a body click resolves the same as the body-only hit test
     let hit = hit_test_regions(&dl, 0, 100.0, 150.0).unwrap();
     assert_eq!(hit.region, HitRegion::Body);
     assert_eq!(hit.r_id, None);

--- a/crates/ooxml-text/src/bidi.rs
+++ b/crates/ooxml-text/src/bidi.rs
@@ -2,7 +2,7 @@
 //!
 //! The layout engine consumes bidi at run granularity: it splits each
 //! paragraph into maximal same-level runs (logical order), shapes each run
-//! separately (see [`crate::shape`]), then reorders runs per line at line
+//! separately (see [`mod@crate::shape`]), then reorders runs per line at line
 //! layout time. This module produces those level runs.
 
 use unicode_bidi::{BidiInfo, Level};

--- a/crates/ooxml-text/src/lib.rs
+++ b/crates/ooxml-text/src/lib.rs
@@ -7,7 +7,7 @@
 //! - [`FontStore`] — registry over raw font **bytes** (never font names) with
 //!   per-font metrics (`head`/`hhea`/`OS/2`), cmap lookup, advance widths, and
 //!   an ordered fallback-chain resolver.
-//! - [`shape`] / [`shape_with_direction`] — OpenType shaping via rustybuzz,
+//! - [`shape()`] / [`shape_with_direction`] — OpenType shaping via rustybuzz,
 //!   returning cluster-mapped glyphs with advances/offsets scaled to the
 //!   requested size.
 //! - [`break_opportunities`] — UAX-14 line-break opportunities via
@@ -20,7 +20,7 @@
 //!   space-stretch ([`line_is_justified`], [`stretch_spaces`]), the w:kern
 //!   threshold ([`kern_enabled`], [`kern_features`]), and the settings.xml
 //!   compat flags that feed them ([`CompatFlags`]). Snap-to-grid (w:docGrid)
-//!   remains a documented TODO there.
+//!   is documented there as a rule this crate does not apply.
 //! - [`outline`] — glyph outline extraction ([`FontStore::outline_glyph`]):
 //!   font-unit path commands ([`PathCmd`]) from the same skrifa bytes the
 //!   metrics came from, for the canvas renderer's `Path2D` glyph pipeline.

--- a/crates/ooxml-text/src/measure/floats.rs
+++ b/crates/ooxml-text/src/measure/floats.rs
@@ -1,8 +1,18 @@
-//! Floating exclusion-zone geometry.
+//! Floating exclusion-zone geometry: which zones a line intersects, how much
+//! width they leave it, and where it must drop to when they leave too little.
+//!
+//! A line `[top, bottom)` misses a zone when `bottom <= topY` or
+//! `top >= bottomY`. Margins from several intersecting zones take the maximum
+//! per side rather than accumulating. A zone carrying non-empty `segments`
+//! replaces margins entirely for the lines it covers, and overlapping segment
+//! lists intersect strip by strip. A `fullWidthBlock` zone short-circuits to a
+//! single zero-width strip, leaving no usable room, which is what pushes an
+//! overlapping line below the band.
 
 use super::input::{FloatSegmentIn, FloatZoneIn};
 
-/// Minimum usable width beside a floating obstruction.
+/// Below this much room beside a float, a line drops past the obstruction
+/// instead of wrapping into the gap.
 pub(super) const MIN_WRAP_SEGMENT_WIDTH: f32 = 24.0;
 
 /// Zone-resolved context for one line probe.
@@ -69,7 +79,9 @@ pub(super) fn available_width(margins: &LineMargins, base_width: f32) -> f32 {
     }
 }
 
-/// Finds the next unobstructed Y with a bounded zone scan.
+/// First Y at or below `start_y` leaving at least `min_width` of room,
+/// stepping zone bottom by zone bottom. The scan is bounded by the zone
+/// count, so a pathological zone set cannot spin.
 pub(super) fn find_clear_line_y(
     start_y: f32,
     line_height: f32,

--- a/crates/ooxml-text/src/measure/input.rs
+++ b/crates/ooxml-text/src/measure/input.rs
@@ -1,4 +1,40 @@
-//! Paragraph measurement input.
+//! Serde input contract for [`super::measure_paragraph`].
+//!
+//! The envelope is camelCase JSON. Unknown fields are ignored, so a host can
+//! pass a richer block through unmapped; only the subset that affects
+//! measurement is captured. An unrecognized *run kind* likewise parses and is
+//! then refused as `UNSUPPORTED`, rather than failing the whole request at
+//! the parse step.
+//!
+//! ```json
+//! {
+//!   "block":      { "kind": "paragraph", "runs": [...], "attrs": {...} },
+//!   "maxWidth":   624.0,
+//!   "fontChains": { "calibri|0|0": [0, 2], "calibri|1|0": [1, 2] },
+//!   "defaults":   { "fontSize": 11, "fontFamily": "Calibri" },
+//!   "compat":     { "noLeading": false, "doNotExpandShiftReturn": false },
+//!   "floatingZones":    [{ "leftMargin": 120.0, "rightMargin": 0.0,
+//!                          "topY": 0.0, "bottomY": 96.0 }],
+//!   "paragraphYOffset": 36.5
+//! }
+//! ```
+//!
+//! `fontChains` keys are `"<family lowercased>|<bold 0|1>|<italic 0|1>"`;
+//! values are ordered fallback chains of ids from `FontStore::register`. The
+//! host must supply a chain for every `(family, bold, italic)` combination
+//! the block's text, tab and field runs use, plus the **regular** (`|0|0`)
+//! chain of any family that can reach the empty-paragraph path and of the
+//! resolved list-marker family when a paragraph shows a marker at zero
+//! hanging indent. A missing or empty chain is `UNSUPPORTED`; this crate
+//! never guesses a face.
+//!
+//! Units: `maxWidth`, indents, spacing before/after, image dimensions and all
+//! float geometry are CSS pixels; font sizes are points; tab stop positions
+//! are twips. Every file-derived number is range-checked before it reaches
+//! layout arithmetic — see the validators at the foot of this module.
+//!
+//! `floatingZones` and `paragraphYOffset` are optional; absent means no float
+//! context. See [`FloatZoneIn`] for their coordinate space.
 
 use std::collections::HashMap;
 
@@ -27,7 +63,10 @@ pub struct MeasureInput {
     /// Paragraph Y offset in the floating-zone coordinate space.
     #[serde(default)]
     pub paragraph_y_offset: Option<f32>,
-    /// Enables lossless advances and Word-oriented metrics.
+    /// Opt in to the exact-advance output — `runAdvances`, `clusterAdvances`
+    /// and `bidiSlices` on every line — and to Word-oriented small-caps
+    /// metrics. Off, the line fields stay absent and callers keep a stable
+    /// JSON shape.
     #[serde(default)]
     pub authoritative_shaping: bool,
 }
@@ -123,16 +162,17 @@ pub struct RunIn {
     pub complex_script: bool,
     #[serde(default)]
     pub language: Option<RunLanguageSlotsIn>,
-    /// Pixels added per UTF-16 inter-character gap.
+    /// Pixels added per gap between shaped clusters inside a word — never
+    /// across a word boundary, and not multiplied by `horizontalScale`.
     #[serde(default)]
     pub letter_spacing: Option<f32>,
     /// Uppercase before shaping (w:caps).
     #[serde(default)]
     pub all_caps: bool,
-    /// Lowercase chars shape as their uppercase glyph with advances scaled
-    /// by the synthesized-small-caps factor (0.7, the Blink/WebKit
-    /// multiplier — see `SMALL_CAPS_ADVANCE_SCALE` in `prepare.rs`).
-    /// `allCaps` wins when both are set.
+    /// w:smallCaps. Lowercase characters render as small capitals: a real
+    /// `smcp` glyph where the face has one, otherwise the uppercase glyph
+    /// with its advance scaled (see the small-caps constants in
+    /// `prepare.rs`). `allCaps` wins when both are set.
     #[serde(default)]
     pub small_caps: bool,
     /// Percent (100 = normal); multiplies glyph advances.
@@ -141,10 +181,10 @@ pub struct RunIn {
     /// Minimum font size in points at which pair kerning is enabled.
     #[serde(default)]
     pub kerning_min_pt: Option<f32>,
-    /// Accepted without measurement effect.
+    /// Shapes at 0.75 of the run's size, raised by 0.4em.
     #[serde(default)]
     pub superscript: bool,
-    /// See `superscript`.
+    /// Shapes at 0.75 of the run's size, lowered by 0.2em.
     #[serde(default)]
     pub subscript: bool,
     /// Hidden/view-suppressed runs retain logical positions but consume no
@@ -169,7 +209,8 @@ pub struct RunIn {
     /// image content frame used by paint.
     #[serde(default)]
     pub rotation_bounds: Option<RotationBoundsIn>,
-    /// Top wrap distance; own-line images default to six pixels.
+    /// Image wrap distances in px (`distT`/`distB`). Default 0 for inline
+    /// images, 6 for block and `topAndBottom` own-line images.
     #[serde(default)]
     pub dist_top: Option<f32>,
     #[serde(default)]
@@ -247,7 +288,9 @@ pub struct AttrsIn {
     /// The "trailing empty paragraph after a table" zero-height anchor.
     #[serde(default)]
     pub suppress_empty_paragraph_height: bool,
-    /// Precomputed marker text.
+    /// Precomputed marker text (`"1."`, `"•"`, …). A visible marker narrows
+    /// the first line by its footprint, but only when `indent.hanging` is
+    /// exactly zero.
     #[serde(default)]
     pub list_marker: Option<String>,
     #[serde(default)]
@@ -263,7 +306,9 @@ pub struct AttrsIn {
     /// §17.9.25 `w:suff`: `"tab"` (default) / `"space"` / `"nothing"`.
     #[serde(default)]
     pub list_marker_suffix: Option<String>,
-    /// Document default tab stop in twips; only marker width uses it.
+    /// §17.6.13 `w:defaultTabStop` in twips, default 720. Only the list
+    /// marker's width consumes it; tab-run widths always use the 720-twip
+    /// grid.
     #[serde(default)]
     pub default_tab_stop_twips: Option<f32>,
 }
@@ -306,7 +351,10 @@ impl SpacingIn {
     }
 }
 
-/// Paragraph tab stop with twip position and alignment mode.
+/// One paragraph tab stop. `val` is the alignment mode —
+/// `start`/`end`/`center`/`decimal`/`bar`/`clear`, anything else behaving
+/// like `start` — and `pos` its position in **twips** from the content-area
+/// left edge.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TabStopIn {
@@ -335,7 +383,9 @@ pub(super) fn validate_tabs(tabs: &[TabStopIn]) -> Result<(), MeasureError> {
     Ok(())
 }
 
-/// `ParagraphIndent` in px.
+/// Paragraph indents in px. `left`/`right` shrink every line; the first line
+/// is additionally offset by `firstLine − hanging`, so a hanging indent
+/// widens it back out past the body edge.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndentIn {
@@ -367,7 +417,14 @@ impl IndentIn {
     }
 }
 
-/// Floating exclusion zone in paragraph flow coordinates.
+/// One floating exclusion zone.
+///
+/// Every field is CSS pixels. `topY`/`bottomY` live in the float group's
+/// coordinate space — Y 0 is the top of the group's anchor block, the same
+/// space [`MeasureInput::paragraph_y_offset`] is measured in — so a line at
+/// paragraph-local `y` probes zones at `paragraphYOffset + y`. Wrap distances
+/// are already folded into the margins and the Y range by whoever extracted
+/// the zone; nothing is added here.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FloatZoneIn {
@@ -381,7 +438,9 @@ pub struct FloatZoneIn {
     /// half-open on both sides in practice: a line `[top, bottom)` misses
     /// the zone when `lineBottom <= topY` or `lineTop >= bottomY`.
     pub bottom_y: f32,
-    /// Usable strips for centered-float line splitting.
+    /// Usable strips for centered-float line splitting. When present and
+    /// non-empty they replace the zone's margins for intersecting lines and
+    /// drive the available width themselves.
     #[serde(default)]
     pub segments: Option<Vec<FloatSegmentIn>>,
     /// OOXML `topAndBottom` wrap: a full-width band — no text beside it, any

--- a/crates/ooxml-text/src/measure/line_filler.rs
+++ b/crates/ooxml-text/src/measure/line_filler.rs
@@ -1,4 +1,36 @@
-//! Greedy line filling over prepared character advances.
+//! Greedy line filling over the per-cluster advance tables built by
+//! [`super::prepare`].
+//!
+//! This module owns every wrap decision and all vertical arithmetic: where a
+//! line breaks, how tall its box is, how floats narrow or displace it, and
+//! which [`TypesetRowOut`] fields come out. The rules it enforces:
+//!
+//! - A word is taken whole — trailing space included — and lands on the line
+//!   it ends, its full advance counted in that line's `width`. A line accepts
+//!   an overshoot of up to [`WRAP_SLACK_PX`], so a sub-half-pixel rounding
+//!   artifact never forces a wrap that exact twip arithmetic would not make.
+//! - A word too wide for a whole line is chopped: the current line takes what
+//!   fits, then each following line takes the longest cluster prefix that
+//!   fits, with a forced minimum of one cluster so filling always terminates.
+//!   Cuts land on cluster boundaries, so no ligature, combining sequence or
+//!   surrogate pair is ever split.
+//! - Line metrics follow the largest font on the line: the first
+//!   font-bearing contribution claims it, and only a strictly larger size
+//!   displaces it. Ascent, descent and leading are per-contribution maxima,
+//!   so even a text run with no characters raises the line box. A line with
+//!   no font-bearing run at all falls back to a 0.8/0.2 em ascent/descent
+//!   split on a [`DEFAULT_SINGLE_LINE_RATIO`] basis.
+//! - An image taller than the ruled text height grows the line box. Alone on
+//!   the line it takes the text descent as a buffer above and below; flowing
+//!   with text it seats on the baseline — full height above, only the text
+//!   descent below. The reported `descent` stays text metrics either way.
+//! - Float geometry is probed per line at the running Y with a fixed
+//!   default-font-size estimate, never the line's real metrics, which are
+//!   unknown until the line closes. That running Y advances by each line's
+//!   *text* height, so image growth never shifts the next probe; float skips
+//!   do, since they move the line itself.
+//! - `totalHeight` is Σ (line height + `floatSkipBefore`) plus
+//!   `spacing.before` and `spacing.after`.
 
 use crate::font_store::FontId;
 
@@ -15,13 +47,16 @@ use crate::word_metrics as wm;
 
 use super::tabs;
 
-/// Half-pixel wrap tolerance.
+/// Half-pixel wrap tolerance: an overshoot this small must not force a wrap
+/// that exact twip arithmetic would never make.
 const WRAP_SLACK_PX: f32 = 0.5;
-/// Empty-paragraph minimum multiplier for auto and at-least spacing.
+/// Empty-paragraph line height floor, as a multiple of the font size; applies
+/// under the `auto` and `atLeast` rules only.
 const WORD_SINGLE_LINE_FLOOR: f32 = 1.15;
-/// Single-line fallback for lines without font-bearing runs.
+/// Single-line basis for a line carrying no font-bearing run.
 const DEFAULT_SINGLE_LINE_RATIO: f32 = 1.15;
 
+/// Everything the filler needs that is fixed for the whole paragraph.
 pub(super) struct FillParams<'a> {
     pub store: &'a crate::font_store::FontStore,
     pub prepared: &'a [PreparedRun],
@@ -47,6 +82,7 @@ pub(super) struct FillParams<'a> {
     pub authoritative_shaping: bool,
 }
 
+/// The line currently being filled. Reset wholesale by `start_new_line`.
 struct LineState {
     head_run: u32,
     head_char: u32,
@@ -70,6 +106,11 @@ struct LineState {
     contributions: Vec<LineContribution>,
 }
 
+/// One advance-bearing piece of the current line, recorded in logical order.
+/// `logical_order` is `run_index × 1_000_000 + position within the run`, so a
+/// single key orders the whole paragraph. `shaped_cluster` distinguishes text
+/// clusters (which reach `clusterAdvances`) from atomic runs such as tabs,
+/// fields and images (which do not).
 #[derive(Debug, Clone, Copy)]
 struct LineContribution {
     run_index: u32,
@@ -81,6 +122,8 @@ struct LineContribution {
     shaped_cluster: bool,
 }
 
+/// Fill state: the paragraph's finished lines, the line in progress, and the
+/// vertical position driving float probes.
 struct Filler<'a> {
     p: &'a FillParams<'a>,
     rule: wm::LineSpacingRule,
@@ -93,7 +136,9 @@ struct Filler<'a> {
     pending_float_skip: f32,
 }
 
-/// Skips below floats that leave insufficient line width.
+/// Hops the running Y past any float leaving less than
+/// [`floats::MIN_WRAP_SEGMENT_WIDTH`] of usable room. The skipped pixels are
+/// added to both the running Y and the pending `floatSkipBefore`.
 fn skip_obstructing_floats(
     p: &FillParams,
     line_height: f32,
@@ -118,12 +163,17 @@ fn skip_obstructing_floats(
     }
 }
 
-/// Returns the default-font probe height for floating zones.
+/// Probe height for zone intersection tests: the default font size in px,
+/// never the line's own metrics, which are unknown until the line closes.
 fn estimated_line_height(p: &FillParams) -> f32 {
     pt_to_px(p.default_font_size_pt)
 }
 
-/// Wraps prepared runs and totals paragraph height.
+/// Wraps the prepared runs into lines and totals the paragraph height.
+///
+/// The first line's float context is resolved before any content is placed:
+/// probe at the paragraph top, hop past obstructions, then take the margins
+/// at the Y actually reached.
 pub(super) fn fill(p: FillParams) -> Result<ParagraphExtentOut, MeasureError> {
     let rule = rule_from_spacing(p.spacing);
     let compat = to_flags(p.compat);
@@ -187,7 +237,9 @@ pub(super) fn fill(p: FillParams) -> Result<ParagraphExtentOut, MeasureError> {
     })
 }
 
-/// Measures an empty paragraph as one zero-width line.
+/// Measures an empty or whitespace-only paragraph as one zero-width line at
+/// the ruled height of `font` at `size_pt`, floored at
+/// [`WORD_SINGLE_LINE_FLOOR`] × the font size under `auto`/`atLeast`.
 pub(super) fn empty_paragraph_extent(
     store: &crate::font_store::FontStore,
     font: FontId,
@@ -234,6 +286,8 @@ pub(super) fn empty_paragraph_extent(
 }
 
 impl Filler<'_> {
+    /// Places every prepared run in order, then closes the last line. A
+    /// paragraph therefore always emits at least one line.
     fn run(&mut self) -> Result<(), MeasureError> {
         for (run_index, prun) in self.p.prepared.iter().enumerate() {
             let ri = run_index as u32;
@@ -264,7 +318,11 @@ impl Filler<'_> {
         self.finalize_line()
     }
 
-    /// Places an inline image and grows the line by its rendered footprint.
+    /// Places an inline image: its declared width joins the line advance and
+    /// its *column-fitted* height plus wrap distances competes for the line
+    /// box. An image wider than the whole line wraps off an empty line too,
+    /// emitting an empty row. Images carry no font, so line metrics are
+    /// untouched.
     fn fill_inline_image(&mut self, ri: u32, img: PreparedImage) -> Result<(), MeasureError> {
         if self.cur.width + img.width > self.cur.available + WRAP_SLACK_PX {
             self.start_new_line(ri, 0)?;
@@ -285,7 +343,11 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Places an authored-size image on its own zero-advance line.
+    /// Gives a block or `topAndBottom` image its own line: finish any line
+    /// already carrying content, take the image's *declared* height plus wrap
+    /// distances as the whole box (no column fit), add no width, and open a
+    /// fresh line. When the image is the paragraph's last run that fresh line
+    /// closes empty.
     fn fill_own_line_image(&mut self, ri: u32, img: PreparedImage) -> Result<(), MeasureError> {
         if self.cur.width > 0.0 {
             self.start_new_line(ri, 0)?;
@@ -298,7 +360,8 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Places a premeasured field as one unbreakable unit.
+    /// Places a premeasured field as one unbreakable unit: it wraps whole to
+    /// the next line rather than splitting, but never off an empty line.
     fn fill_field_run(&mut self, ri: u32, f: PreparedField) -> Result<(), MeasureError> {
         self.update_max_font(f.font_size_pt, f.metrics_font, f.baseline_shift_px);
         if self.cur.width > 0.0 && self.cur.width + f.width > self.cur.available + WRAP_SLACK_PX {
@@ -312,7 +375,10 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Places a tab using content coordinates and following-run width.
+    /// Places a tab. Its width comes from the stop grid at the line's current
+    /// x in content-area coordinates — indent, first-line offset and any
+    /// float left margin all shift that x. A tab that wraps keeps its
+    /// pre-wrap width; it is not recomputed against the new line's x.
     fn fill_tab_run(&mut self, run_index: usize, t: PreparedTab) -> Result<(), MeasureError> {
         let ri = run_index as u32;
         self.update_max_font(t.font_size_pt, t.metrics_font, 0.0);
@@ -358,7 +424,10 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Sums inline widths until the next tab or line break.
+    /// Sums inline widths until the next tab or line break — what `end` and
+    /// `center` stops anchor on. Every image kind contributes its declared
+    /// width here, floating and own-line images included, even though neither
+    /// adds width to the line advance itself.
     fn following_width_after(&self, tab_index: usize) -> f32 {
         let mut width = 0.0f32;
         for prun in &self.p.prepared[tab_index + 1..] {
@@ -376,6 +445,10 @@ impl Filler<'_> {
         width
     }
 
+    /// Fills a text run word by word, a word being the span up to the next
+    /// UAX-14 break opportunity and so including its trailing space. Words
+    /// wider than a whole line are chopped at cluster boundaries with a
+    /// forced minimum of one cluster per line.
     fn fill_text_run(&mut self, ri: u32, t: &PreparedText) -> Result<(), MeasureError> {
         // Empty runs still contribute line metrics.
         self.update_max_font(t.font_size_pt, t.metrics_font, t.baseline_shift_px);
@@ -450,7 +523,11 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Updates line metrics from font-bearing runs.
+    /// Folds one font-bearing contribution into the line's metrics: the first
+    /// claims the line and only a strictly larger size displaces it, while
+    /// ascent, descent and leading accumulate as maxima across every
+    /// contribution. Super/subscript baseline shifts move ascent and descent
+    /// in opposite directions and never go negative.
     fn update_max_font(&mut self, font_size_pt: f32, font: FontId, baseline_shift_px: f32) {
         if self.cur.max_font.is_none() || font_size_pt > self.cur.max_font_size_pt {
             self.cur.max_font_size_pt = font_size_pt;
@@ -470,6 +547,8 @@ impl Filler<'_> {
         }
     }
 
+    /// Records an unbreakable run (tab, field, image) as a single
+    /// contribution spanning one index unit.
     fn record_atomic(
         &mut self,
         run_index: u32,
@@ -489,6 +568,9 @@ impl Filler<'_> {
         });
     }
 
+    /// Records a span of shaped clusters, charging letter spacing to every
+    /// cluster but the last — so gaps are counted within the span, never
+    /// across its trailing edge into the next word.
     fn record_text_clusters(&mut self, run_index: u32, chars: &[CharAdv], spacing: f32) {
         for (index, cluster) in chars.iter().enumerate() {
             self.update_max_font(
@@ -515,7 +597,11 @@ impl Filler<'_> {
         }
     }
 
-    /// Finalizes typography, floating geometry, and advance metadata.
+    /// Closes the current line: resolve typography from its largest font,
+    /// apply the spacing rule, let any taller image grow the box, attach
+    /// float offsets, segments and skip, and push the row. Advances the
+    /// running Y by the *text* height only, so image growth never moves the
+    /// next line's float probe.
     fn finalize_line(&mut self) -> Result<(), MeasureError> {
         if self.lines.len() >= MAX_LINES {
             return Err(MeasureError::Unsupported(format!(
@@ -590,7 +676,12 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Splits one text run across at most two floating-zone strips.
+    /// Splits the just-closed line across the zone's strips. One strip — or a
+    /// line that fits the first strip within the wrap slack — yields a single
+    /// segment covering the whole line. A two-way split needs a line made of
+    /// exactly one text run; the cut is the longest cluster prefix fitting the
+    /// first strip. Anything else (multiple runs, a non-text run, a degenerate
+    /// cut) returns `None` and the line carries no segments.
     fn create_line_segments(
         &self,
         segment_zones: &[FloatSegmentIn],
@@ -652,7 +743,9 @@ impl Filler<'_> {
         ])
     }
 
-    /// Finalizes the current line and opens the next one.
+    /// Closes the current line and opens a fresh one at `(run, char_utf16)`,
+    /// hopped past and narrowed by whatever float zones sit at the new Y.
+    /// Font tracking resets, so the new line's metrics start from scratch.
     fn start_new_line(&mut self, run: u32, char_utf16: u32) -> Result<(), MeasureError> {
         self.finalize_line()?;
         let estimated = estimated_line_height(self.p);
@@ -692,6 +785,10 @@ impl Filler<'_> {
     }
 }
 
+/// Reorders a line's contributions visually and derives the three advance
+/// tables. Cluster and slice x offsets accumulate in visual order; run
+/// advances merge contributions that are adjacent *visually* and share a run
+/// index, so a run cut by a direction change appears once per visual piece.
 fn advance_metadata(
     contributions: &[LineContribution],
 ) -> (
@@ -772,7 +869,9 @@ fn span_width(chars: &[CharAdv], letter_spacing: f32) -> f32 {
     }
 }
 
-/// Finds the longest character prefix within the width.
+/// Longest cluster prefix whose width stays within `max_width`, in clusters.
+/// The early exit assumes width grows monotonically, which holds for
+/// non-negative letter spacing; negative spacing scans the whole span.
 fn max_fitting(chars: &[CharAdv], letter_spacing: f32, max_width: f32) -> usize {
     let mut best = 0usize;
     let mut advance = 0.0f32;
@@ -800,7 +899,10 @@ fn to_flags(compat: &CompatIn) -> wm::CompatFlags {
     }
 }
 
-/// Maps spacing with exact, at-least, multiplier, then pixel precedence.
+/// Maps `w:spacing` onto a line rule, in precedence order: `exact`,
+/// `atLeast` (both needing a `line` value), then `lineUnit` `multiplier`,
+/// then `px`, else single spacing. A `line` with no recognized unit or rule
+/// is ignored, and values are clamped non-negative.
 fn rule_from_spacing(spacing: Option<&SpacingIn>) -> wm::LineSpacingRule {
     let single = wm::LineSpacingRule::Auto { line_240ths: 240 };
     let Some(sp) = spacing else {

--- a/crates/ooxml-text/src/measure/list_marker.rs
+++ b/crates/ooxml-text/src/measure/list_marker.rs
@@ -1,4 +1,15 @@
-//! List-marker inline-width resolution.
+//! List-marker inline width: how much of the first line a visible marker
+//! consumes.
+//!
+//! The marker's face resolves in precedence order — numbering level, then the
+//! paragraph's first text run, then the paragraph default, then the document
+//! default — and always through that family's regular chain, since a marker
+//! is never bold or italic here. `w:suff` then fixes the footprint:
+//! `nothing` is the marker's own width, `space` adds one space glyph, and
+//! `tab` (the default) grows the marker out to the nearest stop past its end,
+//! taking whichever is closer of the first custom stop and the first
+//! `w:defaultTabStop` grid line. With no grid at all — a zero default stop
+//! and no custom stops — the marker takes a half-em gap instead.
 
 use crate::font_store::FontStore;
 
@@ -9,7 +20,8 @@ use super::{MeasureError, pt_to_px};
 /// ECMA-376 §17.6.13 default tab stop.
 const DEFAULT_TAB_STOP_TWIPS: f32 = 720.0;
 
-/// Returns the marker width in pixels for zero-hanging paragraphs.
+/// Marker footprint in pixels. Zero when the paragraph has no marker text or
+/// the marker is hidden; callers apply it only at zero hanging indent.
 pub(super) fn list_marker_inline_width(
     store: &FontStore,
     input: &MeasureInput,

--- a/crates/ooxml-text/src/measure/mod.rs
+++ b/crates/ooxml-text/src/measure/mod.rs
@@ -1,4 +1,120 @@
-//! Paragraph measurement with UTF-16 indices.
+//! Paragraph measurement: one `paragraph` block and a font set in, a
+//! `{ kind: "paragraph", lines, totalHeight }` extent out.
+//!
+//! [`measure_paragraph`] is pure and panic-free on untrusted input. Anything
+//! it will not measure comes back as a [`MeasureError`], never a panic, and
+//! [`MeasureError::Unsupported`] stringifies as `"UNSUPPORTED: <reason>"` —
+//! the signal for the host to measure that one block with the browser.
+//!
+//! # Line spans
+//!
+//! A [`TypesetRowOut`] addresses its text as `headRun..=tailRun` (inclusive
+//! run indices) and `headChar..tailChar` — `headChar` inclusive, `tailChar`
+//! exclusive. Character positions are **UTF-16 code-unit** offsets into the
+//! run's original string, the indexing the wire format uses. Rust text is
+//! UTF-8, so every emitted index is a sum of `char::len_utf16` and always
+//! lands on a `char` boundary: a split surrogate is unrepresentable.
+//! [`TypesetRowSegmentOut`] and the advance metadata index the same way.
+//!
+//! # What is refused
+//!
+//! Four categories, all of them rules:
+//!
+//! - **Resource clamps** on file-derived numbers and counts — font size,
+//!   letter spacing, horizontal scale, spacing, indents, image dimensions,
+//!   tab-stop / zone / segment / run / line counts, over-long run text.
+//!   Degenerate values are refused rather than fed into layout arithmetic.
+//! - **Host-contract misses** — no chain, or an empty chain, registered for
+//!   a `(family, bold, italic)` key the block uses. Resolving a family to
+//!   font bytes is the host's job; measurement never guesses a face.
+//! - **Malformed runs** — a mandatory-break control character (`\n`, `\r`,
+//!   `\t`, `\v`, `\f`, `U+0085`, `U+2028`, `U+2029`) inside a `text` or
+//!   `field` run's string. A well-formed DOCX carries those as `lineBreak`
+//!   and `tab` runs, so this fires only on corrupt or hostile input. An
+//!   unrecognized `run.kind` is refused the same way.
+//! - **Non-paragraph blocks** — `block.kind != "paragraph"`. Tables, block
+//!   images, text boxes and breaks are measured by other code paths and are
+//!   never routed here.
+//!
+//! A character no font in the chain covers is *not* refused: it shapes as
+//! the chain's terminal font's `.notdef`, which is a real advance width.
+//!
+//! # Measurement rules
+//!
+//! - **Metrics come from font tables**: ascent and descent are
+//!   `size_px × usWinAscent/upem` and `size_px × usWinDescent/upem`, and the
+//!   single-line basis is their sum plus GDI external leading
+//!   ([`crate::word_metrics`]).
+//! - **Wrapping is greedy** with a half-pixel tolerance: a line takes the
+//!   last break opportunity that fits. Opportunities are UAX-14
+//!   ([`crate::line_break`]), so consecutive spaces collapse into a single
+//!   opportunity and a soft hyphen permits a break.
+//! - **An overlong unbreakable word** fills the room left on the current
+//!   line and then hard-breaks, at least one shaped cluster per line.
+//! - **Trailing whitespace stays** on the line it ends, and its advance is
+//!   included in that line's `width` — words are measured with their
+//!   trailing space and never trimmed.
+//! - **Widths come from shaping whole same-style subranges**, so kerning and
+//!   ligature advances straddling a hard-break cut are attributed to the
+//!   line before the cut.
+//! - **`allCaps` uppercases before shaping**, `smallCaps` shapes lowercase
+//!   as small capitals, and `horizontalScale` multiplies glyph advances:
+//!   measurement reflects what a painter draws. `letterSpacing` is added
+//!   once per gap between shaped clusters within a word — never between
+//!   words, and not scaled by `horizontalScale`.
+//! - **Line height** follows `spacing.lineRule` (`exact` / `atLeast` /
+//!   `auto`) and `lineUnit` (`multiplier` / `px`), defaulting to single
+//!   spacing. An empty paragraph floors at 1.15 × the font size under the
+//!   `auto` and `atLeast` rules.
+//! - **`totalHeight`** sums line heights and float skips, plus
+//!   `spacing.before` and `spacing.after`.
+//!
+//! # Tabs, fields, images, list markers
+//!
+//! Tab widths resolve against the 720-twip grid overlaid with the
+//! paragraph's declared stops; `end` and `center` stops subtract the width
+//! of the runs that follow the tab. Field runs measure their `fallback`
+//! text (`"1"` when absent or empty) at the run's family, size, bold and
+//! italic, with no caps and no letter spacing.
+//!
+//! An inline image adds its declared width to the line advance and grows the
+//! line box by its column-fitted height plus wrap distances: alone on a line
+//! it takes a descent buffer above and below, flowing with text it seats on
+//! the baseline. A `topAndBottom` or block image takes its own line at its
+//! declared height plus wrap distances (default 6px, never column-fitted),
+//! adds no width, and opens a fresh line after it. An anchored floating
+//! image is positioned by the host, so it contributes neither width nor
+//! height — but its declared width still counts toward the following-runs
+//! width after a tab.
+//!
+//! A visible list marker narrows the first line by its footprint, and only
+//! when the paragraph's hanging indent is exactly zero.
+//!
+//! # Float exclusion zones
+//!
+//! `floatingZones` and `paragraphYOffset` place the paragraph in the float
+//! group's coordinate space. Intersecting zones are resolved per line at the
+//! running Y with a fixed probe height of `pt_to_px(defaults.fontSize)` —
+//! never the line's own fonts, which are unknown until the line closes. That
+//! running Y advances by each finalized line's *text* height, so image
+//! growth reaches `totalHeight` but not the next line's zone probe.
+//!
+//! Lines beside a zone shrink by its margins and report `leftOffset` /
+//! `rightOffset`. When the room left is under `MIN_WRAP_SEGMENT_WIDTH`, the
+//! line hops below the obstruction and the skipped pixels are reported as
+//! `floatSkipBefore`. Zones that split a line into strips emit `segments`;
+//! a two-way split applies only to a single-text-run line, and any other
+//! line emits no segments at all.
+//!
+//! # Bidirectional text
+//!
+//! Text is split into UBA level runs ([`crate::bidi`]) before shaping, so
+//! every shaped segment is a single directional run with an explicit
+//! direction. Everything else stays in logical order: break opportunities,
+//! `headChar`/`tailChar` spans, and widths — a line's width is the
+//! direction-independent sum of its segment advances. `w:bidi` on the
+//! paragraph and `w:rtl` on a run only force the UBA base direction, which
+//! changes how neutral characters segment, never the sums.
 
 mod floats;
 mod input;
@@ -17,11 +133,13 @@ use crate::font_store::{FontId, FontStore};
 /// Why measurement refused an input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MeasureError {
-    /// The input engages a feature this v1 does not cover — the host must
-    /// fall back to browser measurement for this block.
+    /// Outside what this engine measures: a resource clamp, a missing font
+    /// chain, a malformed run, or a non-paragraph block. Displays as
+    /// `"UNSUPPORTED: <reason>"`; the host measures the block with the
+    /// browser instead.
     Unsupported(String),
-    /// The input violates the measurement contract (malformed JSON, unknown
-    /// font ids, non-finite numbers).
+    /// The request itself is unusable — unparseable JSON, a font id absent
+    /// from the store, a shaping failure.
     Invalid(String),
 }
 
@@ -36,7 +154,10 @@ impl std::fmt::Display for MeasureError {
 
 impl std::error::Error for MeasureError {}
 
-/// Typeset line with UTF-16 offsets and omitted unset float fields.
+/// One typeset line. `headRun`/`tailRun` are inclusive run indices;
+/// `headChar` is inclusive and `tailChar` exclusive, both UTF-16 code-unit
+/// offsets (see module docs). Unset optional fields are omitted from the
+/// JSON rather than serialized as null or zero.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRowOut {
@@ -62,16 +183,21 @@ pub struct TypesetRowOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub float_skip_before: Option<f32>,
     /// Exact advances for run slices, emitted in visual paint order.
+    /// `Some` only under `authoritativeShaping`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_advances: Option<Vec<TypesetRunAdvanceOut>>,
     /// Exact shaped cluster advances and visual x offsets.
+    /// `Some` only under `authoritativeShaping`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_advances: Option<Vec<TypesetClusterAdvanceOut>>,
     /// Bidi slices keep logical identity separate from visual paint order.
+    /// `Some` only under `authoritativeShaping`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bidi_slices: Option<Vec<TypesetBidiSliceOut>>,
 }
 
+/// Advance of one run's slice of a line. A run split by direction yields one
+/// entry per visual piece; `logical_order` recovers logical sequence.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRunAdvanceOut {
@@ -82,6 +208,8 @@ pub struct TypesetRunAdvanceOut {
     pub logical_order: u32,
 }
 
+/// One shaped cluster: its advance and its visual x from the line start.
+/// Clusters are indivisible, so a cluster may span several characters.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetClusterAdvanceOut {
@@ -94,6 +222,9 @@ pub struct TypesetClusterAdvanceOut {
     pub logical_order: u32,
 }
 
+/// Every line contribution — text clusters and atomic runs alike — with both
+/// orderings, so a painter can lay out visually without losing logical
+/// identity. Odd `bidi_level` is RTL.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetBidiSliceOut {
@@ -106,7 +237,8 @@ pub struct TypesetBidiSliceOut {
     pub logical_order: u32,
 }
 
-/// Segment strip with UTF-16 offsets and pixel geometry.
+/// One strip of a line split by a segmenting float zone. Spans index exactly
+/// as [`TypesetRowOut`]; offsets and widths are pixels.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRowSegmentOut {
@@ -129,16 +261,17 @@ pub struct ParagraphExtentOut {
     pub total_height: f32,
 }
 
-/// Security caps on file-derived counts (repo security guidelines: resource limits).
+/// Resource limits on file-derived counts. Exceeding any of them is
+/// `UNSUPPORTED`, so a hostile document costs a browser fallback rather than
+/// unbounded work.
 pub(crate) const MAX_RUNS: usize = 10_000;
 pub(crate) const MAX_RUN_TEXT_BYTES: usize = 1_000_000;
 pub(crate) const MAX_LINES: usize = 100_000;
 pub(crate) const MAX_TAB_STOPS: usize = 1_000;
 pub(crate) const MAX_FLOAT_ZONES: usize = 200;
-/// Maximum segment count accepted from untrusted envelopes.
 pub(crate) const MAX_ZONE_SEGMENTS: usize = 100;
 
-/// Converts points to CSS pixels.
+/// Converts points to CSS pixels (1pt = 96/72px).
 pub(crate) fn pt_to_px(pt: f32) -> f32 {
     pt * 96.0 / 72.0
 }
@@ -146,7 +279,12 @@ pub(crate) fn pt_to_px(pt: f32) -> f32 {
 /// Measure one paragraph block against `input.maxWidth`.
 ///
 /// Pure and panic-free on untrusted input; every validation failure or
-/// uncovered feature comes back as a [`MeasureError`], never a panic.
+/// refused feature comes back as a [`MeasureError`], never a panic.
+///
+/// A paragraph with no runs, or with a single whitespace-only text run,
+/// short-circuits to one zero-width line at the resolved line height, always
+/// measured with the regular (`|0|0`) face of the resolved family.
+/// `suppressEmptyParagraphHeight` makes that line zero-height instead.
 pub fn measure_paragraph(
     store: &FontStore,
     input: &MeasureInput,
@@ -258,9 +396,10 @@ pub fn measure_paragraph(
     })
 }
 
-/// JSON boundary mirroring `docx-layout`'s `layout_to_json` pattern: input
-/// JSON in, `ParagraphExtent` JSON out. `Err` strings starting with
-/// `"UNSUPPORTED"` mean the host must fall back to browser measurement.
+/// JSON boundary: a [`MeasureInput`] envelope in, a serialized
+/// [`ParagraphExtentOut`] out. An `Err` starting with `"UNSUPPORTED"` means
+/// the host must measure this block with the browser; one starting with
+/// `"invalid: "` means the envelope itself was unusable.
 pub fn measure_paragraph_json(store: &FontStore, input: &str) -> Result<String, String> {
     let parsed: MeasureInput =
         serde_json::from_str(input).map_err(|e| format!("invalid: parse: {e}"))?;
@@ -296,7 +435,9 @@ fn is_whitespace_only(run: &RunIn) -> bool {
     }
 }
 
-/// Returns the first regular font for empty-paragraph metrics.
+/// Head of the regular (`|0|0`) chain for `family` — the metrics source for
+/// the empty-paragraph and list-marker paths, which never apply bold or
+/// italic.
 fn regular_chain_head(
     store: &FontStore,
     input: &MeasureInput,

--- a/crates/ooxml-text/src/measure/prepare.rs
+++ b/crates/ooxml-text/src/measure/prepare.rs
@@ -5,6 +5,32 @@
 //! Everything downstream (the line filler) works on the per-character
 //! advance tables built here, so all UTF-8 ↔ UTF-16 and shaped-cluster ↔
 //! character conversion happens in exactly one place.
+//!
+//! The decisions this module owns:
+//!
+//! - **Which face each character gets.** The run's `w:rFonts` slots are
+//!   applied per character — complex script, East Asian, ASCII, high ANSI —
+//!   with combining marks inheriting the previous character's slot. The
+//!   complex slot also swaps in `w:bCs`, `w:iCs`, `w:szCs` and the `w:lang`
+//!   bidi tag. One OOXML run can therefore legitimately span Latin, East
+//!   Asian and complex faces without splitting its source positions.
+//! - **What is shaped in place of what.** `w:caps` uppercases before shaping,
+//!   honouring the Turkish and Azerbaijani dotted-I rules, and may expand one
+//!   character into several (ß → SS). `w:smallCaps` prefers a real `smcp`
+//!   substitution and otherwise synthesizes uppercase at a scaled advance.
+//!   `w:w` multiplies every advance and `w:kern` gates pair kerning.
+//! - **Where shaping segments.** A segment continues while font, advance
+//!   scale, UBA level, size, baseline shift, language and feature list all
+//!   hold, so kerning and ligatures survive inside it. Splitting at a level
+//!   boundary keeps every segment a single directional run, which is what
+//!   lets the resolved direction be passed to the shaper explicitly.
+//! - **Where lines may break.** UAX-14 opportunities over the original text,
+//!   translated to cluster indices. The trivial end-of-text opportunity is
+//!   dropped; interior mandatory breaks cannot occur, because control
+//!   characters are refused up front.
+//! - **How images flow.** An anchored floating image is skipped, a
+//!   `topAndBottom` or block image takes its own line, everything else is
+//!   inline. A dimensionless image is zero-size, never a refusal.
 
 use crate::font_store::{FontId, FontStore};
 use crate::line_break::break_opportunities;
@@ -49,7 +75,9 @@ pub(super) struct PreparedText {
     pub baseline_shift_px: f32,
 }
 
-/// Tab run prepared for grid placement and line metrics.
+/// Tab run prepared for grid placement and line metrics. Its width is not
+/// known until fill time — it depends on the line's current x — but its font
+/// already contributes to line metrics.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PreparedTab {
     /// Points, for line-metrics bookkeeping.
@@ -59,7 +87,8 @@ pub(super) struct PreparedTab {
     pub bidi_level: u8,
 }
 
-/// Field run measured from cached display text.
+/// Field run measured from its cached display text; the live value is
+/// substituted at paint time.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PreparedField {
     pub width: f32,
@@ -71,7 +100,10 @@ pub(super) struct PreparedField {
     pub bidi_level: u8,
 }
 
-/// Image footprint used by inline and own-line placement.
+/// Image footprint. Inline placement fits `height` to the column and adds
+/// `width` to the line advance; own-line placement takes `height` as
+/// authored and adds no width. `dist_top`/`dist_bottom` join the footprint
+/// either way.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct PreparedImage {
     pub width: f32,
@@ -90,7 +122,9 @@ pub(super) enum PreparedRun {
     InlineImage(PreparedImage),
     /// Authored-size image occupying its own line.
     OwnLineImage(PreparedImage),
-    /// Floating image omitted from line width but counted after tabs.
+    /// Anchored floating image: the host positions it, so it contributes no
+    /// width and no line growth — but its declared width still counts toward
+    /// the following-runs width after a tab.
     SkippedImage {
         width: f32,
         bidi_level: u8,
@@ -101,7 +135,11 @@ pub(super) enum PreparedRun {
     },
 }
 
-/// Small-caps advance scale for synthesized lowercase glyphs.
+/// Advance scale for a synthesized small cap — an uppercase glyph standing in
+/// for a lowercase character because the face carries no `smcp` substitution.
+/// The browser value is Blink and WebKit's synthesis multiplier; the Word
+/// value is what Word renders small caps at, and applies under
+/// `authoritativeShaping`.
 const BROWSER_SMALL_CAPS_ADVANCE_SCALE: f32 = 0.7;
 const WORD_SMALL_CAPS_ADVANCE_SCALE: f32 = 0.8;
 
@@ -160,6 +198,9 @@ fn base_direction(run_rtl: bool, input: &MeasureInput) -> crate::bidi::BaseDirec
     }
 }
 
+/// Rejects a chain naming an id the store does not hold. Unlike a missing
+/// chain this is [`MeasureError::Invalid`] — the host contradicted itself
+/// rather than merely omitting something.
 pub(super) fn validate_chain(store: &FontStore, chain: &[FontId]) -> Result<(), MeasureError> {
     for &id in chain {
         store.metrics(id).map_err(|_| {
@@ -169,6 +210,10 @@ pub(super) fn validate_chain(store: &FontStore, chain: &[FontId]) -> Result<(), 
     Ok(())
 }
 
+/// Prepares every run of the block, preserving run indices one-to-one so the
+/// filler's spans address the input directly. Bidi levels are resolved across
+/// the whole paragraph first, since a run's neutrals depend on its neighbours.
+/// An unrecognized `kind` is refused.
 pub(super) fn prepare_runs(
     store: &FontStore,
     input: &MeasureInput,
@@ -213,6 +258,10 @@ pub(super) fn prepare_runs(
     Ok(prepared)
 }
 
+/// Per-character UBA levels for every run, resolved over the paragraph's
+/// concatenated text so neutrals see their real context. Non-text runs stand
+/// in as one object-replacement character each. A run carrying `w:rtl`
+/// re-resolves on its own text under an RTL base instead.
 fn paragraph_run_levels(input: &MeasureInput) -> Vec<Vec<u8>> {
     let mut combined = String::new();
     let mut spans = Vec::with_capacity(input.block.runs.len());
@@ -296,7 +345,11 @@ fn validate_image_dist(v: f32, name: &str) -> Result<f32, MeasureError> {
     }
 }
 
-/// Classifies floating, own-line, and inline image runs.
+/// Classifies an image run, in order: anchored and floating (`position` set
+/// plus a float display mode or a text-wrapping wrap type) → skipped;
+/// `topAndBottom` or block display → own-line; everything else → inline.
+/// Rotation bounds, where present, replace the declared width and height as
+/// the layout footprint. Missing dimensions mean zero size, never a refusal.
 fn prepare_image_run(run: &RunIn, bidi_level: u8) -> Result<PreparedRun, MeasureError> {
     let wrap = run.wrap_type.as_deref();
     let display = run.display_mode.as_deref();
@@ -364,7 +417,9 @@ fn prepare_image_run(run: &RunIn, bidi_level: u8) -> Result<PreparedRun, Measure
     }))
 }
 
-/// Measures a field from fallback text and run formatting.
+/// Measures a field at `fallback` (`"1"` when absent or empty) with the run's
+/// family, size, bold and italic. Caps flags and letter spacing do not apply
+/// to fields; super/subscript scaling does.
 fn prepare_field_run(
     store: &FontStore,
     input: &MeasureInput,
@@ -401,6 +456,8 @@ fn prepare_field_run(
     })
 }
 
+/// Size and baseline shift for `w:vertAlign`: both scripts shape at 0.75 of
+/// the run's size, superscript raised 0.4em and subscript lowered 0.2em.
 fn script_metrics(base_size_pt: f32, run: &RunIn) -> (f32, f32) {
     let base_px = pt_to_px(base_size_pt);
     if run.superscript {
@@ -412,11 +469,17 @@ fn script_metrics(base_size_pt: f32, run: &RunIn) -> (f32, f32) {
     }
 }
 
-/// Resolves a character through the fallback chain.
+/// First font in `chain` covering `ch`, or the chain's terminal font when
+/// nothing covers it. A truly uncovered character therefore shapes as that
+/// face's `.notdef` — a real advance width — instead of refusing the block.
+/// `None` only for an empty chain, which `validate_chain` rejects upstream.
 fn resolve_with_fallback(store: &FontStore, chain: &[FontId], ch: char) -> Option<FontId> {
     store.resolve(chain, ch).or_else(|| chain.last().copied())
 }
 
+/// Width of `text` shaped plainly through `chain` — no caps, letter spacing
+/// or horizontal scale — for field fallbacks and list markers. Segments split
+/// at font and UBA level boundaries under `base`.
 pub(super) fn measure_plain_text(
     store: &FontStore,
     chain: &[FontId],
@@ -465,6 +528,10 @@ pub(super) fn measure_plain_text(
     Ok(width)
 }
 
+/// Builds a text run's cluster advance table: validate and clamp the run's
+/// numbers, plan every character's face and casing, shape the resulting
+/// same-style subranges, fold glyph advances back onto original characters,
+/// and record the UAX-14 break opportunities.
 fn prepare_text_run(
     store: &FontStore,
     input: &MeasureInput,

--- a/crates/ooxml-text/src/measure/tabs.rs
+++ b/crates/ooxml-text/src/measure/tabs.rs
@@ -1,12 +1,34 @@
-//! Tab-stop grids and width calculation.
+//! Tab-stop grid and tab-width math.
+//!
+//! The paragraph's declared stops are overlaid on an implicit 720-twip grid.
+//! A tab advances from the line's current x — in content-area coordinates, the
+//! same origin stop positions use — to the next stop past it, less whatever
+//! the stop's alignment reserves for the runs that follow.
+//!
+//! The rules enforced here:
+//!
+//! - The grid interval is **always** 720 twips. `w:defaultTabStop` never
+//!   reaches tab-width measurement; it feeds only the list-marker width.
+//! - `decimal` stops measure like `start` stops: measurement reserves the full
+//!   span, and a painter places the decimal point within it.
+//! - `bar` stops draw a vertical rule and consume no horizontal space.
+//! - Any `val` other than `clear`/`end`/`center`/`decimal`/`bar` behaves like
+//!   `start`.
+//! - A `clear` entry knocks out the grid line at that position as well as a
+//!   declared stop; stops left of the left indent are dropped; and a positive
+//!   left indent gains an implicit stop at the indent itself, so a tab on a
+//!   hanging first line lands on the body text edge.
+//! - When the resolved span shrinks below a pixel — following content wider
+//!   than an `end` stop's room — the tab gives up on the stop and takes plain
+//!   default-grid spacing instead.
 
 use super::input::TabStopIn;
 
-/// Default 0.5-inch tab interval.
+/// Default tab interval: 720 twips = 0.5in = 48px.
 pub(super) const DEFAULT_TAB_INTERVAL_TWIPS: f32 = 720.0;
-/// Maximum twip distance treated as one stop.
+/// Two positions closer than this count as the same stop.
 const STOP_COINCIDENCE_TWIPS: f32 = 20.0;
-/// Implicit grid span past the indent.
+/// The implicit grid is laid out to ten inches past the left indent.
 const GRID_CEILING_SPAN_TWIPS: f32 = 14_400.0;
 
 /// Converts 96-DPI pixels to twips.
@@ -43,7 +65,9 @@ fn same_stop_position(a: f32, b: f32) -> bool {
     (a - b).abs() < STOP_COINCIDENCE_TWIPS
 }
 
-/// Overlays declared stops on the implicit grid.
+/// The paragraph's effective stop list, in twips, sorted by position:
+/// declared stops overlaid on the implicit 720-twip grid, with `clear`
+/// entries knocked out and stops left of the indent dropped.
 fn compute_tab_stops(declared: &[TabStopIn], left_indent_twips: f32) -> Vec<(f32, StopKind)> {
     let mut kept: Vec<(f32, StopKind)> = Vec::new();
     let mut cleared_at: Vec<f32> = Vec::new();
@@ -93,14 +117,17 @@ fn compute_tab_stops(declared: &[TabStopIn], left_indent_twips: f32) -> Vec<(f32
     grid
 }
 
-/// Advances to the next default grid line.
+/// Distance from `from_x_px` to the next default-grid line, a full stride
+/// when already sitting exactly on one.
 fn default_grid_advance(from_x_px: f32) -> f32 {
     let stride_px = twips_to_px(DEFAULT_TAB_INTERVAL_TWIPS);
     let advance = stride_px - (from_x_px % stride_px);
     if advance <= 0.0 { stride_px } else { advance }
 }
 
-/// Calculates a tab advance in content-area coordinates.
+/// Advance a tab occupies starting from `current_x_px`, in content-area
+/// coordinates. `following_width_px` is the inline width of the runs after
+/// the tab, which `end` and `center` stops anchor on.
 pub(super) fn calculate_tab_width(
     current_x_px: f32,
     declared: &[TabStopIn],

--- a/crates/ooxml-text/src/word_metrics.rs
+++ b/crates/ooxml-text/src/word_metrics.rs
@@ -1,9 +1,11 @@
-//! Word-specific measurement rules.
+//! Word-specific measurement rules — the places where reproducing Word
+//! demands something a generic text engine would not do.
 //!
-//! ECMA-376 references are to Part 1 (WordprocessingML); element
-//! semantics are summarized in `reference/quick-ref/wordprocessingml.md`
-//! ("Spacing (w:spacing)" section for line-rule value semantics and the
-//! twips/240ths unit table).
+//! Each rule is a free function taking its inputs explicitly, including the
+//! compat flags, so nothing here reads global state. ECMA-376 references are
+//! to Part 1 (WordprocessingML); element semantics are summarized in
+//! `reference/quick-ref/wordprocessingml.md` ("Spacing (w:spacing)" section
+//! for line-rule value semantics and the twips/240ths unit table).
 //!
 //! # 1. Font-unit line height (single spacing) — [`single_line_box`]
 //!
@@ -58,18 +60,20 @@
 //! happens at line layout, after shaping: shaped cluster advances stay
 //! fixed, only space-cluster advances grow.
 //!
-//! # 4. Snap-to-grid — **TODO, not implemented**
+//! # 4. Snap-to-grid — not applied
 //!
-//! When a section defines a document grid (`w:docGrid`, §17.6.5), line
-//! pitch snaps each line's height up to the next grid multiple unless the
-//! paragraph/run opts out (`w:snapToGrid` on pPr/rPr, §17.3.1/§17.3.2).
-//! Required for CJK document fidelity; the layout input does not carry grid pitch.
+//! Where a section defines a document grid (`w:docGrid`, §17.6.5), Word snaps
+//! each line's height up to the next grid multiple unless the paragraph or
+//! run opts out (`w:snapToGrid` on pPr/rPr, §17.3.1/§17.3.2). Measurement
+//! here never snaps: the input carries no grid pitch, so a line's height is
+//! whatever rules 1 and 2 compute and nothing more. CJK documents relying on
+//! the grid measure slightly short as a result.
 //!
 //! # 5. Kerning threshold — [`kern_enabled`], [`kern_features`]
 //!
 //! Word applies pair kerning only when the run's `w:kern` half-point
 //! threshold (rPr, §17.3.2) is nonzero and the font size is at or above it.
-//! [`crate::shape`] applies default OpenType features (which include GPOS
+//! [`mod@crate::shape`] applies default OpenType features (which include GPOS
 //! pair kerning via the `kern` feature) unconditionally; callers gate it
 //! per run by passing [`kern_features`]`(kern_enabled(..))` as the feature
 //! list. rustybuzz honors `kern=0` for GPOS-carried kerning (proven against
@@ -78,14 +82,13 @@
 //!
 //! # 6. Compatibility flags from `settings.xml` — [`CompatFlags`]
 //!
-//! `w:compat` / `w:compatSetting` (§17.15.3) select metric eras. The flags
-//! consumed by rules 1 and 3 (`w:noLeading`, `w:doNotExpandShiftReturn`)
-//! are carried by [`CompatFlags`]; they arrive parsed from `settings.xml`
-//! on the host side and are threaded into every rule as inputs, not
-//! globals. Still to come as the rules that consume them land:
-//! `compatibilityMode` (12/14/15), `w:useWord97LineBreakRules` (legacy
-//! kinsoku line breaking, layered over [`crate::line_break`]), and
-//! `w:balanceSingleByteDoubleByteWidth`.
+//! `w:compat` / `w:compatSetting` (§17.15.3) select metric eras. The two
+//! flags rules 1 and 3 consume — `w:noLeading` and
+//! `w:doNotExpandShiftReturn` — are carried by [`CompatFlags`], parsed from
+//! `settings.xml` host-side and threaded in as inputs. No rule here reads
+//! `compatibilityMode` (12/14/15), `w:useWord97LineBreakRules` or
+//! `w:balanceSingleByteDoubleByteWidth`, so a document setting them measures
+//! as though they were off.
 
 use crate::font_store::FontMetrics;
 use crate::shape::ShapeFeature;
@@ -110,7 +113,8 @@ pub enum LineSpacingRule {
     AtLeast { px: f32 },
 }
 
-/// One line box in px. total height = ascent + descent + leading.
+/// One line box in px: total height = ascent + descent + leading. Leading
+/// always sits *below* the descent, so the baseline hugs the top of the box.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LineBox {
     pub ascent: f32,

--- a/crates/ooxml-text/tests/measure.rs
+++ b/crates/ooxml-text/tests/measure.rs
@@ -11,6 +11,16 @@
 //!   external leading = 16 × max(0, (1854+434+67)−(1854+434))/2048 = 0.5234375
 //!   single line = 16 × (1854+434)/2048 + leading = 17.875 + 0.5234375 = 18.3984375
 //!   External leading is included in the line height.
+//!
+//! Because the numbers are exact, expectations are written as literal
+//! arithmetic rather than tolerances, and wrap behaviour is pinned by feeding
+//! a width one pixel either side of a computed threshold. Tests run through
+//! [`measure_paragraph_json`], so they also pin the serialized field names and
+//! the omission of unset optional fields.
+//!
+//! The numbered sections run from the core wrap and spacing rules through
+//! tabs, fields, list markers, images, small caps, bidi, indents and float
+//! exclusion zones.
 
 use ooxml_text::{FontStore, measure_paragraph_json};
 use serde_json::{Value, json};

--- a/packages/docx/src/layout/render/displayListQueries.ts
+++ b/packages/docx/src/layout/render/displayListQueries.ts
@@ -1,4 +1,45 @@
-/** Synchronous display-list queries backed by Rust hit testing. */
+/**
+ * Synchronous query facade over one built DisplayList, backed by the Rust
+ * hit-testing module (`crates/docx-layout/src/hit.rs`).
+ *
+ * This is the canvas renderer's only source of pointer and selection geometry:
+ * every rect comes from the immutable display list, never from DOM rects. A
+ * facade is created per display-list build, since the list never mutates in
+ * place, and it holds no state a caller has to keep in sync.
+ *
+ * **Two sources.** A resident editing engine queries its own display list
+ * directly and takes no display-list JSON at all. Otherwise the shared layout
+ * wasm answers, and the facade prefers a SESSION HANDLE: the list is parsed
+ * into the Rust store once (`openDisplayList`) and every later query goes by
+ * handle, with no per-query re-serialization. When the session exports are
+ * absent it stringifies the list once and reuses that string for the JSON-arg
+ * exports. The two paths run the same hit and range logic, so results are
+ * byte-identical and only the cost differs.
+ *
+ * **Handle acquisition is lazy** — on the first query that needs one, or when
+ * a host calls `prime()` from idle time — so replacing the facade on every
+ * keystroke costs no serialization on the input path. A new facade also tries
+ * to ADOPT its predecessor's parsed list, shipping a page delta for the pages
+ * that changed instead of reopening the whole list; superseded generations
+ * chain their donor, so a deferred pickup still costs one delta. The donor's
+ * own later queries degrade to its JSON-arg path.
+ *
+ * **Handle release.** `dispose()` frees the handle immediately. A facade
+ * dropped without it — a `useMemo` replacement, say — is covered by a
+ * `FinalizationRegistry`, and the Rust store additionally caps live handles
+ * and evicts the oldest, so a missed finalize cannot grow memory without
+ * bound.
+ *
+ * **Failure.** A wasm TRAP poisons the whole instance: a guard held across the
+ * query leaks and every later call into it fails, so the engine is marked dead,
+ * all queries stop, and `onDisplayListQuerySourceFailure` subscribers are told
+ * to rebuild the session. An ordinary error just falls back — a bad handle is
+ * dropped and the query retried over JSON.
+ *
+ * Queries are synchronous and return `null`/`[]` until the lazily imported
+ * wasm module resolves. In practice it is already loaded by the time a facade
+ * exists, because building the display list went through the same module.
+ */
 
 import type { DisplayList, DisplayPrimitive } from './displayList';
 import { displayPageRevision } from './frameDelta';
@@ -10,7 +51,11 @@ import {
 } from './displayListImages';
 import { loadRustDisplayListQueryEngine, type RustDisplayListQueryEngine } from './rustDisplayList';
 
-/** Query surface implemented by the editing wasm over its resident list. */
+/**
+ * Query surface of an editing engine that already holds the display list.
+ * None of these take display-list JSON, so this source never opens a handle
+ * and never serializes anything.
+ */
 export interface ResidentDisplayListQueryEngine {
   displayHitTestRegionsJson(pageIndex: number, x: number, y: number): string;
   displayVerticalMoveJson(
@@ -32,9 +77,9 @@ export type DisplayListHitRegion = 'body' | 'header' | 'footer';
 
 /**
  * Region-aware hit result. For `header`/`footer` the position refers to the
- * HF doc identified by `rId`, NOT the body doc — the caller must
- * route the selection to that HF editor, exactly like the DOM path scopes
- * clicks to `.layout-page-header|footer`.
+ * header/footer document identified by `rId`, NOT the body document — the
+ * caller must route the selection to that editor. `pos` is null when the point
+ * is inside the region but resolves to no position.
  */
 export interface DisplayListRegionHit {
   region: DisplayListHitRegion;
@@ -42,6 +87,10 @@ export interface DisplayListRegionHit {
   pos: number | null;
 }
 
+/**
+ * Result of an up/down caret move. `goalX` is the page-local x to feed back
+ * into the next move so a run of them holds one column.
+ */
 export interface DisplayListVerticalMove {
   position: number;
   goalX: number;
@@ -138,7 +187,7 @@ export interface DisplayListQueries {
    * `from`/`to` are positions in THAT doc. The same HF doc paints on every page
    * carrying the part, so this returns one rect-set per such page (each tagged
    * with its `pageIndex`) — the caller picks the page it is editing. Returns
-   * `[]` until the region-aware exports are embedded (feature-detected).
+   * `[]` when the region-aware exports are absent, which is feature-detected.
    */
   hfRangeRects(
     region: 'header' | 'footer',

--- a/packages/docx/src/layout/render/rustDisplayList.ts
+++ b/packages/docx/src/layout/render/rustDisplayList.ts
@@ -1,11 +1,36 @@
-/** Serializes layout inputs through the Rust display-list builder. */
+/**
+ * JS seam to the Rust display-list builder.
+ *
+ * Marshals the `{ measured, options, layout }` envelope across the wasm
+ * boundary and hands back a DisplayList. Every paint and geometry decision
+ * happens in Rust; this module is serialization glue and nothing else, so a
+ * failure here is terminal — the types below carry no second engine to fall
+ * back to, only a typed {@link RustDisplayListSourceError} naming the stage
+ * that failed.
+ *
+ * Two transports exist. {@link buildRustDisplayList} sends the whole envelope
+ * and parses a DisplayList back. {@link buildRustDisplayFrame} prefers an
+ * engine that already retains pagination: it sends only the display-level
+ * extras and receives a binary FrameDelta, which is applied to the previous
+ * frame so unchanged pages keep object identity — the invariant the query
+ * facade's page-delta adoption depends on. An engine without
+ * `buildDisplayListFrame` takes the full-JSON path instead.
+ *
+ * The wasm module is loaded lazily on first build, so the inlined binary costs
+ * nothing until a display list is actually requested.
+ */
 
 import type { Layout } from '../pagination/types';
 import type { MeasuredBlock } from '../pagination/measuredBlock';
 import type { DisplayList } from './displayList';
 import { applyFrameDelta, decodeFrameDelta, type RetainedFrame } from './frameDelta';
 
-/** Measured header/footer variant and band geometry. */
+/**
+ * One header/footer part in the `headersFooters` envelope field: the measured
+ * blocks of the header/footer document identified by `rId`, plus the band
+ * metrics the caller already computed. The builder passes the metrics through
+ * verbatim and re-derives none of them.
+ */
 export interface DisplayListHfVariant {
   rId: string;
   kind: 'header' | 'footer';
@@ -24,15 +49,15 @@ export interface DisplayListHfVariant {
    * line width is measured ONCE at the field's fallback text ("1"), so without
    * this the builder holds the same centered position on every page even though
    * "Page 2 of 3"/"Page 10 of 12" have different widths. Omitted ⇒ the fields
-   * ride the char-distributed fallback width (byte-identical to before).
+   * ride the char-distributed fallback width on every page.
    */
   fieldWidths?: DisplayListFieldWidths[];
 }
 
 /**
  * Per-page widths of one PAGE/NUMPAGES field run in an HF part. `pmStart` is the
- * field run's position in the HF doc (the key the Rust builder
- * matches). `fallbackWidth` is the width the measure baked into `line.width`
+ * field run's position in the header/footer document, and is the key the Rust
+ * builder matches on. `fallbackWidth` is the width the measure baked into `line.width`
  * (the field's fallback text); `perPage[i]` is the width of the field's resolved
  * text on layout page index `i` (PAGE → that page's number, NUMPAGES → total).
  */
@@ -56,7 +81,7 @@ export interface DisplayListHeadersFooters {
   /** Page-level Word watermark, painted behind body/header/footer content. */
   watermark?: DisplayListWatermark;
   variants: DisplayListHfVariant[];
-  /** Stable section identity. Undefined = document-global legacy envelope. */
+  /** Stable section identity. Undefined ⇒ the envelope covers the whole document. */
   sectionId?: string;
   /** Zero-based section index. */
   sectionIndex?: number;
@@ -152,7 +177,7 @@ export interface DisplayListCommentThread {
 
 /** The `{ measured, options, layout }` envelope the Rust builder consumes. */
 export interface DisplayListBuildInputs {
-  /** Serialization contract version. Undefined reads as legacy version 0. */
+  /** Serialization contract version. Undefined reads as version 0. */
   contractVersion?: number;
   measured: MeasuredBlock[];
   options: unknown;
@@ -164,26 +189,30 @@ export interface DisplayListBuildInputs {
    * → measurement `FontStore` ids — the SAME map the measurement input carries.
    * Present only under Rust measurement (the ids must belong to a populated
    * store); its presence against that store is what gates GlyphRun emission.
-   * Omitted ⇒ every text run takes the browser-measured `TextRunPrimitive` path
-   * (byte-identical to the pre-glyph build).
+   * Omitted ⇒ every text run is emitted as a browser-measured
+   * `TextRunPrimitive` rather than a shaped `GlyphRun`.
    */
   fontChains?: Record<string, number[]>;
   /** Page/section note regions. Undefined = no note emission. */
   noteAreas?: DisplayListNoteArea[];
   /** Resolved comments suppressed from active tint. Undefined = none known. */
   resolvedCommentIds?: number[];
-  /** Stable reviewer palette. Undefined = legacy hard-coded colors. */
+  /** Stable reviewer palette. Undefined ⇒ the builder's built-in colors. */
   commentAuthors?: DisplayListCommentAuthor[];
   /** Per-comment thread metadata for a11y announcements. Undefined = none. */
   commentThreads?: DisplayListCommentThread[];
 }
 
-/** Minimal engine surface, injectable so tests can fake the wasm module. */
+/**
+ * Minimal build surface, injectable so tests can fake the wasm module. Only
+ * `buildDisplayListJson` is required; the optional members are what an engine
+ * that retains its own pagination and display state additionally offers.
+ */
 export interface RustDisplayListEngine {
   buildDisplayListJson(input: string): string;
-  /** Resident editing engines expose binary deltas; the stateless layout wasm does not. */
+  /** Binary FrameDelta build; the stateless layout wasm does not offer it. */
   buildDisplayListFrame?(input: string, expectedFrameEpoch: number): Uint8Array;
-  /** One-owner ordinary input path; available on the resident editing engine. */
+  /** Applies one keystroke and returns its frame, without a layout round trip. */
   applyInput?(text: string, expectedFrameEpoch: number): Uint8Array;
   displayHitTestRegionsJson?(pageIndex: number, x: number, y: number): string;
   displayVerticalMoveJson?(
@@ -204,7 +233,10 @@ export type RustDisplayListSourceErrorStage = 'load' | 'build' | 'parse' | 'deco
 
 export interface RustDisplayFrameResult {
   displayList: DisplayList;
-  /** Null only on the compatibility JSON engine path. */
+  /**
+   * The retained frame to pass as `previous` on the next build. Null when the
+   * engine answered over full JSON, which retains nothing.
+   */
   frame: RetainedFrame | null;
   transport: 'frame-delta-v1' | 'json';
 }
@@ -225,7 +257,19 @@ export class RustDisplayListSourceError extends Error {
   }
 }
 
-/** Injectable display-list query surface with optional session handles. */
+/**
+ * Query surface over an already-built display list, injectable so tests can
+ * fake the wasm module.
+ *
+ * The required `*Json` members take the display-list JSON as an argument and
+ * the Rust side re-parses it per query, so callers should cache the string.
+ * The OPTIONAL session-handle members parse the list once (`openDisplayList` →
+ * a handle) and answer many queries by handle with no re-serialization,
+ * reusing the same hit and range logic so results are byte-identical. They are
+ * optional because the embedded wasm may not carry them; `hasDisplayListSession`
+ * and `hasRangeRectsRegion` report what is present, and
+ * `createDisplayListQueries` falls back to the `*Json` path when it is not.
+ */
 export interface RustDisplayListQueryEngine {
   /** region-aware hit test → `{"region","rId"?,"pos"}` or `"null"` JSON */
   hitTestRegionsJson(displayList: string, pageIndex: number, x: number, y: number): string;
@@ -238,7 +282,12 @@ export interface RustDisplayListQueryEngine {
   ): string;
   /** body document range → JSON array of `{pageIndex,x,y,width,height}` rects */
   rangeRectsJson(displayList: string, from: number, to: number): string;
-  /** Region-aware document range rectangles when supported. */
+  /**
+   * Region-aware document range → JSON array of rects. `region` is
+   * `'body' | 'header' | 'footer'`; `rId` scopes a header/footer to one part
+   * (empty for body, or to match any). Optional — the facade returns `[]`
+   * when it is absent.
+   */
   rangeRectsRegionJson?(
     displayList: string,
     region: string,
@@ -420,8 +469,9 @@ const measureFragmentCache = new WeakMap<object, string>();
 
 /**
  * Build a DisplayList for a computed layout through the Rust engine. Throws
- * when the wasm module fails to load or the builder rejects the input — the
- * caller is expected to fall back to the DOM painter.
+ * {@link RustDisplayListSourceError} tagged with the failing stage — `load`,
+ * `build` or `parse` — when the wasm module cannot be loaded, the builder
+ * rejects the input, or its output does not parse.
  */
 export async function buildRustDisplayList(
   inputs: DisplayListBuildInputs,
@@ -451,7 +501,17 @@ export async function buildRustDisplayList(
   }
 }
 
-/** Builds a display frame with JSON fallback when frame deltas are unavailable. */
+/**
+ * Build one display frame. An engine that retains pagination returns a binary
+ * FrameDelta, decoded and applied on top of `previous` so unchanged pages keep
+ * object identity; `previous` also supplies the frame epoch the engine checks
+ * before sending a delta rather than a full frame. An engine without
+ * `buildDisplayListFrame` takes the full-JSON path, and its result carries
+ * `frame: null` and `transport: 'json'`.
+ *
+ * Throws {@link RustDisplayListSourceError} tagged with the failing stage:
+ * `load`, `build`, `decode` or `apply`.
+ */
 export async function buildRustDisplayFrame(
   inputs: DisplayListBuildInputs,
   engine?: RustDisplayListEngine,

--- a/packages/docx/src/wasm/layout.ts
+++ b/packages/docx/src/wasm/layout.ts
@@ -21,7 +21,9 @@ import wasmInit, {
   range_rects_json,
   register_measure_font,
 } from './generated/layout/docx_layout.js';
-// Resolve optional exports dynamically when generated declarations omit them.
+// Namespace view of the same glue. Exports the generated .d.ts does not
+// declare are resolved by name through this, since a named import of an
+// undeclared export would not typecheck.
 import * as layoutGlue from './generated/layout/docx_layout.js';
 import { createWasmModuleState, type WasmAsyncInput } from './loadWasmAsset';
 
@@ -64,7 +66,20 @@ export function rangeRectsJson(displayList: string, from: number, to: number): s
   return range_rects_json(displayList, from, to);
 }
 
-// Optional session exports avoid repeated display-list serialization.
+// ---------------------------------------------------------------------------
+// session-handle query surface
+//
+// The JSON-arg queries above re-send the whole display list on every call and
+// Rust re-parses it each time, which dominates the cost of click and drag
+// paths. The session exports parse the list ONCE (`open_display_list` → a
+// handle) and answer many queries by handle, reusing the same hit and range
+// logic, so results are byte-identical and only the cost differs.
+//
+// These exports are OPTIONAL: the embedded wasm may not carry them. Every
+// wrapper below throws when its export is missing, so callers feature-detect
+// with `hasDisplayListSession()` / `hasDisplayListUpdate()` /
+// `hasRangeRectsRegion()` and fall back to the JSON-arg path.
+// ---------------------------------------------------------------------------
 
 type OpenDisplayListExport = (json: string) => number;
 type CloseDisplayListExport = (handle: number) => void;
@@ -117,13 +132,24 @@ export function hasDisplayListSession(): boolean {
   return glueExport<OpenDisplayListExport>('open_display_list') !== undefined;
 }
 
-/** Reports whether region-aware range rectangles are available. */
+/**
+ * True when the embedded layout wasm carries the region-aware range-rect
+ * exports (`range_rects_region_json` and its by-handle twin). Callers gate
+ * header/footer selection and caret geometry on this and otherwise return
+ * `[]`; probing avoids invoking — and so dropping the session handle over — an
+ * absent export.
+ */
 export function hasRangeRectsRegion(): boolean {
   state.ensure();
   return glueExport<RangeRectsRegionJsonExport>('range_rects_region_json') !== undefined;
 }
 
-/** Opens a reusable display-list handle. */
+/**
+ * Parse a display list once and return the handle the by-handle queries reuse.
+ * The caller owns it and must `closeDisplayList` it. Throws when the export is
+ * absent or the JSON is malformed; the query facade catches that and stays on
+ * the JSON-arg path.
+ */
 export function openDisplayList(displayList: string): number {
   state.ensure();
   const open = glueExport<OpenDisplayListExport>('open_display_list');
@@ -176,7 +202,11 @@ export function hitTestRegionsByHandle(
   return query(handle, pageIndex, x, y);
 }
 
-/** Resolve the closest caret position on the adjacent visual line. */
+/**
+ * Closest caret position on the adjacent visual line: `{"position","goalX"}`
+ * JSON, or `"null"` when there is no line in that direction. `goalX` is the
+ * page-local x the caret holds across successive moves.
+ */
 export function verticalMoveJson(
   displayList: string,
   position: number,
@@ -215,7 +245,12 @@ export function rangeRectsByHandle(handle: number, from: number, to: number): st
   return query(handle, from, to);
 }
 
-/** Returns region range rects or throws when the optional export is unavailable. */
+/**
+ * Region-aware highlight rects: `region` is `"body" | "header" | "footer"`,
+ * and `rId` scopes a header/footer to one part (empty string for body, or to
+ * match any). `from`/`to` are positions in THAT region's document. Throws when
+ * the export is absent, so the facade falls back to `[]`.
+ */
 export function rangeRectsRegionJson(
   displayList: string,
   region: string,
@@ -296,13 +331,23 @@ export function measureParagraphJson(input: string): string {
 
 type OutlineGlyphExport = (fontId: number, glyphId: number) => string;
 
-// Missing outline exports fall back to fillText.
+// Optional like the session exports: when the embedded wasm has no
+// `outline_glyph_json` this resolves to undefined, `outlineGlyphJson` throws,
+// and the canvas backend paints the run with `fillText` instead.
 function resolveOutlineGlyphExport(): OutlineGlyphExport | undefined {
   const fn = (layoutGlue as unknown as Record<string, unknown>).outline_glyph_json;
   return typeof fn === 'function' ? (fn as OutlineGlyphExport) : undefined;
 }
 
-/** Returns a glyph outline or throws when it is unavailable. */
+/**
+ * Glyph outline for `(fontId, glyphId)` as JSON:
+ * `{"upem":2048,"cmds":[{"t":"M",…},{"t":"L",…},{"t":"Q",…},{"t":"C",…},{"t":"Z"}]}`
+ * — commands in font units, y-up per the font convention. `fontId` is a
+ * measurement FontStore id from {@link registerMeasureFont}, `glyphId` a glyph
+ * index from shaping. Throws when the export is absent or the glyph cannot be
+ * extracted; the canvas backend catches that and paints the run via
+ * `fillText`, so text is never invisible.
+ */
 export function outlineGlyphJson(fontId: number, glyphId: number): string {
   state.ensure();
   const outlineExport = resolveOutlineGlyphExport();


### PR DESCRIPTION
TL;DR:


Summary:
- Adds module-level docs to `docx-layout`, `ooxml-text`, `docx-edit` and the `packages/docx` render seam, stating what each module owns and the rules it enforces.
- Documents the contracts that cannot be inferred from a signature: every wasm entry point's accepted JSON, receipt and error shape; the `canonical-stream-v1` byte layout; measurement span semantics and the four refusal categories; display-list paint order and determinism rules.
- Corrects several places where existing prose described behaviour the code no longer has — column-balancing break snapping, first-page header/footer selection, letter-spacing granularity, uncovered-character fallback, and `pPrChange` resolution.
- Fixes a stale build-script path in `docx-edit/Cargo.toml` and three ambiguous intra-doc links that broke `cargo doc -D warnings`.

Comments and docstrings only. The 12 non-comment lines in the diff are two reworded test assertion messages and one rustfmt re-layout of a struct variant that gained a doc comment.

Test plan:
- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`
- [ ] `bun run --filter './packages/*' typecheck`
- [ ] spot-read `crates/ooxml-text/src/measure/mod.rs` and `crates/docx-edit/src/wasm.rs` — the two highest-traffic contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified documentation for document editing, layout, text measurement, pagination, hit testing, display lists, WASM APIs, and serialization contracts.
  * Clarified coordinate systems, formatting behavior, tracked changes, tables, floats, lists, tabs, comments, and error handling.
  * Updated build instructions and API descriptions to reflect current behavior.
* **Tests**
  * Improved test documentation and assertion messages without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->