### PR TITLE
feat(docx): drive the canvas cursor from what a click would act on

### DIFF
--- a/.changeset/docx-hover-cursor.md
+++ b/.changeset/docx-hover-cursor.md
@@ -1,0 +1,15 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/docx-react": patch
+"@betteroffice/rust-crates": patch
+---
+
+The DOCX editor's mouse cursor now reflects what is under it. Hovering typeable text shows the caret cursor and everything else shows the arrow, where the canvas renderer previously painted one arrow over the whole document.
+
+A position alone could not drive this: the display hit test resolves a caret everywhere on a page that carries any text, margins included, so it cannot say whether a click there would type. `hit_test_regions` now also reports what the point landed on, as `target` on its result — `"text"`, `"image"` or `"none"`. It is the same answer a click acts on and follows the same order: a selectable picture first, since the pointer path picks one before it ever asks for a position, then a run's own box, then the page's typeable area. That area is the authored content box, so the gutter between columns counts like the columns it separates, minus the page's note areas, which this path cannot edit — a click in a footnote lands in the body above it, and the pointer no longer invites one. An area with no positionable text reads as no target for the same reason: a click there jumps the caret to the end of the document.
+
+A picture is a select target rather than text whatever its wrap mode, because both inline and anchored images carry a document position. One that carries none cannot be selected — a picture watermark — so text painted over it stays readable through it.
+
+`target` is additive and optional on `DisplayListRegionHit`, so a display-list query answered by an older wasm build still typechecks and reads as "not text". All three query paths — the stateless JSON exports, the session handle, and the resident editing engine — answer from the same resolver, so none can disagree.
+
+Header and footer bands read as text over their own runs and arrow elsewhere: a double-click there opens the band for editing at that word. While one is open only that band types; a read-only document types nowhere.

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -2103,10 +2103,10 @@ mod tests {
         assert_eq!(engine.stats().retained_pages, 1);
     }
 
-    #[test]
-    fn region_layout_operation_stabilizes_and_emits_note_areas() {
-        let engine = EngineSession::new(132);
-        let request = serde_json::json!({
+    /// One 200x120 page (10px margins, so a content box of x 10..190 /
+    /// y 10..110) whose single paragraph carries a footnote reference.
+    fn note_area_layout_request() -> serde_json::Value {
+        serde_json::json!({
             "measured": [{
                 "block": {
                     "kind": "paragraph",
@@ -2152,11 +2152,15 @@ mod tests {
             "notes": {
                 "contents": [{"id": 7, "height": 20}]
             }
-        });
+        })
+    }
 
+    #[test]
+    fn region_layout_operation_stabilizes_and_emits_note_areas() {
+        let engine = EngineSession::new(132);
         let output: serde_json::Value = serde_json::from_str(
             &engine
-                .layout_document_with_regions_json(&request.to_string())
+                .layout_document_with_regions_json(&note_area_layout_request().to_string())
                 .unwrap(),
         )
         .unwrap();
@@ -2170,6 +2174,41 @@ mod tests {
         assert_eq!(page["noteAreas"][0]["columns"], 2);
         assert_eq!(page["noteAreas"][0]["notes"][0]["displayLabel"], "III");
         assert_eq!(engine.stats().pagination_calls, 2);
+    }
+
+    /// Note text is not editable through the display hit test, which answers a
+    /// click in the note band with the BODY position above it. The pointer must
+    /// not invite that click.
+    #[test]
+    fn hover_target_is_absent_over_a_laid_out_note_area() {
+        let engine = EngineSession::new(133);
+        let output = engine
+            .layout_document_with_regions_json(&note_area_layout_request().to_string())
+            .unwrap();
+        engine.build_display_list_json(&output).unwrap();
+        let band = engine
+            .with_display_list(|list| {
+                let area = &list.pages[0].note_areas[0];
+                (
+                    area.y.as_ref().unwrap().as_f64().unwrap(),
+                    area.height.as_ref().unwrap().as_f64().unwrap(),
+                )
+            })
+            .expect("the display list is built");
+        assert!(band.1 > 0.0, "the note band has no height");
+
+        let hit = |y: f64| -> serde_json::Value {
+            serde_json::from_str(&engine.display_hit_test_regions_json(0, 20.0, y).unwrap())
+                .unwrap()
+        };
+        let note = hit(band.0 + band.1 / 2.0);
+        assert_eq!(note["target"], "none");
+        assert!(
+            note["pos"].is_i64(),
+            "the note band still resolves a body position"
+        );
+        // the body line above the band stays typeable
+        assert_eq!(hit(band.0 - 2.0)["target"], "text");
     }
 
     #[test]
@@ -2910,7 +2949,7 @@ mod tests {
             engine
                 .display_hit_test_regions_json(0, 100.0, 100.0)
                 .unwrap(),
-            r#"{"region":"body","pos":null}"#
+            r#"{"region":"body","pos":null,"target":"none"}"#
         );
         assert_eq!(engine.display_range_rects_json(0, 1).unwrap(), "[]");
         assert_eq!(
@@ -2979,5 +3018,17 @@ mod tests {
 
         assert_eq!(hit["region"], "body");
         assert!((target.3..=target.4).contains(&position));
+        assert_eq!(hit["target"], "text");
+
+        // the same line's left margin resolves a position all the same, but is
+        // not typeable area
+        let margin: serde_json::Value = serde_json::from_str(
+            &engine
+                .display_hit_test_regions_json(target.0, 8.0, target.2)
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(margin["pos"].is_i64());
+        assert_eq!(margin["target"], "none");
     }
 }

--- a/crates/docx-edit/src/wasm.rs
+++ b/crates/docx-edit/src/wasm.rs
@@ -1457,9 +1457,11 @@ impl EditSession {
 
     /// Region-aware hit test against the resident display list, so no
     /// display-list JSON crosses the boundary. `x`/`y` are page-local px.
-    /// Returns `{"region":"body"|"header"|"footer","rId"?,"pos":n|null}`, or
-    /// `"null"` for a page index outside the frame. A header/footer `pos`
-    /// refers to that header/footer's own document, not the body.
+    /// Returns
+    /// `{"region":"body"|"header"|"footer","rId"?,"pos":n|null,"target":"text"|"image"|"none"}`,
+    /// or `"null"` for a page index outside the frame. A header/footer `pos`
+    /// refers to that header/footer's own document, not the body; `target` is
+    /// what sits under the point, which is what a pointer cursor needs.
     pub fn display_hit_test_regions_json(
         &self,
         page_index: u32,

--- a/crates/docx-layout/src/hit.rs
+++ b/crates/docx-layout/src/hit.rs
@@ -38,8 +38,16 @@
 //! the selection-geometry twin, and [`range_rects`] the body-only wrapper. The
 //! same header/footer part paints on every page that uses it, so a scoped range
 //! query emits one rect set per such page, each stamped with its own page index.
+//!
+//! Resolving a point also reports what it landed on ([`HoverTarget`]), which a
+//! pointer cursor needs and a position cannot give: the nearest-line fallback
+//! answers everywhere on a page carrying any text. The target instead names
+//! what a click would act on, in the pointer path's own order — a selectable
+//! image, then a run's own box, then [`in_typeable_area`].
 
-use crate::display_list::{DisplayList, DocAttrs, HfRegion, Primitive, TableCellRef};
+use crate::display_list::{
+    DisplayBounds, DisplayList, DisplayPage, DocAttrs, HfRegion, Primitive, TableCellRef,
+};
 use serde::Serialize;
 use serde_json::Number;
 use std::collections::{BTreeMap, HashMap};
@@ -689,13 +697,100 @@ pub fn vertical_move(
 /// Region-aware callers use [`hit_test_regions`].
 pub fn hit_test(dl: &DisplayList, page_index: usize, x: f64, y: f64) -> Option<i64> {
     let page = dl.pages.get(page_index)?;
-    resolve_point(&page.primitives, x, y)
+    resolve_point(&page.primitives, in_typeable_area(page, x, y), x, y).pos
+}
+
+/// What a resolved point landed on: the caret position, plus the thing under
+/// the pointer that earned it.
+struct PointResolution {
+    pos: Option<i64>,
+    target: HoverTarget,
+}
+
+/// What sits under a point, for pointer-cursor feedback.
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HoverTarget {
+    /// typeable text — a run's own box, or the typeable area around it
+    #[serde(rename = "text")]
+    Text,
+    /// a selectable picture, which a click selects instead of typing into
+    #[serde(rename = "image")]
+    Image,
+    #[serde(rename = "none")]
+    None,
+}
+
+fn in_bounds(bounds: &DisplayBounds, x: f64, y: f64) -> bool {
+    let left = bounds.x.as_f64().unwrap_or(0.0);
+    let top = bounds.y.as_f64().unwrap_or(0.0);
+    x >= left
+        && x <= left + bounds.width.as_f64().unwrap_or(0.0)
+        && y >= top
+        && y <= top + bounds.height.as_f64().unwrap_or(0.0)
+}
+
+/// Whether a body point lies in the page's typeable area: the authored content
+/// box (so a column gutter counts like the columns it separates), minus note
+/// areas, whose text this path cannot reach. Column boxes are the fallback for
+/// a list without a content box, and neither degrades to the runs alone.
+///
+/// Deliberately blind to content positioned OUTSIDE the content box — a
+/// floating text box in a margin. Its glyphs still read as text (a run's own
+/// box is tested first), but the blank tail of its lines does not, since no
+/// container rect for it exists in the display list. That under-claims, never
+/// over-claims: the cursor is an arrow where a click would still type.
+fn in_typeable_area(page: &DisplayPage, x: f64, y: f64) -> bool {
+    let boxed = match &page.content_bounds {
+        Some(bounds) => in_bounds(bounds, x, y),
+        None => page.column_bounds.iter().any(|c| in_bounds(c, x, y)),
+    };
+    boxed
+        && !page.note_areas.iter().any(|area| {
+            let top = area.y.as_ref().and_then(Number::as_f64).unwrap_or(0.0);
+            let height = area.height.as_ref().and_then(Number::as_f64).unwrap_or(0.0);
+            height > 0.0 && y >= top && y <= top + height
+        })
+}
+
+/// Whether the topmost image under the point is one a click would select.
+/// Mirrors `displayListImages.ts`: reverse paint order, and no document
+/// position means nothing selects it (a picture watermark), so text painted
+/// over such an image stays readable through it.
+fn over_selectable_image(prims: &[Primitive], x: f64, y: f64) -> bool {
+    prims
+        .iter()
+        .rev()
+        .filter_map(|p| match p {
+            Primitive::Image(img) => Some(img),
+            _ => None,
+        })
+        .find(|img| {
+            let (ix, iy) = (img.x.as_f64().unwrap_or(0.0), img.y.as_f64().unwrap_or(0.0));
+            let (iw, ih) = (img.w.as_f64().unwrap_or(0.0), img.h.as_f64().unwrap_or(0.0));
+            x >= ix && x <= ix + iw && y >= iy && y <= iy + ih
+        })
+        .is_some_and(|img| img.attrs.doc_start.is_some())
 }
 
 /// The shared point resolver over one primitive list — a page body or a single
-/// header/footer band, both of which use page coordinates.
-fn resolve_point(prims: &[Primitive], x: f64, y: f64) -> Option<i64> {
+/// header/footer band, both of which use page coordinates. `typeable` says the
+/// point is in the region's typeable area (false for a band, which has no
+/// content box); it widens the target only, never the position.
+fn resolve_point(prims: &[Primitive], typeable: bool, x: f64, y: f64) -> PointResolution {
+    // outranks text for the CURSOR only: the pointer path selects an image
+    // before it asks for a position, so position resolution keeps its own order
+    let image_target = over_selectable_image(prims, x, y);
     let hits = text_hits(prims);
+    // What the point earns once no run claims it. An area with no positionable
+    // text is not typeable whatever it encloses: such a click is answered with
+    // the document's end.
+    let target = if image_target {
+        HoverTarget::Image
+    } else if typeable && !hits.is_empty() {
+        HoverTarget::Text
+    } else {
+        HoverTarget::None
+    };
 
     // 1. direct hit on a text primitive's box, in paint order
     for h in &hits {
@@ -703,11 +798,20 @@ fn resolve_point(prims: &[Primitive], x: f64, y: f64) -> Option<i64> {
             continue;
         }
         if x >= h.x && x <= h.x + h.width && y >= h.top - BAND_SLACK && y <= h.bottom + BAND_SLACK {
-            return Some(position_in_run(h, x));
+            return PointResolution {
+                pos: Some(position_in_run(h, x)),
+                target: if image_target {
+                    HoverTarget::Image
+                } else {
+                    HoverTarget::Text
+                },
+            };
         }
     }
 
-    // 2. direct hit on an image with a doc position (caret parks before it)
+    // 2. direct hit on an image with a doc position (caret parks before it).
+    // Only the topmost image decides the target, so an unselectable one over
+    // this leaves the area's answer standing.
     for p in prims {
         let Primitive::Image(img) = p else { continue };
         let Some(ds) = img.attrs.doc_start else {
@@ -716,12 +820,15 @@ fn resolve_point(prims: &[Primitive], x: f64, y: f64) -> Option<i64> {
         let (ix, iy) = (img.x.as_f64().unwrap_or(0.0), img.y.as_f64().unwrap_or(0.0));
         let (iw, ih) = (img.w.as_f64().unwrap_or(0.0), img.h.as_f64().unwrap_or(0.0));
         if x >= ix && x <= ix + iw && y >= iy && y <= iy + ih {
-            return Some(ds);
+            return PointResolution {
+                pos: Some(ds),
+                target,
+            };
         }
     }
 
     if hits.is_empty() {
-        return None;
+        return PointResolution { pos: None, target };
     }
 
     // 3. nearest line by vertical center distance (blank-line markers included)
@@ -744,13 +851,17 @@ fn resolve_point(prims: &[Primitive], x: f64, y: f64) -> Option<i64> {
 
     // 4. nearest primitive on the line; inside -> interpolate, outside -> snap
     // to the closer edge's position
-    position_for_hits(line.iter().copied(), x)
+    PointResolution {
+        pos: position_for_hits(line.iter().copied(), x),
+        target,
+    }
 }
 
-/// Which part of the page owns a point, and the position inside that part's
-/// document. For `header` / `footer` the position addresses the header/footer
-/// document identified by `rId`, never the body document, so the caller must
-/// route the resulting selection to that editor.
+/// Which part of the page owns a point, the position inside that part's
+/// document, and what sits under the pointer. For `header` / `footer` the
+/// position addresses the header/footer document identified by `rId`, never the
+/// body document, so the caller must route the resulting selection to that
+/// editor.
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RegionHit {
@@ -758,6 +869,7 @@ pub struct RegionHit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r_id: Option<String>,
     pub pos: Option<i64>,
+    pub target: HoverTarget,
 }
 
 #[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -801,25 +913,31 @@ pub fn hit_test_regions(dl: &DisplayList, page_index: usize, x: f64, y: f64) -> 
     if let Some(h) = &page.header
         && in_band(h)
     {
+        let resolved = resolve_point(&h.primitives, false, x, y);
         return Some(RegionHit {
             region: HitRegion::Header,
             r_id: Some(h.r_id.clone()),
-            pos: resolve_point(&h.primitives, x, y),
+            pos: resolved.pos,
+            target: resolved.target,
         });
     }
     if let Some(f) = &page.footer
         && in_band(f)
     {
+        let resolved = resolve_point(&f.primitives, false, x, y);
         return Some(RegionHit {
             region: HitRegion::Footer,
             r_id: Some(f.r_id.clone()),
-            pos: resolve_point(&f.primitives, x, y),
+            pos: resolved.pos,
+            target: resolved.target,
         });
     }
+    let resolved = resolve_point(&page.primitives, in_typeable_area(page, x, y), x, y);
     Some(RegionHit {
         region: HitRegion::Body,
         r_id: None,
-        pos: resolve_point(&page.primitives, x, y),
+        pos: resolved.pos,
+        target: resolved.target,
     })
 }
 
@@ -1092,8 +1210,8 @@ pub fn range_rects_region_json(
 }
 
 /// `hit_test_regions` over serialized inputs; returns
-/// `{"region":"body"|"header"|"footer","rId"?,"pos":n|null}` or `"null"`
-/// for an out-of-range page
+/// `{"region":"body"|"header"|"footer","rId"?,"pos":n|null,"target":"text"|"image"|"none"}`
+/// or `"null"` for an out-of-range page
 pub fn hit_test_regions_json(
     display_list: &str,
     page_index: usize,
@@ -1110,6 +1228,203 @@ pub fn hit_test_regions_json(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn run(x: f64, baseline: f64, width: f64, doc_start: i64) -> serde_json::Value {
+        serde_json::json!({
+            "kind": "text",
+            "text": "hello",
+            "x": x,
+            "baselineY": baseline,
+            "width": width,
+            "font": "400 16px Calibri",
+            "color": "#000000",
+            "docStart": doc_start,
+            "docEnd": doc_start + 5,
+            "blockId": doc_start,
+            "lineIndex": 0
+        })
+    }
+
+    fn image(x: f64, y: f64, doc_start: Option<i64>) -> serde_json::Value {
+        let mut image = serde_json::json!({
+            "kind": "image", "relId": "rId1", "x": x, "y": y, "w": 60, "h": 40
+        });
+        if let Some(doc_start) = doc_start {
+            image["docStart"] = doc_start.into();
+            image["docEnd"] = (doc_start + 1).into();
+        }
+        image
+    }
+
+    fn page(content: serde_json::Value, primitives: Vec<serde_json::Value>) -> DisplayList {
+        serde_json::from_value(serde_json::json!({
+            "pages": [{
+                "pageIndex": 0,
+                "width": 500,
+                "height": 500,
+                "contentBounds": content,
+                "primitives": primitives
+            }]
+        }))
+        .unwrap()
+    }
+
+    /// A content box at x 80..420 / y 80..420, one run whose band is y 84..104
+    /// (± [`BAND_SLACK`]) over x 100..150, and one inline image at
+    /// x 100..160 / y 200..240.
+    fn hover_fixture() -> DisplayList {
+        page(
+            serde_json::json!({"x": 80, "y": 80, "width": 340, "height": 340}),
+            vec![run(100.0, 100.0, 50.0, 1), image(100.0, 200.0, Some(10))],
+        )
+    }
+
+    fn target(dl: &DisplayList, x: f64, y: f64) -> HoverTarget {
+        hit_test_regions(dl, 0, x, y).unwrap().target
+    }
+
+    #[test]
+    fn hover_target_reports_the_typeable_area_and_direct_hits() {
+        let dl = hover_fixture();
+
+        assert_eq!(target(&dl, 120.0, 95.0), HoverTarget::Text);
+        assert_eq!(target(&dl, 120.0, 220.0), HoverTarget::Image);
+        // right of a short line and below the last one — typeable, no primitive
+        assert_eq!(target(&dl, 380.0, 95.0), HoverTarget::Text);
+        assert_eq!(target(&dl, 120.0, 400.0), HoverTarget::Text);
+        // margins and page background
+        assert_eq!(target(&dl, 40.0, 95.0), HoverTarget::None);
+        assert_eq!(target(&dl, 120.0, 460.0), HoverTarget::None);
+    }
+
+    /// The target discriminates where the position cannot: the nearest-line
+    /// fallback answers over the margins too.
+    #[test]
+    fn hover_target_narrows_a_position_that_resolves_everywhere() {
+        let dl = hover_fixture();
+        let margin = hit_test_regions(&dl, 0, 40.0, 95.0).unwrap();
+        assert!(margin.pos.is_some());
+        assert_eq!(margin.target, HoverTarget::None);
+    }
+
+    /// Column boxes stand in for a list built without a content box; with
+    /// neither, only the runs' own boxes answer.
+    #[test]
+    fn hover_target_without_a_content_box_falls_back() {
+        let mut dl = hover_fixture();
+        dl.pages[0].content_bounds = None;
+        dl.pages[0].column_bounds = serde_json::from_value(
+            serde_json::json!([{"x": 80, "y": 80, "width": 340, "height": 340}]),
+        )
+        .unwrap();
+        assert_eq!(target(&dl, 380.0, 95.0), HoverTarget::Text);
+
+        dl.pages[0].column_bounds.clear();
+        assert_eq!(target(&dl, 120.0, 95.0), HoverTarget::Text);
+        assert_eq!(target(&dl, 380.0, 95.0), HoverTarget::None);
+    }
+
+    /// Content positioned outside the content box — a floating text box in a
+    /// margin — reads as text over its glyphs but not over the blank tail of
+    /// its lines, which no container rect in the display list describes. The
+    /// cursor under-claims there; it must never claim what a click will not do.
+    #[test]
+    fn hover_target_outside_the_content_box_covers_glyphs_only() {
+        let dl = page(
+            serde_json::json!({"x": 80, "y": 80, "width": 340, "height": 340}),
+            vec![run(100.0, 100.0, 50.0, 1), run(440.0, 450.0, 50.0, 20)],
+        );
+        assert_eq!(target(&dl, 460.0, 445.0), HoverTarget::Text);
+
+        let tail = hit_test_regions(&dl, 0, 520.0, 445.0).unwrap();
+        assert_eq!(tail.target, HoverTarget::None);
+        assert!(
+            tail.pos.is_some(),
+            "the blank tail still resolves a position"
+        );
+    }
+
+    /// The gutter between columns is typeable — a click there lands in one of
+    /// them — so the content box, not the column boxes, defines the area.
+    #[test]
+    fn hover_target_covers_the_gutter_between_columns() {
+        let mut dl = hover_fixture();
+        dl.pages[0].column_bounds = serde_json::from_value(serde_json::json!([
+            {"x": 80, "y": 80, "width": 150, "height": 340},
+            {"x": 270, "y": 80, "width": 150, "height": 340}
+        ]))
+        .unwrap();
+        assert_eq!(target(&dl, 250.0, 300.0), HoverTarget::Text);
+    }
+
+    /// Note text lives outside `primitives` and is not editable through this
+    /// path, so the pointer must not invite a click that lands in the body.
+    #[test]
+    fn hover_target_treats_note_areas_as_holes() {
+        let mut dl = hover_fixture();
+        dl.pages[0].note_areas =
+            serde_json::from_value(serde_json::json!([{"y": 360, "height": 60}])).unwrap();
+        let note = hit_test_regions(&dl, 0, 120.0, 390.0).unwrap();
+        assert_eq!(note.target, HoverTarget::None);
+        // the position it would have handed a click is the body run above it
+        assert!(matches!(note.pos, Some(pos) if (1..=6).contains(&pos)));
+        assert_eq!(target(&dl, 120.0, 340.0), HoverTarget::Text);
+    }
+
+    /// A picture with a document position is a click target whatever its wrap
+    /// mode, and outranks text painted under it — the pointer path selects one
+    /// before it asks for a position.
+    #[test]
+    fn hover_target_prefers_a_selectable_image_over_the_text_it_covers() {
+        let dl = page(
+            serde_json::json!({"x": 80, "y": 80, "width": 340, "height": 340}),
+            vec![run(100.0, 100.0, 50.0, 1), image(100.0, 80.0, Some(10))],
+        );
+        assert_eq!(target(&dl, 120.0, 95.0), HoverTarget::Image);
+    }
+
+    /// A picture with no document position cannot be selected (a watermark),
+    /// so text painted over it stays typeable.
+    #[test]
+    fn hover_target_reads_through_an_unpositioned_image() {
+        let dl = page(
+            serde_json::json!({"x": 80, "y": 80, "width": 340, "height": 340}),
+            vec![image(80.0, 80.0, None), run(100.0, 100.0, 50.0, 1)],
+        );
+        assert_eq!(target(&dl, 120.0, 95.0), HoverTarget::Text);
+        assert_eq!(target(&dl, 120.0, 110.0), HoverTarget::Text);
+    }
+
+    /// Only the TOPMOST image decides, as the click does: a watermark over a
+    /// positioned picture leaves nothing to select, and the reverse selects.
+    #[test]
+    fn hover_target_takes_the_topmost_of_stacked_images() {
+        let area = serde_json::json!({"x": 80, "y": 80, "width": 340, "height": 340});
+        let covered = page(
+            area.clone(),
+            vec![image(100.0, 200.0, Some(10)), image(80.0, 180.0, None)],
+        );
+        assert_eq!(target(&covered, 120.0, 220.0), HoverTarget::None);
+
+        let on_top = page(
+            area,
+            vec![image(80.0, 180.0, None), image(100.0, 200.0, Some(10))],
+        );
+        assert_eq!(target(&on_top, 120.0, 220.0), HoverTarget::Image);
+    }
+
+    /// With nothing positionable on the page a click jumps the caret to the
+    /// document's end, so the area must not advertise typing.
+    #[test]
+    fn hover_target_ignores_an_area_with_no_positionable_text() {
+        let dl = page(
+            serde_json::json!({"x": 80, "y": 80, "width": 340, "height": 340}),
+            vec![image(100.0, 200.0, None)],
+        );
+        let hit = hit_test_regions(&dl, 0, 300.0, 300.0).unwrap();
+        assert_eq!(hit.pos, None);
+        assert_eq!(hit.target, HoverTarget::None);
+    }
 
     #[test]
     fn vertical_move_materializes_hits_only_for_neighboring_pages() {

--- a/crates/docx-layout/src/lib.rs
+++ b/crates/docx-layout/src/lib.rs
@@ -406,8 +406,9 @@ pub fn range_rects_region_json(
 }
 
 /// wasm wrapper over [`hit::hit_test_regions_json`]: region-aware hit test —
-/// `{"region":"body"|"header"|"footer","rId"?,"pos":n|null}` (or `"null"` for
-/// an out-of-range page). The plain `hit_test_json` export stays body-only.
+/// `{"region":"body"|"header"|"footer","rId"?,"pos":n|null,"target":"text"|"image"|"none"}`
+/// (or `"null"` for an out-of-range page). The plain `hit_test_json` export
+/// stays body-only.
 #[wasm_bindgen]
 pub fn hit_test_regions_json(
     display_list: &str,

--- a/crates/docx-layout/tests/display_list.rs
+++ b/crates/docx-layout/tests/display_list.rs
@@ -26,7 +26,10 @@ use docx_layout::display_list::{
     RevisionKind, ShapePathCommand, StructuralRevisionKind, StructuralRevisionScope, TableCellRef,
     build_display_list_json,
 };
-use docx_layout::hit::{VerticalDirection, caret_rect, hit_test, range_rects, vertical_move};
+use docx_layout::hit::{
+    HoverTarget, VerticalDirection, caret_rect, hit_test, hit_test_regions, range_rects,
+    vertical_move,
+};
 
 const DEMO_FIXTURE: &str =
     include_str!("../../../packages/docx/src/layout/render/__fixtures__/displayList.demo.json");
@@ -234,6 +237,49 @@ fn hit_test_resolves_clicks_to_nearest_text_position() {
 
     // out-of-range page yields nothing
     assert_eq!(hit_test(&dl, 5, 100.0, 100.0), None);
+}
+
+// column-break-in-multi-column: two column boxes, x 96..396 and x 420..720,
+// inside one content box of x 96..720 / y 96..960
+#[test]
+fn hover_target_covers_the_gutter_between_laid_out_columns() {
+    let dl = snapshot("column-break-in-multi-column");
+    let gutter = hit_test_regions(&dl, 0, 408.0, 300.0).unwrap();
+
+    // a click in the gutter lands in one of the columns, so it is typeable
+    assert!(gutter.pos.is_some());
+    assert_eq!(gutter.target, HoverTarget::Text);
+    assert_eq!(
+        hit_test_regions(&dl, 0, 40.0, 300.0).unwrap().target,
+        HoverTarget::None
+    );
+}
+
+// same fixture: an 816x1056 page whose single column box is x 96..720,
+// y 96..960
+#[test]
+fn hover_target_separates_the_typeable_column_from_the_margins() {
+    let dl = build("single-page-multi-paragraph");
+    let target = |x: f64, y: f64| hit_test_regions(&dl, 0, x, y).unwrap().target;
+
+    // over the glyphs, right of a short line, and below the last paragraph
+    assert_eq!(target(120.0, 110.0), HoverTarget::Text);
+    assert_eq!(target(600.0, 110.0), HoverTarget::Text);
+    assert_eq!(target(300.0, 900.0), HoverTarget::Text);
+
+    // every margin, where a click still resolves a position
+    for (x, y) in [
+        (40.0, 110.0),
+        (780.0, 110.0),
+        (300.0, 40.0),
+        (300.0, 1000.0),
+    ] {
+        assert_eq!(target(x, y), HoverTarget::None, "margin ({x},{y})");
+        assert!(
+            hit_test(&dl, 0, x, y).is_some(),
+            "margin ({x},{y}) position"
+        );
+    }
 }
 
 #[test]

--- a/crates/docx-layout/tests/hf_bands.rs
+++ b/crates/docx-layout/tests/hf_bands.rs
@@ -1,7 +1,9 @@
 //! Header/footer fixture and interaction gates.
 
 use docx_layout::display_list::{DisplayList, HfKind, build_display_list_json};
-use docx_layout::hit::{HitRegion, hit_test, hit_test_regions, range_rects, range_rects_in_region};
+use docx_layout::hit::{
+    HitRegion, HoverTarget, hit_test, hit_test_regions, range_rects, range_rects_in_region,
+};
 
 const SCENARIOS: &[&str] = &["hf-default-both", "hf-title-page", "hf-even-odd"];
 
@@ -156,6 +158,27 @@ fn hit_test_regions_resolves_bands_and_body() {
 
     // out-of-range page
     assert!(hit_test_regions(&dl, 9, 0.0, 0.0).is_none());
+}
+
+#[test]
+fn hover_target_in_a_band_follows_its_runs_not_the_body_columns() {
+    // hf-default-both: header band y 48..72, footer band y 984..1008, each
+    // paragraph painted from x 96. A band carries no content box, so only its
+    // own runs read as text — the body's must not leak into a band hit.
+    let dl = build("hf-default-both");
+
+    for y in [60.0, 990.0] {
+        assert_eq!(
+            hit_test_regions(&dl, 0, 120.0, y).unwrap().target,
+            HoverTarget::Text,
+            "over the run at y {y}"
+        );
+        assert_eq!(
+            hit_test_regions(&dl, 0, 700.0, y).unwrap().target,
+            HoverTarget::None,
+            "past the run at y {y}"
+        );
+    }
 }
 
 #[test]

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.cursor.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.cursor.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The hover cursor's imperative path: real pointer events on a real host,
+ * through the hook's delegated listeners. The mapping and the write guard are
+ * unit-tested in `hoverCursor.test.ts`; only a mounted hook shows the wiring.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createRef } from 'react';
+import type { DisplayListQueries } from '@betteroffice/docx/layout/render';
+import type { YrsSession } from '@betteroffice/docx/yrs';
+import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
+import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
+
+// Registered only if nobody else did, and handed back at the end: a leaked
+// happy-dom replaces globalThis.fetch with one that rejects `file:`, which
+// kills wasm init in every suite that runs after this one.
+const ownsDom = !GlobalRegistrator.isRegistered;
+if (ownsDom) GlobalRegistrator.register();
+const { act, cleanup, renderHook } = await import('@testing-library/react');
+
+const PAGE = { width: 800, height: 1000 };
+/** x below this is "margin" in the fake engine; at or past it is body text. */
+const TEXT_FROM = 100;
+
+let host: HTMLDivElement;
+
+function fakeQueries(): DisplayListQueries {
+  return {
+    displayList: {
+      pages: [{ pageIndex: 0, width: PAGE.width, height: PAGE.height, primitives: [] }],
+    },
+    pageCount: () => 1,
+    pageSize: () => PAGE,
+    hitTestRegions: (_pageIndex: number, x: number) => ({
+      region: 'body' as const,
+      pos: 1,
+      target: x >= TEXT_FROM ? ('text' as const) : ('none' as const),
+    }),
+    imageAtPoint: () => null,
+  } as unknown as DisplayListQueries;
+}
+
+/**
+ * Every identity here is stable across renders, as the editor's own are: a ref
+ * that changed identity per render would re-run effects keyed on it and could
+ * repaint the cursor for reasons a mode change never causes.
+ */
+function stableOptions(): (overrides?: Partial<UsePagesPointerOptions>) => UsePagesPointerOptions {
+  const canvasHostRef = createRef<HTMLDivElement>() as { current: HTMLDivElement | null };
+  canvasHostRef.current = host;
+  const projection = {
+    size: 10,
+    targetAt: () => null,
+    tableAtPosition: () => null,
+    cellPosition: () => null,
+  } as unknown as YrsPositionProjection;
+  const base: UsePagesPointerOptions = {
+    pagesContainerRef: { current: null },
+    yrsInputRef: { current: null },
+    yrsSession: null as unknown as YrsSession,
+    yrsRootStory: 'body',
+    getYrsPositionProjection: () => projection,
+    applyYrsCommand: () => false,
+    syncYrsInputState: () => false,
+    readOnly: false,
+    displayListQueries: fakeQueries(),
+    canvasHostRef,
+    setSelectionRects: () => {},
+    setCaretPosition: () => {},
+    setIsFocused: () => {},
+    scrollToPositionImpl: () => {},
+  };
+  return (overrides = {}) => ({ ...base, ...overrides });
+}
+
+function mouse(type: string, clientX: number, clientY: number, target: EventTarget): void {
+  act(() => {
+    target.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, button: 0 })
+    );
+  });
+}
+
+beforeEach(() => {
+  host = document.createElement('div');
+  host.className = 'canvas-pages';
+  const canvas = document.createElement('canvas');
+  canvas.dataset.pageIndex = '0';
+  canvas.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: PAGE.width,
+      bottom: PAGE.height,
+      width: PAGE.width,
+      height: PAGE.height,
+    }) as DOMRect;
+  host.append(canvas);
+  document.body.append(host);
+});
+
+afterEach(() => {
+  cleanup();
+  host.remove();
+});
+
+afterAll(async () => {
+  if (ownsDom) await GlobalRegistrator.unregister();
+});
+
+const canvasOf = () => host.firstElementChild as HTMLCanvasElement;
+
+describe('pages pointer hover cursor', () => {
+  test('a move over text paints the caret cursor, and the margin drops it', () => {
+    const options = stableOptions();
+    renderHook(() => usePagesPointer(options()));
+    const canvas = canvasOf();
+
+    mouse('mousemove', 400, 500, canvas);
+    expect(host.style.cursor).toBe('text');
+
+    mouse('mousemove', 40, 500, canvas);
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('a drag holds its cursor, and the release re-reads the point under it', () => {
+    const options = stableOptions();
+    renderHook(() => usePagesPointer(options()));
+    const canvas = canvasOf();
+
+    mouse('mousemove', 400, 500, canvas);
+    expect(host.style.cursor).toBe('text');
+
+    mouse('mousedown', 400, 500, canvas);
+    // dragging into the margin keeps the cursor the gesture started with
+    mouse('mousemove', 40, 500, canvas);
+    expect(host.style.cursor).toBe('text');
+
+    // released there without ever moving again
+    mouse('mouseup', 40, 500, window);
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('leaving the pages drops the cursor', () => {
+    const options = stableOptions();
+    renderHook(() => usePagesPointer(options()));
+
+    mouse('mousemove', 400, 500, canvasOf());
+    expect(host.style.cursor).toBe('text');
+
+    mouse('mousemove', 400, 500, document.body);
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('a drag that runs off the pages keeps its cursor', () => {
+    const options = stableOptions();
+    renderHook(() => usePagesPointer(options()));
+
+    mouse('mousemove', 400, 500, canvasOf());
+    mouse('mousedown', 400, 500, canvasOf());
+    mouse('mousemove', 400, 2000, document.body);
+
+    expect(host.style.cursor).toBe('text');
+  });
+
+  test('unmounting takes back the cursor it stamped on the host', () => {
+    const options = stableOptions();
+    const { unmount } = renderHook(() => usePagesPointer(options()));
+
+    mouse('mousemove', 400, 500, canvasOf());
+    expect(host.style.cursor).toBe('text');
+
+    act(() => unmount());
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('a mode flip mid-drag waits for the release', () => {
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (hfEditMode: 'header' | 'footer' | null) => usePagesPointer(options({ hfEditMode })),
+      { initialProps: null as 'header' | 'footer' | null }
+    );
+
+    mouse('mousemove', 400, 500, canvasOf());
+    mouse('mousedown', 400, 500, canvasOf());
+
+    // the body becomes inert behind an open band editor, but not mid-gesture
+    act(() => rerender('header'));
+    expect(host.style.cursor).toBe('text');
+
+    mouse('mouseup', 400, 500, window);
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('a re-render that changes no mode leaves the cursor alone', () => {
+    // options rebuilt per render, as an editor's own props may be
+    const { rerender } = renderHook(() => usePagesPointer(stableOptions()()));
+
+    mouse('mousemove', 400, 500, canvasOf());
+    expect(host.style.cursor).toBe('text');
+
+    act(() => rerender());
+    expect(host.style.cursor).toBe('text');
+  });
+
+  test('a read-only document never paints the caret cursor', () => {
+    const options = stableOptions();
+    renderHook(() => usePagesPointer(options({ readOnly: true })));
+
+    mouse('mousemove', 400, 500, canvasOf());
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('opening a header editor re-resolves a pointer that has not moved', () => {
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (hfEditMode: 'header' | 'footer' | null) => usePagesPointer(options({ hfEditMode })),
+      { initialProps: null as 'header' | 'footer' | null }
+    );
+
+    mouse('mousemove', 400, 500, canvasOf());
+    expect(host.style.cursor).toBe('text');
+
+    // the body is inert behind an open band editor, under the same pointer
+    act(() => rerender('header'));
+    expect(host.style.cursor).toBe('default');
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
@@ -18,6 +18,11 @@ import type { YrsCellLoc, YrsSession } from '@betteroffice/docx/yrs';
 
 import type { YrsInputRef } from '../YrsInput';
 import { useDragAutoScroll } from '../../../hooks/useDragAutoScroll';
+import {
+  canvasHoverCursor,
+  createCursorPainter,
+  type CanvasHoverCursor,
+} from '../hoverCursor';
 import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
 import type { YrsEditorCommand } from '../yrsCommands';
 
@@ -71,6 +76,8 @@ export interface UsePagesPointerOptions {
 export interface UsePagesPointerReturn {
   handlePagesMouseDown: (e: React.MouseEvent) => void;
   handlePagesMouseMove: (e: React.MouseEvent) => void;
+  /** drops the hover cursor when the pointer leaves the pages */
+  handlePagesMouseLeave: () => void;
   handlePagesClick: (e: React.MouseEvent) => void;
   handlePagesContextMenu: (e: React.MouseEvent) => void;
   handleTableInsertClick: (e: React.MouseEvent) => void;
@@ -213,6 +220,40 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     },
     [displayListQueries, canvasHostRef, pagesContainerRef]
   );
+
+  // written straight to the DOM: hover fires on every pointer move, and
+  // re-rendering the editor for it is not affordable
+  const cursorPainterRef = useRef(createCursorPainter());
+  const paintHoverCursor = useCallback(
+    (cursor: CanvasHoverCursor) => {
+      cursorPainterRef.current(canvasHostRef?.current ?? pagesContainerRef.current, cursor);
+    },
+    [canvasHostRef, pagesContainerRef]
+  );
+  // last point over the pages, so a cursor that outlived what it described can
+  // be re-resolved without waiting for a move. Null while it is elsewhere.
+  const hoverPointRef = useRef<{ x: number; y: number } | null>(null);
+  const resolveHoverCursor = useCallback(
+    (clientX: number, clientY: number) => {
+      hoverPointRef.current = { x: clientX, y: clientY };
+      const hit = readOnly ? null : (resolveCanvasHit(clientX, clientY, false)?.hit ?? null);
+      paintHoverCursor(canvasHoverCursor({ readOnly, hfEditMode }, hit));
+    },
+    [hfEditMode, paintHoverCursor, readOnly, resolveCanvasHit]
+  );
+  // A mode flip changes what is typeable under a pointer that has not moved.
+  // A gesture still holds its own cursor; the release resolves the new mode.
+  useEffect(() => {
+    const point = hoverPointRef.current;
+    if (!point || isDraggingRef.current || yrsCellDraggingRef.current) return;
+    resolveHoverCursor(point.x, point.y);
+  }, [resolveHoverCursor]);
+  // Clears the cursor on unmount only. Keying this on the painter would clear
+  // it on every identity change too — the effect above re-resolves in the same
+  // commit, so nothing shows, but the write is redundant and reads as an exit.
+  const paintHoverCursorRef = useRef(paintHoverCursor);
+  paintHoverCursorRef.current = paintHoverCursor;
+  useEffect(() => () => paintHoverCursorRef.current('default'), []);
 
   const getPositionFromMouse = useCallback(
     (clientX: number, clientY: number): number | null => {
@@ -383,12 +424,19 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     [extendCellSelection, getPositionFromMouse, setTextSelection, updateDragScroll]
   );
 
-  const handleMouseUp = useCallback(() => {
-    isDraggingRef.current = false;
-    yrsCellDragAnchorRef.current = null;
-    yrsCellDraggingRef.current = false;
-    stopDragAutoScroll();
-  }, [stopDragAutoScroll]);
+  const handleMouseUp = useCallback(
+    (e: MouseEvent) => {
+      const wasDragging = isDraggingRef.current || yrsCellDraggingRef.current;
+      isDraggingRef.current = false;
+      yrsCellDragAnchorRef.current = null;
+      yrsCellDraggingRef.current = false;
+      stopDragAutoScroll();
+      // the gesture held its own cursor; a pointer that never moves again
+      // gets its answer here
+      if (wasDragging) resolveHoverCursor(e.clientX, e.clientY);
+    },
+    [resolveHoverCursor, stopDragAutoScroll]
+  );
 
   useEffect(() => {
     window.addEventListener('mousemove', handleMouseMove);
@@ -401,7 +449,13 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
   const handlePagesMouseMove = useCallback(
     (e: React.MouseEvent) => {
-      if (readOnly || isDraggingRef.current || yrsCellDraggingRef.current) return;
+      // a live gesture keeps the cursor it started with, and the release is
+      // what re-reads the point under it
+      if (isDraggingRef.current || yrsCellDraggingRef.current) return;
+      hoverPointRef.current = { x: e.clientX, y: e.clientY };
+      const point = readOnly ? null : resolveCanvasHit(e.clientX, e.clientY, false);
+      paintHoverCursor(canvasHoverCursor({ readOnly, hfEditMode }, point?.hit ?? null));
+      if (readOnly) return;
       const scheduleHide = () => {
         tableInsertHideTimerRef.current ??= setTimeout(() => {
           setTableInsertButton(null);
@@ -413,7 +467,6 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       const overlayTarget = canvasOverlayTarget ?? pagesContainerRef.current?.parentElement;
       const projection = getYrsPositionProjection(yrsRootStory);
       if (!queries || !host || !overlayTarget || !projection) return;
-      const point = resolveCanvasHit(e.clientX, e.clientY, false);
       const pageSize = point ? queries.pageSize(point.pageIndex) : null;
       const pageRect = point ? resolveDisplayPageClientRect(host, queries, point.pageIndex) : null;
       if (!point || !pageSize || !pageRect) {
@@ -463,11 +516,19 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       getYrsPositionProjection,
       hfEditMode,
       pagesContainerRef,
+      paintHoverCursor,
       readOnly,
       resolveCanvasHit,
       yrsRootStory,
     ]
   );
+
+  const handlePagesMouseLeave = useCallback(() => {
+    // a drag that runs off the pages keeps its cursor, like the move path
+    if (isDraggingRef.current || yrsCellDraggingRef.current) return;
+    hoverPointRef.current = null;
+    paintHoverCursor('default');
+  }, [paintHoverCursor]);
 
   const handleTableInsertClick = useCallback(
     (e: React.MouseEvent) => {
@@ -682,12 +743,14 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
   const canvasHandlersRef = useRef({
     mousedown: handlePagesMouseDown,
     mousemove: handlePagesMouseMove,
+    mouseleave: handlePagesMouseLeave,
     click: handlePagesClick,
     contextmenu: handlePagesContextMenu,
   });
   canvasHandlersRef.current = {
     mousedown: handlePagesMouseDown,
     mousemove: handlePagesMouseMove,
+    mouseleave: handlePagesMouseLeave,
     click: handlePagesClick,
     contextmenu: handlePagesContextMenu,
   };
@@ -703,7 +766,10 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       if (onCurrentCanvas(e)) canvasHandlersRef.current.mousedown(asReactEvent(e));
     };
     const onMouseMove = (e: MouseEvent) => {
+      // no event fires once the pointer is off the pages, so the move that
+      // leaves them is what drops the hover cursor
       if (onCurrentCanvas(e)) canvasHandlersRef.current.mousemove(asReactEvent(e));
+      else canvasHandlersRef.current.mouseleave();
     };
     const onClick = (e: MouseEvent) => {
       if (onCurrentCanvas(e)) canvasHandlersRef.current.click(asReactEvent(e));
@@ -729,6 +795,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
   return {
     handlePagesMouseDown,
     handlePagesMouseMove,
+    handlePagesMouseLeave,
     handlePagesClick,
     handlePagesContextMenu,
     handleTableInsertClick,

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.engine.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.engine.test.ts
@@ -1,0 +1,113 @@
+/**
+ * End-to-end: the real layout wasm builds a display list, the real query
+ * facade answers, and the mapping turns that into a cursor.
+ *
+ * The header-band case is the only probe that reaches the direct-run branch —
+ * a band has no typeable area, so nothing else there can answer `text`.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  createDisplayListQueries,
+  type DisplayList,
+  type DisplayListQueries,
+} from '@betteroffice/docx/layout/render';
+import { buildDisplayListJson, preloadLayoutWasm } from '@betteroffice/docx/wasm/layout';
+import { canvasHoverCursor } from './hoverCursor';
+
+const root = resolve(import.meta.dir, '../../../../..');
+const fixture = (path: string) => resolve(root, 'crates/docx-layout/tests/fixtures', path);
+// three one-line paragraphs on an 816x1056 page whose content box is
+// x 96..720, y 96..960
+const BODY = fixture('single-page-multi-paragraph.input.json');
+// one header band at y 48..72 and one footer band at y 984..1008, each with a
+// paragraph; a band carries no content box
+const BANDS = fixture('hf/hf-default-both.input.json');
+
+const facades: DisplayListQueries[] = [];
+
+function open(path: string): { list: DisplayList; queries: DisplayListQueries } {
+  const list = JSON.parse(buildDisplayListJson(readFileSync(path, 'utf8'))) as DisplayList;
+  const queries = createDisplayListQueries(list);
+  facades.push(queries);
+  return { list, queries };
+}
+
+let body: ReturnType<typeof open>;
+let bands: ReturnType<typeof open>;
+
+const cursorAt = (
+  opened: ReturnType<typeof open>,
+  x: number,
+  y: number,
+  readOnly = false
+): string => canvasHoverCursor({ readOnly }, opened.queries.hitTestRegions(0, x, y));
+
+beforeAll(async () => {
+  await preloadLayoutWasm();
+  body = open(BODY);
+  bands = open(BANDS);
+  await Promise.all(facades.map((facade) => facade.whenReady()));
+});
+
+afterAll(() => {
+  for (const facade of facades) facade.dispose();
+});
+
+describe('hover cursor over an engine-built page', () => {
+  test('every laid-out run reads as text', () => {
+    const runs = body.list.pages[0].primitives.filter((primitive) => primitive.kind === 'text');
+    expect(runs.length).toBeGreaterThan(0);
+    for (const run of runs) {
+      expect(cursorAt(body, run.x + run.width / 2, run.baselineY - 4)).toBe('text');
+    }
+  });
+
+  test('the content box is typeable and the margins are not', () => {
+    const page = body.list.pages[0];
+    const content = page.contentBounds;
+    if (!content) throw new Error('the fixture page has no content box');
+    const inside = (x: number, y: number) =>
+      x >= content.x &&
+      x <= content.x + content.width &&
+      y >= content.y &&
+      y <= content.y + content.height;
+
+    const disagreements: string[] = [];
+    for (let y = 0; y <= page.height; y += 24) {
+      for (let x = 0; x <= page.width; x += 24) {
+        const cursor = cursorAt(body, x, y);
+        const expected = inside(x, y) ? 'text' : 'default';
+        if (cursor !== expected) disagreements.push(`(${x},${y}) ${cursor} != ${expected}`);
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  test('a read-only document never shows the caret cursor', () => {
+    const run = body.list.pages[0].primitives.find((primitive) => primitive.kind === 'text');
+    if (!run) throw new Error('the fixture page has no run');
+    expect(cursorAt(body, run.x + run.width / 2, run.baselineY - 4, true)).toBe('default');
+  });
+
+  // A band has no content box, so only a run's own box can answer here — this
+  // is what separates the direct-hit branch from the typeable-area fallback.
+  test('a header band reads as text over its runs and nowhere else', () => {
+    const page = bands.list.pages[0];
+    const band = page.header;
+    if (!band) throw new Error('the fixture page has no header band');
+    const run = band.primitives.find((primitive) => primitive.kind === 'text');
+    if (!run) throw new Error('the header band has no run');
+
+    const hit = bands.queries.hitTestRegions(0, run.x + run.width / 2, run.baselineY - 2);
+    expect(hit?.region).toBe('header');
+    expect(cursorAt(bands, run.x + run.width / 2, run.baselineY - 2)).toBe('text');
+
+    // same band, past the run: inside the region, outside every run
+    const past = run.x + run.width + 200;
+    expect(bands.queries.hitTestRegions(0, past, run.baselineY - 2)?.region).toBe('header');
+    expect(cursorAt(bands, past, run.baselineY - 2)).toBe('default');
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
+import { canvasHoverCursor, createCursorPainter } from './hoverCursor';
+
+const hit = (over: Partial<DisplayListRegionHit>): DisplayListRegionHit => ({
+  region: 'body',
+  pos: 12,
+  target: 'none',
+  ...over,
+});
+
+const editing = { readOnly: false };
+
+describe('canvas hover cursor', () => {
+  test('follows the engine target inside the body', () => {
+    expect(canvasHoverCursor(editing, hit({ target: 'text' }))).toBe('text');
+    expect(canvasHoverCursor(editing, hit({ target: 'none' }))).toBe('default');
+    expect(canvasHoverCursor(editing, hit({ target: 'image' }))).toBe('default');
+  });
+
+  test('a resolved position off the typeable area is still not text', () => {
+    expect(canvasHoverCursor(editing, hit({ pos: 40, target: 'none' }))).toBe('default');
+  });
+
+  test('an idle header or footer band reads as text over its own runs', () => {
+    expect(canvasHoverCursor(editing, hit({ region: 'header', target: 'text' }))).toBe('text');
+    expect(canvasHoverCursor(editing, hit({ region: 'footer', target: 'none' }))).toBe('default');
+  });
+
+  test('editing a band makes only that band typeable', () => {
+    const mode = { readOnly: false, hfEditMode: 'header' as const };
+    expect(canvasHoverCursor(mode, hit({ region: 'header', target: 'none' }))).toBe('text');
+    expect(canvasHoverCursor(mode, hit({ region: 'header', target: 'text' }))).toBe('text');
+    expect(canvasHoverCursor(mode, hit({ region: 'header', target: 'image' }))).toBe('default');
+    expect(canvasHoverCursor(mode, hit({ region: 'body', target: 'text' }))).toBe('default');
+    expect(canvasHoverCursor(mode, hit({ region: 'footer', target: 'text' }))).toBe('default');
+  });
+
+  test('read-only and off-page points never type', () => {
+    expect(canvasHoverCursor({ readOnly: true }, hit({ target: 'text' }))).toBe('default');
+    expect(
+      canvasHoverCursor({ readOnly: true, hfEditMode: 'footer' }, hit({ region: 'footer' }))
+    ).toBe('default');
+    expect(canvasHoverCursor(editing, null)).toBe('default');
+  });
+
+  test('a wasm build without the target degrades to the pre-hover behaviour', () => {
+    const older: DisplayListRegionHit = { region: 'body', pos: 12 };
+    expect(canvasHoverCursor(editing, older)).toBe('default');
+    // an open band types regardless: the whole band is its typeable area
+    expect(
+      canvasHoverCursor({ readOnly: false, hfEditMode: 'header' }, { ...older, region: 'header' })
+    ).toBe('text');
+  });
+});
+
+describe('cursor painter', () => {
+  const fakeHost = () => ({ style: { cursor: '' } }) as unknown as HTMLElement;
+
+  test('writes once per change and skips repeats', () => {
+    const paint = createCursorPainter();
+    const host = fakeHost();
+
+    expect(paint(host, 'text')).toBe(true);
+    expect(host.style.cursor).toBe('text');
+    expect(paint(host, 'text')).toBe(false);
+    expect(paint(host, 'default')).toBe(true);
+    expect(host.style.cursor).toBe('default');
+  });
+
+  test('re-stamps a replaced host holding the same cursor', () => {
+    const paint = createCursorPainter();
+    const first = fakeHost();
+    const second = fakeHost();
+
+    paint(first, 'text');
+    expect(paint(second, 'text')).toBe(true);
+    expect(second.style.cursor).toBe('text');
+  });
+
+  test('a missing host is skipped without poisoning the guard', () => {
+    const paint = createCursorPainter();
+    const host = fakeHost();
+
+    expect(paint(null, 'text')).toBe(false);
+    expect(paint(host, 'text')).toBe(true);
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
@@ -1,0 +1,60 @@
+/**
+ * Which pointer cursor the canvas pages paint, from one engine hit.
+ *
+ * `target` comes from `hit_test_regions` (`crates/docx-layout/src/hit.rs`) and
+ * names what a click would act on; nothing here re-derives geometry. This maps
+ * it onto the editor's modes, as the DOM painter's stylesheet also did for a
+ * read-only document, for the body behind an open header/footer editor, and
+ * for a picture as a select target.
+ *
+ * An idle header/footer band deliberately DIFFERS from that stylesheet, which
+ * gave the whole band a hand: here it reads as text over its own runs, since a
+ * single click on an idle band is inert and only a double-click opens it for
+ * editing at that word.
+ *
+ * A wasm build predating `target` omits it, which reads as "not text".
+ */
+
+import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
+
+export type CanvasHoverCursor = 'default' | 'text';
+
+export interface CanvasHoverMode {
+  readOnly: boolean;
+  /** the header/footer region being edited inline, if any */
+  hfEditMode?: 'header' | 'footer' | null;
+}
+
+export function canvasHoverCursor(
+  mode: CanvasHoverMode,
+  hit: DisplayListRegionHit | null
+): CanvasHoverCursor {
+  if (mode.readOnly || !hit) return 'default';
+  if (mode.hfEditMode) {
+    // only the edited band accepts typing; the body and the sibling band are inert
+    if (hit.region !== mode.hfEditMode) return 'default';
+    // the whole band is typeable once open, so an absent target still types
+    return hit.target === 'image' ? 'default' : 'text';
+  }
+  return hit.target === 'text' ? 'text' : 'default';
+}
+
+/**
+ * Stamps the cursor on the pages host, skipping repeats. `cursor` is
+ * inherited, so one write covers every page, and affordances carrying their
+ * own (SDT widgets, the image and table overlays) still win. The host is part
+ * of the guard, so a replaced one is re-stamped. Returns whether it wrote.
+ */
+export function createCursorPainter(): (
+  host: HTMLElement | null,
+  cursor: CanvasHoverCursor
+) => boolean {
+  let painted: { host: HTMLElement; cursor: CanvasHoverCursor } | null = null;
+  return (host, cursor) => {
+    if (!host) return false;
+    if (painted?.host === host && painted.cursor === cursor) return false;
+    painted = { host, cursor };
+    host.style.cursor = cursor;
+    return true;
+  };
+}

--- a/packages/docx/src/layout/render/displayListQueries.ts
+++ b/packages/docx/src/layout/render/displayListQueries.ts
@@ -76,6 +76,14 @@ export interface ResidentDisplayListQueryEngine {
 export type DisplayListHitRegion = 'body' | 'header' | 'footer';
 
 /**
+ * What a click at a hit point would act on — mirrors `HoverTarget` in hit.rs.
+ * `'text'` is the typeable area (a run's box, or the content box around it),
+ * which is what a pointer cursor keys off; `pos` cannot say, since it resolves
+ * everywhere on a page that carries text.
+ */
+export type DisplayListHoverTarget = 'text' | 'image' | 'none';
+
+/**
  * Region-aware hit result. For `header`/`footer` the position refers to the
  * header/footer document identified by `rId`, NOT the body document — the
  * caller must route the selection to that editor. `pos` is null when the point
@@ -85,6 +93,8 @@ export interface DisplayListRegionHit {
   region: DisplayListHitRegion;
   rId?: string;
   pos: number | null;
+  /** Absent from a wasm build predating it; read that as "not text". */
+  target?: DisplayListHoverTarget;
 }
 
 /**

--- a/packages/docx/src/layout/render/index.ts
+++ b/packages/docx/src/layout/render/index.ts
@@ -106,6 +106,7 @@ export {
   isDisplayListQuerySourceDead,
   onDisplayListQuerySourceFailure,
   type DisplayListHitRegion,
+  type DisplayListHoverTarget,
   type DisplayListImageGeometry,
   type DisplayListParagraphGeometry,
   type DisplayListQueries,

--- a/packages/docx/src/layout/render/rustDisplayList.ts
+++ b/packages/docx/src/layout/render/rustDisplayList.ts
@@ -271,7 +271,7 @@ export class RustDisplayListSourceError extends Error {
  * `createDisplayListQueries` falls back to the `*Json` path when it is not.
  */
 export interface RustDisplayListQueryEngine {
-  /** region-aware hit test → `{"region","rId"?,"pos"}` or `"null"` JSON */
+  /** region-aware hit test → `{"region","rId"?,"pos","target"}` or `"null"` JSON */
   hitTestRegionsJson(displayList: string, pageIndex: number, x: number, y: number): string;
   /** closest caret position on the adjacent visual line */
   verticalMoveJson?(

--- a/packages/docx/src/wasm/layout.ts
+++ b/packages/docx/src/wasm/layout.ts
@@ -42,9 +42,10 @@ export function preloadLayoutWasm(input?: WasmAsyncInput): Promise<void> {
 
 /**
  * Region-aware hit test over a display list: page-local point in,
- * `{"region":"body"|"header"|"footer","rId"?,"pos":n|null}` (or `"null"` for
- * an out-of-range page) JSON out. Header/footer hits identify the HF doc
- * by `rId`; their `pos` refers to that doc, not the body doc.
+ * `{"region":"body"|"header"|"footer","rId"?,"pos":n|null,"target":"text"|"image"|"none"}`
+ * (or `"null"` for an out-of-range page) JSON out. Header/footer hits identify
+ * the HF doc by `rId`; their `pos` refers to that doc, not the body doc.
+ * `target` is what sits under the point, which is what a pointer cursor needs.
  */
 export function hitTestRegionsJson(
   displayList: string,


### PR DESCRIPTION
TL;DR:


Summary:
- The DOCX canvas painted a plain arrow everywhere; hovering typeable text now shows the I-beam, and images and non-typeable areas read as the arrow
- The engine's existing hit resolution answers it: `resolve_point` returns a `target` alongside `pos`, so there is no second hit-testing implementation to drift from the click path
- `RegionHit` gains an optional `target`, so an older wasm build degrades to the previous behaviour
- The cursor is written once on the pages host, guarded by the last painted value, and skipped during a gesture and in read-only mode

Known behaviour, deliberate:
- Scroll and zoom leave a stale cursor until the next pointer movement; browsers do not synthesize a move for this and it self-corrects
- Idle header and footer bands now differ between the two render paths: the DOM painter shows a hand across the whole band, the canvas path shows the I-beam over the band's own runs and the arrow elsewhere

Test plan:
- [ ] `cargo test` passes
- [ ] `bun test packages/docx packages/docx-react` passes
- [ ] `bun run typecheck` passes in `packages/docx` and `packages/docx-react`
- [ ] Hovering body text shows the I-beam; page margins show the arrow
- [ ] Hovering an image shows the arrow, and clicking it selects the image
- [ ] Dragging a selection keeps the I-beam for the whole gesture