### PR TITLE
fix(xlsx): refuse a save that would rewrite a shared chart part

### DIFF
--- a/.changeset/xlsx-shared-chart-parts.md
+++ b/.changeset/xlsx-shared-chart-parts.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/xlsx": patch
+"@betteroffice/rust-crates": patch
+---
+
+A chart or drawing part that two sheets both anchor is no longer written from whichever sheet came last. Saving such a workbook used to patch the shared part once, silently rewriting the chart the other sheet shows: inserting a row on one sheet moved its references and, on reopen, the other sheet's chart had moved with it. A part is now written only when every sheet anchoring it patches it into the same bytes, which covers the sheet a cache is rebuilt against, and the save is refused with an error naming the part and both sheets otherwise. Workbooks whose sheets want the same content out of a shared part — including every workbook that shares no part at all — save exactly as before, byte for byte.

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -733,6 +733,112 @@ fn renaming_a_sheet_rewrites_hash_prefixed_hyperlink_locations() {
     );
 }
 
+/// Two sheets whose drawings both name one chart part, which the package
+/// format permits. The chart's references are unqualified, so each sheet
+/// resolves them against itself.
+fn shared_chart_fixture() -> Vec<u8> {
+    let mut model = WorkbookModel::default();
+    model.sheets.push(Sheet::new("First"));
+    model.sheets.push(Sheet::new("Second"));
+    let mut parts = xlsx_parse::serialize_workbook(&model).unwrap();
+
+    for index in 1..=2 {
+        let path = format!("xl/worksheets/sheet{index}.xml");
+        let worksheet = test_part_text(&parts, &path).replace(
+            "</worksheet>",
+            r#"<drawing r:id="rIdDrawing"/></worksheet>"#,
+        );
+        set_test_part(&mut parts, &path, worksheet.into_bytes());
+        parts.push((
+            format!("xl/worksheets/_rels/sheet{index}.xml.rels"),
+            format!(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing{index}.xml"/></Relationships>"#
+            )
+            .into_bytes(),
+        ));
+        parts.push((
+            format!("xl/drawings/drawing{index}.xml"),
+            br#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor editAs="oneCell"><xdr:from><xdr:col>2</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>4</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from><xdr:to><xdr:col>8</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>19</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to><xdr:graphicFrame><a:graphic><a:graphicData><c:chart r:id="rIdChart"/></a:graphicData></a:graphic></xdr:graphicFrame><xdr:clientData/></xdr:twoCellAnchor></xdr:wsDr>"#.to_vec(),
+        ));
+        parts.push((
+            format!("xl/drawings/_rels/drawing{index}.xml.rels"),
+            br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/></Relationships>"#.to_vec(),
+        ));
+    }
+    parts.push((
+        "xl/charts/chart1.xml".to_owned(),
+        br#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:barChart><c:ser><c:idx val="0"/><c:val><c:numRef><c:f>$A$1:$A$2</c:f><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#.to_vec(),
+    ));
+    let content_types = test_part_text(&parts, "[Content_Types].xml").replace(
+        "</Types>",
+        r#"<Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/><Override PartName="/xl/drawings/drawing2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#,
+    );
+    set_test_part(
+        &mut parts,
+        "[Content_Types].xml",
+        content_types.into_bytes(),
+    );
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+fn shared_chart_formula(workbook: &Workbook, sheet: SheetId) -> String {
+    workbook.model().sheet(sheet).unwrap().charts[0].refs[0]
+        .formula
+        .clone()
+}
+
+/// Inserting a row on one of two sheets that share a chart part moves only that
+/// sheet's references, so the part can no longer carry both. The save is
+/// refused rather than rewriting the chart the other sheet shows.
+#[test]
+fn refuses_to_save_a_shared_chart_part_a_structural_edit_split() {
+    let mut workbook = Workbook::open(&shared_chart_fixture()).unwrap();
+    assert_eq!(shared_chart_formula(&workbook, SheetId(0)), "$A$1:$A$2");
+    assert_eq!(shared_chart_formula(&workbook, SheetId(1)), "$A$1:$A$2");
+    let untouched = workbook.save().unwrap();
+
+    workbook
+        .apply_ops(
+            vec![Op::InsertRows {
+                sheet: SheetId(0),
+                at: 0,
+                count: 1,
+            }],
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(shared_chart_formula(&workbook, SheetId(0)), "$A$2:$A$3");
+    assert_eq!(shared_chart_formula(&workbook, SheetId(1)), "$A$1:$A$2");
+
+    let error = workbook.save().unwrap_err();
+    assert!(
+        matches!(&error, Error::Spreadsheet(xlsx_parse::ParseError::UnsupportedEdit(message))
+            if message.contains("xl/charts/chart1.xml")
+                && message.contains("sheet First")
+                && message.contains("sheet Second")),
+        "{error:?}"
+    );
+
+    workbook.undo(CalculationOptions::default()).unwrap();
+    assert_eq!(shared_chart_formula(&workbook, SheetId(1)), "$A$1:$A$2");
+    let restored = package_map(&workbook.save().unwrap());
+    let before = package_map(&untouched);
+    for path in [
+        "xl/charts/chart1.xml",
+        "xl/drawings/drawing1.xml",
+        "xl/drawings/drawing2.xml",
+    ] {
+        assert_eq!(
+            restored.get(path),
+            before.get(path),
+            "undoing the split lets {path} save unchanged again"
+        );
+    }
+    let reopened = Workbook::open(&workbook.save().unwrap()).unwrap();
+    assert_eq!(shared_chart_formula(&reopened, SheetId(0)), "$A$1:$A$2");
+    assert_eq!(shared_chart_formula(&reopened, SheetId(1)), "$A$1:$A$2");
+}
+
 #[test]
 fn edits_recalculate_render_and_round_trip() {
     let mut workbook =

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -1728,6 +1728,57 @@ const DRAWING: &[u8] = br#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.or
 
 const CHART: &[u8] = br#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><c:chart><c:plotArea><c:barChart><c:ser><c:idx val="0"/><c:tx><c:strRef><c:f>Data!$B$1</c:f><c:strCache><c:pt idx="0"><c:v>Series</c:v></c:pt></c:strCache></c:strRef></c:tx><c:spPr><a:solidFill><a:schemeClr val="accent2"/></a:solidFill></c:spPr><c:cat><c:strRef><c:f>Data!$A$2:$A$4</c:f><c:strCache><c:pt idx="0"><c:v>Q1</c:v></c:pt></c:strCache></c:strRef></c:cat><c:val><c:numRef><c:f>Data!$B$2:$B$4</c:f><c:numCache><c:pt idx="0"><c:v>3</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
 
+/// A two-sheet package whose sheets each anchor the same chart part through
+/// their own drawing. The package format permits it, and the chart's
+/// references are unqualified, so each sheet resolves them against itself.
+fn shared_chart_package() -> Vec<(String, Vec<u8>)> {
+    let mut parts = package(r#"<sheetData/><drawing r:id="rIdDrawing"/>"#, &[], false);
+    parts[0] = (
+        "xl/workbook.xml".to_owned(),
+        br#"<workbook><sheets><sheet name="First" sheetId="1" r:id="rId1"/><sheet name="Second" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
+    );
+    parts[1] = (
+        "xl/_rels/workbook.xml.rels".to_owned(),
+        br#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
+    );
+    let sheet_rels = |drawing: &str| {
+        format!(
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/{drawing}"/></Relationships>"#
+        )
+        .into_bytes()
+    };
+    parts.extend([
+        (
+            "xl/worksheets/sheet2.xml".to_owned(),
+            br#"<worksheet><sheetData/><drawing r:id="rIdDrawing"/></worksheet>"#.to_vec(),
+        ),
+        (
+            "xl/worksheets/_rels/sheet1.xml.rels".to_owned(),
+            sheet_rels("drawing1.xml"),
+        ),
+        (
+            "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+            sheet_rels("drawing2.xml"),
+        ),
+        ("xl/drawings/drawing1.xml".to_owned(), DRAWING.to_vec()),
+        ("xl/drawings/drawing2.xml".to_owned(), DRAWING.to_vec()),
+        (
+            "xl/drawings/_rels/drawing1.xml.rels".to_owned(),
+            SHARED_DRAWING_RELS.to_vec(),
+        ),
+        (
+            "xl/drawings/_rels/drawing2.xml.rels".to_owned(),
+            SHARED_DRAWING_RELS.to_vec(),
+        ),
+        ("xl/charts/chart1.xml".to_owned(), SHARED_CHART.to_vec()),
+    ]);
+    parts
+}
+
+const SHARED_DRAWING_RELS: &[u8] = br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/></Relationships>"#;
+
+const SHARED_CHART: &[u8] = br#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:barChart><c:ser><c:idx val="0"/><c:val><c:numRef><c:f>$A$1:$A$2</c:f><c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
+
 fn pivoted_package() -> Vec<(String, Vec<u8>)> {
     let mut parts = package(r#"<sheetData/>"#, &[], false);
     parts[0] = (
@@ -2167,6 +2218,202 @@ fn refuses_chart_state_with_no_one_to_one_source() {
         matches!(&error, ParseError::UnsupportedEdit(message)
             if message.contains("cannot create one")),
         "{error:?}"
+    );
+}
+
+fn save_shared(
+    parsed: &crate::ParsedWorkbook,
+    workbook: &Workbook,
+) -> Result<Vec<(String, Vec<u8>)>, ParseError> {
+    crate::serialize_workbook_with_package_and_origins_after_edits(
+        workbook,
+        &parsed.package,
+        &[Some(0), Some(1)],
+        &vec![SharedStringCells::new(); 2],
+        SaveEdits {
+            changed: true,
+            moved_references: false,
+        },
+    )
+}
+
+/// One chart part cannot hold two sheets' references at once. A save where the
+/// sheets sharing it no longer want the same content is refused, rather than
+/// writing whichever sheet came last and silently rewriting the chart the other
+/// one shows.
+#[test]
+fn refuses_a_shared_chart_part_its_sheets_disagree_on() {
+    let parsed = parse_workbook_with_package(&shared_chart_package()).unwrap();
+    assert_eq!(
+        parsed.workbook.sheets[0].charts[0].part,
+        "xl/charts/chart1.xml"
+    );
+    assert_eq!(
+        parsed.workbook.sheets[1].charts[0].part,
+        "xl/charts/chart1.xml"
+    );
+    assert_eq!(
+        parsed.workbook.sheets[0].charts[0].refs[0].formula,
+        "$A$1:$A$2"
+    );
+    assert_eq!(
+        parsed.workbook.sheets[1].charts[0].refs[0].formula,
+        "$A$1:$A$2"
+    );
+
+    let mut one_sheet_moved = parsed.workbook.clone();
+    one_sheet_moved.sheets[0].charts[0].refs[0].formula = "$A$2:$A$3".to_owned();
+    let error = save_shared(&parsed, &one_sheet_moved).unwrap_err();
+    assert!(
+        matches!(&error, ParseError::UnsupportedEdit(message)
+            if message.contains("xl/charts/chart1.xml")
+                && message.contains("sheet First")
+                && message.contains("sheet Second")),
+        "{error:?}"
+    );
+
+    let mut owners_diverge = parsed.workbook.clone();
+    owners_diverge.sheets[0].set_cell(
+        CellRef::parse_a1("A2").unwrap(),
+        Cell {
+            value: CellValue::Number { value: 5.0 },
+            ..Cell::default()
+        },
+    );
+    for sheet in &mut owners_diverge.sheets {
+        sheet.charts[0].refs[0].formula = "$A$2:$A$3".to_owned();
+    }
+    let error = save_shared(&parsed, &owners_diverge).unwrap_err();
+    assert!(
+        matches!(&error, ParseError::UnsupportedEdit(message)
+            if message.contains("xl/charts/chart1.xml")),
+        "an unqualified reference each sheet caches differently is still a disagreement: {error:?}"
+    );
+}
+
+/// Sharing a chart part between two sheets is legal, and the common case is
+/// that both want the same thing out of it. That must keep saving: untouched,
+/// byte for byte; moved on both sheets alike, patched once.
+#[test]
+fn saves_a_shared_chart_part_its_sheets_agree_on() {
+    let source = shared_chart_package();
+    let parsed = parse_workbook_with_package(&source).unwrap();
+
+    let mut untouched = parsed.workbook.clone();
+    edit_a1(&mut untouched, 1.0);
+    let saved = save_shared(&parsed, &untouched).unwrap();
+    for path in [
+        "xl/charts/chart1.xml",
+        "xl/drawings/drawing1.xml",
+        "xl/drawings/drawing2.xml",
+    ] {
+        assert_eq!(
+            part_bytes(&saved, path),
+            part_bytes(&source, path),
+            "{path} must not change when no chart did"
+        );
+    }
+
+    let mut both_moved = parsed.workbook.clone();
+    for sheet in &mut both_moved.sheets {
+        sheet.charts[0].refs[0].formula = "$A$2:$A$3".to_owned();
+    }
+    let saved = save_shared(&parsed, &both_moved).unwrap();
+    let patched = String::from_utf8(part_bytes(&saved, "xl/charts/chart1.xml")).unwrap();
+    assert_eq!(
+        patched,
+        String::from_utf8(SHARED_CHART.to_vec())
+            .unwrap()
+            .replace("$A$1:$A$2", "$A$2:$A$3")
+            .replace(
+                r#"<c:numCache><c:pt idx="0"><c:v>1</c:v></c:pt></c:numCache>"#,
+                r#"<c:numCache><c:ptCount val="2"/></c:numCache>"#,
+            )
+    );
+    let reopened = parse_workbook_with_package(&saved).unwrap();
+    for sheet in &reopened.workbook.sheets {
+        assert_eq!(sheet.charts[0].refs[0].formula, "$A$2:$A$3");
+    }
+
+    let mut renamed = parsed.workbook.clone();
+    renamed.sheets[0].set_cell(
+        CellRef::parse_a1("A2").unwrap(),
+        Cell {
+            value: CellValue::Number { value: 5.0 },
+            ..Cell::default()
+        },
+    );
+    for sheet in &mut renamed.sheets {
+        sheet.charts[0].refs[0].formula = "First!$A$1:$A$2".to_owned();
+    }
+    let saved = save_shared(&parsed, &renamed).unwrap();
+    let patched = String::from_utf8(part_bytes(&saved, "xl/charts/chart1.xml")).unwrap();
+    assert!(
+        patched.contains("<c:f>First!$A$1:$A$2</c:f>")
+            && patched
+                .contains(r#"<c:ptCount val="2"/><c:pt idx="1"><c:v>5</c:v></c:pt></c:numCache>"#),
+        "a qualified reference both sheets took resolves the same either way: {patched}"
+    );
+}
+
+/// The same aliasing reaches drawing parts: two sheets may relate to one
+/// drawing, whose anchors then belong to both. An anchor one sheet moved and
+/// the other did not is refused for the same reason a chart part is.
+#[test]
+fn refuses_a_shared_drawing_its_sheets_disagree_on() {
+    let mut source = shared_chart_package();
+    set_part(
+        &mut source,
+        "xl/worksheets/_rels/sheet2.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#,
+    );
+    let parsed = parse_workbook_with_package(&source).unwrap();
+    assert_eq!(
+        parsed.workbook.sheets[1].charts[0].drawing,
+        "xl/drawings/drawing1.xml"
+    );
+
+    let moved = |anchor: xlsx_model::ChartAnchor| match anchor {
+        xlsx_model::ChartAnchor::TwoCell { from, to, edit_as } => {
+            xlsx_model::ChartAnchor::TwoCell {
+                from: xlsx_model::AnchorCell {
+                    row: from.row + 1,
+                    ..from
+                },
+                to: xlsx_model::AnchorCell {
+                    row: to.row + 1,
+                    ..to
+                },
+                edit_as,
+            }
+        }
+        other => other,
+    };
+
+    let mut one_sheet_moved = parsed.workbook.clone();
+    one_sheet_moved.sheets[0].charts[0].anchor = moved(one_sheet_moved.sheets[0].charts[0].anchor);
+    let error = save_shared(&parsed, &one_sheet_moved).unwrap_err();
+    assert!(
+        matches!(&error, ParseError::UnsupportedEdit(message)
+            if message.contains("xl/drawings/drawing1.xml")
+                && message.contains("sheet First")
+                && message.contains("sheet Second")),
+        "{error:?}"
+    );
+
+    let mut both_moved = parsed.workbook.clone();
+    for sheet in &mut both_moved.sheets {
+        sheet.charts[0].anchor = moved(sheet.charts[0].anchor);
+    }
+    let saved = save_shared(&parsed, &both_moved).unwrap();
+    let patched = String::from_utf8(part_bytes(&saved, "xl/drawings/drawing1.xml")).unwrap();
+    assert_eq!(
+        patched,
+        String::from_utf8(DRAWING.to_vec())
+            .unwrap()
+            .replace("<xdr:row>4</xdr:row>", "<xdr:row>5</xdr:row>")
+            .replace("<xdr:row>19</xdr:row>", "<xdr:row>20</xdr:row>"),
+        "an anchor both sheets moved alike is written once"
     );
 }
 

--- a/crates/xlsx-parse/src/write.rs
+++ b/crates/xlsx-parse/src/write.rs
@@ -3,7 +3,7 @@
 //! are copied through byte for byte; only what changed is reserialized, and
 //! that reserialization carries just the subset `read` models.
 
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque, btree_map};
 use std::io;
 
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
@@ -11,7 +11,8 @@ use quick_xml::{Reader, Writer};
 use xlsx_model::addr::RowId;
 use xlsx_model::styles::{Alignment, Border, BorderEdge, Color, Fill, Font, Stylesheet, Xf};
 use xlsx_model::{
-    Cell, CellRef, CellValue, ChartAnchor, ChartRef, DateSystem, Sheet, SheetId, Workbook,
+    Cell, CellRef, CellValue, ChartAnchor, ChartRef, DateSystem, Sheet, SheetChart, SheetId,
+    Workbook,
 };
 
 use crate::ParseError;
@@ -473,17 +474,32 @@ pub fn serialize_workbook_with_package_and_origins_after_edits_and_active_sheet(
     Ok(parts.finish())
 }
 
+/// What one sheet wants written into a chart part it anchors.
+struct ChartClaim<'a> {
+    refs: &'a [ChartRef],
+    sheet: &'a str,
+}
+
+/// What one sheet wants written into a drawing anchor it holds.
+struct AnchorClaim<'a> {
+    anchor: ChartAnchor,
+    sheet: &'a str,
+    moved: bool,
+}
+
 /// Writes moved chart references and anchors back into the parts that hold
 /// them. Each part is patched once, from its source bytes, so unmodelled chart
-/// markup survives byte for byte.
+/// markup survives byte for byte. A part two sheets anchor is written only when
+/// both want the same bytes out of it, because one part cannot hold two.
 fn patch_chart_parts(
     wb: &Workbook,
     package: &PreservedPackage,
     origins: &[Option<usize>],
     parts: &mut PartStore<'_>,
 ) -> Result<(), ParseError> {
-    let mut chart_refs: BTreeMap<&str, (&[ChartRef], &str)> = BTreeMap::new();
-    let mut anchors: BTreeMap<&str, Vec<(usize, ChartAnchor)>> = BTreeMap::new();
+    let mut chart_refs: BTreeMap<&str, Vec<ChartClaim<'_>>> = BTreeMap::new();
+    let mut moved_refs: HashSet<&str> = HashSet::new();
+    let mut anchors: BTreeMap<&str, BTreeMap<usize, AnchorClaim<'_>>> = BTreeMap::new();
     for (sheet, origin) in wb.sheets.iter().zip(origins) {
         let source = origin
             .and_then(|origin| package.original_workbook.sheets.get(origin))
@@ -512,28 +528,42 @@ fn patch_chart_parts(
                     chart.part
                 )));
             }
+            chart_refs
+                .entry(chart.part.as_str())
+                .or_default()
+                .push(ChartClaim {
+                    refs: chart.refs.as_slice(),
+                    sheet: sheet.name.as_str(),
+                });
             if original.refs != chart.refs {
-                chart_refs.insert(
-                    chart.part.as_str(),
-                    (chart.refs.as_slice(), sheet.name.as_str()),
-                );
+                moved_refs.insert(chart.part.as_str());
             }
-            if original.anchor != chart.anchor {
-                anchors
-                    .entry(chart.drawing.as_str())
-                    .or_default()
-                    .push((chart.anchor_index, chart.anchor));
-            }
+            claim_anchor(
+                anchors.entry(chart.drawing.as_str()).or_default(),
+                chart,
+                &sheet.name,
+                original.anchor != chart.anchor,
+            )?;
         }
     }
-    for (path, (refs, owner)) in chart_refs {
+    for (path, claims) in chart_refs {
+        if !moved_refs.contains(path) {
+            continue;
+        }
         let source = package.part_bytes(path).ok_or_else(|| missing_part(path))?;
-        parts.set(
-            path.to_owned(),
-            crate::chart::patch_chart_refs(source, refs, wb, owner)?,
-        )?;
+        if let Some(bytes) = agreed_chart_bytes(source, path, &claims, wb)? {
+            parts.set(path.to_owned(), bytes)?;
+        }
     }
-    for (path, moved) in anchors {
+    for (path, claims) in anchors {
+        let moved = claims
+            .into_iter()
+            .filter(|(_, claim)| claim.moved)
+            .map(|(index, claim)| (index, claim.anchor))
+            .collect::<Vec<_>>();
+        if moved.is_empty() {
+            continue;
+        }
         let source = package.part_bytes(path).ok_or_else(|| missing_part(path))?;
         parts.set(
             path.to_owned(),
@@ -541,6 +571,69 @@ fn patch_chart_parts(
         )?;
     }
     Ok(())
+}
+
+/// Records what one sheet wants at a drawing anchor, refusing when a sheet
+/// that shares the drawing already asked for a different one.
+fn claim_anchor<'a>(
+    claims: &mut BTreeMap<usize, AnchorClaim<'a>>,
+    chart: &SheetChart,
+    sheet: &'a str,
+    moved: bool,
+) -> Result<(), ParseError> {
+    match claims.entry(chart.anchor_index) {
+        btree_map::Entry::Vacant(slot) => {
+            slot.insert(AnchorClaim {
+                anchor: chart.anchor,
+                sheet,
+                moved,
+            });
+        }
+        btree_map::Entry::Occupied(mut slot) => {
+            if slot.get().anchor != chart.anchor {
+                return Err(conflicting_shared_part(
+                    &chart.drawing,
+                    slot.get().sheet,
+                    sheet,
+                ));
+            }
+            slot.get_mut().moved |= moved;
+        }
+    }
+    Ok(())
+}
+
+/// The bytes a chart part must take, refused when the sheets anchoring it do
+/// not all patch it into the same thing. A shared part's references may be
+/// unqualified, so the sheet a cache is rebuilt against is part of what the
+/// sheets must agree on.
+fn agreed_chart_bytes(
+    source: &[u8],
+    path: &str,
+    claims: &[ChartClaim<'_>],
+    wb: &Workbook,
+) -> Result<Option<Vec<u8>>, ParseError> {
+    let mut agreed: Option<(Vec<u8>, &str)> = None;
+    for claim in claims {
+        let bytes = crate::chart::patch_chart_refs(source, claim.refs, wb, claim.sheet)?;
+        match &agreed {
+            Some((first, owner)) if *first != bytes => {
+                return Err(conflicting_shared_part(path, owner, claim.sheet));
+            }
+            Some(_) => {}
+            None => agreed = Some((bytes, claim.sheet)),
+        }
+    }
+    Ok(agreed.map(|(bytes, _)| bytes))
+}
+
+/// Two sheets anchor one part and no longer agree on what it holds. The part
+/// can carry only one of them, so the save is refused rather than rewriting the
+/// chart the other sheet shows.
+fn conflicting_shared_part(path: &str, first: &str, second: &str) -> ParseError {
+    ParseError::UnsupportedEdit(format!(
+        "{path} is anchored by both sheet {first} and sheet {second}, which no longer agree on what it holds, and one part cannot carry both"
+    ))
 }
 
 fn missing_part(path: &str) -> ParseError {


### PR DESCRIPTION
TL;DR:


Repro file:
`crates/betteroffice-xlsx/tests/workbook.rs` — `refuses_to_save_a_shared_chart_part_a_structural_edit_split` builds a two-sheet workbook whose drawings both name `xl/charts/chart1.xml`, inserts a row on one sheet, and saves.

Summary:
- Two sheets whose drawings name the same chart part were patched once, from whichever sheet the writer reached first, so a structural edit on one sheet silently rewrote the other sheet's chart and the save still returned success
- Every sheet anchoring a part now records what it wants written, and a part is written only when every sharer agrees on the resulting bytes; a disagreement refuses the save and names the part and both sheets
- Comparison is on the patched bytes rather than on references, which also catches two sheets holding identical unqualified references that resolve against different owners and so regenerate different caches
- Shared drawing parts had the same aliasing and are covered the same way. That also removes a spurious failure where two sheets moving one anchor identically produced an overlapping-rewrite error on a legitimate save
- Images are unaffected: media parts are carried through byte for byte and never patched

Known consequence:
- This converts silent corruption into an unsaveable workbook. A user who edits one of two sheets sharing a chart cannot save until they undo. The durable fix is to model the sharing so the edit is propagated or rejected at edit time rather than at save time

Test plan:
- [ ] `cargo test` passes
- [ ] A workbook whose sheets share a chart part and agree still saves byte-identically
- [ ] A structural edit on one sharing sheet is refused with an error naming the part and both sheets
- [ ] Undoing that edit lets the workbook save and reopen unchanged on both sheets