### PR TITLE
fix(docx): table border button consistency

### DIFF
--- a/.changeset/docx-table-border-buttons.md
+++ b/.changeset/docx-table-border-buttons.md
@@ -1,0 +1,11 @@
+---
+"@betteroffice/rust-crates": patch
+"@betteroffice/docx": patch
+"@betteroffice/docx-react": patch
+---
+
+The table border toolbar's buttons now do what their names say. `set_cell_borders` replaced a cell's whole `tcPr.borders` object with whatever it was handed, so pressing Top Border on a cell of a bordered table silently deleted that cell's other three rules, and Outside Borders gave every selected cell all four edges — a full grid rather than an outline. It now merges the sides it is given: an omitted side is left alone, `style: "none"` authors an explicit no-border, and a JSON `null` drops the authored side, the same patch convention `set_cell_text_format` already uses.
+
+Inside Borders wrote `insideH`/`insideV` straight onto each cell. Those keys describe a table's interior edges and have no meaning on a single cell, so nothing rendered them and the grid vanished on screen, while the writer still lifted a complete `w:tblBorders` into the file and the rules reappeared on reopen. `insideH`/`insideV` now resolve per cell to the physical edges interior to the selection, reusing the mapping seeding already applies when it pushes `w:tblBorders` down to cell positions — so an Inside Borders command paints the interior rules of whatever is selected and leaves the outline untouched, and a single-side button applies to the selection's own edge rather than to every cell in it.
+
+Saving no longer invents table borders no cell carries: the `w:tblBorders` lifted back out of a table is now read from the cells that own each boundary, with `insideH`/`insideV` taken from an interior edge, instead of filling every missing side from the first border found anywhere in the table.

--- a/crates/docx-edit/src/ops/table.rs
+++ b/crates/docx-edit/src/ops/table.rs
@@ -343,6 +343,8 @@ fn merge_cell_borders<'a>(
     } else {
         cell.tc_pr.insert("borders".to_owned(), to_any_map(merged));
     }
+}
+
 /// `tcPr.borders` for a freshly inserted table: Word's Table Grid rules, a
 /// single 0.5pt (`w:sz="4"`) black line on every edge.
 fn default_cell_borders() -> Any {

--- a/crates/docx-edit/src/ops/table.rs
+++ b/crates/docx-edit/src/ops/table.rs
@@ -18,6 +18,7 @@ use yrs::{
 };
 
 use crate::op::{OpError, OpResult};
+use crate::seed::border_side_sources;
 use crate::{
     EditCtx, EditingDoc, KIND_KEY, Position, STORIES, check_position, insertion_attrs, map_string,
     out_len, revision_value, story_ref, write_pilcrow_properties,
@@ -315,6 +316,33 @@ fn to_any_map(map: HashMap<String, Any>) -> Any {
 
 fn to_any_array(values: Vec<Any>) -> Any {
     Any::Array(Arc::from(values))
+}
+
+/// Merges physical border edges into a cell's `tcPr.borders`. A `None` value
+/// drops that edge; an emptied object drops the whole key.
+fn merge_cell_borders<'a>(
+    cell: &mut CellData,
+    edges: impl IntoIterator<Item = (&'a str, &'a Option<Any>)>,
+) {
+    let mut merged = cell
+        .tc_pr
+        .get("borders")
+        .and_then(|value| match value {
+            Any::Map(map) => Some(map.as_ref().clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    for (edge, value) in edges {
+        match value {
+            Some(value) => merged.insert(edge.to_owned(), value.clone()),
+            None => merged.remove(edge),
+        };
+    }
+    if merged.is_empty() {
+        cell.tc_pr.remove("borders");
+    } else {
+        cell.tc_pr.insert("borders".to_owned(), to_any_map(merged));
+    }
 }
 
 fn write_table(txn: &mut TransactionMut<'_>, map: &MapRef, data: &TableData) {
@@ -1673,7 +1701,11 @@ impl EditingDoc {
         receipt(locator, Some(&data), Vec::new(), Vec::new(), Vec::new())
     }
 
-    /// Replaces the complete `tcPr.borders` object on every selected cell.
+    /// Merges the supplied border sides into every selected cell's
+    /// `tcPr.borders`. `insideH`/`insideV` resolve per cell to the physical
+    /// edges interior to the selection, the same mapping seeding uses to push
+    /// `tblBorders` down. An omitted side is left untouched, `style: "none"`
+    /// authors an explicit no-border, and JSON `null` drops the authored side.
     pub fn set_cell_borders(
         &self,
         ctx: &EditCtx,
@@ -1684,21 +1716,43 @@ impl EditingDoc {
         let mut txn = self.transact_for(ctx);
         let (_, table, _) = table_at(&txn, &locator)?;
         let mut data = read_table(&table, &txn)?;
+        let rect = checked_rect(&data, range)?;
         let selected = selected_anchors(&data, range)?;
         let (all, _) = anchors(&data)?;
 
-        for anchor in &selected {
-            data.rows[anchor.row].cells[anchor.cell_index]
-                .tc_pr
-                .insert("borders".to_owned(), to_any_map(borders.clone()));
+        let resolved: Vec<(&CellAnchor, Vec<(&'static str, Option<Any>)>)> = selected
+            .iter()
+            .map(|anchor| {
+                let edges = border_side_sources(
+                    anchor.row == rect.top,
+                    anchor.row + anchor.rowspan == rect.bottom,
+                    anchor.column == rect.left,
+                    anchor.column + anchor.colspan == rect.right,
+                )
+                .into_iter()
+                .filter_map(|(edge, source)| {
+                    let value = borders.get(source)?;
+                    let keep = !matches!(value, Any::Null | Any::Undefined);
+                    Some((edge, keep.then(|| value.clone())))
+                })
+                .collect();
+                (anchor, edges)
+            })
+            .collect();
+
+        for (anchor, edges) in &resolved {
+            merge_cell_borders(
+                &mut data.rows[anchor.row].cells[anchor.cell_index],
+                edges.iter().map(|(edge, value)| (*edge, value)),
+            );
         }
 
-        // Keep shared edges symmetric. A supplied top/bottom/left/right value
-        // is mirrored onto every cell touching that edge, including cells just
-        // outside the selection.
-        for anchor in &selected {
-            for (side, value) in borders {
-                let (facing, slots): (&str, Vec<(usize, usize)>) = match side.as_str() {
+        // Keep shared edges symmetric. A resolved edge is mirrored onto the
+        // facing edge of every cell across it, including cells just outside
+        // the selection.
+        for (anchor, edges) in &resolved {
+            for (edge, value) in edges {
+                let (facing, slots): (&str, Vec<(usize, usize)>) = match *edge {
                     "top" if anchor.row > 0 => (
                         "bottom",
                         (anchor.column..anchor.column + anchor.colspan)
@@ -1733,18 +1787,10 @@ impl EditingDoc {
                     if !neighbors.insert(neighbor.cell.story.clone()) {
                         continue;
                     }
-                    let cell = &mut data.rows[neighbor.row].cells[neighbor.cell_index];
-                    let mut neighbor_borders = cell
-                        .tc_pr
-                        .get("borders")
-                        .and_then(|value| match value {
-                            Any::Map(map) => Some(map.as_ref().clone()),
-                            _ => None,
-                        })
-                        .unwrap_or_default();
-                    neighbor_borders.insert(facing.to_owned(), value.clone());
-                    cell.tc_pr
-                        .insert("borders".to_owned(), to_any_map(neighbor_borders));
+                    merge_cell_borders(
+                        &mut data.rows[neighbor.row].cells[neighbor.cell_index],
+                        std::iter::once((facing, value)),
+                    );
                 }
             }
         }
@@ -2224,6 +2270,283 @@ mod tests {
         assert_eq!(grid[0], 2400);
         assert_eq!(tbl_pr["width"], 5000);
         assert_eq!(tbl_pr["widthType"], "dxa");
+    }
+
+    fn line(color: &str) -> Any {
+        Any::from_json(&format!(
+            r#"{{"style":"single","size":4,"color":{{"rgb":"{color}"}}}}"#
+        ))
+        .unwrap()
+    }
+
+    fn cleared() -> Any {
+        Any::from_json(r#"{"style":"none","size":0,"color":{"rgb":"000000"}}"#).unwrap()
+    }
+
+    fn sides(names: &[&str], value: &Any) -> HashMap<String, Any> {
+        names
+            .iter()
+            .map(|name| ((*name).to_owned(), value.clone()))
+            .collect()
+    }
+
+    /// The six-, four- and two-key payloads the border toolbar actually sends.
+    const ALL: &[&str] = &["top", "bottom", "left", "right", "insideH", "insideV"];
+    const OUTSIDE: &[&str] = &["top", "bottom", "left", "right"];
+    const INSIDE: &[&str] = &["insideH", "insideV"];
+
+    fn whole_table() -> TableRange {
+        TableRange::new(cell(0, 0), cell(1, 1))
+    }
+
+    fn grid_table() -> EditingDoc {
+        let doc = seed_table();
+        doc.set_cell_borders(&direct(), &whole_table(), &sides(ALL, &line("000000")))
+            .unwrap();
+        doc
+    }
+
+    /// Every cell's four physical edge styles, `None` where unauthored.
+    fn edges(doc: &EditingDoc, row: usize, column: usize) -> [Option<String>; 4] {
+        let (_, _, rows) = table_value(doc);
+        let borders = &rows[row]["cells"][column]["tcPr"]["borders"];
+        ["top", "bottom", "left", "right"].map(|side| {
+            borders[side]["style"]
+                .as_str()
+                .filter(|style| *style != "none")
+                .map(str::to_owned)
+        })
+    }
+
+    fn authored(styles: [&str; 4]) -> [Option<String>; 4] {
+        styles.map(|style| Some(style.to_owned()))
+    }
+
+    /// Painted table-border rules as `(x1, y1, x2, y2, color)` page pixels.
+    fn rules(doc: &EditingDoc) -> Vec<(f64, f64, f64, f64, String)> {
+        use docx_layout::display_list::{LineRole, Primitive};
+        use docx_layout::measure_blocks::{MeasurementConfig, measure_blocks};
+        use docx_layout::types::{Input, LayoutOptions, MeasuredBlock, PageMargins, Size};
+
+        let mut blocks = yrs_doc_to_layout_blocks(doc, "body", &RenderEnv::default()).unwrap();
+        let measures = measure_blocks(&mut blocks, 600.0, &MeasurementConfig::default()).unwrap();
+        let mut input = Input {
+            measured: blocks
+                .into_iter()
+                .zip(measures)
+                .map(|(block, measure)| MeasuredBlock { block, measure })
+                .collect(),
+            options: LayoutOptions {
+                page_size: Some(Size {
+                    w: 816.0,
+                    h: 1056.0,
+                }),
+                margins: Some(PageMargins {
+                    top: 96.0,
+                    right: 108.0,
+                    bottom: 96.0,
+                    left: 108.0,
+                    header: None,
+                    footer: None,
+                }),
+                ..LayoutOptions::default()
+            },
+        };
+        let layout = docx_layout::compute_layout_input(&mut input).unwrap();
+        let display_list = docx_layout::build_display_list(&input, &layout).unwrap();
+        let number = |value: &serde_json::Number| value.as_f64().unwrap();
+        display_list.pages[0]
+            .primitives
+            .iter()
+            .filter_map(|primitive| match primitive {
+                Primitive::Line(l) if l.role == Some(LineRole::TableBorder) => Some((
+                    number(&l.x1),
+                    number(&l.y1),
+                    number(&l.x2),
+                    number(&l.y2),
+                    l.color.clone(),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// `(horizontal, vertical)` painted rule segments.
+    fn rule_counts(doc: &EditingDoc) -> (usize, usize) {
+        let painted = rules(doc);
+        (
+            painted.iter().filter(|rule| rule.1 == rule.3).count(),
+            painted.iter().filter(|rule| rule.0 == rule.2).count(),
+        )
+    }
+
+    #[test]
+    fn border_all_authors_four_physical_edges_and_no_inside_keys() {
+        let doc = grid_table();
+        let (_, _, rows) = table_value(&doc);
+        for row in 0..2 {
+            for column in 0..2 {
+                assert_eq!(edges(&doc, row, column), authored(["single"; 4]));
+                let borders = &rows[row]["cells"][column]["tcPr"]["borders"];
+                assert!(borders["insideH"].is_null(), "insideH reached a cell");
+                assert!(borders["insideV"].is_null(), "insideV reached a cell");
+            }
+        }
+        assert_eq!(rule_counts(&doc), (6, 6));
+    }
+
+    #[test]
+    fn a_single_side_button_keeps_the_cell_s_other_three_sides() {
+        let doc = grid_table();
+        assert_eq!(rule_counts(&doc), (6, 6));
+        doc.set_cell_borders(
+            &direct(),
+            &TableRange::cell(cell(0, 0)),
+            &sides(&["top"], &line("FF0000")),
+        )
+        .unwrap();
+        assert_eq!(edges(&doc, 0, 0), authored(["single"; 4]));
+        assert_eq!(rule_counts(&doc), (6, 6));
+    }
+
+    #[test]
+    fn single_side_buttons_apply_to_the_selection_s_own_edge() {
+        for (side, painted, authored_at) in [
+            ("top", (2, 0), [(0, 0), (0, 1)]),
+            ("bottom", (2, 0), [(1, 0), (1, 1)]),
+            ("left", (0, 2), [(0, 0), (1, 0)]),
+            ("right", (0, 2), [(0, 1), (1, 1)]),
+        ] {
+            let doc = seed_table();
+            doc.set_cell_borders(&direct(), &whole_table(), &sides(&[side], &line("000000")))
+                .unwrap();
+            let index = ["top", "bottom", "left", "right"]
+                .iter()
+                .position(|name| *name == side)
+                .unwrap();
+            for row in 0..2 {
+                for column in 0..2 {
+                    let expected = authored_at.contains(&(row, column));
+                    assert_eq!(
+                        edges(&doc, row, column)[index].is_some(),
+                        expected,
+                        "{side} on cell ({row},{column})"
+                    );
+                }
+            }
+            assert_eq!(rule_counts(&doc), painted, "{side}");
+        }
+    }
+
+    #[test]
+    fn border_outside_leaves_the_selection_s_interior_alone() {
+        let doc = seed_table();
+        doc.set_cell_borders(&direct(), &whole_table(), &sides(OUTSIDE, &line("000000")))
+            .unwrap();
+        assert_eq!(
+            edges(&doc, 0, 0),
+            [
+                Some("single".to_owned()),
+                None,
+                Some("single".to_owned()),
+                None
+            ]
+        );
+        assert_eq!(
+            edges(&doc, 1, 1),
+            [
+                None,
+                Some("single".to_owned()),
+                None,
+                Some("single".to_owned())
+            ]
+        );
+        assert_eq!(rule_counts(&doc), (4, 4));
+
+        let grid = grid_table();
+        grid.set_cell_borders(&direct(), &whole_table(), &sides(OUTSIDE, &line("FF0000")))
+            .unwrap();
+        assert_eq!(rule_counts(&grid), (6, 6));
+        let painted = rules(&grid);
+        let interior = painted.iter().filter(|rule| rule.4 == "#000000").count();
+        assert_eq!(interior, 4, "the four interior segments keep their colour");
+    }
+
+    #[test]
+    fn border_inside_paints_the_interior_rules_and_no_exterior_ones() {
+        let doc = seed_table();
+        doc.set_cell_borders(&direct(), &whole_table(), &sides(INSIDE, &line("000000")))
+            .unwrap();
+        let interior = Some("single".to_owned());
+        assert_eq!(
+            edges(&doc, 0, 0),
+            [None, interior.clone(), None, interior.clone()]
+        );
+        // the same two edges seen from the far side, kept symmetric
+        assert_eq!(edges(&doc, 1, 1), [interior.clone(), None, interior, None]);
+
+        let painted = rules(&doc);
+        let horizontal: Vec<_> = painted.iter().filter(|rule| rule.1 == rule.3).collect();
+        let vertical: Vec<_> = painted.iter().filter(|rule| rule.0 == rule.2).collect();
+        assert_eq!((horizontal.len(), vertical.len()), (2, 2));
+        let y = horizontal[0].1;
+        let x = vertical[0].0;
+        assert!(horizontal.iter().all(|rule| rule.1 == y));
+        assert!(vertical.iter().all(|rule| rule.0 == x));
+        let left = horizontal
+            .iter()
+            .map(|rule| rule.0)
+            .fold(f64::MAX, f64::min);
+        let right = horizontal
+            .iter()
+            .map(|rule| rule.2)
+            .fold(f64::MIN, f64::max);
+        let top = vertical.iter().map(|rule| rule.1).fold(f64::MAX, f64::min);
+        let bottom = vertical.iter().map(|rule| rule.3).fold(f64::MIN, f64::max);
+        assert!(left < x && x < right, "the column rule is interior");
+        assert!(top < y && y < bottom, "the row rule is interior");
+    }
+
+    #[test]
+    fn border_none_clears_the_selection_and_the_edges_its_neighbours_own() {
+        let doc = grid_table();
+        doc.set_cell_borders(&direct(), &whole_table(), &sides(ALL, &cleared()))
+            .unwrap();
+        assert_eq!(edges(&doc, 0, 0), [const { None }; 4]);
+        assert_eq!(rule_counts(&doc), (0, 0));
+
+        let corner = grid_table();
+        corner
+            .set_cell_borders(
+                &direct(),
+                &TableRange::cell(cell(1, 1)),
+                &sides(ALL, &cleared()),
+            )
+            .unwrap();
+        assert_eq!(rule_counts(&corner), (4, 4));
+    }
+
+    #[test]
+    fn one_side_clears_by_style_none_or_by_null_without_touching_the_rest() {
+        for value in [cleared(), Any::Null] {
+            let doc = grid_table();
+            doc.set_cell_borders(
+                &direct(),
+                &TableRange::cell(cell(0, 0)),
+                &sides(&["top"], &value),
+            )
+            .unwrap();
+            assert_eq!(
+                edges(&doc, 0, 0),
+                [
+                    None,
+                    Some("single".to_owned()),
+                    Some("single".to_owned()),
+                    Some("single".to_owned())
+                ]
+            );
+            assert_eq!(rule_counts(&doc), (5, 6));
+        }
     }
 
     #[test]

--- a/crates/docx-edit/src/seed.rs
+++ b/crates/docx-edit/src/seed.rs
@@ -2183,6 +2183,22 @@ fn revision_attrs(info: &Value) -> Value {
     })
 }
 
+/// Maps each physical cell edge to the border side that feeds it: the matching
+/// outer side where the cell sits on the boundary, `insideH`/`insideV` within.
+pub(crate) fn border_side_sources(
+    first_row: bool,
+    last_row: bool,
+    first_column: bool,
+    last_column: bool,
+) -> [(&'static str, &'static str); 4] {
+    [
+        ("top", if first_row { "top" } else { "insideH" }),
+        ("bottom", if last_row { "bottom" } else { "insideH" }),
+        ("left", if first_column { "left" } else { "insideV" }),
+        ("right", if last_column { "right" } else { "insideV" }),
+    ]
+}
+
 fn cell_borders(
     formatting: Option<&Value>,
     table_borders: Option<&Value>,
@@ -2192,12 +2208,12 @@ fn cell_borders(
     last_column: bool,
 ) -> Option<Value> {
     let inherited = object(table_borders).map(|borders| {
-        json!({
-            "top": nullish(if first_row { borders.get("top") } else { borders.get("insideH") }),
-            "bottom": nullish(if last_row { borders.get("bottom") } else { borders.get("insideH") }),
-            "left": nullish(if first_column { borders.get("left") } else { borders.get("insideV") }),
-            "right": nullish(if last_column { borders.get("right") } else { borders.get("insideV") })
-        })
+        Value::Object(
+            border_side_sources(first_row, last_row, first_column, last_column)
+                .into_iter()
+                .map(|(edge, source)| (edge.to_owned(), nullish(borders.get(source))))
+                .collect(),
+        )
     });
     let direct = field(formatting, "borders");
     if inherited.is_none() && direct.is_none() {

--- a/crates/docx-edit/src/wasm.rs
+++ b/crates/docx-edit/src/wasm.rs
@@ -2296,8 +2296,9 @@ impl EditSession {
         serde_json::to_string(&receipt).map_err(js_err)
     }
 
-    /// Replaces every selected cell's complete `tcPr.borders` object with the
-    /// JSON object `borders_json`. `range_json` is a [`TableRange`]. Always a
+    /// Merges the sides of the JSON object `borders_json` into every selected
+    /// cell's `tcPr.borders`; `insideH`/`insideV` resolve to the physical edges
+    /// interior to the selection. `range_json` is a [`TableRange`]. Always a
     /// plain local edit.
     pub fn set_cell_borders(
         &self,

--- a/packages/docx-react/src/components/DocxEditor/hooks/useTableDialogs.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useTableDialogs.ts
@@ -98,13 +98,12 @@ export function useTableDialogs({
           borderSpecRef.current = { ...borderSpecRef.current, size: action.size };
           applyBorders(allBorders(borderSpecRef.current));
         } else if (action.type === 'cellBorder') {
-          applyBorders({
-            [action.side]: {
-              style: action.style,
-              size: action.size,
-              color: { rgb: action.color.replace(/^#/, '') },
-            },
-          });
+          const border = {
+            style: action.style,
+            size: action.size,
+            color: { rgb: action.color.replace(/^#/, '') },
+          };
+          applyBorders(action.side === 'all' ? allBorders(border) : { [action.side]: border });
         } else if (action.type === 'openTableProperties') {
           setTablePropsOpen(true);
         } else if (action.type === 'applyTableStyle') {

--- a/packages/docx/src/wasm/generated/edit/docx_edit.d.ts
+++ b/packages/docx/src/wasm/generated/edit/docx_edit.d.ts
@@ -587,8 +587,9 @@ export class EditSession {
      */
     selection_context(story: string, start_para: string, start_offset: number, end_para: string, end_offset: number): string;
     /**
-     * Replaces every selected cell's complete `tcPr.borders` object with the
-     * JSON object `borders_json`. `range_json` is a [`TableRange`]. Always a
+     * Merges the sides of the JSON object `borders_json` into every selected
+     * cell's `tcPr.borders`; `insideH`/`insideV` resolve to the physical edges
+     * interior to the selection. `range_json` is a [`TableRange`]. Always a
      * plain local edit.
      */
     set_cell_borders(range_json: string, borders_json: string): string;

--- a/packages/docx/src/yrs/index.ts
+++ b/packages/docx/src/yrs/index.ts
@@ -604,12 +604,14 @@ export interface YrsCellBorder {
 }
 
 /**
- * Complete per-side border object for {@link YrsSession.setCellBorders}.
+ * Per-side border patch for {@link YrsSession.setCellBorders}. An omitted side
+ * is left alone, `style: 'none'` authors an explicit no-border, and `null`
+ * drops the authored side.
  *
  * @public
  */
 export type YrsCellBorders = Partial<
-  Record<'top' | 'bottom' | 'left' | 'right' | 'insideH' | 'insideV', YrsCellBorder>
+  Record<'top' | 'bottom' | 'left' | 'right' | 'insideH' | 'insideV', YrsCellBorder | null>
 >;
 
 /**
@@ -776,7 +778,10 @@ export interface YrsSession extends CollaborationReplica {
     range: YrsTableRange,
     patch: Readonly<Record<string, unknown>>
   ): YrsTableReceipt;
-  /** Replaces the complete selected-cell border property object. */
+  /**
+   * Merges border sides into the selected cells. `insideH`/`insideV` resolve
+   * per cell to the physical edges interior to the selection.
+   */
   setCellBorders(range: YrsTableRange, borders: YrsCellBorders): YrsTableReceipt;
   /** Sets one authored grid-column width in twips. */
   setColumnWidth(at: YrsCellLoc, widthTwips: number): YrsTableReceipt;

--- a/packages/docx/src/yrs/tableBorders.test.ts
+++ b/packages/docx/src/yrs/tableBorders.test.ts
@@ -1,0 +1,204 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parseDocx } from '../docx';
+import { repackDocx } from '../docx/rezip';
+import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
+import type { Document, Table } from '../types/document';
+import { preloadEditWasm } from '../wasm/edit';
+import {
+  createYrsSession,
+  type YrsCellBorders,
+  type YrsSession,
+  type YrsTableRange,
+} from './index';
+import { yrsToDocument } from './yrsToDocument';
+
+const WASM = resolve(import.meta.dir, '../wasm/generated/edit/docx_edit_bg.wasm');
+
+const OFFICE_DOC = 'application/vnd.openxmlformats-officedocument';
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="${OFFICE_DOC}.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="${OFFICE_DOC}.wordprocessingml.styles+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPkg1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>Anchor</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault><w:rPr><w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/><w:sz w:val="22"/></w:rPr></w:rPrDefault>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`;
+
+function blankDocx(): Uint8Array {
+  const parts: PartsMap = new Map();
+  parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
+  parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
+  parts.set('word/document.xml', toBytes(DOCUMENT));
+  parts.set('word/styles.xml', toBytes(STYLES));
+  return new Uint8Array(rezipPartsToArrayBuffer(parts));
+}
+
+const BLACK = { style: 'single', size: 4, color: { rgb: '000000' } };
+const RED = { style: 'single', size: 4, color: { rgb: 'FF0000' } };
+const CLEARED = { style: 'none', size: 0, color: { rgb: '000000' } };
+
+/** The toolbar's own payloads. */
+const ALL_BORDERS: YrsCellBorders = {
+  top: BLACK,
+  bottom: BLACK,
+  left: BLACK,
+  right: BLACK,
+  insideH: BLACK,
+  insideV: BLACK,
+};
+const INSIDE_BORDERS: YrsCellBorders = { insideH: BLACK, insideV: BLACK };
+
+const SIDES = ['top', 'bottom', 'left', 'right'] as const;
+
+function range(row: number, column: number, toRow = row, toColumn = column): YrsTableRange {
+  return {
+    anchor: { story: 'body', tableIndex: 0, row, column },
+    head: { story: 'body', tableIndex: 0, row: toRow, column: toColumn },
+  };
+}
+
+interface RenderedTable {
+  kind: string;
+  rows: Array<{
+    cells: Array<{ borders?: Partial<Record<string, { style?: string; color?: string }>> }>;
+  }>;
+}
+
+function renderedTable(session: YrsSession): RenderedTable {
+  const blocks = session.yrsBlocksForStory('body') as RenderedTable[];
+  const table = blocks.find((block) => block.kind === 'table');
+  if (!table) throw new Error('no table in the rendered body');
+  return table;
+}
+
+/** The edges `lower_cell_borders` actually hands the renderer, with colours. */
+function paintedEdges(session: YrsSession, row: number, column: number): Record<string, string> {
+  const borders = renderedTable(session).rows[row].cells[column].borders ?? {};
+  const painted: Record<string, string> = {};
+  for (const side of SIDES) {
+    const edge = borders[side];
+    if (edge && edge.style !== 'none') painted[side] = edge.color ?? '';
+  }
+  return painted;
+}
+
+function tableOf(document: Document): Table {
+  const table = document.package.document.content.find((block) => block.type === 'table');
+  if (!table) throw new Error('no table in document body');
+  return table as Table;
+}
+
+async function griddedTable(clientId: number): Promise<{
+  session: YrsSession;
+  parsed: Document;
+}> {
+  const bytes = blankDocx();
+  const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+  const session = await createYrsSession({ clientId });
+  session.seedFromDocx(bytes);
+  const anchor = session.paragraphs('body')[0];
+  session.insertTable({ story: 'body', paraId: anchor.paraId, offset: 0 }, 2, 2);
+  return { session, parsed };
+}
+
+describe('the table border toolbar', () => {
+  beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
+
+  it('leaves a cell’s other three sides alone when one side button is pressed', async () => {
+    const { session } = await griddedTable(52001);
+    try {
+      session.setCellBorders(range(0, 0, 1, 1), ALL_BORDERS);
+      expect(Object.keys(paintedEdges(session, 0, 0)).sort()).toEqual([
+        'bottom',
+        'left',
+        'right',
+        'top',
+      ]);
+
+      session.setCellBorders(range(0, 0), { top: RED });
+      expect(paintedEdges(session, 0, 0)).toEqual({
+        top: '#FF0000',
+        bottom: '#000000',
+        left: '#000000',
+        right: '#000000',
+      });
+    } finally {
+      session.destroy();
+    }
+  });
+
+  it('clears one side without disturbing the rest', async () => {
+    const { session } = await griddedTable(52002);
+    try {
+      session.setCellBorders(range(0, 0, 1, 1), ALL_BORDERS);
+      session.setCellBorders(range(0, 0), { top: CLEARED });
+      expect(Object.keys(paintedEdges(session, 0, 0)).sort()).toEqual(['bottom', 'left', 'right']);
+
+      session.setCellBorders(range(0, 1), { top: null });
+      expect(Object.keys(paintedEdges(session, 0, 1)).sort()).toEqual(['bottom', 'left', 'right']);
+    } finally {
+      session.destroy();
+    }
+  });
+
+  it('renders inside borders as interior rules and saves no exterior ones', async () => {
+    const { session, parsed } = await griddedTable(52003);
+    let saved: Document;
+    try {
+      session.setCellBorders(range(0, 0, 1, 1), INSIDE_BORDERS);
+      expect(Object.keys(paintedEdges(session, 0, 0)).sort()).toEqual(['bottom', 'right']);
+      expect(Object.keys(paintedEdges(session, 1, 1)).sort()).toEqual(['left', 'top']);
+      saved = yrsToDocument(session, parsed);
+    } finally {
+      session.destroy();
+    }
+
+    const borders = tableOf(saved).formatting?.borders;
+    expect(borders?.insideH).toMatchObject(BLACK);
+    expect(borders?.insideV).toMatchObject(BLACK);
+    for (const side of SIDES) {
+      expect(borders?.[side], `tblBorders.${side} must not be fabricated`).toBeUndefined();
+    }
+  });
+
+  it('round-trips all borders through a save and reopen', async () => {
+    const { session, parsed } = await griddedTable(52004);
+    let saved: Document;
+    try {
+      session.setCellBorders(range(0, 0, 1, 1), ALL_BORDERS);
+      saved = yrsToDocument(session, parsed);
+    } finally {
+      session.destroy();
+    }
+
+    const reopened = await parseDocx(await repackDocx(saved), { preloadFonts: false });
+    const borders = tableOf(reopened).formatting?.borders;
+    for (const side of [...SIDES, 'insideH', 'insideV'] as const) {
+      expect(borders?.[side], `reopened tblBorders.${side}`).toMatchObject(BLACK);
+    }
+  });
+});

--- a/packages/docx/src/yrs/yrsToDocument.ts
+++ b/packages/docx/src/yrs/yrsToDocument.ts
@@ -1297,30 +1297,26 @@ function paragraphFromStory(
   return paragraph;
 }
 
+/**
+ * Lifts a `w:tblBorders` back out of the per-cell edges seeding pushed down:
+ * outer sides come from the cells owning the table's boundary, `insideH`/
+ * `insideV` from an interior edge. Sides no cell authors stay absent.
+ */
 function inferTableBorders(rows: TableRow[]): TableBorders | undefined {
-  for (const row of rows) {
-    for (const cell of row.cells) {
-      const borders = cell.formatting?.borders;
-      if (!borders) continue;
-      const base =
-        borders.top ||
-        borders.left ||
-        borders.right ||
-        borders.bottom ||
-        borders.insideH ||
-        borders.insideV;
-      if (!base) return undefined;
-      return {
-        top: borders.top ?? base,
-        bottom: borders.bottom ?? base,
-        left: borders.left ?? base,
-        right: borders.right ?? base,
-        insideH: borders.insideH ?? borders.bottom ?? base,
-        insideV: borders.insideV ?? borders.right ?? base,
-      };
-    }
-  }
-  return undefined;
+  const firstRow = rows[0]?.cells;
+  const lastRow = rows[rows.length - 1]?.cells;
+  const corner = firstRow?.[0]?.formatting?.borders;
+  if (!firstRow || !lastRow || !corner) return undefined;
+  const borders: TableBorders = {
+    top: corner.top,
+    left: corner.left,
+    bottom: lastRow[0]?.formatting?.borders?.bottom,
+    right: firstRow[firstRow.length - 1]?.formatting?.borders?.right,
+    insideH: rows.length > 1 ? corner.bottom : undefined,
+    insideV: firstRow.length > 1 ? corner.right : undefined,
+  };
+  const authored = Object.entries(borders).filter(([, value]) => value !== undefined);
+  return authored.length > 0 ? (Object.fromEntries(authored) as TableBorders) : undefined;
 }
 
 function normalizeVMergeRuns(rows: TableRow[]): void {


### PR DESCRIPTION
TL;DR:


Repro file:
`packages/docx/src/yrs/tableBorders.test.ts` — drives each button through the engine and back out through a save, asserting what the renderer paints and what the file records.

Summary:
- A single-side button replaced a cell's entire border set instead of merging into it, so setting one edge silently cleared the other three. Sides now merge; an explicit no-border value still clears one, and a null drops an authored override
- Inside Borders wrote table-level keys the renderer never reads, so the rules vanished on screen while the saved file still recorded them. Interior edges now resolve per cell against the selection, reusing the mapping seeding already applies rather than a second copy of it
- Outside Borders gave every selected cell all four sides, drawing a full grid rather than an outline. It now applies to boundary cells only
- All Borders was visually right but wrote dead keys onto every cell; a table style declaring only top and bottom produced interior horizontal rules it never asked for; and a border side of `all` was silently a no-op
- On save, missing sides were filled in from the first border found anywhere, so Inside Borders on a plain table wrote an outer border that was never set. The save is now the true inverse of what seeding pushes down

Known behaviour, unchanged:
- Choosing a border colour or width re-applies All Borders in that colour, so picking a colour on an outlined table turns it into a grid. Word treats these as a pen for the next command; changing that is a product decision rather than a defect

Test plan:
- [x] `cargo test` passes
- [x] `bun test packages/docx packages/docx-react` passes
- [x] On a table with a full grid, click Top Border on one cell: the other three edges survive
- [x] Inside Borders draws interior rules only; Outside Borders draws an outline only
- [x] Save and reopen after each: the file records what the screen shows