### PR TITLE
docs(python): correct and sharpen the binding READMEs

### DIFF
--- a/.changeset/python-readme-accuracy.md
+++ b/.changeset/python-readme-accuracy.md
@@ -1,0 +1,36 @@
+---
+"@betteroffice/python-xlsx": patch
+"@betteroffice/python-pptx": patch
+---
+
+Both Python READMEs now describe what the bindings actually do. The
+`betteroffice-xlsx` page said `save` regenerated the package and dropped parts
+the model does not cover; saving has preserved charts, drawings, pivot tables,
+comments, macros and custom XML since part preservation landed, so the Status
+section now states the preservation and the limits that remain — an edited sheet
+is still reserialized from the model, and this binding exposes no structural
+edits at all. The `betteroffice-pptx` page said unregistered families fell back
+to a metrics-only path; `render_slide` raises `RenderError: no font has been
+registered for slide text` instead, so the layout section leads with that error
+and then shows registering a face, and says what a family you did not register
+resolves to once one exists. That page also told readers to `pip install
+betteroffice-pptx`, which is not on PyPI; it now gives the editable install from
+a checkout.
+
+Both READMEs name the import next to the install line, because `pip install
+betteroffice-xlsx` gives `import betteroffice_xlsx`, and both name the incumbent
+they are compared against in the opening paragraph rather than a hundred lines
+down. The xlsx API table stops presenting the static `Workbook.open_collaborative`
+as an instance method, and gains `value`, `formula`, `proposals`,
+`merged_ranges`, `last_calculation`, `sheet_index`, `can_undo`/`can_redo`, and
+the `now_serial` keyword that supplies the clock `TODAY()` and `NOW()` read.
+`StaleProposalError` now documents its way out, `accept_proposal(id,
+force=True)`. The proposals example prints the value it actually produces, and
+the pptx snippets no longer assume the first slide has a shape or that the shape
+bears text.
+
+Both distributions declare `Operating System :: OS Independent` and per-minor
+`Programming Language :: Python` classifiers for 3.9 through 3.13, so PyPI's
+version filter finds them, swap the `openpyxl-alternative` and
+`python-pptx-alternative` keywords nobody searches for the bare project names,
+and add a `Changelog` project URL.

--- a/bindings/python-pptx/README.md
+++ b/bindings/python-pptx/README.md
@@ -1,15 +1,21 @@
 # betteroffice-pptx
 
-Read, edit, and lay out PPTX presentations from Python. The engine is the Rust
-[BetterOffice](https://betteroffice.dev) PPTX core, compiled into the wheel —
+Read, edit, and lay out PPTX presentations from Python. `python-pptx` reads a
+deck and writes one back; this also *lays slides out* — line breaking, text
+metrics, a display list — and merges edits across replicas, because the Rust
+[BetterOffice](https://betteroffice.dev) PPTX core is compiled into the wheel:
 no PowerPoint, no LibreOffice subprocess, no COM.
 
 Editing is in-memory today: see [Writing](#writing) before you reach for
 `save()`.
 
+Not on PyPI yet. From a checkout, with a Rust toolchain installed:
+
 ```bash
-pip install betteroffice-pptx
+pip install -e bindings/python-pptx
 ```
+
+The distribution is hyphenated, the module is not: `import betteroffice_pptx`.
 
 ## Read a deck
 
@@ -21,8 +27,9 @@ deck = Presentation.open_path("quarterly.pptx")
 for slide in deck:
     print(slide.index, slide.name, repr(slide.text))
 
-shape = deck[0].shapes[0]
-print(shape.kind, shape.geometry, shape.x, shape.y, shape.width, shape.height)
+shape = next((s for slide in deck for s in slide.shapes), None)
+if shape is not None:
+    print(shape.kind, shape.geometry, shape.x, shape.y, shape.width, shape.height)
 ```
 
 Geometry is in English Metric Units — 914400 to the inch. The module exports
@@ -69,15 +76,21 @@ UTF-16 code units, and every paragraph ends with a pilcrow occupying one of
 them.
 
 ```python
-story = deck[0].shapes[0].stories[0]
-print(story.text, story.length)
+story = next(
+    (s for slide in deck for shape in slide.shapes for s in shape.stories), None
+)
+if story is not None:
+    print(story.text, story.length)
 
-deck.insert_text(story.id, 0, "Q3 ", bold=True)
-deck.format_text(story.id, 0, 3, color="#dc2626")
-deck.insert_paragraph_break(story.id, 3)
-removed = deck.delete_text(story.id, 0, 3)
-print(removed.text)          # 'Q3 '
+    deck.insert_text(story.id, 0, "Q3 ", bold=True)
+    deck.format_text(story.id, 0, 3, color="#dc2626")
+    deck.insert_paragraph_break(story.id, 3)
+    removed = deck.delete_text(story.id, 0, 3)
+    print(removed.text)      # 'Q3 '
 ```
+
+A shape with no text has no story, so a deck of pictures alone yields none.
+`deck.story(id)` looks one up directly and raises `KeyError` if it is gone.
 
 `format_text` patches only the arguments you pass, and a range spanning several
 paragraphs styles each of them as a single undoable edit. `delete_text` is the
@@ -86,9 +99,22 @@ than silently swallowing the break.
 
 ## Lay a slide out
 
+**No font is compiled into the wheel**, so laying out a slide that has text
+needs at least one registered face. Before that, `render_slide` raises:
+
 ```python
-deck.register_font("Inter", open("Inter-Regular.ttf", "rb").read())
-deck.register_font("Inter", open("Inter-Bold.ttf", "rb").read(), bold=True)
+deck.render_slide(0)
+# RenderError: no font has been registered for slide text
+```
+
+Register the faces the deck uses — one call per family, weight, and slant — and
+it lays out:
+
+```python
+from pathlib import Path
+
+deck.register_font("Inter", Path("Inter-Regular.ttf").read_bytes())
+deck.register_font("Inter", Path("Inter-Bold.ttf").read_bytes(), bold=True)
 
 layout = deck.render_slide(0)
 print(layout.width, layout.height, len(layout))   # 1280.0 720.0 42
@@ -96,12 +122,15 @@ layout.write("slide-0.json")
 scene = layout.to_dict()
 ```
 
+Once at least one face exists nothing raises again: a family the deck names but
+you never registered resolves to the same family at regular weight, and failing
+that to the first face you registered at all. One registration therefore renders
+every slide — in that one typeface, at its metrics. Register the real faces when
+line breaking has to match what PowerPoint would do.
+
 `render_slide` returns the display list — the same drawing contract the browser
 editor paints, as JSON. There is no PPTX rasterizer yet, so this is a scene
 description rather than pixels; feed it to your own canvas or renderer.
-
-No font is compiled into the wheel, so families you do not register fall back
-to the engine's metrics-only path. Register the faces you actually use.
 
 ## Collaboration
 
@@ -112,7 +141,7 @@ order to converge:
 left = Presentation.open_collaborative(data)
 right = Presentation.open_collaborative(data)
 
-left.move_shape(0, left[0].shapes[0].id, 100000, 100000)
+left.add_text_box(0, x=INCH, y=INCH, width=4 * INCH, height=INCH, text="Q3")
 right.apply_update(left.diff(right.state_vector()))   # right now agrees
 
 joiner = Presentation.open_collaborative(data)
@@ -141,7 +170,8 @@ oversized payload is refused before it is copied.
 
 ```python
 deck.author = "ana"
-deck.move_shape(0, shape_id, 0, 0)
+edit = deck.add_text_box(0, x=INCH, y=INCH, width=INCH, height=INCH, text="Q3")
+deck.move_shape(0, edit.shape_id, 0, 0)
 deck.add_undo_barrier()      # the next edit starts a new undo step
 deck.undo()
 deck.redo()
@@ -205,6 +235,8 @@ edits that merge across replicas, that is the gap this fills.
 | `deck.snapshot()` | the whole deck as plain data |
 | `deck[key]` / `deck.slide(key)` | a `Slide` by index or ID |
 | `deck.slide_ids` / `slide_count` / `layouts` | deck metadata |
+| `deck.width_emu` / `height_emu` | slide size in EMU |
+| `deck.author` / `deck.origin` | who an edit is attributed to, and how |
 | `deck.story(id)` | one text flow |
 | `deck.media()` | embedded images and other binary parts |
 | `insert_slide` / `delete_slide` / `move_slide` | slide order |
@@ -215,7 +247,7 @@ edits that merge across replicas, that is the gap this fills.
 | `insert_paragraph_break` | split a paragraph |
 | `register_font` / `render_slide` | layout |
 | `diff` / `apply_update` / `state_vector` / `state_as_update` | Yrs replicas |
-| `deck.is_collaborative` | whether this deck may exchange updates |
+| `deck.is_collaborative` / `deck.client_id` | whether this deck may exchange updates, and as whom |
 | `deck.is_edited` | whether an accepted edit has made `save` refuse |
 | `undo` / `redo` / `add_undo_barrier` / `can_undo` / `can_redo` | history |
 | `deck.save()` / `save_path(path)` | serialize to PPTX — see *Writing* |
@@ -284,7 +316,7 @@ Wheels are built for Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows
 ## Links
 
 - [BetterOffice](https://betteroffice.dev) — the project
-- [Documentation](https://docs.betteroffice.dev)
+- [Documentation](https://docs.betteroffice.dev/docs/python)
 - [Source](https://github.com/openooxml/betteroffice) — `bindings/python-pptx`
 - [betteroffice-pptx on crates.io](https://crates.io/crates/betteroffice-pptx) — the engine this wraps
 

--- a/bindings/python-pptx/pyproject.toml
+++ b/bindings/python-pptx/pyproject.toml
@@ -18,15 +18,21 @@ keywords = [
   "ooxml",
   "presentationml",
   "slides",
-  "python-pptx-alternative",
+  "python-pptx",
   "rust",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Rust",
   "Topic :: Office/Business :: Office Suites",
   "Topic :: Software Development :: Libraries",
@@ -36,6 +42,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://betteroffice.dev"
 Documentation = "https://docs.betteroffice.dev/docs/python"
+Changelog = "https://github.com/openooxml/betteroffice/blob/main/bindings/python-pptx/CHANGELOG.md"
 Source = "https://github.com/openooxml/betteroffice"
 Issues = "https://github.com/openooxml/betteroffice/issues"
 

--- a/bindings/python-xlsx/README.md
+++ b/bindings/python-xlsx/README.md
@@ -1,12 +1,16 @@
 # betteroffice-xlsx
 
-Read, recalculate, render, and write XLSX workbooks from Python. The engine is
-the Rust [BetterOffice](https://betteroffice.dev) XLSX core, compiled into the
-wheel — no Excel, no LibreOffice subprocess, no COM.
+Read, recalculate, render, and write XLSX workbooks from Python. Where
+`openpyxl` hands back a formula's source text or whatever value the authoring
+application happened to cache, this evaluates the formula and can rasterize the
+sheet: the Rust [BetterOffice](https://betteroffice.dev) XLSX core is compiled
+into the wheel — no Excel, no LibreOffice subprocess, no COM.
 
 ```bash
 pip install betteroffice-xlsx
 ```
+
+The distribution is hyphenated, the module is not: `import betteroffice_xlsx`.
 
 ## Formulas actually calculate
 
@@ -90,19 +94,38 @@ local history, so undo will not revert someone else's work.
 ## Agent proposals
 
 An agent can stage edits for a human instead of applying them. Each proposed
-edit carries the before and after text a reviewer would compare:
+edit carries the display text a reviewer would compare — `before` and `after`
+are what the cell shows, as strings, while `input` is what would be written:
 
 ```python
-proposal = wb.propose("copilot", [("Sheet1", "H1", "=SUM(B3:B10)")], note="add a total")
+proposal = wb.propose("copilot", [("Sheet1", "H1", "=B3*2")], note="double the total")
 
 for edit in proposal.edits:
-    print(edit.address, edit.before, "->", edit.after)   # H1  ''  ->  3600
+    print(edit.address, repr(edit.before), "->", repr(edit.after))   # H1 '' -> '84'
 
 wb.accept_proposal(proposal.id)     # or wb.reject_proposal(proposal.id)
 ```
 
 Nothing is written until the proposal is accepted, and accepting applies it as
-a single undo step.
+a single undo step. `proposals()` lists the ones still awaiting a decision.
+
+A proposal goes stale when one of its target cells changes after it was staged.
+`accept_proposal` then raises `StaleProposalError`, whose `cells` names the
+addresses that moved underneath it — re-propose against the new values, or
+apply it anyway with `force=True`:
+
+```python
+from betteroffice_xlsx import StaleProposalError
+
+try:
+    wb.accept_proposal(proposal.id)
+except StaleProposalError as stale:
+    print("changed underneath:", stale.cells)   # ['H1']
+    wb.accept_proposal(proposal.id, force=True)
+```
+
+An unknown proposal ID raises `KeyError`; `reject_proposal` returns `False`
+instead when there is nothing left to reject.
 
 ## Formatting
 
@@ -147,20 +170,38 @@ formulas evaluated or a sheet rasterized, that is the gap this fills.
 | `Workbook.open(data)` | open from `bytes` |
 | `Workbook.open_path(path)` | open from a path |
 | `Workbook.open_recalculated(data)` | open and evaluate every formula |
+| `Workbook.open_collaborative(data)` | open a Yrs replica — on the class, like the other openers |
 | `wb.recalculate()` | re-evaluate; returns a `Calculation` summary |
+| `wb.last_calculation()` | the `Calculation` the most recent one produced |
 | `wb.sheet_names` / `wb.sheet_count` | sheet metadata |
 | `wb[key]` / `wb.sheet(key)` | a `Sheet` by name or index |
+| `wb.sheet_index(key)` | resolve a name or index to an index |
 | `sheet[addr]` | cell value — see the note below on when it is recalculated |
 | `sheet[addr] = value` | set from what a user would type |
-| `wb.set_many(sheet, edits)` | write many cells as one undo step |
-| `wb.undo()` / `wb.redo()` | walk local history |
-| `wb.propose(...)` / `accept_proposal` / `reject_proposal` | staged agent edits |
-| `wb.set_style(...)` / `set_number_format(...)` | formatting over a range |
-| `wb.open_collaborative(...)` / `diff` / `apply_update` | Yrs replicas |
-| `wb.active_sheet` / `set_active_sheet(...)` | read or persist the active tab |
 | `sheet.formula(addr)` | source formula, or `None` |
+| `wb.value(sheet, addr)` / `wb.formula(sheet, addr)` | the same two reads without a `Sheet` |
+| `wb.set(sheet, addr, value)` / `wb.set_many(sheet, edits)` | write one cell, or many as one undo step |
+| `wb.merged_ranges(sheet, range)` | merged regions overlapping a range |
+| `wb.undo()` / `wb.redo()` | walk local history |
+| `wb.can_undo` / `wb.can_redo` / `wb.history()` | what history is available |
+| `wb.propose(...)` / `proposals()` / `accept_proposal` / `reject_proposal` | staged agent edits |
+| `wb.set_style(...)` / `set_number_format(...)` | formatting over a range |
+| `wb.diff(sv)` / `apply_update(u)` / `state_vector()` / `state_as_update()` | exchange Yrs updates |
+| `wb.client_id` / `wb.is_collaborative` | which kind of workbook you are holding |
+| `wb.active_sheet` / `set_active_sheet(...)` | read or persist the active tab |
 | `wb.render_png(sheet, ...)` | render to PNG |
 | `wb.save()` / `wb.save_path(path)` | serialize to XLSX |
+
+Every call that can trigger a calculation — `open_recalculated`,
+`open_collaborative`, `recalculate`, `set`, `set_many`, `undo`, `redo`,
+`apply_update`, `propose`, `accept_proposal`, `set_number_format`, and
+`set_style` — takes a keyword-only `now_serial`. It is the clock `TODAY()` and
+`NOW()` read, as an Excel serial number. The engine has none of its own, so
+both return `#VALUE!` unless you pass one:
+
+```python
+wb.recalculate(now_serial=45658.5)   # 2025-01-01, midday
+```
 
 Cell values come back as `None`, `float`, `str`, `bool`, or `CellError`.
 Numbers are `f64` in the engine, so they arrive as `float` and are not narrowed
@@ -189,22 +230,40 @@ sheet["A2"] = "=1+1"    # the formula, evaluating to 2.0
 ```
 
 Mutating calls return a `Mutation` — truthy when something changed, with
-`changed` listing the cells the engine *recalculated* as a result. A cell you
-wrote directly is not itself a recalculation, so it will not always appear
-there.
+`changed` listing the cells the engine *recalculated* as a result, and `cycles`
+and `limited` the ones it gave up on. A cell you wrote directly is not itself a
+recalculation, so it will not always appear there. Addresses are bare A1 on the
+active sheet and `Sheet!A1` anywhere else, so match on the suffix rather than
+the whole string.
 
-Errors raise `XlsxError` or a more specific subclass. Invalid peer updates,
-broken local collaboration state, stale proposals, and collaboration-only
-operations use `InvalidUpdateError`, `CollaborativeStateError`,
-`StaleProposalError`, and `NotCollaborativeError`. `StaleProposalError.cells`
-lists the changed A1 addresses, and an unknown proposal ID raises `KeyError`.
+Errors raise `XlsxError` or a more specific subclass: `ParseError`,
+`RangeError`, `RenderError`, `InvalidUpdateError`, `CollaborativeStateError`,
+`StaleProposalError`, `NotCollaborativeError`. Invalid peer updates, broken
+local collaboration state, stale proposals, and collaboration-only operations
+are the last four in that order. `StaleProposalError.cells` lists the changed A1
+addresses, and an unknown proposal ID raises `KeyError`.
 
 ## Status
 
-`0.0.x`, and the API may change before `0.1.0`. `save` regenerates the package
-from the features the model represents; package parts the model does not cover
-are not retained, so this is not a round-trip-preserving editor for arbitrary
-workbooks.
+`0.0.x`, and the API may change before `0.1.0`.
+
+`save` keeps the parts the model does not represent — charts, drawings, pivot
+tables, comments, macros, custom XML, and their relationships — rather than
+regenerating the package from the modeled features, and sheets you did not
+touch are copied through byte for byte. The stylesheet is left alone unless
+styles actually change.
+
+A sheet you *do* edit is reserialized from the model, so unmodeled row, column,
+and cell markup on that one sheet is lost, and its autofilter, data-validation,
+conditional-formatting, table, and sparkline ranges stay at their source
+coordinates. Collaborative sessions compare only the modeled workbook, so two
+peers holding the same cells but different macros or custom XML still accept
+each other as the same base.
+
+This binding exposes no structural edits: no sheet rename or removal, no row or
+column insert or delete. The engine refuses those anyway while a pivot table or
+an unmodeled chart part is preserved, because it cannot rewrite the references
+they hold.
 
 Wheels are built for Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows
 (x86_64) against the stable ABI for CPython 3.9 and up.
@@ -217,7 +276,7 @@ package's own code is Apache-2.0.
 ## Links
 
 - [BetterOffice](https://betteroffice.dev) — the project
-- [Documentation](https://docs.betteroffice.dev)
+- [Documentation](https://docs.betteroffice.dev/docs/python)
 - [Source](https://github.com/openooxml/betteroffice) — `bindings/python-xlsx`
 - [betteroffice-xlsx on crates.io](https://crates.io/crates/betteroffice-xlsx) — the engine this wraps
 

--- a/bindings/python-xlsx/pyproject.toml
+++ b/bindings/python-xlsx/pyproject.toml
@@ -20,19 +20,27 @@ keywords = [
   "xlsx",
   "excel",
   "spreadsheet",
+  "spreadsheet-engine",
   "ooxml",
   "formula",
+  "formulas",
   "recalculate",
   "render",
-  "openpyxl-alternative",
+  "openpyxl",
   "rust",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Rust",
   "Topic :: Office/Business :: Financial :: Spreadsheet",
   "Topic :: Software Development :: Libraries",
@@ -42,6 +50,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://betteroffice.dev"
 Documentation = "https://docs.betteroffice.dev/docs/python"
+Changelog = "https://github.com/openooxml/betteroffice/blob/main/bindings/python-xlsx/CHANGELOG.md"
 Source = "https://github.com/openooxml/betteroffice"
 Issues = "https://github.com/openooxml/betteroffice/issues"
 


### PR DESCRIPTION
TL;DR:


Summary:
- The XLSX status section said saving does not retain package parts the model does not cover, which stopped being true when part preservation landed. It is live on the PyPI page today, telling evaluators their macros are dropped. Rewritten to state the preservation and the real limit — a sheet you edit is still reserialized, so unmodeled markup on that one sheet is lost
- The PPTX layout section said unregistered families fall back to a metrics-only path. There is no fallback: rendering with no registered face raises. The section now leads with that error, then registration, and states what a family you did not register actually does once a face exists
- The PPTX README told readers to `pip install betteroffice-pptx`, which is not on PyPI. Replaced with the editable install from a checkout, matching the docs page
- Both READMEs name the incumbent in the opening paragraph, state the import name beside the install line, and point Documentation at the Python docs page
- XLSX: `Workbook.open_collaborative` is documented as the class-level call it is rather than an instance method, the stale-proposal recovery path is documented, and the previously undocumented value, formula, proposal, merge, calculation and undo accessors are covered — as is `now_serial`, without which the date functions return an error
- PyPI metadata gains the OS and per-minor Python classifiers the browse filters use, searchable keywords, and a changelog URL

Test plan:
- [ ] `bun test scripts` passes
- [ ] Every code sample in both READMEs runs against a fresh install
- [ ] The rendered PyPI preview shows the incumbent comparison and install line on the first screen