### PR TITLE
chore(deps): bump the brace-expansion override to 5.0.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -271,7 +271,7 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.10",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
     "minimatch": "^10.2.5",
@@ -1153,7 +1153,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
     "sharp": "^0.35.0",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "minimatch": "^10.2.5"
   },
   "scripts": {


### PR DESCRIPTION
TL;DR:


Summary:
- GHSA-rgw5-rvv9-x895 (high) covers `brace-expansion >=4.0.0 <5.0.9`, so the existing `5.0.8` override is itself affected
- `bun audit --audit-level=high` fails on clean `main` today, which red-lights the Security audit job on every branch
- Bumps the override to `5.0.9` and refreshes the lockfile; no other dependency moves

Test plan:
- [ ] `bun audit --audit-level=high` reports no vulnerabilities
- [ ] `bun install --frozen-lockfile` succeeds
- [ ] CI Security audit passes