### PR TITLE
chore(deps): pin fast-uri 3.1.5 and undici 7.29.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -273,10 +273,11 @@
     "@hono/node-server": "2.0.10",
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "minimatch": "^10.2.5",
     "postcss": "8.5.23",
     "sharp": "^0.35.0",
+    "undici": "7.29.0",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -1389,7 +1390,7 @@
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -2157,7 +2158,7 @@
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "overrides": {
     "@hono/node-server": "2.0.10",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "postcss": "8.5.23",
     "sharp": "^0.35.0",
     "brace-expansion": "5.0.9",
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.5",
+    "undici": "7.29.0"
   },
   "scripts": {
     "dev": "bun run --filter './apps/web' dev",


### PR DESCRIPTION
TL;DR:


Summary:
- GHSA-7p8r-x3mc-p8w7 (high) covers `fast-uri >=3.0.0 <3.1.5`, so the existing `3.1.4` override is itself affected
- GHSA-4cwx-7wf7-3272 (high) covers `undici >=7.0.0 <7.29.0`; `undici` had no override and resolved to `7.28.0`
- Both reach the tree through `apps/demo` via `shadcn`, `wrangler` and `@opennextjs/cloudflare`, so `bun audit --audit-level=high` fails on `main` and red-lights the Security audit job on every branch
- Pins the minimum fixed version in each existing major line rather than jumping to `fast-uri` 4.x or `undici` 8.x, to avoid a breaking bump under the Cloudflare tooling

Test plan:
- [ ] `bun audit --audit-level=high` reports no vulnerabilities
- [ ] `bun install --frozen-lockfile` succeeds
- [ ] `bun run --filter '@betteroffice/demo' typecheck` passes
- [ ] CI Security audit passes