### PR TITLE
chore(python): refresh the bindings lockfile

### DIFF
--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -52,6 +52,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "betteroffice-drawingml"
+version = "0.0.4"
+dependencies = [
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "betteroffice-opc"
 version = "0.0.4"
 dependencies = [
@@ -65,6 +73,7 @@ dependencies = [
 name = "betteroffice-xlsx"
 version = "0.0.4"
 dependencies = [
+ "betteroffice-drawingml",
  "betteroffice-opc",
  "betteroffice-xlsx-calc",
  "betteroffice-xlsx-model",
@@ -105,6 +114,7 @@ dependencies = [
 name = "betteroffice-xlsx-parse"
 version = "0.0.4"
 dependencies = [
+ "betteroffice-drawingml",
  "betteroffice-xlsx-model",
  "quick-xml",
 ]
@@ -131,6 +141,7 @@ dependencies = [
 name = "betteroffice-xlsx-render"
 version = "0.0.4"
 dependencies = [
+ "betteroffice-drawingml",
  "betteroffice-xlsx-model",
  "serde",
 ]
@@ -373,6 +384,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]


### PR DESCRIPTION
TL;DR:


Summary:
- Refreshes `bindings/python/Cargo.lock`, which went stale when the xlsx crates gained a dependency on `betteroffice-drawingml` through the chart work.
- `cargo check --manifest-path bindings/python/Cargo.toml --locked` now succeeds; before this it could not resolve without regenerating.

Why it went unnoticed: the Python gate runs `pip install -e .`, which invokes cargo without `--locked`, so a stale lockfile is silently regenerated during the build rather than failing. The practical symptoms are that builds are not reproducible from the committed lock, and any local build leaves the lockfile modified in the working tree.

Worth considering separately: adding `--locked` to the Python build would turn this class of drift into a CI failure instead of a silent regeneration, the same way the Rust gate treats the workspace lock.

Test plan:
- [ ] `cargo check --manifest-path bindings/python/Cargo.toml --locked`
- [ ] Python gate green
- [ ] decide whether the Python build should pass `--locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)