### PR TITLE
docs(web): give every package ecosystem a place to land

### DIFF
--- a/.changeset/python-docs-url.md
+++ b/.changeset/python-docs-url.md
@@ -1,0 +1,10 @@
+---
+"@betteroffice/python-xlsx": patch
+"@betteroffice/python-pptx": patch
+---
+
+Both distributions point their PyPI `Documentation` link at
+https://docs.betteroffice.dev/docs/python, a page that names the package, gives
+the install line and a first example, and says plainly that the PPTX binding is
+not on PyPI yet and that there is no DOCX binding. The link used to land on the
+documentation root, which never mentioned Python at all.

--- a/README.md
+++ b/README.md
@@ -28,14 +28,22 @@
 | [`betteroffice-xlsx`](https://crates.io/crates/betteroffice-xlsx) | typed Rust API for opening, editing, calculating, rendering, and saving XLSX workbooks |
 | [`@betteroffice/xlsx`](https://www.npmjs.com/package/@betteroffice/xlsx) | framework-free spreadsheet core powered by the Rust engine through WebAssembly |
 | [`@betteroffice/xlsx-react`](https://www.npmjs.com/package/@betteroffice/xlsx-react) | drop-in React spreadsheet editor |
+| [`betteroffice-xlsx`](https://pypi.org/project/betteroffice-xlsx/) (PyPI) | Python API for opening, recalculating, styling, rendering, and saving XLSX workbooks |
 | [`betteroffice-pptx`](https://crates.io/crates/betteroffice-pptx) | typed Rust API for opening, editing, rendering, and saving PPTX presentations |
 | [`@betteroffice/pptx`](https://www.npmjs.com/package/@betteroffice/pptx) | framework-free .pptx editor core — slide model, masters, and rendering in Rust through WebAssembly |
 | [`@betteroffice/pptx-react`](https://www.npmjs.com/package/@betteroffice/pptx-react) | drop-in React .pptx editor |
+| [`betteroffice-pptx`](./bindings/python-pptx) (Python) | Python API for reading, editing, and laying out PPTX presentations — not published to PyPI yet |
+
+What to install for which language, with a first example each:
+[npm](https://docs.betteroffice.dev/docs/javascript),
+[crates.io](https://docs.betteroffice.dev/docs/rust),
+[PyPI](https://docs.betteroffice.dev/docs/python).
 
 ## Structure
 
 - `crates/` — the Rust engines
 - `packages/` — the TypeScript editor packages
+- `bindings/` — the Python bindings
 - `apps/web` — [betteroffice.dev](https://betteroffice.dev) (Next.js on Cloudflare Workers)
 - `apps/docs` — documentation
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -4,9 +4,16 @@ description: Browser-native DOCX, XLSX, and PPTX editors
 ---
 
 BetterOffice provides Rust and WebAssembly document engines with framework-neutral
-core packages and React editors.
+core packages and React editors. The same engines publish to npm, crates.io, and
+PyPI.
 
 ## Guides
 
+- [Packages](./packages): what to install, for which language, to do what.
+- [JavaScript](./javascript): the npm packages — React editors, framework-free
+  cores, and locale strings.
+- [Rust](./rust): the crates.io packages — three format facades and the
+  per-layer crates behind them.
+- [Python](./python): `betteroffice-xlsx` on PyPI, and what is not published yet.
 - [Collaboration](./collaboration): connect DOCX, XLSX, and PPTX editors through
   a shared transport and deploy a Cloudflare Durable Object relay.

--- a/apps/docs/content/docs/javascript.mdx
+++ b/apps/docs/content/docs/javascript.mdx
@@ -1,0 +1,74 @@
+---
+title: JavaScript
+description: The npm packages — React editors, framework-free cores, and locale strings
+---
+
+Every format ships three packages under the `@betteroffice` scope: a
+framework-free core, a React editor built on it, and that editor's locale
+strings. There is no Vue package — React and framework-free JavaScript are the
+supported entry points.
+
+```bash
+npm install @betteroffice/docx-react @betteroffice/docx react react-dom
+```
+
+`react` and `react-dom` (18 or 19) are peer dependencies of every `-react`
+package.
+
+## Drop in an editor
+
+```tsx
+import { DocxEditor } from "@betteroffice/docx-react";
+import "@betteroffice/docx-react/styles.css";
+
+<DocxEditor documentBuffer={bytes} onSave={(saved) => upload(saved)} />;
+```
+
+`documentBuffer` accepts an `ArrayBuffer`, `Uint8Array`, `Blob`, or `File`.
+Without `onSave`, File > Save downloads the edited bytes. The other two editors
+take their file as a `Uint8Array`:
+
+```tsx
+<XlsxEditor file={bytes} fileName="report.xlsx" />
+<PptxEditor file={bytes} fonts={[{ family: "Inter", bytes: fontBytes }]} />
+```
+
+`PptxEditor` needs `fonts`: no face is bundled, and the engine refuses to lay out
+slide text until the host registers at least one.
+
+## Drive the core yourself
+
+```ts
+import { initWasm, openWorkbook, paintDisplayList } from "@betteroffice/xlsx";
+
+await initWasm();
+const workbook = openWorkbook(new Uint8Array(await file.arrayBuffer()));
+
+const frame = workbook.displayList({ x: 0, y: 0, width: 800, height: 600 });
+paintDisplayList(canvas.getContext("2d")!, frame, devicePixelRatio);
+
+workbook.editCell(0, 9, 2, "=SUM(C1:C9)");
+const saved = workbook.save();
+```
+
+`initWasm()` fetches the packaged wasm asset once in browsers; pass wasm bytes or
+a precompiled `WebAssembly.Module` in runtimes that cannot fetch that URL. Around
+the handle the core exports what a custom grid needs — hit-testing, viewport
+math, an accessibility tree, and TSV clipboard helpers.
+
+## Every package
+
+| Package | What it is |
+| --- | --- |
+| `@betteroffice/docx` | Framework-free DOCX core: OOXML parse and serialize, CRDT editing, text shaping, pagination, canvas rendering. Saving round-trips the original package, so untouched parts survive. |
+| `@betteroffice/docx-react` | The DOCX editor and viewer as a React component: toolbar, paginated canvas, comments, tracked changes. |
+| `@betteroffice/docx-i18n` | UI locale strings and types for the DOCX React editor. |
+| `@betteroffice/xlsx` | Framework-free XLSX core: SpreadsheetML parse and serialize, formula recalculation, grid display lists, hit-testing, PNG export, and agent proposals a human accepts or rejects. |
+| `@betteroffice/xlsx-react` | The spreadsheet editor and viewer as a React component. |
+| `@betteroffice/xlsx-i18n` | UI locale strings and types for the XLSX React editor. |
+| `@betteroffice/pptx` | Framework-free PPTX core: PresentationML parse, deck model, masters and layouts, slide display lists, canvas rendering. Editing and collaboration are live; writing edits back to a `.pptx` file is not exposed here yet. |
+| `@betteroffice/pptx-react` | The slides editor and viewer as a React component. |
+| `@betteroffice/pptx-i18n` | UI locale strings and types for the PPTX React editor. |
+
+Connecting any of the three editors to a relay is the same shape in each:
+see [Collaboration](./collaboration).

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,0 +1,3 @@
+{
+  "pages": ["index", "packages", "javascript", "rust", "python", "collaboration"]
+}

--- a/apps/docs/content/docs/packages.mdx
+++ b/apps/docs/content/docs/packages.mdx
@@ -1,0 +1,39 @@
+---
+title: Packages
+description: What to install from npm, crates.io, and PyPI, and what each package does
+---
+
+Every BetterOffice package is a face on the same Rust engines — one parser, one
+editing core, and one layout pass per format. What changes between registries is
+the runtime you call them from and how much of the pipeline is exposed.
+
+| Runtime | Install | Guide |
+| --- | --- | --- |
+| Browser, React, or Node | `npm install @betteroffice/docx-react` | [JavaScript](./javascript) |
+| Native Rust | `cargo add betteroffice-docx` | [Rust](./rust) |
+| Python | `pip install betteroffice-xlsx` | [Python](./python) |
+
+## What exists per format
+
+| Format | npm | crates.io | PyPI |
+| --- | --- | --- | --- |
+| DOCX | `@betteroffice/docx`, `@betteroffice/docx-react` | `betteroffice-docx` | none |
+| XLSX | `@betteroffice/xlsx`, `@betteroffice/xlsx-react` | `betteroffice-xlsx` | `betteroffice-xlsx` |
+| PPTX | `@betteroffice/pptx`, `@betteroffice/pptx-react` | `betteroffice-pptx` | not published yet |
+
+npm and crates.io carry all three formats. PyPI carries one distribution today,
+`betteroffice-xlsx`. The PPTX binding is built and tested in the repository but
+has no PyPI project yet, and there is no DOCX binding for Python at all.
+
+## Picking one
+
+- **An editor UI in a React app** — the `-react` packages. They own the toolbar,
+  canvas, selection, keyboard, and review UI.
+- **Your own UI in the browser** — the framework-free cores. Same engine, no
+  React: display lists, hit-testing, and a document handle.
+- **A server, a CLI, or a pipeline in Rust** — the three facade crates.
+- **A server, a notebook, or an agent in Python** — `betteroffice-xlsx`.
+- **One stage of the pipeline** — the per-layer crates, published individually.
+
+Versions are `0.0.x` and the APIs are still settling. Breaking changes are listed
+in each package's changelog.

--- a/apps/docs/content/docs/python.mdx
+++ b/apps/docs/content/docs/python.mdx
@@ -1,0 +1,94 @@
+---
+title: Python
+description: betteroffice-xlsx on PyPI — open, recalculate, render, and save workbooks
+---
+
+```bash
+pip install betteroffice-xlsx
+```
+
+[`betteroffice-xlsx`](https://pypi.org/project/betteroffice-xlsx/) is the one
+BetterOffice distribution on PyPI today. The Rust XLSX engine is compiled into
+the wheel: no Excel, no LibreOffice subprocess, no COM. Wheels are built for
+Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows (x86_64) against the
+stable ABI for CPython 3.9 and up.
+
+## Formulas calculate
+
+```python
+from betteroffice_xlsx import Workbook
+
+wb = Workbook.open_path("budget.xlsx")
+sheet = wb["Sheet1"]
+
+sheet["B1"] = 10
+sheet["B2"] = 32
+sheet["B3"] = "=SUM(B1:B2)"
+
+print(sheet["B3"])           # 42.0, computed here
+print(sheet.formula("B3"))   # 'SUM(B1:B2)'
+
+wb.save_path("budget-out.xlsx")
+```
+
+Writing a cell recalculates its dependents. A cell you have not touched keeps
+whatever the authoring application cached, stale or not; `Workbook.open_recalculated`
+or a later `recalculate()` evaluates the whole workbook with this engine instead.
+Values come back as `None`, `float`, `str`, `bool`, or a `CellError` that compares
+equal to its code, so `#DIV/0!` as a value stays distinguishable from a cell
+holding that text.
+
+## Render a sheet
+
+```python
+png = wb.render_png("Sheet1", scale=2.0, range="A1:H40")
+png.write("preview.png")
+```
+
+This is the same grid layout and display list the browser editor uses, and the
+raster backend embeds Carlito to measure and draw cell text, so nothing has to be
+registered first. Opening, recalculating, rendering, and saving release the GIL,
+so they run in parallel across threads instead of serializing your workers.
+
+## What a save keeps
+
+`save()` returns bytes and `save_path()` writes a file. The parts the model does
+not represent — charts, pivot tables, comments, macros, custom XML — are kept,
+and sheets an edit did not touch are copied through byte for byte. A sheet you do
+edit is reserialized from the model, so unmodeled markup on that one sheet is
+lost.
+
+## Collaboration and agent proposals
+
+`Workbook.open_collaborative` makes the workbook a Yrs replica and exposes the
+byte-level primitives — `state_vector`, `state_as_update`, `diff`,
+`apply_update` — rather than a transport, so it drops into a WebSocket server, a
+queue, or a test harness without committing you to asyncio. `propose` stages an
+agent's edits with the before and after text of each one, and nothing reaches the
+sheet until `accept_proposal` applies it as a single undo step.
+
+The package README on PyPI carries the full API table, the openpyxl comparison,
+and the error hierarchy.
+
+## PPTX and DOCX
+
+The PPTX binding is not on PyPI yet, so `pip` will not find it. It lives in the
+repository at
+[`bindings/python-pptx`](https://github.com/openooxml/betteroffice/tree/main/bindings/python-pptx),
+and CI builds and tests it on every change. From a checkout, with a Rust
+toolchain installed:
+
+```bash
+pip install -e bindings/python-pptx
+```
+
+It reads decks, edits shapes and text in memory, and lays slides out into the
+same display-list contract the canvas paints. `render_slide` fails until
+`register_font` has supplied at least one face — no font is compiled into that
+wheel — and `save()` raises `UnsupportedWriteError` once a deck has been edited,
+because the engine cannot write model edits back to PPTX yet. A `Presentation` is
+also pinned to the thread that opened it, and must be released there.
+
+There is no DOCX binding for Python. Reach for
+[`betteroffice-docx`](./rust) in Rust, or
+[`@betteroffice/docx`](./javascript) in JavaScript.

--- a/apps/docs/content/docs/rust.mdx
+++ b/apps/docs/content/docs/rust.mdx
@@ -1,0 +1,112 @@
+---
+title: Rust
+description: The crates.io packages — three format facades and the per-layer crates behind them
+---
+
+The crates are the engines the WebAssembly packages are compiled from, without
+the wasm boundary: parsed models and Yrs state are plain Rust structs, and calls
+do not cross JSON. Use one of the three facades unless you want a single stage of
+the pipeline.
+
+```bash
+cargo add betteroffice-xlsx
+```
+
+## Open, edit, render, save
+
+```rust
+use betteroffice_xlsx::{CalculationOptions, CellRef, RenderOptions, SheetId, Workbook};
+
+let mut workbook = Workbook::open_recalculated(&xlsx_bytes, CalculationOptions::default())?;
+
+workbook.edit_cell(
+    SheetId(0),
+    CellRef::parse_a1("A1").unwrap(),
+    "42",
+    CalculationOptions::default(),
+)?;
+
+let png = workbook.render_sheet(SheetId(0), &RenderOptions::default())?;
+let saved = workbook.save()?;
+```
+
+Saving preserves the source package: parts the model does not represent — charts,
+pivot tables, comments, macros, custom XML and their relationships — are kept,
+and sheets an edit did not touch are copied through byte for byte. A sheet you do
+edit is reserialized from the model, so unmodeled markup on that one sheet is
+lost.
+
+DOCX and PPTX have the same shape:
+
+```rust
+use betteroffice_docx::Document;
+
+let mut document = Document::open(&docx_bytes)?;
+let paragraph_id = document.paragraphs()[0].para_id.clone().unwrap();
+
+document.replace_paragraph_text(&paragraph_id, "Updated in Rust")?;
+let saved = document.save()?;
+```
+
+```rust
+use betteroffice_pptx::Presentation;
+
+let mut presentation = Presentation::open(&pptx_bytes)?;
+let deck = presentation.snapshot()?; // slides, shapes, and text as plain structs
+
+presentation.register_font("Inter", false, false, &font_bytes)?;
+let rendered = presentation.render_slide(0)?; // display list + hit-test metadata
+```
+
+`open_with_limits` on DOCX and PPTX swaps the parser's default resource budget
+for one you supply, which is what a host ingesting untrusted uploads wants. A
+file past any cap is refused, never truncated.
+
+## Rendering
+
+XLSX rasterizes by default: `render_sheet` returns a PNG, and the raster backend
+embeds Carlito to measure and paint cell text. DOCX keeps its raster backend
+behind a feature, because the default build still targets
+`wasm32-unknown-unknown`:
+
+```bash
+cargo add betteroffice-docx --features raster
+```
+
+PPTX has no rasterizer. `render_slide` returns the display list the browser
+editor paints — vector geometry, images, shaped text, caret data — alongside
+hit-test metadata, and it fails until at least one font face has been registered.
+Yrs edits reach that display list but are not projected back into
+PresentationML, so `save` re-zips the parts it retained rather than your edits.
+
+## The facades
+
+| Crate | What it is |
+| --- | --- |
+| `betteroffice-docx` | Typed native API for opening, editing, laying out, and saving DOCX documents. |
+| `betteroffice-xlsx` | Typed native API for opening, editing, collaborating, calculating, rendering, and saving XLSX workbooks. |
+| `betteroffice-pptx` | Typed native API for opening, editing, collaborating on, and rendering PPTX presentations. |
+
+## The layers
+
+| Crate | What it is |
+| --- | --- |
+| `betteroffice-opc` | The OPC container reader and writer, with zip-bomb and path-traversal limits enforced by construction. Shared by all three formats. |
+| `betteroffice-ooxml-text` | Shared text shaping, measurement, line breaking, and bidirectional text. |
+| `betteroffice-drawingml` | The DrawingML colors, themes, shape models, and preset geometry shared by all three formats. |
+| `betteroffice-docx-parse` | WordprocessingML parsing, typed relationship models, and the canonical document contract. |
+| `betteroffice-docx-layout` | DOCX pagination, line flow, tables, floats, notes, and display lists. |
+| `betteroffice-docx-edit` | The pilcrow-stream Yrs editing schema for DOCX. |
+| `betteroffice-docx-raster` | The tiny-skia backend that paints a DOCX display list to PNG. Never part of the wasm build. |
+| `betteroffice-xlsx-model` | The workbook, worksheet, and cell model: address types, values, styles. IO-free. |
+| `betteroffice-xlsx-parse` | Streaming SpreadsheetML parse and serialize. |
+| `betteroffice-xlsx-calc` | The standalone formula engine: lexer, parser, dependency graph, and evaluator, written spec-first from ECMA-376. |
+| `betteroffice-xlsx-ops` | The invertible op log behind undo, redo, address remapping, and agent proposals. |
+| `betteroffice-xlsx-render` | Grid geometry and the target-agnostic display list. |
+| `betteroffice-xlsx-raster` | The tiny-skia backend that paints an XLSX display list to PNG. Never part of the wasm build. |
+| `betteroffice-pptx-parse` | Bounded PresentationML parsing and part-preserving package writes. |
+| `betteroffice-pptx-edit` | The Yrs deck model for PPTX. |
+| `betteroffice-pptx-render` | Slide layout and the PPTX display-list compiler. |
+
+Every crate publishes to crates.io from one release train, so they always share a
+version.

--- a/apps/web/app/content.ts
+++ b/apps/web/app/content.ts
@@ -3,6 +3,9 @@ export const REPO = "https://github.com/openooxml/betteroffice";
 export const DOCS = "https://docs.betteroffice.dev";
 export const DEMO = "https://demo.betteroffice.dev";
 export const OPENOOXML = "https://openooxml.org";
+export const NPM = "https://www.npmjs.com/org/betteroffice";
+export const CRATES = "https://crates.io/search?q=betteroffice";
+export const PYPI = "https://pypi.org/project/betteroffice-xlsx";
 
 export const HERO = {
   title: "BetterOffice",
@@ -10,7 +13,32 @@ export const HERO = {
     "The open-source office suite. Word-faithful editing and real-time collaboration on engines we build ourselves — running entirely in your browser, by the OpenOOXML project.",
 };
 
-export const INSTALL = "npm install @betteroffice/docx-react";
+export const ECOSYSTEMS = [
+  {
+    name: "JavaScript",
+    registry: "npm",
+    install: "npm install @betteroffice/docx-react",
+    url: NPM,
+    docs: `${DOCS}/docs/javascript`,
+    desc: "React editors and framework-free cores for all three formats.",
+  },
+  {
+    name: "Rust",
+    registry: "crates.io",
+    install: "cargo add betteroffice-docx",
+    url: CRATES,
+    docs: `${DOCS}/docs/rust`,
+    desc: "The same engines natively, for servers, CLIs and agent pipelines.",
+  },
+  {
+    name: "Python",
+    registry: "PyPI",
+    install: "pip install betteroffice-xlsx",
+    url: PYPI,
+    docs: `${DOCS}/docs/python`,
+    desc: "Spreadsheets from Python: formulas evaluated, sheets rendered to PNG, workbooks saved.",
+  },
+];
 
 export const SUITE = {
   label: "Suite",
@@ -44,7 +72,7 @@ export const PACKAGES_SECTION = {
   label: "Packages",
   heading: "Ships as components, not iframes",
   prose:
-    "The editors install from npm and render inside your app — no embeds, no external services, documents never leave the page.",
+    "The editors install from npm and render inside your app — no embeds, no external services, documents never leave the page. The same engines publish to crates.io for native Rust and to PyPI for Python.",
 };
 
 export const PACKAGES = [

--- a/apps/web/app/llms-txt.test.js
+++ b/apps/web/app/llms-txt.test.js
@@ -1,42 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  PYPI_DISTRIBUTIONS,
+  publishedCrates,
+  publishedPackages,
+} from "../../../scripts/published-packages.mjs";
 
 const ROOT = join(import.meta.dir, "..", "..", "..");
 const LLMS = readFileSync(join(ROOT, "apps/web/public/llms.txt"), "utf8");
-
-function publishedPackages() {
-  const dir = join(ROOT, "packages");
-  const names = [];
-  for (const entry of readdirSync(dir)) {
-    let manifest;
-    try {
-      manifest = JSON.parse(readFileSync(join(dir, entry, "package.json"), "utf8"));
-    } catch {
-      continue;
-    }
-    if (manifest.private) continue;
-    if (manifest.name?.startsWith("@betteroffice/")) names.push(manifest.name);
-  }
-  return names.sort();
-}
-
-function publishedCrates() {
-  const dir = join(ROOT, "crates");
-  const names = [];
-  for (const entry of readdirSync(dir)) {
-    let manifest;
-    try {
-      manifest = readFileSync(join(dir, entry, "Cargo.toml"), "utf8");
-    } catch {
-      continue;
-    }
-    if (!manifest.includes('publish = ["crates-io"]')) continue;
-    const name = manifest.match(/^name = "([^"]+)"/m)?.[1];
-    if (name) names.push(name);
-  }
-  return names.sort();
-}
 
 describe("llms.txt", () => {
   test("names no npm package that does not exist", () => {
@@ -53,13 +25,33 @@ describe("llms.txt", () => {
 
   test("names no crate that is not published", () => {
     const real = new Set(publishedCrates());
+    // A PyPI distribution shares the crate naming shape without being a crate.
+    const pypi = new Set(PYPI_DISTRIBUTIONS);
     const claimed = [...LLMS.matchAll(/\bbetteroffice(?:-[a-z0-9]+)+\b/g)].map((m) => m[0]);
-    const phantom = [...new Set(claimed)].filter((name) => !real.has(name));
+    const phantom = [...new Set(claimed)].filter(
+      (name) => !real.has(name) && !pypi.has(name),
+    );
     expect(phantom).toEqual([]);
   });
 
   test("names every published crate", () => {
     const missing = publishedCrates().filter((name) => !LLMS.includes(name));
     expect(missing).toEqual([]);
+  });
+
+  test("links every published PyPI distribution", () => {
+    // A bare name would already match the same-named crate.
+    const missing = PYPI_DISTRIBUTIONS.filter(
+      (name) => !LLMS.includes(`https://pypi.org/project/${name}`),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  test("tells no one to install a distribution that is not on PyPI", () => {
+    const real = new Set(PYPI_DISTRIBUTIONS);
+    const claimed = [...LLMS.matchAll(/pip install (betteroffice-[a-z0-9-]+)/g)].map(
+      (m) => m[1],
+    );
+    expect(claimed.filter((name) => !real.has(name))).toEqual([]);
   });
 });

--- a/apps/web/app/markdown.test.js
+++ b/apps/web/app/markdown.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { prefersMarkdown } from "../../../shared/accept.ts";
 import { homepageMarkdown } from "./markdown.ts";
-import { EDITORS, HERO, PACKAGES } from "./content.ts";
+import { ECOSYSTEMS, EDITORS, HERO, PACKAGES } from "./content.ts";
 
 describe("accept negotiation", () => {
   test("serves HTML to browsers", () => {
@@ -52,6 +52,13 @@ describe("homepage markdown", () => {
     for (const pkg of PACKAGES) {
       expect(markdown).toContain(pkg.name);
       expect(markdown).toContain(pkg.desc);
+    }
+  });
+
+  test("carries an install line and a guide for every ecosystem", () => {
+    for (const eco of ECOSYSTEMS) {
+      expect(markdown).toContain(eco.install);
+      expect(markdown).toContain(eco.docs);
     }
   });
 

--- a/apps/web/app/markdown.ts
+++ b/apps/web/app/markdown.ts
@@ -3,10 +3,10 @@ import {
   COLLABORATION,
   DEMO,
   DOCS,
+  ECOSYSTEMS,
   EDITORS,
   FOUNDATION,
   HERO,
-  INSTALL,
   OPENOOXML,
   PACKAGES,
   PACKAGES_SECTION,
@@ -33,6 +33,11 @@ export function homepageMarkdown(): string {
       `- [\`${pkg.name}\`](https://www.npmjs.com/package/${pkg.name}) — ${pkg.desc}`,
   ).join("\n");
 
+  const ecosystems = ECOSYSTEMS.map(
+    (eco) =>
+      `- **${eco.name}** (\`${eco.install}\`) — ${eco.desc} [${eco.registry}](${eco.url}), [guide](${eco.docs})`,
+  ).join("\n");
+
   return `# ${HERO.title}
 
 ${HERO.tagline}
@@ -55,9 +60,9 @@ ${PACKAGES_SECTION.prose}
 
 ${packages}
 
-\`\`\`bash
-${INSTALL}
-\`\`\`
+One install line per ecosystem:
+
+${ecosystems}
 
 ## ${FOUNDATION.heading}
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,16 +6,19 @@ import { FadeIn, Reveal } from "./components/motion";
 import {
   CAPABILITIES,
   COLLABORATION,
+  CRATES,
   DEMO,
   DOCS,
+  ECOSYSTEMS,
   EDITORS,
   FOUNDATION,
   HERO,
-  INSTALL,
+  NPM,
   OPENOOXML,
   PACKAGES,
   PACKAGES_SECTION,
   PEERS,
+  PYPI,
   REPO,
   SITE,
   SUITE,
@@ -41,6 +44,8 @@ const cardName =
   "flex items-center justify-between gap-3 font-mono text-[0.8125rem] text-fg";
 const cardLink =
   "inline-flex items-center gap-1 font-mono text-[0.6875rem] text-dim no-underline hover:text-fg";
+const ecoLabel =
+  "mb-2 flex items-baseline gap-3 font-mono text-[0.6875rem] uppercase tracking-[0.16em] text-dim";
 const demoLink =
   "ml-auto inline-flex items-center gap-1 rounded border border-line px-2 py-0.5 font-mono text-[0.6875rem] text-ink no-underline transition-colors hover:border-dim hover:text-fg";
 
@@ -69,7 +74,7 @@ const JSON_LD = {
     name: "OpenOOXML",
     url: OPENOOXML,
   },
-  sameAs: [REPO, "https://www.npmjs.com/org/betteroffice", OPENOOXML],
+  sameAs: [REPO, NPM, CRATES, PYPI, OPENOOXML],
 };
 
 export default function Home() {
@@ -204,7 +209,27 @@ export default function Home() {
               </article>
             ))}
           </div>
-          <Cmd command={INSTALL} />
+          <div className="flex flex-col gap-4">
+            {ECOSYSTEMS.map((eco) => (
+              <div key={eco.name}>
+                <p className={ecoLabel}>
+                  {eco.name}
+                  <a
+                    href={eco.url}
+                    target="_blank"
+                    rel="noopener"
+                    className={cardLink}
+                  >
+                    {eco.registry} <ArrowUpRight size={11} strokeWidth={2} />
+                  </a>
+                  <a href={eco.docs} className={cardLink}>
+                    docs <ArrowUpRight size={11} strokeWidth={2} />
+                  </a>
+                </p>
+                <Cmd command={eco.install} />
+              </div>
+            ))}
+          </div>
         </Reveal>
       </section>
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,6 +1,6 @@
 # BetterOffice
 
-> BetterOffice is an Apache-2.0 office suite from the OpenOOXML project: Word-faithful DOCX, Excel-faithful XLSX, and PowerPoint-faithful PPTX editors and viewers. The OOXML engines are written in Rust, in-house, and ship two ways — compiled to WebAssembly for the browser packages, and published to crates.io as native crates for servers. Files are edited in their own format, with no conversion to an intermediate model on open or save. Real-time collaboration is a Yrs CRDT inside the engine rather than a server-side merge, and every engine also runs headless for server-side and agent pipelines.
+> BetterOffice is an Apache-2.0 office suite from the OpenOOXML project: Word-faithful DOCX, Excel-faithful XLSX, and PowerPoint-faithful PPTX editors and viewers. The OOXML engines are written in Rust, in-house, and ship three ways — compiled to WebAssembly for the browser packages, published to crates.io as native crates for servers, and compiled into Python wheels on PyPI. Files are edited in their own format, with no conversion to an intermediate model on open or save. Real-time collaboration is a Yrs CRDT inside the engine rather than a server-side merge, and every engine also runs headless for server-side and agent pipelines.
 
 All three formats are available today. The packages work as full editors or as read-only viewers. Versions are `0.0.x` and the APIs are still settling; breaking changes are listed in each package changelog.
 
@@ -47,6 +47,14 @@ The per-layer crates are published for direct use when you need one stage of the
 - [betteroffice-ooxml-text](https://crates.io/crates/betteroffice-ooxml-text): shared text shaping, measurement, and line breaking.
 - [betteroffice-drawingml](https://crates.io/crates/betteroffice-drawingml): the DrawingML colors, themes, and geometry shared by all three formats.
 
+## Python packages
+
+Published to PyPI, Apache-2.0. The Rust engine is compiled into the wheel — no Excel, no LibreOffice subprocess, no COM. Wheels cover Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows (x86_64) against the stable ABI for CPython 3.9 and up. The [Python guide](https://docs.betteroffice.dev/docs/python) carries the install line, a first example, and what is not published yet.
+
+- [betteroffice-xlsx](https://pypi.org/project/betteroffice-xlsx/): `pip install betteroffice-xlsx`. Open, recalculate, style, render to PNG, and save XLSX workbooks; formulas are evaluated by this engine rather than read back from the file. Yrs collaboration and agent proposals are exposed as byte-level primitives, and opening, recalculating, rendering, and saving release the GIL.
+
+The PPTX binding lives in the repository at `bindings/python-pptx` and is built and tested in CI, but it has no PyPI project yet, so `pip` will not find it. There is no DOCX binding for Python.
+
 ## Collaboration
 
 Every editor replica is a Yrs (Rust Yjs) document, and the provider speaks the standard Yjs sync-v1 wire protocol used by y-websocket. Room routing, authentication, awareness, and reconnection stay transport concerns, so any reliable binary transport works. Updates flow between the connection and the Rust replica without a second JavaScript `Y.Doc`.
@@ -54,6 +62,7 @@ Every editor replica is a Yrs (Rust Yjs) document, and the provider speaks the s
 ## Docs and demos
 
 - [Documentation](https://docs.betteroffice.dev): guides and API reference.
+- [Packages](https://docs.betteroffice.dev/docs/packages): what to install from npm, crates.io, and PyPI, and what each one does.
 - [Live demos](https://demo.betteroffice.dev): DOCX, XLSX, and PPTX editors running in the browser.
 
 ## Migrating from eigenpal

--- a/bindings/python-pptx/pyproject.toml
+++ b/bindings/python-pptx/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://betteroffice.dev"
-Documentation = "https://docs.betteroffice.dev"
+Documentation = "https://docs.betteroffice.dev/docs/python"
 Source = "https://github.com/openooxml/betteroffice"
 Issues = "https://github.com/openooxml/betteroffice/issues"
 

--- a/bindings/python-xlsx/pyproject.toml
+++ b/bindings/python-xlsx/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://betteroffice.dev"
-Documentation = "https://docs.betteroffice.dev"
+Documentation = "https://docs.betteroffice.dev/docs/python"
 Source = "https://github.com/openooxml/betteroffice"
 Issues = "https://github.com/openooxml/betteroffice/issues"
 

--- a/scripts/docs-packages.test.ts
+++ b/scripts/docs-packages.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PYTHON_BINDINGS } from './python-bindings.mjs';
+import {
+  PYPI_DISTRIBUTIONS,
+  publishedCrates,
+  publishedPackages,
+  workspacePackages
+} from './published-packages.mjs';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const CONTENT = join(ROOT, 'apps/docs/content/docs');
+const DOCS_SITE = 'https://docs.betteroffice.dev/docs/';
+
+function mdx(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return mdx(path);
+    return entry.name.endsWith('.mdx') ? [readFileSync(path, 'utf8')] : [];
+  });
+}
+
+const DOCS = mdx(CONTENT).join('\n');
+
+describe('docs cover every published package', () => {
+  test('names every published npm package', () => {
+    expect(publishedPackages().filter((name) => !DOCS.includes(name))).toEqual([]);
+  });
+
+  test('names every published crate', () => {
+    expect(publishedCrates().filter((name) => !DOCS.includes(name))).toEqual([]);
+  });
+
+  test('links every published PyPI distribution', () => {
+    // A bare name would already match the same-named crate.
+    const missing = PYPI_DISTRIBUTIONS.filter(
+      (name) => !DOCS.includes(`https://pypi.org/project/${name}`)
+    );
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('docs name nothing that does not exist', () => {
+  test('every npm package named is a package in this repository', () => {
+    const real = new Set(workspacePackages());
+    const claimed = [...DOCS.matchAll(/@betteroffice\/[a-z0-9-]+/g)].map((m) => m[0]);
+    expect([...new Set(claimed)].filter((name) => !real.has(name))).toEqual([]);
+  });
+
+  test('every crate named is published, or is a PyPI distribution', () => {
+    const real = new Set([...publishedCrates(), ...PYPI_DISTRIBUTIONS]);
+    const claimed = [...DOCS.matchAll(/\bbetteroffice(?:-[a-z0-9]+)+\b/g)].map((m) => m[0]);
+    expect([...new Set(claimed)].filter((name) => !real.has(name))).toEqual([]);
+  });
+
+  test('tells no one to install a distribution that is not on PyPI', () => {
+    const real = new Set(PYPI_DISTRIBUTIONS);
+    const claimed = [...DOCS.matchAll(/pip install (betteroffice-[a-z0-9-]+)/g)].map((m) => m[1]);
+    expect(claimed.filter((name) => !real.has(name))).toEqual([]);
+  });
+});
+
+describe('the PyPI sidebar link', () => {
+  test('sends every binding at a docs page that exists', () => {
+    for (const binding of PYTHON_BINDINGS) {
+      const manifest = readFileSync(join(ROOT, binding, 'pyproject.toml'), 'utf8');
+      const url = manifest.match(/^Documentation = "([^"]+)"/m)?.[1] ?? '';
+      expect(url.startsWith(DOCS_SITE)).toBe(true);
+      expect(existsSync(join(CONTENT, `${url.slice(DOCS_SITE.length)}.mdx`))).toBe(true);
+    }
+  });
+});

--- a/scripts/published-packages.mjs
+++ b/scripts/published-packages.mjs
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export { PYPI_DISTRIBUTIONS } from './python-bindings.mjs';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const WORKSPACES = ['apps', 'bindings', 'packages'];
+
+function workspaceManifests() {
+  const manifests = [];
+  for (const workspace of WORKSPACES) {
+    for (const entry of readdirSync(join(ROOT, workspace))) {
+      try {
+        manifests.push(JSON.parse(readFileSync(join(ROOT, workspace, entry, 'package.json'), 'utf8')));
+      } catch {
+        continue;
+      }
+    }
+  }
+  return manifests;
+}
+
+/** Every `@betteroffice` package name in the repository, published or not. */
+export function workspacePackages() {
+  return workspaceManifests()
+    .map((manifest) => manifest.name)
+    .filter((name) => name?.startsWith('@betteroffice/'))
+    .sort();
+}
+
+/** The npm packages a release uploads. */
+export function publishedPackages() {
+  return workspaceManifests()
+    .filter((manifest) => !manifest.private && manifest.name?.startsWith('@betteroffice/'))
+    .map((manifest) => manifest.name)
+    .sort();
+}
+
+/** The crates a release uploads to crates.io. */
+export function publishedCrates() {
+  const dir = join(ROOT, 'crates');
+  const names = [];
+  for (const entry of readdirSync(dir)) {
+    let manifest;
+    try {
+      manifest = readFileSync(join(dir, entry, 'Cargo.toml'), 'utf8');
+    } catch {
+      continue;
+    }
+    if (!manifest.includes('publish = ["crates-io"]')) continue;
+    const name = manifest.match(/^name = "([^"]+)"/m)?.[1];
+    if (name) names.push(name);
+  }
+  return names.sort();
+}


### PR DESCRIPTION
TL;DR:


Before/After:
<!-- the homepage packages section changed from one install command to three; screenshots needed before review -->

Summary:
- Adds a packages hub plus one page per registry (`/docs/javascript`, `/docs/rust`, `/docs/python`), so a reader arriving from an npm, crates.io or PyPI sidebar link lands on content that names their own package with a working install line and a first example
- Repoints `Documentation` in both Python distributions at `/docs/python`; it previously pointed at a docs site with no Python content at all, which is live and wrong on the `betteroffice-xlsx` PyPI page today
- Adds a Python section to `llms.txt`, Python install commands to the homepage and the agent markdown, both Python distributions to the README package table, and PyPI and crates.io to the homepage JSON-LD
- Derives the package lists from `scripts/published-packages.mjs` rather than hand-maintained prose, and adds tests that fail when a published package is missing from the docs, when a documented name is not a real package, when a `pip install` line names something not on PyPI, or when a `Documentation` URL stops resolving to a page that exists
- `betteroffice-pptx` is not on PyPI yet, so it is never presented as installable — the page says so and gives the editable-install command CI uses

Test plan:
- [ ] `bun run --filter './apps/docs' build` passes
- [ ] `bun test apps/web/app scripts` passes
- [ ] `bun run --filter './apps/*' typecheck` passes
- [ ] `/docs/packages`, `/docs/javascript`, `/docs/rust` and `/docs/python` all render, and appear in the sidebar, sitemap and llms.txt
- [ ] Attach before/after screenshots of the homepage packages section