### PR TITLE
fix(docx): give an inserted table Word's default grid borders

### DIFF
--- a/.changeset/docx-insert-table-borders.md
+++ b/.changeset/docx-insert-table-borders.md
@@ -1,0 +1,10 @@
+---
+"@betteroffice/rust-crates": patch
+"@betteroffice/docx": patch
+---
+
+Inserting a DOCX table now produces one with borders. `insert_table` gave each new cell only its spans, so a table dropped into a document whose styles carry no bordered table style rendered as bare text with no rules at all — and saved that way too, since the writer lifts `w:tblBorders` out of the cells it finds.
+
+Every cell of a new table now carries Word's Table Grid rules: a single 0.5pt (`w:sz="4"`) black line on each of its four edges, so the grid reads the same as the one Word draws for its own inserted table. Resolved table borders have always lived on the cells in this engine — seeding pushes `w:tblBorders` down per position, the display list paints only what `tcPr.borders` names, and the toolbar reads its border state from there — so authoring them at the cell is what makes the table visible, survive a save, and come back bordered when the file is reopened.
+
+Referencing a style instead would not have worked: nothing synthesises a `TableGrid` definition into `styles.xml`, so a blank document has none to inherit from. Rows and columns added later still inherit the borders, since both copy their template cell's `tcPr`, and a suggested insertion carries them exactly like a direct one.

--- a/crates/docx-edit/src/ops/table.rs
+++ b/crates/docx-edit/src/ops/table.rs
@@ -317,6 +317,25 @@ fn to_any_array(values: Vec<Any>) -> Any {
     Any::Array(Arc::from(values))
 }
 
+/// `tcPr.borders` for a freshly inserted table: Word's Table Grid rules, a
+/// single 0.5pt (`w:sz="4"`) black line on every edge.
+fn default_cell_borders() -> Any {
+    let edge = to_any_map(HashMap::from([
+        ("style".to_owned(), Any::from("single")),
+        ("size".to_owned(), Any::Number(4.0)),
+        (
+            "color".to_owned(),
+            to_any_map(HashMap::from([("rgb".to_owned(), Any::from("000000"))])),
+        ),
+    ]));
+    to_any_map(HashMap::from([
+        ("top".to_owned(), edge.clone()),
+        ("bottom".to_owned(), edge.clone()),
+        ("left".to_owned(), edge.clone()),
+        ("right".to_owned(), edge),
+    ]))
+}
+
 fn write_table(txn: &mut TransactionMut<'_>, map: &MapRef, data: &TableData) {
     let rows = data
         .rows
@@ -1073,6 +1092,7 @@ impl EditingDoc {
         let revision = revision_id
             .as_ref()
             .map(|id| revision_value(id, &ctx.revision_author()));
+        let borders = default_cell_borders();
         let mut table_rows = Vec::with_capacity(rows as usize);
         for row in 0..rows as usize {
             let mut cells = Vec::with_capacity(columns as usize);
@@ -1083,6 +1103,7 @@ impl EditingDoc {
                     tc_pr: HashMap::from([
                         ("rowspan".to_owned(), Any::Number(1.0)),
                         ("colspan".to_owned(), Any::Number(1.0)),
+                        ("borders".to_owned(), borders.clone()),
                     ]),
                     story: story_id.clone(),
                 });
@@ -1935,6 +1956,97 @@ mod tests {
         let value = serde_json::to_value(&blocks).unwrap();
         assert_eq!(value[0]["kind"], "table");
         assert_eq!(value[0]["rows"].as_array().unwrap().len(), 3);
+    }
+
+    fn inserted(ctx: &EditCtx, rows: u32, columns: u32) -> EditingDoc {
+        let doc = EditingDoc::new(74);
+        doc.create_story("body", "", "Normal", "left").unwrap();
+        doc.insert_table(ctx, Position::new("body", 0), rows, columns)
+            .unwrap();
+        doc
+    }
+
+    fn assert_grid_borders(doc: &EditingDoc) {
+        let (_, _, rows) = table_value(doc);
+        for row in rows.as_array().unwrap() {
+            for cell in row["cells"].as_array().unwrap() {
+                let borders = &cell["tcPr"]["borders"];
+                for side in ["top", "bottom", "left", "right"] {
+                    assert_eq!(borders[side]["style"], "single", "{side} of {cell}");
+                    assert_eq!(borders[side]["size"], 4.0, "{side} of {cell}");
+                    assert_eq!(borders[side]["color"]["rgb"], "000000", "{side} of {cell}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn inserted_table_carries_word_default_grid_borders() {
+        assert_grid_borders(&inserted(&direct(), 3, 2));
+        assert_grid_borders(&inserted(&suggesting(), 3, 2));
+    }
+
+    #[test]
+    fn inserted_table_keeps_grid_borders_when_rows_and_columns_grow() {
+        let doc = inserted(&direct(), 2, 2);
+        doc.insert_row(&direct(), &cell(1, 0), true).unwrap();
+        doc.insert_column(&direct(), &cell(0, 1), true).unwrap();
+        let (_, grid, rows) = table_value(&doc);
+        assert_eq!(grid.as_array().unwrap().len(), 3);
+        assert_eq!(rows.as_array().unwrap().len(), 3);
+        assert_grid_borders(&doc);
+    }
+
+    #[test]
+    fn inserted_table_paints_a_rule_on_every_cell_edge() {
+        use docx_layout::display_list::{LineRole, Primitive};
+        use docx_layout::measure_blocks::{MeasurementConfig, measure_blocks};
+        use docx_layout::types::{Input, LayoutOptions, MeasuredBlock, PageMargins, Size};
+
+        let doc = inserted(&direct(), 2, 2);
+        let mut blocks = yrs_doc_to_layout_blocks(&doc, "body", &RenderEnv::default()).unwrap();
+        let measures = measure_blocks(&mut blocks, 600.0, &MeasurementConfig::default()).unwrap();
+        let mut input = Input {
+            measured: blocks
+                .into_iter()
+                .zip(measures)
+                .map(|(block, measure)| MeasuredBlock { block, measure })
+                .collect(),
+            options: LayoutOptions {
+                page_size: Some(Size {
+                    w: 816.0,
+                    h: 1056.0,
+                }),
+                margins: Some(PageMargins {
+                    top: 96.0,
+                    right: 108.0,
+                    bottom: 96.0,
+                    left: 108.0,
+                    header: None,
+                    footer: None,
+                }),
+                ..LayoutOptions::default()
+            },
+        };
+        let layout = docx_layout::compute_layout_input(&mut input).unwrap();
+        let display_list = docx_layout::build_display_list(&input, &layout).unwrap();
+        let rules: Vec<_> = display_list.pages[0]
+            .primitives
+            .iter()
+            .filter_map(|primitive| match primitive {
+                Primitive::Line(line) if line.role == Some(LineRole::TableBorder) => Some(line),
+                _ => None,
+            })
+            .collect();
+        // A 2x2 grid draws three horizontal and three vertical rules, each
+        // split into one segment per cell it borders.
+        let horizontal = rules.iter().filter(|line| line.y1 == line.y2).count();
+        let vertical = rules.iter().filter(|line| line.x1 == line.x2).count();
+        assert_eq!((horizontal, vertical), (6, 6), "every grid edge is painted");
+        for line in &rules {
+            assert_eq!(line.color, "#000000");
+            assert_eq!(line.stroke_width.as_f64(), Some(1.0));
+        }
     }
 
     #[test]

--- a/packages/docx/src/yrs/insertTable.test.ts
+++ b/packages/docx/src/yrs/insertTable.test.ts
@@ -1,0 +1,121 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parseDocx } from '../docx';
+import { repackDocx } from '../docx/rezip';
+import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
+import type { Document, Table } from '../types/document';
+import { preloadEditWasm } from '../wasm/edit';
+import { createYrsSession } from './index';
+import { yrsToDocument } from './yrsToDocument';
+
+const WASM = resolve(import.meta.dir, '../wasm/generated/edit/docx_edit_bg.wasm');
+
+const OFFICE_DOC = 'application/vnd.openxmlformats-officedocument';
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="${OFFICE_DOC}.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="${OFFICE_DOC}.wordprocessingml.styles+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPkg1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>Anchor</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+/** No table style at all — the blank document the bug report starts from. */
+const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault><w:rPr><w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/><w:sz w:val="22"/></w:rPr></w:rPrDefault>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`;
+
+function blankDocx(): Uint8Array {
+  const parts: PartsMap = new Map();
+  parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
+  parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
+  parts.set('word/document.xml', toBytes(DOCUMENT));
+  parts.set('word/styles.xml', toBytes(STYLES));
+  return new Uint8Array(rezipPartsToArrayBuffer(parts));
+}
+
+function onlyTable(document: Document): Table {
+  const table = document.package.document.content.find((block) => block.type === 'table');
+  if (!table) throw new Error('no table in document body');
+  return table as Table;
+}
+
+const GRID_EDGE = { style: 'single', size: 4, color: { rgb: '000000' } };
+
+describe('a table inserted into a document without a bordered table style', () => {
+  beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
+
+  it('saves and reopens with Word default grid borders', async () => {
+    const bytes = blankDocx();
+    const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+    const session = await createYrsSession({ clientId: 51001 });
+
+    let saved: Document;
+    try {
+      session.seedFromDocx(bytes);
+      const anchor = session.paragraphs('body')[0];
+      session.insertTable({ story: 'body', paraId: anchor.paraId, offset: 0 }, 2, 2);
+      saved = yrsToDocument(session, parsed);
+    } finally {
+      session.destroy();
+    }
+
+    const table = onlyTable(saved);
+    for (const side of ['top', 'bottom', 'left', 'right', 'insideH', 'insideV'] as const) {
+      expect(table.formatting?.borders?.[side], `tblBorders.${side}`).toMatchObject(GRID_EDGE);
+    }
+
+    const reopenedBytes = await repackDocx(saved);
+    const reopened = await parseDocx(reopenedBytes, { preloadFonts: false });
+    const reopenedTable = onlyTable(reopened);
+    for (const side of ['top', 'bottom', 'left', 'right', 'insideH', 'insideV'] as const) {
+      expect(reopenedTable.formatting?.borders?.[side], `reopened tblBorders.${side}`).toMatchObject(
+        GRID_EDGE
+      );
+    }
+
+    const reseeded = await createYrsSession({ clientId: 51002 });
+    try {
+      reseeded.seedFromDocx(new Uint8Array(reopenedBytes));
+      const blocks = reseeded.yrsBlocksForStory('body') as Array<{ kind: string }>;
+      const block = blocks.find((entry) => entry.kind === 'table');
+      expect(block, 'reseeded body still carries a table').toBeDefined();
+      const { rows } = block as unknown as {
+        rows: Array<{ cells: Array<{ borders?: Record<string, unknown> }> }>;
+      };
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        for (const cell of row.cells) {
+          for (const side of ['top', 'bottom', 'left', 'right'] as const) {
+            expect(cell.borders?.[side], `reseeded rendered ${side} rule`).toEqual({
+              width: 1,
+              color: '#000000',
+              style: 'solid',
+            });
+          }
+        }
+      }
+    } finally {
+      reseeded.destroy();
+    }
+  });
+});


### PR DESCRIPTION
TL;DR:


Repro file:
`packages/docx/src/yrs/insertTable.test.ts` — a blank document with no table style, inserted table, saved, reparsed and reseeded, asserting all six border sides survive the bytes and the renderer paints a rule on every cell edge.

Summary:
- A table created by the editor carried no border data at all: `insert_table` set only the table width, and neither the cells nor the table carried borders, so a new table rendered and saved with no rules. Reported as #163
- Resolved table borders live on the cells throughout the engine — seeding pushes `tblBorders` down per position, rendering reads only `tcPr.borders`, saving lifts `tblBorders` back out of them, and the toolbar reads its state from there — so a new table's cells now carry a single 0.5pt black line on every edge, the same weight and colour as the editor's own Table Grid preset
- Growth is unaffected: inserting a row or column clones the template cell, so new cells inherit the same edges, including at the table's outer edges
- Covered at the operation level, at the render level (a 2×2 grid paints six horizontal and six vertical rules where it previously painted none), and through a full save, reparse and reseed round-trip

Known difference from Word:
- Word writes a `TableGrid` style reference plus a matching definition in the styles part; this writes the equivalent direct formatting on each cell, because nothing in the engine synthesises a table style into a document that lacks one. The visible result is the same, but applying a different Table Style in Word will not override these borders until they are cleared

Test plan:
- [x] `cargo test` passes
- [x] `bun test packages/docx packages/docx-react` passes
- [x] Insert a table in the editor: it has rules on every edge
- [x] Save that document and reopen it: the rules are still there
- [x] Insert a row and a column: the new cells match