### PR TITLE
fix(docx): read file: wasm assets from disk in preload

### DIFF
--- a/.changeset/docx-wasm-file-preload.md
+++ b/.changeset/docx-wasm-file-preload.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/docx": patch
+---
+
+`preloadOpcWasm`, `preloadParseWasm`, `preloadEditWasm` and `preloadLayoutWasm` now read a `file:` wasm asset from disk instead of handing its URL to `fetch`, matching what the synchronous path already did. This affects only hosts where the packaged asset resolves to a `file:` URL and the global `fetch` rejects that scheme: plain Node, and any Node or Bun process that has installed a DOM shim, since happy-dom replaces `fetch` with one that rejects `file:`. Browser and bundler consumers are unaffected — there the asset URL is http(s), so it still streams through `fetch` exactly as before, as does any other non-`file:` URL and any module or URL passed explicitly. Resolving the asset path also no longer passes a `URL` object to `fileURLToPath`, so a shim supplying its own non-native `URL` cannot defeat the disk read.

--- a/packages/docx/src/wasm/loadWasmAsset.test.ts
+++ b/packages/docx/src/wasm/loadWasmAsset.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The default `file:` init path must not reach global fetch: Node's rejects
+ * that scheme, and a DOM shim replaces Bun's with one that rejects it too.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { createWasmModuleState, readWasmSync, type WasmAsyncInput } from './loadWasmAsset';
+
+const ASSET = new URL('./generated/opc/ooxml_opc_bg.wasm', import.meta.url);
+const realFetch = globalThis.fetch;
+
+/** Mirrors wasm-bindgen's `__wbg_init`: string/URL inputs go through global fetch. */
+function recordingInit(seen: WasmAsyncInput[]) {
+  return async ({
+    module_or_path,
+  }: {
+    module_or_path: WasmAsyncInput | Promise<WasmAsyncInput>;
+  }): Promise<void> => {
+    const resolved = await module_or_path;
+    seen.push(resolved);
+    const bytes =
+      typeof resolved === 'string' || resolved instanceof URL
+        ? await (await fetch(resolved)).arrayBuffer()
+        : (resolved as BufferSource);
+    await WebAssembly.compile(bytes);
+  };
+}
+
+function stateFor(assetUrl: () => URL, seen: WasmAsyncInput[]) {
+  return createWasmModuleState({
+    label: 'test',
+    preloadName: 'preloadTestWasm',
+    assetUrl,
+    initAsync: recordingInit(seen),
+    initSync: () => {},
+  });
+}
+
+describe('preload', () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('initializes a file: asset when global fetch rejects the file: scheme', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(
+        new Error(`Failed to fetch from "${ASSET.href}": URL scheme "file" is not supported.`)
+      )) as unknown as typeof fetch;
+    const seen: WasmAsyncInput[] = [];
+
+    await stateFor(() => ASSET, seen).preload();
+
+    expect(seen).toHaveLength(1);
+    expect(ArrayBuffer.isView(seen[0])).toBe(true);
+  });
+
+  it('still streams a non-file: asset through fetch', async () => {
+    const wasm = readWasmSync(ASSET);
+    expect(wasm).toBeDefined();
+    const requested: unknown[] = [];
+    globalThis.fetch = ((input: unknown) => {
+      requested.push(input);
+      return Promise.resolve(new Response(wasm as Uint8Array<ArrayBuffer>));
+    }) as unknown as typeof fetch;
+    const remote = new URL('https://cdn.example/ooxml_opc_bg.wasm');
+    const seen: WasmAsyncInput[] = [];
+
+    await stateFor(() => remote, seen).preload();
+
+    expect(seen).toEqual([remote]);
+    expect(requested).toEqual([remote]);
+  });
+
+  it('honours an explicit input over the packaged asset', async () => {
+    const bytes = readWasmSync(ASSET) as Uint8Array;
+    globalThis.fetch = (() => Promise.reject(new Error('unreachable'))) as unknown as typeof fetch;
+    const seen: WasmAsyncInput[] = [];
+
+    await stateFor(() => ASSET, seen).preload(bytes);
+
+    expect(seen).toEqual([bytes]);
+  });
+});
+
+describe('readWasmSync', () => {
+  it('reads through a foreign URL implementation', () => {
+    // fileURLToPath brand-checks objects; happy-dom's URL is native, but a
+    // shim that supplies its own must not defeat the read.
+    const foreign = { href: ASSET.href, protocol: 'file:' } as URL;
+    expect(readWasmSync(foreign)?.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/packages/docx/src/wasm/loadWasmAsset.ts
+++ b/packages/docx/src/wasm/loadWasmAsset.ts
@@ -6,7 +6,8 @@
  *
  * Two ways a module becomes ready:
  *  - `preload()` (async): browsers and workers — passes the asset URL to the
- *    wasm-bindgen glue, which fetches and instantiates it.
+ *    wasm-bindgen glue, which fetches and instantiates it. A `file:` asset is
+ *    read from disk instead, since `fetch` may reject that scheme.
  *  - `ensure()` (sync): Node/Bun/SSR — reads the asset from disk via
  *    `process.getBuiltinModule` (no static `node:fs` import, so browser
  *    bundlers never see a node builtin) and feeds `initSync`. In a browser
@@ -27,7 +28,7 @@ interface NodeFsLike {
   readFileSync(path: string): Uint8Array;
 }
 interface NodeUrlLike {
-  fileURLToPath(url: URL): string;
+  fileURLToPath(url: string): string;
 }
 
 function builtinModule<T>(name: string): T | undefined {
@@ -51,10 +52,23 @@ export function readWasmSync(url: URL): Uint8Array | undefined {
   const nodeUrl = builtinModule<NodeUrlLike>('node:url');
   if (!fs || !nodeUrl) return undefined;
   try {
-    return fs.readFileSync(nodeUrl.fileURLToPath(url));
+    // `.href` and not the URL object: fileURLToPath brand-checks its argument,
+    // so a shim supplying a non-native URL would otherwise fail the read.
+    return fs.readFileSync(nodeUrl.fileURLToPath(url.href));
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Default async input. wasm-bindgen fetches URL inputs, but `file:` is served
+ * only by Bun's own `fetch` — Node's rejects it, and a DOM shim replaces Bun's
+ * with one that rejects it too. So `file:` assets resolve to disk bytes, as
+ * `ensure()` already does; http(s) stays a URL for the browser streaming path.
+ */
+function defaultAsyncInput(url: URL): WasmAsyncInput {
+  if (url.protocol !== 'file:') return url;
+  return readWasmSync(url) ?? url;
 }
 
 export interface WasmModuleState {
@@ -79,7 +93,7 @@ export function createWasmModuleState(options: {
       if (initialized) return Promise.resolve();
       if (pending) return pending;
       pending = options
-        .initAsync({ module_or_path: input ?? options.assetUrl() })
+        .initAsync({ module_or_path: input ?? defaultAsyncInput(options.assetUrl()) })
         .then(
           () => {
             initialized = true;

--- a/packages/pptx-react/src/components/Toolbar.test.tsx
+++ b/packages/pptx-react/src/components/Toolbar.test.tsx
@@ -1,17 +1,25 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, describe, expect, it } from 'bun:test';
 import type { ShapeFormattingAction } from './Toolbar';
 import { LocaleProvider } from '../i18n';
 import { Toolbar } from './Toolbar';
 
 if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
-Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+const elementPrototype = HTMLElement.prototype;
+const clientWidth = Object.getOwnPropertyDescriptor(elementPrototype, 'clientWidth');
+Object.defineProperty(elementPrototype, 'clientWidth', {
   configurable: true,
   get: () => 1_200,
 });
 const { cleanup, fireEvent, render } = await import('@testing-library/react');
 
 afterEach(cleanup);
+// The globals are process-wide; leaving them installed poisons every later suite.
+afterAll(async () => {
+  if (clientWidth) Object.defineProperty(elementPrototype, 'clientWidth', clientWidth);
+  else Reflect.deleteProperty(elementPrototype, 'clientWidth');
+  if (GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
+});
 
 describe('Toolbar shape controls', () => {
   it('arms a preset shape placement tool', () => {

--- a/packages/pptx-react/src/components/ui/EditableCombobox.test.tsx
+++ b/packages/pptx-react/src/components/ui/EditableCombobox.test.tsx
@@ -1,5 +1,5 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, describe, expect, it } from 'bun:test';
 import { useState } from 'react';
 import { EditableCombobox } from './EditableCombobox';
 
@@ -7,6 +7,10 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 const { cleanup, fireEvent, render } = await import('@testing-library/react');
 
 afterEach(cleanup);
+// The globals are process-wide; leaving them installed poisons every later suite.
+afterAll(async () => {
+  if (GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
+});
 
 describe('EditableCombobox', () => {
   it('restores the applied value after a rejected commit', () => {

--- a/packages/xlsx-react/src/components/ui/EditableCombobox.test.tsx
+++ b/packages/xlsx-react/src/components/ui/EditableCombobox.test.tsx
@@ -1,5 +1,5 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, describe, expect, it } from 'bun:test';
 import { useState } from 'react';
 import { EditableCombobox } from './EditableCombobox';
 
@@ -7,6 +7,10 @@ if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
 const { cleanup, fireEvent, render } = await import('@testing-library/react');
 
 afterEach(cleanup);
+// The globals are process-wide; leaving them installed poisons every later suite.
+afterAll(async () => {
+  if (GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
+});
 
 describe('EditableCombobox', () => {
   it('restores the applied value after a rejected commit', () => {


### PR DESCRIPTION
TL;DR:


Summary:
- Registering happy-dom in any test file replaced `globalThis.fetch` with one that rejects `file:` URLs, which broke docx wasm init for every test file that ran afterwards; `main` was green only by the CI runner's directory-walk order and is already red locally on macOS with the exact CI command
- `preload*()` now resolves a `file:` asset URL to disk bytes, matching what the synchronous `ensure()` path already did; non-`file:` URLs and explicit inputs are untouched, so browser and bundler consumers are unaffected
- Adds `afterAll` cleanup to the three suites that registered happy-dom without unregistering, and restores the `clientWidth` descriptor that one of them redefined permanently
- Either fix alone cures the reproduction, so the loader is now immune regardless of test ordering

Test plan:
- [ ] `bun test packages/docx packages/pptx-react` passes (was 16 failures)
- [ ] `bun test packages apps/web/app apps/demo/lib scripts` passes (was 16 failures)
- [ ] `bun run --filter '@betteroffice/docx' typecheck` passes
- [ ] CI Package gate passes