### PR TITLE
fix(docx): let a group label delete reach a series in the JSON path

### DIFF
--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -7762,8 +7762,15 @@ fn plot_labels_from<'a>(
     group: Option<&'a ChartDataLabelsIn>,
     series: Option<&'a ChartDataLabelsIn>,
 ) -> Option<PlotDataLabels<'a>> {
-    let inherited = if series.is_some() { series } else { group };
-    if inherited?.delete == Some(true) {
+    let levels = [series, group];
+    levels.iter().copied().flatten().next()?;
+    if levels
+        .iter()
+        .copied()
+        .flatten()
+        .find_map(|labels| labels.delete)
+        == Some(true)
+    {
         return None;
     }
     let switch = |read: fn(&ChartDataLabelsIn) -> Option<bool>| {
@@ -10515,5 +10522,32 @@ mod tests {
                 .iter()
                 .any(|primitive| primitive["fill"] == "#abcdef")
         );
+    }
+
+    #[test]
+    fn a_group_delete_suppresses_a_series_that_sets_other_switches() {
+        let group = ChartDataLabelsIn {
+            delete: Some(true),
+            ..Default::default()
+        };
+        let series = ChartDataLabelsIn {
+            show_value: Some(true),
+            ..Default::default()
+        };
+        assert!(plot_labels_from(Some(&group), Some(&series)).is_none());
+
+        let restoring = ChartDataLabelsIn {
+            delete: Some(false),
+            show_value: Some(true),
+            ..Default::default()
+        };
+        let resolved = plot_labels_from(Some(&group), Some(&restoring)).unwrap();
+        assert!(resolved.show_value);
+
+        let series_only = ChartDataLabelsIn {
+            delete: Some(true),
+            ..Default::default()
+        };
+        assert!(plot_labels_from(None, Some(&series_only)).is_none());
     }
 }


### PR DESCRIPTION
TL;DR:


Summary:
- `plot_labels_from` in `crates/docx-layout/src/display_list.rs` resolved `delete` by picking a single level — series if present, group otherwise — so a group-level `delete: true` was ignored as soon as a series declared any other switch.
- It now takes the first explicitly specified `delete` down series → group, matching the shared model path, so an explicit `false` at a lower level still restores an inherited delete.
- Adds a regression test covering suppression, restoration, and the series-only case.

Context: the same defect was fixed in the shared `ooxml-drawingml` cascade, but this parallel implementation for the docx JSON input path was not updated, leaving two divergent implementations of one OOXML rule. This closes that gap. Not a regression against any released behaviour — the docx JSON path never handled it correctly.

Known remaining gap, not addressed here: `ChartDataLabelsIn` has no `points` field, so per-point `c:dLbl` overrides are ignored entirely on the docx JSON path, while `packages/docx/src/types/content/chart.ts` advertises `points?: ChartPointLabel[]`. Closing that means extending the input type and threading per-point resolution through, which is a wire-format change and deserves its own PR.

Test plan:
- [ ] `cargo test -p betteroffice-docx-layout`
- [ ] decide whether the `points` gap above is worth closing or the TS type should stop advertising it

🤖 Generated with [Claude Code](https://claude.com/claude-code)