### PR TITLE
chore(deps): pin ip-address 10.4.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -274,6 +274,7 @@
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.5",
+    "ip-address": "10.4.0",
     "minimatch": "^10.2.5",
     "postcss": "8.5.23",
     "sharp": "^0.35.0",
@@ -1518,7 +1519,7 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 minimumReleaseAge = 604800
 # Per-advisory exemptions; remove each after its pinned version clears the release-age window.
-minimumReleaseAgeExcludes = ["fast-uri", "next", "postcss", "brace-expansion"]
+minimumReleaseAgeExcludes = ["fast-uri", "next", "postcss", "brace-expansion", "ip-address"]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "sharp": "^0.35.0",
     "brace-expansion": "5.0.9",
     "minimatch": "^10.2.5",
-    "undici": "7.29.0"
+    "undici": "7.29.0",
+    "ip-address": "10.4.0"
   },
   "scripts": {
     "dev": "bun run --filter './apps/web' dev",


### PR DESCRIPTION
TL;DR:


Summary:
- GHSA-mwp4-54f8-5fhr (high) covers `ip-address <=10.3.0`, reached through `apps/demo` via `shadcn`, so `bun audit --audit-level=high` fails on `main` and red-lights the Security audit job on every branch
- Pins `10.4.0`, the first fixed release
- That release is newer than the seven-day `minimumReleaseAge` floor, so `ip-address` joins `minimumReleaseAgeExcludes` alongside the other security-motivated pins already there

Test plan:
- [ ] `bun audit --audit-level=high` reports no vulnerabilities
- [ ] `bun install --frozen-lockfile` succeeds
- [ ] `bun run --filter '@betteroffice/demo' typecheck` passes
- [ ] CI Security audit passes