### PR TITLE
ci(python): put the Python binding on the changeset release train

### DIFF
--- a/bindings/python/package.json
+++ b/bindings/python/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@betteroffice/python-bindings",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "typecheck": "true"
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,10 @@
         "wrangler": "^4.106.0",
       },
     },
+    "bindings/python": {
+      "name": "@betteroffice/python-bindings",
+      "version": "0.0.1",
+    },
     "crates": {
       "name": "@betteroffice/rust-crates",
       "version": "0.0.4",
@@ -464,6 +468,8 @@
     "@betteroffice/pptx-i18n": ["@betteroffice/pptx-i18n@workspace:packages/pptx-i18n"],
 
     "@betteroffice/pptx-react": ["@betteroffice/pptx-react@workspace:packages/pptx-react"],
+
+    "@betteroffice/python-bindings": ["@betteroffice/python-bindings@workspace:bindings/python"],
 
     "@betteroffice/redact-worker": ["@betteroffice/redact-worker@workspace:apps/redact-worker"],
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "workspaces": [
     "apps/*",
+    "bindings/*",
     "packages/*",
     "crates"
   ],

--- a/scripts/version-packages.mjs
+++ b/scripts/version-packages.mjs
@@ -8,6 +8,28 @@ import {
   validateRustTrain
 } from './rust-crates.mjs';
 
+const PYTHON_RELEASE_MANIFEST = 'bindings/python/package.json';
+const PYTHON_MANIFEST = 'bindings/python/Cargo.toml';
+
+function pythonReleaseVersion() {
+  return JSON.parse(readFileSync(PYTHON_RELEASE_MANIFEST, 'utf8')).version;
+}
+
+function packageVersion(source) {
+  const section = source.match(/\[package\]\n([\s\S]*?)(?=\n\[|$)/);
+  const version = section?.[1].match(/^version = "([^"]+)"$/m)?.[1];
+  if (!version) throw new Error('bindings/python package.version is missing');
+  return version;
+}
+
+// pyproject reads its version from Cargo.toml, so this is the only file to rewrite.
+function synchronizePythonVersion(source, from, to) {
+  if (packageVersion(source) !== from) {
+    throw new Error(`Python binding is not at ${from}`);
+  }
+  return source.replace(/(\[package\]\n[\s\S]*?^version = ")[^"]+("$)/m, `$1${to}$2`);
+}
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -48,7 +70,14 @@ function validate(version, locked) {
 
 const checkOnly = process.argv.includes('--check');
 const before = rustReleaseVersion();
+const pythonBefore = pythonReleaseVersion();
 const cargoBefore = readFileSync(WORKSPACE_MANIFEST, 'utf8');
+const pythonCargoBefore = readFileSync(PYTHON_MANIFEST, 'utf8');
+if (packageVersion(pythonCargoBefore) !== pythonBefore) {
+  throw new Error(
+    `Python changeset marker is ${pythonBefore}, but Cargo is ${packageVersion(pythonCargoBefore)}`
+  );
+}
 if (workspaceVersion(cargoBefore) !== before) {
   throw new Error(`Rust changeset marker is ${before}, but Cargo is ${workspaceVersion(cargoBefore)}`);
 }
@@ -58,8 +87,13 @@ if (checkOnly) {
   if (workspaceVersion(simulated) !== '999.999.999') {
     throw new Error('Cargo release train version synchronization failed');
   }
+  const simulatedPython = synchronizePythonVersion(pythonCargoBefore, pythonBefore, '999.999.999');
+  if (packageVersion(simulatedPython) !== '999.999.999') {
+    throw new Error('Python binding version synchronization failed');
+  }
   validate(before, true);
   console.log(`Rust release train is synchronized at ${before}.`);
+  console.log(`Python binding is synchronized at ${pythonBefore}.`);
   process.exit(0);
 }
 
@@ -74,7 +108,20 @@ if (after !== before) {
   validate(after, false);
 }
 
+const pythonAfter = pythonReleaseVersion();
+if (pythonAfter !== pythonBefore) {
+  writeFileSync(
+    PYTHON_MANIFEST,
+    synchronizePythonVersion(readFileSync(PYTHON_MANIFEST, 'utf8'), pythonBefore, pythonAfter)
+  );
+}
+
 validate(after, true);
+console.log(
+  pythonAfter === pythonBefore
+    ? `Python binding remains at ${pythonAfter}.`
+    : `Synchronized Python binding ${pythonBefore} -> ${pythonAfter}.`
+);
 console.log(
   after === before
     ? `Rust release train remains at ${after}.`


### PR DESCRIPTION
TL;DR:


Summary:

- New `bindings/python/package.json` — private, `@betteroffice/python-bindings`, no-op `typecheck` like the crates shim.
- `bindings/*` added to `workspaces`; `bun.lock` updated so `--frozen-lockfile` still passes in CI.
- `version-packages.mjs` reads the shim before and after `changeset version` and rewrites `[package] version` in `bindings/python/Cargo.toml` when it moves. The `--check` path simulates it, same as the Rust train.

Test plan:

- [x] `bun install --frozen-lockfile` succeeds with the new workspace member
- [x] `bun run version-packages --check` reports both trains
- [x] Add a changeset for `@betteroffice/python-bindings`, run `bun run version-packages`, confirm `bindings/python/Cargo.toml` moves, then reset
- [x] Confirm the binding should have its own version rather than joining the crates train
- [x] Confirm `bun run --filter '*' typecheck` still passes with the shim present

🤖 Generated with [Claude Code](https://claude.com/claude-code)