### PR TITLE
refactor(docx): parse limits entry point and a native undo session

### DIFF
--- a/crates/docx-edit/src/lib.rs
+++ b/crates/docx-edit/src/lib.rs
@@ -99,7 +99,7 @@ pub use queries::{
 pub use raw::RawOp;
 pub use read_state::{RevisionInfo, SelectionContextInfo, TriState};
 pub use seed::seed_from_docx;
-pub use undo::{DocUndoManager, UNDO_CAPTURE_TIMEOUT_MS, UNDO_DEPTH};
+pub use undo::{DocUndoManager, UNDO_CAPTURE_TIMEOUT_MS, UNDO_DEPTH, UndoSession};
 
 #[cfg(feature = "wasm")]
 pub mod wasm;

--- a/crates/docx-edit/src/undo.rs
+++ b/crates/docx-edit/src/undo.rs
@@ -6,14 +6,15 @@
 //! [`EditingDoc::undo_scope_with_clock`]; the plain [`EditingDoc::undo_scope`] picks a per-target
 //! default.
 
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::sync::Arc;
 
 use yrs::sync::time::Clock;
-use yrs::{Origin, Transact};
+use yrs::{Origin, ReadTxn, Transact};
 
 use crate::op::OpResult;
-use crate::{EditingDoc, story_ref};
+use crate::{EditingDoc, STORIES, story_ref};
 
 /// Undo capture window.
 pub const UNDO_CAPTURE_TIMEOUT_MS: u64 = 500;
@@ -142,5 +143,98 @@ impl DocUndoManager {
     /// Low-level escape hatch for the transport/awareness bridges.
     pub fn raw(&mut self) -> &mut yrs::undo::UndoManager<()> {
         &mut self.inner
+    }
+}
+
+/// One tracked undo scope per session, shared by the WASM boundary and the native facade.
+///
+/// Every accessor is inert until a scope is tracked, so a host may call it before import.
+#[derive(Default)]
+pub struct UndoSession {
+    manager: RefCell<Option<DocUndoManager>>,
+    scope: RefCell<Option<String>>,
+}
+
+impl UndoSession {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Tracks one story, replacing any other scope and its history. Re-tracking is a no-op.
+    pub fn track(&self, doc: &EditingDoc, story: &str) -> OpResult<()> {
+        if self.scope.borrow().as_deref() == Some(story) {
+            return Ok(());
+        }
+        let manager = doc.undo_scope(&[story])?;
+        *self.manager.borrow_mut() = Some(manager);
+        *self.scope.borrow_mut() = Some(story.to_owned());
+        Ok(())
+    }
+
+    /// [`UndoSession::track`] widened to the stories root so structural table edits also
+    /// restore the cell stories they created or destroyed. Tracked as its own scope.
+    pub fn track_table(&self, doc: &EditingDoc, story: &str) -> OpResult<()> {
+        let scope = format!("table:{story}");
+        if self.scope.borrow().as_deref() == Some(scope.as_str()) {
+            return Ok(());
+        }
+        let mut manager = doc.undo_scope(&[story])?;
+        let txn = doc.yrs_doc().transact();
+        let stories = txn
+            .get_map(STORIES)
+            .expect("stories root is declared by EditingDoc::new");
+        drop(txn);
+        manager.raw().expand_scope(doc.yrs_doc(), &stories);
+        *self.manager.borrow_mut() = Some(manager);
+        *self.scope.borrow_mut() = Some(scope);
+        Ok(())
+    }
+
+    pub fn undo(&self) -> bool {
+        self.manager
+            .borrow_mut()
+            .as_mut()
+            .is_some_and(DocUndoManager::undo)
+    }
+
+    pub fn redo(&self) -> bool {
+        self.manager
+            .borrow_mut()
+            .as_mut()
+            .is_some_and(DocUndoManager::redo)
+    }
+
+    pub fn can_undo(&self) -> bool {
+        self.manager
+            .borrow()
+            .as_ref()
+            .is_some_and(DocUndoManager::can_undo)
+    }
+
+    pub fn can_redo(&self) -> bool {
+        self.manager
+            .borrow()
+            .as_ref()
+            .is_some_and(DocUndoManager::can_redo)
+    }
+
+    pub fn add_undo_barrier(&self) {
+        if let Some(manager) = self.manager.borrow_mut().as_mut() {
+            manager.add_undo_barrier();
+        }
+    }
+
+    pub fn undo_depth(&self) -> usize {
+        self.manager
+            .borrow()
+            .as_ref()
+            .map_or(0, DocUndoManager::undo_depth)
+    }
+
+    pub fn redo_depth(&self) -> usize {
+        self.manager
+            .borrow()
+            .as_ref()
+            .map_or(0, DocUndoManager::redo_depth)
     }
 }

--- a/crates/docx-edit/src/wasm.rs
+++ b/crates/docx-edit/src/wasm.rs
@@ -50,10 +50,10 @@ use crate::presence::{
     apply_update_with_typing_inference, encode_sticky, resolve_sticky_selection,
 };
 use crate::{
-    CellLoc, ChangeKind, ChangeTarget, ColorPatch, DocUndoManager, EditCtx, EditingDoc,
-    EngineSession, FontFamilyPatch, FormatPolicy, InlineFormatDelta, MergeDirection, ParaAttrDelta,
-    ParaSelector, Patch, Position, RawOp, SegmentContent, SimpleFormat, StoryRange, TabStop,
-    TableLocator, TableRange, TriState, story_ref,
+    CellLoc, ChangeKind, ChangeTarget, ColorPatch, EditCtx, EditingDoc, EngineSession,
+    FontFamilyPatch, FormatPolicy, InlineFormatDelta, MergeDirection, ParaAttrDelta, ParaSelector,
+    Patch, Position, RawOp, SegmentContent, SimpleFormat, StoryRange, TabStop, TableLocator,
+    TableRange, TriState, UndoSession, story_ref,
 };
 
 #[wasm_bindgen]
@@ -833,8 +833,7 @@ pub struct EditSession {
     docx_source: RefCell<Option<Vec<u8>>>,
     update_observer: Option<Subscription>,
     update_event_observer: Option<UpdateEventObserver>,
-    undo: RefCell<Option<DocUndoManager>>,
-    undo_story: RefCell<Option<String>>,
+    undo: UndoSession,
     selection: RefCell<Option<LocalSelection>>,
     cell_selection: RefCell<Option<LocalCellSelection>>,
     last_apply_profile_json: RefCell<String>,
@@ -1076,8 +1075,7 @@ impl EditSession {
             docx_source: RefCell::new(None),
             update_observer: None,
             update_event_observer: None,
-            undo: RefCell::new(None),
-            undo_story: RefCell::new(None),
+            undo: UndoSession::new(),
             selection: RefCell::new(None),
             cell_selection: RefCell::new(None),
             last_apply_profile_json: RefCell::new("{}".to_owned()),
@@ -1796,13 +1794,7 @@ impl EditSession {
     /// Re-tracking the same story is a no-op that preserves the history.
     /// Errors on an unknown story.
     pub fn track_undo(&self, story: &str) -> Result<(), JsValue> {
-        if self.undo_story.borrow().as_deref() == Some(story) {
-            return Ok(());
-        }
-        let manager = self.engine.doc().undo_scope(&[story]).map_err(js_err)?;
-        *self.undo.borrow_mut() = Some(manager);
-        *self.undo_story.borrow_mut() = Some(story.to_owned());
-        Ok(())
+        self.undo.track(self.engine.doc(), story).map_err(js_err)
     }
 
     /// Starts local undo tracking for a structural table edit in `story`.
@@ -1812,73 +1804,42 @@ impl EditSession {
     /// [`EditSession::track_undo`] on the same story, so switching between
     /// them starts a fresh history. Errors on an unknown story.
     pub fn track_table_undo(&self, story: &str) -> Result<(), JsValue> {
-        let scope_key = format!("table:{story}");
-        if self.undo_story.borrow().as_deref() == Some(scope_key.as_str()) {
-            return Ok(());
-        }
-        let mut manager = self.engine.doc().undo_scope(&[story]).map_err(js_err)?;
-        let txn = self.engine.doc().yrs_doc().transact();
-        let stories = txn
-            .get_map(STORIES)
-            .expect("stories root is declared by EditingDoc::new");
-        drop(txn);
-        manager
-            .raw()
-            .expand_scope(self.engine.doc().yrs_doc(), &stories);
-        *self.undo.borrow_mut() = Some(manager);
-        *self.undo_story.borrow_mut() = Some(scope_key);
-        Ok(())
+        self.undo
+            .track_table(self.engine.doc(), story)
+            .map_err(js_err)
     }
 
     /// Reverts the latest local-origin transaction and reports whether
     /// anything was reverted. Remote and system transactions are excluded by
     /// the manager's tracked-origin policy; `false` before a story is tracked.
     pub fn undo(&self) -> bool {
-        self.undo
-            .borrow_mut()
-            .as_mut()
-            .is_some_and(DocUndoManager::undo)
+        self.undo.undo()
     }
 
     /// Reapplies the latest locally undone transaction and reports whether
     /// anything was reapplied.
     pub fn redo(&self) -> bool {
-        self.undo
-            .borrow_mut()
-            .as_mut()
-            .is_some_and(DocUndoManager::redo)
+        self.undo.redo()
     }
 
     /// Whether [`EditSession::undo`] would revert something.
     pub fn can_undo(&self) -> bool {
-        self.undo
-            .borrow()
-            .as_ref()
-            .is_some_and(DocUndoManager::can_undo)
+        self.undo.can_undo()
     }
 
     /// Whether [`EditSession::redo`] would reapply something.
     pub fn can_redo(&self) -> bool {
-        self.undo
-            .borrow()
-            .as_ref()
-            .is_some_and(DocUndoManager::can_redo)
+        self.undo.can_redo()
     }
 
     /// Current local undo stack size. Zero before a story starts tracking.
     pub fn undo_depth(&self) -> u32 {
-        self.undo
-            .borrow()
-            .as_ref()
-            .map_or(0, |undo| undo.undo_depth() as u32)
+        self.undo.undo_depth() as u32
     }
 
     /// Current local redo stack size. Zero before a story starts tracking.
     pub fn redo_depth(&self) -> u32 {
-        self.undo
-            .borrow()
-            .as_ref()
-            .map_or(0, |undo| undo.redo_depth() as u32)
+        self.undo.redo_depth() as u32
     }
 
     /// Stores this peer's anchor and head as sticky positions, replacing any

--- a/crates/docx-parse/src/lib.rs
+++ b/crates/docx-parse/src/lib.rs
@@ -149,7 +149,7 @@ pub use s8::{
 };
 pub use s9::{
     BinaryPartWire, S9DocumentBodyWire, S9DocumentWire, S9PackageWire, S9ParseOptions,
-    S9SectionWire, S9WireEnvelope, parse_docx_s9_wire,
+    S9SectionWire, S9WireEnvelope, parse_docx_s9_wire, parse_docx_s9_wire_with_limits,
 };
 pub use scalars::{
     ColorValue, RunScalarProperties, ShadingProperties, UnderlineValue, parse_color_value,

--- a/crates/docx-parse/src/s9.rs
+++ b/crates/docx-parse/src/s9.rs
@@ -174,9 +174,17 @@ pub fn parse_docx_s9_wire(
     data: &[u8],
     options: S9ParseOptions,
 ) -> Result<S9WireEnvelope, ParseError> {
+    parse_docx_s9_wire_with_limits(data, options, &ParseLimits::default())
+}
+
+/// [`parse_docx_s9_wire`] with a caller-supplied resource budget.
+pub fn parse_docx_s9_wire_with_limits(
+    data: &[u8],
+    options: S9ParseOptions,
+    limits: &ParseLimits,
+) -> Result<S9WireEnvelope, ParseError> {
     let parts = ooxml_opc::unzip_parts(data).map_err(ParseError::Container)?;
-    let limits = ParseLimits::default();
-    let mut budget = ParseBudget::new(&limits);
+    let mut budget = ParseBudget::new(limits);
 
     let settings = parse_settings(
         find_part(&parts, "word/settings.xml").map(|(_, bytes)| bytes),


### PR DESCRIPTION
TL;DR:


Summary:

- `docx_parse::parse_docx_s9_wire_with_limits` lets a caller pass an explicit `ParseLimits` instead of always getting the default. `parse_docx_s9_wire` becomes a thin wrapper over it, so every existing caller behaves exactly as before.
- Lifts the session-level undo state out of `docx-edit`'s wasm boundary into a `UndoSession` type in `undo.rs`. `EditSession` keeps its eight methods as one-line delegations, so native consumers can now reach undo/redo without the `wasm` feature.

Both are groundwork for extending the DOCX facade. They are split out because they are independently verifiable and carry no behaviour change, while the facade work they support needs a redesign.

Notes for review:

- The wasm surface is unchanged. Building `docx_edit.js`, the public `.d.ts`, the low-level wasm `.d.ts`, and the package metadata from `main` and from this branch produces byte-identical output. Runtime behaviour was compared for pre-track accessors, same-story re-tracking, failed tracking, story switching, table scope, undo/redo, and depths.
- The `usize -> u32` casts stay at the JS boundary, at the same position as before.
- `add_undo_barrier` already existed on `DocUndoManager`; it is exposed on the new core type but deliberately not added to the wasm surface.

Test plan:

- [ ] `cargo test -p betteroffice-docx-edit -p betteroffice-docx-parse` passes
- [ ] `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean
- [ ] the four DOCX wasm modules still build for `wasm32-unknown-unknown`
- [ ] `wasm-pack` output is byte-identical to main
