### PR TITLE
fix(pptx): drive the slide canvas cursor from hover

### DIFF
--- a/crates/pptx-render/src/layout.rs
+++ b/crates/pptx-render/src/layout.rs
@@ -274,6 +274,7 @@ impl RenderedSlide {
             return None;
         }
         for region in self.hit_regions.iter().rev() {
+            let (x, y) = region.local_point(x, y);
             if !region.rect.contains(x, y) {
                 continue;
             }
@@ -458,6 +459,7 @@ impl<'a> LayoutBuilder<'a> {
         self.hit_regions.push(HitRegion {
             shape_id: stable_id,
             rect,
+            transform,
             text: text_hit,
         });
         Ok(())
@@ -568,6 +570,7 @@ impl<'a> LayoutBuilder<'a> {
         self.hit_regions.push(HitRegion {
             shape_id: stable_id.to_owned(),
             rect,
+            transform,
             text: text_hit,
         });
         Ok(())
@@ -1626,7 +1629,32 @@ impl Space {
 struct HitRegion {
     shape_id: String,
     rect: PxRect,
+    transform: Transform,
     text: Option<TextHit>,
+}
+
+impl HitRegion {
+    /// Undoes the rotate-then-flip the shape paints with, so `rect` and the text
+    /// lines can both be read in their unrotated frame.
+    fn local_point(&self, x: f32, y: f32) -> (f32, f32) {
+        if self.transform.is_identity() {
+            return (x, y);
+        }
+        let center_x = self.rect.x + self.rect.w / 2.0;
+        let center_y = self.rect.y + self.rect.h / 2.0;
+        let (sin, cos) = self.transform.rotation_deg.to_radians().sin_cos();
+        let dx = x - center_x;
+        let dy = y - center_y;
+        let mut local_x = dx * cos + dy * sin;
+        let mut local_y = dy * cos - dx * sin;
+        if self.transform.flip_h {
+            local_x = -local_x;
+        }
+        if self.transform.flip_v {
+            local_y = -local_y;
+        }
+        (center_x + local_x, center_y + local_y)
+    }
 }
 
 struct TextHit {
@@ -1980,6 +2008,109 @@ mod tests {
             renderer.register_font("Arial", bold, false, FONT).unwrap();
         }
         renderer
+    }
+
+    #[test]
+    fn hit_testing_a_rotated_shape_follows_its_painted_frame() {
+        let slide = |transform| RenderedSlide {
+            display_list: SurfaceDisplayList {
+                contract_version: CONTRACT_VERSION,
+                width: 400.0,
+                height: 400.0,
+                background: None,
+                primitives: Vec::new(),
+            },
+            hit_regions: vec![HitRegion {
+                shape_id: "rotated".to_owned(),
+                rect: PxRect {
+                    x: 100.0,
+                    y: 100.0,
+                    w: 100.0,
+                    h: 100.0,
+                },
+                transform,
+                text: None,
+            }],
+        };
+        let turned = |rotation_deg| Transform {
+            rotation_deg,
+            ..Transform::default()
+        };
+
+        // turned 45°, the square's corners point along the axes: its bounding box
+        // corners fall outside it and the axis midpoints fall inside
+        assert!(slide(turned(0.0)).hit_test(105.0, 105.0).is_some());
+        assert!(slide(turned(45.0)).hit_test(105.0, 105.0).is_none());
+        assert!(slide(turned(0.0)).hit_test(150.0, 90.0).is_none());
+        assert!(slide(turned(45.0)).hit_test(150.0, 90.0).is_some());
+
+        // a flip maps the square onto itself, so membership is unchanged
+        let flipped = Transform {
+            rotation_deg: 45.0,
+            flip_h: true,
+            flip_v: false,
+        };
+        assert!(slide(flipped).hit_test(150.0, 90.0).is_some());
+        assert!(slide(flipped).hit_test(105.0, 105.0).is_none());
+    }
+
+    #[test]
+    fn hit_testing_flipped_text_reads_the_mirrored_caret() {
+        // membership cannot catch a flip — the rect maps onto itself — so pin it
+        // on the caret, where the sign of the local point decides the answer
+        let slide = |flip_h| RenderedSlide {
+            display_list: SurfaceDisplayList {
+                contract_version: CONTRACT_VERSION,
+                width: 400.0,
+                height: 400.0,
+                background: None,
+                primitives: Vec::new(),
+            },
+            hit_regions: vec![HitRegion {
+                shape_id: "mirrored".to_owned(),
+                rect: PxRect {
+                    x: 100.0,
+                    y: 100.0,
+                    w: 120.0,
+                    h: 40.0,
+                },
+                transform: Transform {
+                    rotation_deg: 0.0,
+                    flip_h,
+                    flip_v: false,
+                },
+                text: Some(TextHit {
+                    story_id: "story".to_owned(),
+                    lines: vec![PositionedTextLine {
+                        x: 110.0,
+                        y: 110.0,
+                        width: 100.0,
+                        height: 20.0,
+                        baseline: 125.0,
+                        start: 0,
+                        end: 5,
+                        runs: Vec::new(),
+                        caret_stops: vec![
+                            CaretStop {
+                                position: 0,
+                                x: 110.0,
+                            },
+                            CaretStop {
+                                position: 5,
+                                x: 210.0,
+                            },
+                        ],
+                    }],
+                }),
+            }],
+        };
+        let position = |flip_h| match slide(flip_h).hit_test(120.0, 120.0) {
+            Some(HitTestResult::Text { position, .. }) => position,
+            other => panic!("expected a text hit, got {other:?}"),
+        };
+
+        assert_eq!(position(false), 0);
+        assert_eq!(position(true), 5);
     }
 
     #[test]

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -404,6 +404,10 @@ function PptxEditorContent({
     return () => collaborationOnReplica(null);
   }, [collaborationOnReplica, collaborationReplica]);
 
+  // hover goes untracked under a non-select tool, so drop it rather than let a
+  // stale target paint the cursor when the tool switches back
+  useEffect(() => setHoverTarget(null), [activeTool]);
+
   useEffect(() => {
     if (!collaborationPresence) {
       setRemotePeers([]);
@@ -969,6 +973,8 @@ function PptxEditorContent({
       event.preventDefault();
       return;
     }
+    // a non-select tool paints its own cursor, and a live gesture holds the one it started with
+    if (pointerGestureRef.current || activeTool !== 'select') return;
     const current = modelRef.current;
     if (!current?.frame) return;
     const point = slidePoint(

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -48,13 +48,14 @@ import {
   findShape,
   findTopLevelShape,
   frameBoundsForShape,
+  hoverTargetAtPoint,
   indexShapes,
   movedShapePosition,
   passedDragThreshold,
   slidePoint,
   textPositionAtPoint,
 } from './interactions';
-import type { FrameBounds, SlidePoint } from './interactions';
+import type { FrameBounds, HoverTarget, SlidePoint } from './interactions';
 import {
   groupPresenceBySlide,
   groupShapePresence,
@@ -244,6 +245,7 @@ function PptxEditorContent({
   const [historyState, setHistoryState] = useState({ canUndo: false, canRedo: false });
   const [zoom, setZoom] = useState<PptxZoom>('fit');
   const [activeTool, setActiveTool] = useState<PptxEditorTool>('select');
+  const [hoverTarget, setHoverTarget] = useState<HoverTarget | null>(null);
   const [viewport, setViewport] = useState({ width: 0, height: 0 });
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -963,7 +965,23 @@ function PptxEditorContent({
   };
 
   const pointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
-    if (updatePointerGesture(event)) event.preventDefault();
+    if (updatePointerGesture(event)) {
+      event.preventDefault();
+      return;
+    }
+    const current = modelRef.current;
+    if (!current?.frame) return;
+    const point = slidePoint(
+      event.currentTarget.getBoundingClientRect(),
+      current.frame,
+      event.clientX,
+      event.clientY
+    );
+    setHoverTarget(point ? hoverTargetAtPoint(current.frame, point) : null);
+  };
+
+  const pointerLeave = () => {
+    if (!pointerGestureRef.current) setHoverTarget(null);
   };
 
   const pointerUp = (event: PointerEvent<HTMLCanvasElement>) => {
@@ -1280,7 +1298,6 @@ function PptxEditorContent({
   const currentSlide = model?.slideIndex ?? 0;
   const shapeDragDelta =
     dragPreview && dragPreview.shapeId === shapeSelection?.shapeId ? dragPreview.delta : null;
-  const selectedShapeMovable = selectedShape ? canMoveShape(selectedShape) : false;
 
   return (
     <div className={className} style={styles.root}>
@@ -1423,15 +1440,16 @@ function PptxEditorContent({
                     cursor:
                       activeTool !== 'select'
                         ? 'crosshair'
-                        : selection
+                        : hoverTarget === 'text'
                           ? 'text'
-                          : selectedShapeMovable
+                          : hoverTarget === 'shape'
                             ? 'move'
                             : 'default',
                   }}
                   onPointerDown={pointerDown}
                   onPointerMove={pointerMove}
                   onPointerUp={pointerUp}
+                  onPointerLeave={pointerLeave}
                   onPointerCancel={cancelPointerGesture}
                   onLostPointerCapture={cancelPointerGesture}
                   aria-label={

--- a/packages/pptx-react/src/interactions.engine.test.ts
+++ b/packages/pptx-react/src/interactions.engine.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { PresentationHandle, SlideDisplayList } from '@betteroffice/pptx';
+import { initWasm, openPresentation } from '@betteroffice/pptx';
+import { farEdge, hoverTargetAtPoint } from './interactions';
+
+const root = resolve(import.meta.dir, '../../..');
+let handle: PresentationHandle;
+let frame: SlideDisplayList;
+
+beforeAll(async () => {
+  const [wasm, deck, font] = await Promise.all([
+    readFile(resolve(root, 'packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm')),
+    readFile(resolve(root, 'apps/demo/public/betteroffice-demo.pptx')),
+    readFile(resolve(root, 'crates/ooxml-text/tests/fonts/LiberationSans-Regular.ttf')),
+  ]);
+  await initWasm(wasm);
+  handle = openPresentation(deck, {
+    clientId: 9101,
+    fonts: [{ family: 'Liberation Sans', bytes: font }],
+  });
+  frame = handle.layoutSlide(0);
+});
+
+afterAll(() => handle.dispose());
+
+describe('hover target parity with the engine', () => {
+  test('agrees with hitTest across the slide', () => {
+    const disagreements: string[] = [];
+    for (let y = 0; y < frame.height; y += 20) {
+      for (let x = 0; x < frame.width; x += 20) {
+        const hovered = hoverTargetAtPoint(frame, { x, y });
+        const engine = handle.hitTest(x, y)?.kind ?? null;
+        if (hovered !== engine) {
+          disagreements.push(`(${x},${y}) hover=${hovered} engine=${engine}`);
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  test('agrees on every primitive corner', () => {
+    const disagreements: string[] = [];
+    for (const primitive of frame.primitives) {
+      if (!primitive.shapeId) continue;
+      // the far edges are f32 sums; the whole-pixel values astride them are the
+      // positions a real cursor actually reports, so probe both
+      const [x0, y0] = [Math.fround(primitive.x), Math.fround(primitive.y)];
+      const [x1, y1] = [
+        farEdge(primitive.x, primitive.w),
+        farEdge(primitive.y, primitive.h),
+      ];
+      const corners = [
+        [x0, y0],
+        [x1, y0],
+        [x0, y1],
+        [x1, y1],
+        [Math.round(x0), Math.round(y0)],
+        [Math.round(x1), Math.round(y1)],
+        [Math.round(x0), Math.round(y1)],
+        [Math.round(x1), Math.round(y0)],
+        [x0 + primitive.w / 2, y0 + primitive.h / 2],
+      ];
+      // sub-pixel offsets straddle the f32 narrowing wasm-bindgen applies to
+      // hitTest's arguments, which a whole-pixel probe cannot reach
+      for (const [cx, cy] of corners) {
+        for (const delta of [0, -1e-8, 1e-8, -1e-6, 1e-6]) {
+          const [x, y] = [cx + delta, cy + delta];
+          const hovered = hoverTargetAtPoint(frame, { x, y });
+          const engine = handle.hitTest(x, y)?.kind ?? null;
+          if (hovered !== engine) {
+            disagreements.push(`${primitive.shapeId} (${x},${y}) hover=${hovered} engine=${engine}`);
+          }
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+});

--- a/packages/pptx-react/src/interactions.test.ts
+++ b/packages/pptx-react/src/interactions.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'bun:test';
-import type { DeckSnapshot, ShapeSnapshot, SlideDisplayList } from '@betteroffice/pptx';
+import type {
+  DeckSnapshot,
+  ShapeSnapshot,
+  SlideDisplayList,
+  TextBoxPrimitive,
+} from '@betteroffice/pptx';
 import {
   canMoveShape,
   findShape,
   findTopLevelShape,
   frameBoundsForShape,
+  hoverTargetAtPoint,
   indexShapes,
   movedShapePosition,
   passedDragThreshold,
@@ -130,6 +136,30 @@ describe('pptx interactions', () => {
     expect(passedDragThreshold(10, 10, 12, 12)).toBe(false);
     expect(passedDragThreshold(10, 10, 14, 10)).toBe(true);
     expect(passedDragThreshold(10, 10, 16, 10, 8)).toBe(false);
+  });
+
+  it('reports the hovered primitive for cursor feedback', () => {
+    expect(hoverTargetAtPoint(frame, { x: 300, y: 150 })).toBe('text');
+    expect(hoverTargetAtPoint(frame, { x: 50, y: 60 })).toBe('shape');
+    expect(hoverTargetAtPoint(frame, { x: 600, y: 600 })).toBeNull();
+  });
+
+  it('prefers the topmost primitive where they overlap', () => {
+    expect(hoverTargetAtPoint(frame, { x: 110, y: 120 })).toBe('text');
+  });
+
+  it('respects primitive rotation when hovering', () => {
+    expect(hoverTargetAtPoint(frame, { x: 198, y: 275 })).toBe('shape');
+    expect(hoverTargetAtPoint(frame, { x: 260, y: 338 })).toBeNull();
+  });
+
+  it('treats a text box without a story as a movable shape', () => {
+    const textBox = frame.primitives[2] as TextBoxPrimitive;
+    const storyless: SlideDisplayList = {
+      ...frame,
+      primitives: [{ ...textBox, storyId: undefined }],
+    };
+    expect(hoverTargetAtPoint(storyless, { x: 300, y: 150 })).toBe('shape');
   });
 
   it('clamps captured text dragging to the nearest caret', () => {

--- a/packages/pptx-react/src/interactions.test.ts
+++ b/packages/pptx-react/src/interactions.test.ts
@@ -153,13 +153,32 @@ describe('pptx interactions', () => {
     expect(hoverTargetAtPoint(frame, { x: 260, y: 338 })).toBeNull();
   });
 
-  it('treats a text box without a story as a movable shape', () => {
+  it('treats a text box with nowhere to put a caret as a movable shape', () => {
     const textBox = frame.primitives[2] as TextBoxPrimitive;
-    const storyless: SlideDisplayList = {
+    const only = (patch: Partial<TextBoxPrimitive>): SlideDisplayList => ({
       ...frame,
-      primitives: [{ ...textBox, storyId: undefined }],
+      primitives: [{ ...textBox, ...patch }],
+    });
+    expect(hoverTargetAtPoint(only({ storyId: undefined }), { x: 300, y: 150 })).toBe('shape');
+    expect(hoverTargetAtPoint(only({ lines: [] }), { x: 300, y: 150 })).toBe('shape');
+    expect(
+      hoverTargetAtPoint(
+        only({ lines: textBox.lines.map((line) => ({ ...line, caretStops: [] })) }),
+        { x: 300, y: 150 }
+      )
+    ).toBe('shape');
+  });
+
+  it('resolves a drag inside a rotated text box in its unrotated frame', () => {
+    const textBox = frame.primitives[2] as TextBoxPrimitive;
+    const rotated: SlideDisplayList = {
+      ...frame,
+      primitives: [{ ...textBox, transform: { rotationDeg: 90 } }],
     };
-    expect(hoverTargetAtPoint(storyless, { x: 300, y: 150 })).toBe('shape');
+    // (285,10) lands on the first caret once the 90° turn is undone; read in
+    // slide coordinates it would resolve to the far end of the line instead
+    expect(textPositionAtPoint(rotated, 'text', 'story', { x: 285, y: 10 })).toBe(0);
+    expect(textPositionAtPoint(frame, 'text', 'story', { x: 285, y: 10 })).toBe(5);
   });
 
   it('clamps captured text dragging to the nearest caret', () => {

--- a/packages/pptx-react/src/interactions.ts
+++ b/packages/pptx-react/src/interactions.ts
@@ -12,9 +12,12 @@ export interface SlidePoint {
   y: number;
 }
 
-/** What the pointer is over, for cursor feedback only — the engine's
- *  `hitTest` remains the authority for what a click actually selects. */
 export type HoverTarget = 'text' | 'shape';
+
+type PrimitiveGeometry = Pick<SlidePrimitive, 'x' | 'y' | 'w' | 'h' | 'transform'>;
+
+/** `f32::to_radians` folds PI/180 to one f32 constant before multiplying. */
+const RADIANS_PER_DEGREE = Math.fround(Math.fround(Math.PI) / 180);
 
 export interface FrameBounds {
   x: number;
@@ -137,9 +140,12 @@ export function textPositionAtPoint(
       primitive.storyId === storyId
   );
   if (!textBox || textBox.lines.length === 0) return null;
+  // lines are laid out unrotated, so a drag has to resolve in the same frame the
+  // engine's hitTest used when the gesture started
+  const local = localPoint(textBox, point);
   const line = textBox.lines.reduce((nearest, candidate) =>
-    lineDistance(candidate.y, candidate.height, point.y) <
-    lineDistance(nearest.y, nearest.height, point.y)
+    lineDistance(candidate.y, candidate.height, local.y) <
+    lineDistance(nearest.y, nearest.height, local.y)
       ? candidate
       : nearest
   );
@@ -147,32 +153,79 @@ export function textPositionAtPoint(
   if (!firstCaret) return line.start;
   const caret = line.caretStops.reduce(
     (nearest, candidate) =>
-      Math.abs(candidate.x - point.x) < Math.abs(nearest.x - point.x) ? candidate : nearest,
+      Math.abs(candidate.x - local.x) < Math.abs(nearest.x - local.x) ? candidate : nearest,
     firstCaret
   );
   return caret.position;
 }
 
+/** Mirrors the engine's `hitTest`, which resolves text only where a caret can
+ *  land — an empty story reads as a plain shape in both. */
 export function hoverTargetAtPoint(
   frame: SlideDisplayList,
   point: SlidePoint
 ): HoverTarget | null {
+  // wasm-bindgen narrows hitTest's arguments to f32 before the engine sees them
+  const at = { x: Math.fround(point.x), y: Math.fround(point.y) };
   for (let index = frame.primitives.length - 1; index >= 0; index -= 1) {
     const primitive = frame.primitives[index];
-    if (!primitive.shapeId || !primitiveContains(primitive, point)) continue;
-    return primitive.kind === 'textBox' && primitive.storyId ? 'text' : 'shape';
+    if (!primitive.shapeId) continue;
+    const local = containedPoint(primitive, at);
+    if (!local) continue;
+    return primitive.kind === 'textBox' && primitive.storyId && hasCaretNear(primitive, local.y)
+      ? 'text'
+      : 'shape';
   }
   return null;
 }
 
-function primitiveContains(primitive: SlidePrimitive, point: SlidePoint): boolean {
-  if (primitive.w <= 0 || primitive.h <= 0) return false;
-  const angle = ((primitive.transform?.rotationDeg ?? 0) * Math.PI) / 180;
-  const dx = point.x - (primitive.x + primitive.w / 2);
-  const dy = point.y - (primitive.y + primitive.h / 2);
-  const localX = dx * Math.cos(angle) + dy * Math.sin(angle);
-  const localY = dy * Math.cos(angle) - dx * Math.sin(angle);
-  return Math.abs(localX) <= primitive.w / 2 && Math.abs(localY) <= primitive.h / 2;
+/** Undoes the rotate-then-flip the primitive paints with. Mirrors the engine's
+ *  `HitRegion::local_point`; the display list is f32, so the arithmetic is too —
+ *  an f64 sum puts the far edges up to 1e-5 off, which whole pixels fall into. */
+export function localPoint(primitive: PrimitiveGeometry, point: SlidePoint): SlidePoint {
+  const transform = primitive.transform;
+  if (!transform || (!transform.rotationDeg && !transform.flipH && !transform.flipV)) {
+    return point;
+  }
+  const f32 = Math.fround;
+  const centerX = f32(f32(primitive.x) + f32(f32(primitive.w) / 2));
+  const centerY = f32(f32(primitive.y) + f32(f32(primitive.h) / 2));
+  const angle = f32(f32(transform.rotationDeg ?? 0) * RADIANS_PER_DEGREE);
+  const cos = f32(Math.cos(angle));
+  const sin = f32(Math.sin(angle));
+  const dx = f32(point.x - centerX);
+  const dy = f32(point.y - centerY);
+  let localX = f32(f32(dx * cos) + f32(dy * sin));
+  let localY = f32(f32(dy * cos) - f32(dx * sin));
+  if (transform.flipH) localX = -localX;
+  if (transform.flipV) localY = -localY;
+  return { x: f32(centerX + localX), y: f32(centerY + localY) };
+}
+
+/** The far edge of a primitive, as the engine's f32 arithmetic computes it. */
+export function farEdge(origin: number, extent: number): number {
+  return Math.fround(Math.fround(origin) + Math.fround(extent));
+}
+
+/** The local point when it lands inside the primitive, else null. */
+function containedPoint(primitive: SlidePrimitive, point: SlidePoint): SlidePoint | null {
+  const local = localPoint(primitive, point);
+  return local.x >= Math.fround(primitive.x) &&
+    local.x <= farEdge(primitive.x, primitive.w) &&
+    local.y >= Math.fround(primitive.y) &&
+    local.y <= farEdge(primitive.y, primitive.h)
+    ? local
+    : null;
+}
+
+function hasCaretNear(textBox: TextBoxPrimitive, y: number): boolean {
+  if (textBox.lines.length === 0) return false;
+  const nearest = textBox.lines.reduce((best, candidate) =>
+    lineDistance(candidate.y, candidate.height, y) < lineDistance(best.y, best.height, y)
+      ? candidate
+      : best
+  );
+  return nearest.caretStops.length > 0;
 }
 
 export function movedShapePosition(

--- a/packages/pptx-react/src/interactions.ts
+++ b/packages/pptx-react/src/interactions.ts
@@ -2,6 +2,7 @@ import type {
   DeckSnapshot,
   ShapeSnapshot,
   SlideDisplayList,
+  SlidePrimitive,
   SlideSnapshot,
   TextBoxPrimitive,
 } from '@betteroffice/pptx';
@@ -10,6 +11,10 @@ export interface SlidePoint {
   x: number;
   y: number;
 }
+
+/** What the pointer is over, for cursor feedback only — the engine's
+ *  `hitTest` remains the authority for what a click actually selects. */
+export type HoverTarget = 'text' | 'shape';
 
 export interface FrameBounds {
   x: number;
@@ -146,6 +151,28 @@ export function textPositionAtPoint(
     firstCaret
   );
   return caret.position;
+}
+
+export function hoverTargetAtPoint(
+  frame: SlideDisplayList,
+  point: SlidePoint
+): HoverTarget | null {
+  for (let index = frame.primitives.length - 1; index >= 0; index -= 1) {
+    const primitive = frame.primitives[index];
+    if (!primitive.shapeId || !primitiveContains(primitive, point)) continue;
+    return primitive.kind === 'textBox' && primitive.storyId ? 'text' : 'shape';
+  }
+  return null;
+}
+
+function primitiveContains(primitive: SlidePrimitive, point: SlidePoint): boolean {
+  if (primitive.w <= 0 || primitive.h <= 0) return false;
+  const angle = ((primitive.transform?.rotationDeg ?? 0) * Math.PI) / 180;
+  const dx = point.x - (primitive.x + primitive.w / 2);
+  const dy = point.y - (primitive.y + primitive.h / 2);
+  const localX = dx * Math.cos(angle) + dy * Math.sin(angle);
+  const localY = dy * Math.cos(angle) - dx * Math.sin(angle);
+  return Math.abs(localX) <= primitive.w / 2 && Math.abs(localY) <= primitive.h / 2;
 }
 
 export function movedShapePosition(


### PR DESCRIPTION
The canvas cursor was computed from selection state, so text showed no I-beam until it was already selected, and an active caret painted the I-beam across the whole canvas including empty background.

TL;DR:
The slide canvas cursor was based on what was selected rather than what you were pointing at, so text gave no I-beam until you'd already clicked it. It now follows the pointer.

Summary:
- Slide canvas cursor now follows the pointer instead of selection state
- New `hoverTargetAtPoint` helper resolves the topmost primitive under the pointer, honouring primitive rotation
- Text boxes with a story report an I-beam; other shapes report `move`; bare background reports the default arrow
- Hover resolution is skipped while a drag gesture is active, so the cursor holds steady through a drag

Test plan:
- [ ] `bun test packages/pptx-react/src/interactions.test.ts` passes
- [ ] `bun run typecheck` passes in `packages/pptx-react`
- [ ] Hovering text in the slide canvas shows an I-beam before any selection exists
- [ ] With a caret active, empty background shows the arrow rather than the I-beam
- [ ] Dragging a shape keeps the move cursor for the duration of the drag
