### PR TITLE
chore(ci): security advisories 07/08

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,11 @@ jobs:
         run: bun audit
         continue-on-error: true
 
+      # GHSA-5p4m-2wfm-xmqj reaches only read-yaml-file under @changesets/cli,
+      # which parses our own changesets; every way to move it is worse than the
+      # advisory. See SECURITY.md.
       - name: Fail on high or critical advisories
-        run: bun audit --audit-level=high
+        run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj
 
   rust:
     name: Rust gate

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,26 @@
 Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/openooxml/betteroffice/security/advisories/new). Please do not open a public issue.
 
 We aim to acknowledge reports within 5 business days and will keep you updated on the fix and disclosure timeline.
+
+## Audit exemptions
+
+`bun audit --audit-level=high` gates every branch. An advisory is exempted only
+when it cannot be reached in shipped code and no upgrade path exists that does
+not cause a worse problem. Each exemption is listed here with its reason, and
+`bun audit` still reports it unfiltered so it stays visible.
+
+### GHSA-5p4m-2wfm-xmqj — js-yaml quadratic CPU on `!!omap`
+
+Reached only through `@changesets/cli › @manypkg/get-packages › read-yaml-file`,
+which parses the changeset files in this repository. It is release tooling, is
+never shipped to users, and never reads untrusted YAML.
+
+`read-yaml-file@1.1.0` calls `yaml.safeLoad`, removed in js-yaml 4, so it cannot
+move off the affected 3.x line. Bun resolves `overrides` globally and supports
+neither nested nor path-scoped forms, so the only reachable alternatives are to
+pin js-yaml 3.15.1 for every consumer — putting the packages that expect 4.x and
+5.x onto js-yaml 3's unsafe-by-default loader — or to pin 5.x and break
+changesets outright. Both are worse than the advisory.
+
+Remove this exemption when `@manypkg/get-packages` drops `read-yaml-file`, or
+when Bun supports scoping an override to one dependency path.


### PR DESCRIPTION
TL;DR:


Summary:
- GHSA-5p4m-2wfm-xmqj (high) fails `bun audit --audit-level=high` on `main`, red-lighting the Security audit job on every branch
- It is reached only through `@changesets/cli › @manypkg/get-packages › read-yaml-file`, which parses this repository's own changeset files. It is release tooling, is never shipped, and never reads untrusted YAML
- There is no upgrade path that is not worse. `read-yaml-file@1.1.0` calls `yaml.safeLoad`, removed in js-yaml 4, so it cannot leave the affected 3.x line. Bun resolves `overrides` globally and supports neither nested nor path-scoped forms, so the options are pinning 3.15.1 for everyone — putting the packages that expect 4.x and 5.x onto js-yaml 3's unsafe-by-default loader — or pinning 5.x and breaking changesets
- Exempts that one advisory on the failing gate only. `bun audit` still runs unfiltered in the reporting step, so it stays visible
- Records the exemption and the conditions for removing it in `SECURITY.md`, alongside a policy for when an exemption is acceptable at all

Test plan:
- [ ] `bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj` exits clean
- [ ] `bun audit` still lists the advisory in the reporting step
- [ ] `bun install --frozen-lockfile` succeeds with no dependency changes
- [ ] CI Security audit passes