### PR TITLE
perf(ci): speed up the demo deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,23 @@ jobs:
           bun-version: "1.3.14"
 
       - uses: dtolnay/rust-toolchain@stable
+        id: rust
         with:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --version 0.15.0 --locked
+      # rust-cache prunes the workspace's own artifacts, and wasm-opt costs minutes per module.
+      - uses: actions/cache@v4
+        with:
+          path: target/wasm-pack
+          key: wasm-pack-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**', 'scripts/*wasm*.ts') }}
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.15.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
   deploy:
     name: Deploy ${{ matrix.app }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -28,24 +28,32 @@ jobs:
           bun-version: "1.3.14"
 
       - uses: dtolnay/rust-toolchain@stable
+        id: rust
         if: matrix.app == 'demo'
         with:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
         if: matrix.app == 'demo'
+        with:
+          shared-key: wasm
 
-      - name: Install wasm-pack
+      # rust-cache prunes the workspace's own artifacts, and wasm-opt costs minutes per module.
+      - uses: actions/cache@v4
         if: matrix.app == 'demo'
-        run: cargo install wasm-pack --version 0.15.0 --locked
+        with:
+          path: target/wasm-pack
+          key: wasm-pack-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**', 'scripts/*wasm*.ts') }}
+
+      - uses: taiki-e/install-action@v2
+        if: matrix.app == 'demo'
+        with:
+          tool: wasm-pack@0.15.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build packages
-        if: matrix.app == 'demo'
-        run: bun run build:packages
-
+      # The demo's prebuild builds the wasm and the packages it needs; a step here would repeat it.
       - name: Deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install wasm-pack
+      - uses: taiki-e/install-action@v2
         if: steps.pending.outputs.publishing == 'true'
-        run: cargo install wasm-pack --version 0.15.0 --locked
+        with:
+          tool: wasm-pack@0.15.0
 
       - name: Type check
         if: steps.pending.outputs.publishing == 'true'

--- a/packages/docx/src/yrs/tableBorders.test.ts
+++ b/packages/docx/src/yrs/tableBorders.test.ts
@@ -169,6 +169,19 @@ describe('the table border toolbar', () => {
     const { session, parsed } = await griddedTable(52003);
     let saved: Document;
     try {
+      // an inserted table arrives fully gridded, so strip it first: what the
+      // inside-borders button paints is only visible against a bare table, and
+      // the interior edges answer to insideH/insideV rather than to the sides
+      session.setCellBorders(range(0, 0, 1, 1), {
+        top: null,
+        bottom: null,
+        left: null,
+        right: null,
+        insideH: null,
+        insideV: null,
+      });
+      expect(paintedEdges(session, 0, 0)).toEqual({});
+
       session.setCellBorders(range(0, 0, 1, 1), INSIDE_BORDERS);
       expect(Object.keys(paintedEdges(session, 0, 0)).sort()).toEqual(['bottom', 'right']);
       expect(Object.keys(paintedEdges(session, 1, 1)).sort()).toEqual(['left', 'top']);

--- a/scripts/build-docx-wasm.ts
+++ b/scripts/build-docx-wasm.ts
@@ -1,95 +1,35 @@
 // Builds the four docx wasm cores (container / layout / edit / parse) and
-// vendors the wasm-pack output into packages/docx/src/wasm/generated/.
-// The glue .js/.d.ts are committed; the *_bg.wasm binaries are gitignored and
-// rebuilt on demand (predev/prebuild hooks), mirroring scripts/build-xlsx-wasm.ts
-// so the repo never carries multi-MB binaries in history.
-import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+// vendors the wasm-pack output into packages/docx/src/wasm/generated/. The glue
+// .js and the *_bg.wasm binaries are gitignored and rebuilt on demand
+// (predev/prebuild hooks) so the repo never carries multi-MB binaries.
+import { buildWasmModules, type WasmModule } from './wasm.ts';
 
-interface WasmModuleBuild {
-  crate: string;
-  name: string;
-  dir: string;
-  cargoArgs: string[];
-}
-
-const WASM_PACK_VERSION = '0.15.0';
-const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-
-const version = spawnSync('wasm-pack', ['--version'], { encoding: 'utf8' });
-const versionErrorCode =
-  version.error && 'code' in version.error && typeof version.error.code === 'string'
-    ? version.error.code
-    : undefined;
-if (versionErrorCode === 'ENOENT') {
-  throw new Error(
-    `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`
-  );
-}
-if (version.status !== 0) process.exit(version.status ?? 1);
-if (version.stdout.trim() !== `wasm-pack ${WASM_PACK_VERSION}`) {
-  throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version.stdout.trim()}`);
-}
-
-// name = wasm-bindgen artifact base name (crate name with dashes underscored);
-// dir = subdirectory under packages/docx/src/wasm/generated/;
-// cargoArgs = extra flags after `--` (docx-edit keeps its wasm-bindgen boundary
-// behind the `wasm` cargo feature so native builds never pull that stack).
-const MODULES: WasmModuleBuild[] = [
+// docx-edit, docx-parse and ooxml-opc keep their wasm-bindgen boundary behind a
+// `wasm` cargo feature so native builds never pull that stack.
+const MODULES: WasmModule[] = [
   {
     crate: 'ooxml-opc',
     name: 'ooxml_opc',
-    dir: 'opc',
+    generated: 'packages/docx/src/wasm/generated/opc',
     cargoArgs: ['--locked', '--features', 'wasm'],
   },
-  { crate: 'docx-layout', name: 'docx_layout', dir: 'layout', cargoArgs: [] },
-  // --locked must ride with the cargo pass-through here: wasm-pack forwards its
-  // own trailing args verbatim once a `--` section exists, and cargo rejects a
-  // stray `--` marker.
-  { crate: 'docx-edit', name: 'docx_edit', dir: 'edit', cargoArgs: ['--locked', '--features', 'wasm'] },
+  {
+    crate: 'docx-layout',
+    name: 'docx_layout',
+    generated: 'packages/docx/src/wasm/generated/layout',
+  },
+  {
+    crate: 'docx-edit',
+    name: 'docx_edit',
+    generated: 'packages/docx/src/wasm/generated/edit',
+    cargoArgs: ['--locked', '--features', 'wasm'],
+  },
   {
     crate: 'docx-parse',
     name: 'docx_parse',
-    dir: 'parse',
+    generated: 'packages/docx/src/wasm/generated/parse',
     cargoArgs: ['--locked', '--features', 'wasm'],
   },
 ];
 
-for (const { crate, name, dir, cargoArgs } of MODULES) {
-  const crateDir = resolve(root, 'crates', crate);
-  const output = resolve(root, 'target/wasm-pack/docx', dir);
-  const generated = resolve(root, 'packages/docx/src/wasm/generated', dir);
-
-  await rm(output, { recursive: true, force: true });
-  const build = spawnSync(
-    'wasm-pack',
-    [
-      'build',
-      crateDir,
-      '--release',
-      '--target',
-      'web',
-      '--out-dir',
-      output,
-      ...(cargoArgs.length ? ['--', ...cargoArgs] : ['--locked']),
-    ],
-    { stdio: 'inherit' }
-  );
-  if (build.status !== 0) process.exit(build.status ?? 1);
-
-  await mkdir(generated, { recursive: true });
-  const gluePath = resolve(output, `${name}.js`);
-  const glue = await readFile(gluePath, 'utf8');
-  const fallback = `module_or_path = new URL('${name}_bg.wasm', import.meta.url);`;
-  if (!glue.includes(fallback)) throw new Error(`wasm-pack glue fallback changed (${name})`);
-  await writeFile(
-    resolve(generated, `${name}.js`),
-    glue.replace(fallback, `throw new Error('${crate} wasm requires an explicit module or URL');`)
-  );
-
-  for (const file of [`${name}.d.ts`, `${name}_bg.wasm`, `${name}_bg.wasm.d.ts`]) {
-    await copyFile(resolve(output, file), resolve(generated, file));
-  }
-}
+await buildWasmModules(MODULES);

--- a/scripts/build-pptx-wasm.ts
+++ b/scripts/build-pptx-wasm.ts
@@ -1,47 +1,9 @@
-import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { buildWasmModules } from './wasm.ts';
 
-const WASM_PACK_VERSION = '0.15.0';
-const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const crate = resolve(root, 'crates/pptx-wasm');
-const output = resolve(root, 'target/wasm-pack/pptx');
-const generated = resolve(root, 'packages/pptx/src/wasm/generated');
-
-const version = spawnSync('wasm-pack', ['--version'], { encoding: 'utf8' });
-const versionErrorCode =
-  version.error && 'code' in version.error && typeof version.error.code === 'string'
-    ? version.error.code
-    : undefined;
-if (versionErrorCode === 'ENOENT') {
-  throw new Error(
-    `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`
-  );
-}
-if (version.status !== 0) process.exit(version.status ?? 1);
-if (version.stdout.trim() !== `wasm-pack ${WASM_PACK_VERSION}`) {
-  throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version.stdout.trim()}`);
-}
-
-await rm(output, { recursive: true, force: true });
-const build = spawnSync(
-  'wasm-pack',
-  ['build', crate, '--release', '--target', 'web', '--out-dir', output, '--locked'],
-  { stdio: 'inherit' }
-);
-if (build.status !== 0) process.exit(build.status ?? 1);
-
-await mkdir(generated, { recursive: true });
-const gluePath = resolve(output, 'pptx_wasm.js');
-const glue = await readFile(gluePath, 'utf8');
-const fallback = "module_or_path = new URL('pptx_wasm_bg.wasm', import.meta.url);";
-if (!glue.includes(fallback)) throw new Error('wasm-pack glue fallback changed');
-await writeFile(
-  resolve(generated, 'pptx_wasm.js'),
-  glue.replace(fallback, "throw new Error('pptx-wasm requires an explicit module or URL');")
-);
-
-for (const file of ['pptx_wasm.d.ts', 'pptx_wasm_bg.wasm', 'pptx_wasm_bg.wasm.d.ts']) {
-  await copyFile(resolve(output, file), resolve(generated, file));
-}
+await buildWasmModules([
+  {
+    crate: 'pptx-wasm',
+    name: 'pptx_wasm',
+    generated: 'packages/pptx/src/wasm/generated',
+  },
+]);

--- a/scripts/build-stale-packages.ts
+++ b/scripts/build-stale-packages.ts
@@ -26,7 +26,9 @@ async function readTargets(): Promise<Target[]> {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const dir = resolve(packages, entry.name);
-    const manifest = JSON.parse(await readFile(resolve(dir, 'package.json'), 'utf8'));
+    const packaged = await readFile(resolve(dir, 'package.json'), 'utf8').catch(() => null);
+    if (!packaged) continue;
+    const manifest = JSON.parse(packaged);
     if (!manifest.scripts?.build) continue;
     const deps = Object.entries<string>(manifest.dependencies ?? {})
       .filter(([, range]) => range.startsWith('workspace:'))
@@ -79,12 +81,15 @@ async function hashInputs(dir: string): Promise<string> {
 const targets = order(await readTargets());
 const keys = new Map<string, string>();
 
-for (const target of targets) {
-  const inputs = await hashInputs(target.dir);
-  const key = createHash('sha256')
-    .update(inputs)
+async function keyOf(target: Target): Promise<string> {
+  return createHash('sha256')
+    .update(await hashInputs(target.dir))
     .update(target.deps.map((dep) => keys.get(dep) ?? '').join('\0'))
     .digest('hex');
+}
+
+for (const target of targets) {
+  const key = await keyOf(target);
   keys.set(target.name, key);
 
   const stamp = resolve(target.dir, 'dist', STAMP);
@@ -100,5 +105,10 @@ for (const target of targets) {
     stdio: 'inherit',
   });
   if (build.status !== 0) process.exit(build.status ?? 1);
-  await writeFile(stamp, key);
+
+  // The wasm builds vendor their output back into the hashed tree, so a key
+  // taken beforehand never matches again; stamp the tree as it settled.
+  const settled = await keyOf(target);
+  keys.set(target.name, settled);
+  await writeFile(stamp, settled);
 }

--- a/scripts/build-xlsx-wasm.ts
+++ b/scripts/build-xlsx-wasm.ts
@@ -1,51 +1,9 @@
-import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { buildWasmModules } from './wasm.ts';
 
-const WASM_PACK_VERSION = '0.15.0';
-const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const crate = resolve(root, 'crates/xlsx-wasm');
-const output = resolve(root, 'target/wasm-pack/xlsx');
-const generated = resolve(root, 'packages/xlsx/src/wasm/generated');
-
-const version = spawnSync('wasm-pack', ['--version'], { encoding: 'utf8' });
-const versionErrorCode =
-  version.error && 'code' in version.error && typeof version.error.code === 'string'
-    ? version.error.code
-    : undefined;
-if (versionErrorCode === 'ENOENT') {
-  throw new Error(
-    `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`
-  );
-}
-if (version.status !== 0) process.exit(version.status ?? 1);
-if (version.stdout.trim() !== `wasm-pack ${WASM_PACK_VERSION}`) {
-  throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version.stdout.trim()}`);
-}
-
-await rm(output, { recursive: true, force: true });
-const build = spawnSync(
-  'wasm-pack',
-  ['build', crate, '--release', '--target', 'web', '--out-dir', output, '--locked'],
-  { stdio: 'inherit' }
-);
-if (build.status !== 0) process.exit(build.status ?? 1);
-
-await mkdir(generated, { recursive: true });
-const gluePath = resolve(output, 'xlsx_wasm.js');
-const glue = await readFile(gluePath, 'utf8');
-const fallback = "module_or_path = new URL('xlsx_wasm_bg.wasm', import.meta.url);";
-if (!glue.includes(fallback)) throw new Error('wasm-pack glue fallback changed');
-await writeFile(
-  resolve(generated, 'xlsx_wasm.js'),
-  glue.replace(fallback, "throw new Error('xlsx-wasm requires an explicit module or URL');")
-);
-
-for (const file of [
-  'xlsx_wasm.d.ts',
-  'xlsx_wasm_bg.wasm',
-  'xlsx_wasm_bg.wasm.d.ts',
-]) {
-  await copyFile(resolve(output, file), resolve(generated, file));
-}
+await buildWasmModules([
+  {
+    crate: 'xlsx-wasm',
+    name: 'xlsx_wasm',
+    generated: 'packages/xlsx/src/wasm/generated',
+  },
+]);

--- a/scripts/wasm.ts
+++ b/scripts/wasm.ts
@@ -1,0 +1,161 @@
+// Drives the wasm-pack builds vendored into packages/*/src/wasm/generated. The
+// predev/prebuild hooks, the package build scripts and CI each invoke these back
+// to back, and wasm-pack rewrites its output unconditionally, so every module is
+// fingerprinted: its wasm-opt pass alone costs minutes under the workspace's
+// `lto = true` release profile.
+import { spawnSync } from 'node:child_process';
+import { createHash, type Hash } from 'node:crypto';
+import { copyFile, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface WasmModule {
+  /** Directory under crates/. */
+  crate: string;
+  /** wasm-bindgen artifact base name: the crate name with dashes underscored. */
+  name: string;
+  /** Destination for the vendored output, relative to the repo root. */
+  generated: string;
+  /** Flags passed through to cargo. */
+  cargoArgs?: string[];
+}
+
+interface Stamp {
+  key: string;
+  outputs: Record<string, string>;
+}
+
+const WASM_PACK_VERSION = '0.15.0';
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function requireWasmPack(): void {
+  const version = spawnSync('wasm-pack', ['--version'], { encoding: 'utf8' });
+  const versionErrorCode =
+    version.error && 'code' in version.error && typeof version.error.code === 'string'
+      ? version.error.code
+      : undefined;
+  if (versionErrorCode === 'ENOENT') {
+    throw new Error(
+      `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`
+    );
+  }
+  if (version.status !== 0) process.exit(version.status ?? 1);
+  if (version.stdout.trim() !== `wasm-pack ${WASM_PACK_VERSION}`) {
+    throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version.stdout.trim()}`);
+  }
+}
+
+async function hashTree(hash: Hash, dir: string, prefix: string): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  entries.sort((left, right) => (left.name < right.name ? -1 : 1));
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await hashTree(hash, path, `${prefix}${entry.name}/`);
+      continue;
+    }
+    hash.update(`${prefix}${entry.name}\0`);
+    hash.update(await readFile(path));
+  }
+}
+
+/** Digest of every input the emitted wasm depends on: the crates, the workspace
+ * manifest (release profiles) and these scripts. */
+async function hashSources(): Promise<string> {
+  const hash = createHash('sha256');
+  for (const file of ['Cargo.toml', 'Cargo.lock']) {
+    hash.update(`${file}\0`);
+    hash.update(await readFile(resolve(root, file)));
+  }
+  await hashTree(hash, resolve(root, 'crates'), 'crates/');
+  const scripts = resolve(root, 'scripts');
+  const names = (await readdir(scripts)).filter((name) => name.includes('wasm')).sort();
+  for (const name of names) {
+    hash.update(`scripts/${name}\0`);
+    hash.update(await readFile(join(scripts, name)));
+  }
+  return hash.digest('hex');
+}
+
+function vendored(name: string): string[] {
+  return [`${name}.js`, `${name}.d.ts`, `${name}_bg.wasm`, `${name}_bg.wasm.d.ts`];
+}
+
+async function digest(path: string): Promise<string | null> {
+  const bytes = await readFile(path).catch(() => null);
+  return bytes ? createHash('sha256').update(bytes).digest('hex') : null;
+}
+
+// The stamp lives under target/ and the vendored .wasm is gitignored, so a
+// target/ restored from a CI cache can outlive the output it describes; hashing
+// the output too keeps the skip from serving a file that is no longer there.
+async function isFresh(stamp: string, key: string, dest: string, name: string): Promise<boolean> {
+  const recorded: Stamp | null = await readFile(stamp, 'utf8')
+    .then((text) => JSON.parse(text))
+    .catch(() => null);
+  if (recorded?.key !== key) return false;
+  for (const file of vendored(name)) {
+    if ((await digest(resolve(dest, file))) !== recorded.outputs[file]) return false;
+  }
+  return true;
+}
+
+/** Builds every module whose inputs or vendored output changed. */
+export async function buildWasmModules(modules: WasmModule[]): Promise<void> {
+  requireWasmPack();
+  const sources = await hashSources();
+
+  for (const { crate, name, generated, cargoArgs = [] } of modules) {
+    const dest = resolve(root, generated);
+    const stamp = resolve(root, 'target/wasm-pack', `${crate}.json`);
+    const key = createHash('sha256')
+      .update(sources)
+      .update(`\0${WASM_PACK_VERSION}\0${crate}\0${name}\0${cargoArgs.join(' ')}`)
+      .digest('hex');
+
+    if (await isFresh(stamp, key, dest, name)) {
+      console.log(`[wasm] ${crate}: up to date`);
+      continue;
+    }
+
+    const output = resolve(root, 'target/wasm-pack', crate);
+    await rm(output, { recursive: true, force: true });
+    // --locked must ride with the cargo pass-through: wasm-pack forwards its own
+    // trailing args verbatim once a `--` section exists, and cargo rejects a
+    // stray `--` marker.
+    const build = spawnSync(
+      'wasm-pack',
+      [
+        'build',
+        resolve(root, 'crates', crate),
+        '--release',
+        '--target',
+        'web',
+        '--out-dir',
+        output,
+        ...(cargoArgs.length ? ['--', ...cargoArgs] : ['--locked']),
+      ],
+      { stdio: 'inherit' }
+    );
+    if (build.status !== 0) process.exit(build.status ?? 1);
+
+    await mkdir(dest, { recursive: true });
+    const glue = await readFile(resolve(output, `${name}.js`), 'utf8');
+    const fallback = `module_or_path = new URL('${name}_bg.wasm', import.meta.url);`;
+    if (!glue.includes(fallback)) throw new Error(`wasm-pack glue fallback changed (${name})`);
+    await writeFile(
+      resolve(dest, `${name}.js`),
+      glue.replace(fallback, `throw new Error('${crate} requires an explicit module or URL');`)
+    );
+    for (const file of [`${name}.d.ts`, `${name}_bg.wasm`, `${name}_bg.wasm.d.ts`]) {
+      await copyFile(resolve(output, file), resolve(dest, file));
+    }
+
+    const outputs: Record<string, string> = {};
+    for (const file of vendored(name)) {
+      outputs[file] = (await digest(resolve(dest, file))) as string;
+    }
+    await mkdir(dirname(stamp), { recursive: true });
+    await writeFile(stamp, JSON.stringify({ key, outputs } satisfies Stamp));
+  }
+}

--- a/scripts/wasm.ts
+++ b/scripts/wasm.ts
@@ -20,9 +20,13 @@ export interface WasmModule {
   cargoArgs?: string[];
 }
 
+// `source` is what wasm-pack left in target/, `vendored` what was copied into the
+// package. Both are recorded so a target/ restored from a CI cache can be
+// re-vendored — the expensive part is wasm-opt, not the copy.
 interface Stamp {
   key: string;
-  outputs: Record<string, string>;
+  source: Record<string, string>;
+  vendored: Record<string, string>;
 }
 
 const WASM_PACK_VERSION = '0.15.0';
@@ -60,9 +64,14 @@ async function hashTree(hash: Hash, dir: string, prefix: string): Promise<void> 
 }
 
 /** Digest of every input the emitted wasm depends on: the crates, the workspace
- * manifest (release profiles) and these scripts. */
+ * manifest (release profiles), the toolchain and these scripts. */
 async function hashSources(): Promise<string> {
   const hash = createHash('sha256');
+  // `stable` moves, so the toolchain has to be part of the identity.
+  const rustc = spawnSync('rustc', ['-vV'], { encoding: 'utf8' });
+  if (rustc.status !== 0) throw new Error('rustc -vV failed');
+  hash.update(rustc.stdout);
+  hash.update(`${WASM_PACK_VERSION}\0${process.env.RUSTFLAGS ?? ''}\0`);
   for (const file of ['Cargo.toml', 'Cargo.lock']) {
     hash.update(`${file}\0`);
     hash.update(await readFile(resolve(root, file)));
@@ -77,25 +86,22 @@ async function hashSources(): Promise<string> {
   return hash.digest('hex');
 }
 
-function vendored(name: string): string[] {
-  return [`${name}.js`, `${name}.d.ts`, `${name}_bg.wasm`, `${name}_bg.wasm.d.ts`];
-}
-
 async function digest(path: string): Promise<string | null> {
   const bytes = await readFile(path).catch(() => null);
   return bytes ? createHash('sha256').update(bytes).digest('hex') : null;
 }
 
-// The stamp lives under target/ and the vendored .wasm is gitignored, so a
-// target/ restored from a CI cache can outlive the output it describes; hashing
-// the output too keeps the skip from serving a file that is no longer there.
-async function isFresh(stamp: string, key: string, dest: string, name: string): Promise<boolean> {
-  const recorded: Stamp | null = await readFile(stamp, 'utf8')
-    .then((text) => JSON.parse(text))
-    .catch(() => null);
-  if (recorded?.key !== key) return false;
-  for (const file of vendored(name)) {
-    if ((await digest(resolve(dest, file))) !== recorded.outputs[file]) return false;
+async function hashAll(dir: string, files: string[]): Promise<Record<string, string>> {
+  const hashes: Record<string, string> = {};
+  for (const file of files) hashes[file] = (await digest(resolve(dir, file))) as string;
+  return hashes;
+}
+
+async function intact(dir: string, expected: Record<string, string> | undefined): Promise<boolean> {
+  const entries = Object.entries(expected ?? {});
+  if (entries.length === 0) return false;
+  for (const [file, hash] of entries) {
+    if ((await digest(resolve(dir, file))) !== hash) return false;
   }
   return true;
 }
@@ -107,37 +113,46 @@ export async function buildWasmModules(modules: WasmModule[]): Promise<void> {
 
   for (const { crate, name, generated, cargoArgs = [] } of modules) {
     const dest = resolve(root, generated);
+    const output = resolve(root, 'target/wasm-pack', crate);
     const stamp = resolve(root, 'target/wasm-pack', `${crate}.json`);
+    const files = [`${name}.js`, `${name}.d.ts`, `${name}_bg.wasm`, `${name}_bg.wasm.d.ts`];
     const key = createHash('sha256')
       .update(sources)
-      .update(`\0${WASM_PACK_VERSION}\0${crate}\0${name}\0${cargoArgs.join(' ')}`)
+      .update(`\0${crate}\0${name}\0${cargoArgs.join(' ')}`)
       .digest('hex');
 
-    if (await isFresh(stamp, key, dest, name)) {
+    const recorded: Stamp | null = await readFile(stamp, 'utf8')
+      .then((text) => JSON.parse(text))
+      .catch(() => null);
+    const current = recorded?.key === key;
+    if (current && (await intact(dest, recorded?.vendored))) {
       console.log(`[wasm] ${crate}: up to date`);
       continue;
     }
 
-    const output = resolve(root, 'target/wasm-pack', crate);
-    await rm(output, { recursive: true, force: true });
-    // --locked must ride with the cargo pass-through: wasm-pack forwards its own
-    // trailing args verbatim once a `--` section exists, and cargo rejects a
-    // stray `--` marker.
-    const build = spawnSync(
-      'wasm-pack',
-      [
-        'build',
-        resolve(root, 'crates', crate),
-        '--release',
-        '--target',
-        'web',
-        '--out-dir',
-        output,
-        ...(cargoArgs.length ? ['--', ...cargoArgs] : ['--locked']),
-      ],
-      { stdio: 'inherit' }
-    );
-    if (build.status !== 0) process.exit(build.status ?? 1);
+    if (current && (await intact(output, recorded?.source))) {
+      console.log(`[wasm] ${crate}: vendoring the cached build`);
+    } else {
+      await rm(output, { recursive: true, force: true });
+      // --locked must ride with the cargo pass-through: wasm-pack forwards its
+      // own trailing args verbatim once a `--` section exists, and cargo rejects
+      // a stray `--` marker.
+      const build = spawnSync(
+        'wasm-pack',
+        [
+          'build',
+          resolve(root, 'crates', crate),
+          '--release',
+          '--target',
+          'web',
+          '--out-dir',
+          output,
+          ...(cargoArgs.length ? ['--', ...cargoArgs] : ['--locked']),
+        ],
+        { stdio: 'inherit' }
+      );
+      if (build.status !== 0) process.exit(build.status ?? 1);
+    }
 
     await mkdir(dest, { recursive: true });
     const glue = await readFile(resolve(output, `${name}.js`), 'utf8');
@@ -147,15 +162,18 @@ export async function buildWasmModules(modules: WasmModule[]): Promise<void> {
       resolve(dest, `${name}.js`),
       glue.replace(fallback, `throw new Error('${crate} requires an explicit module or URL');`)
     );
-    for (const file of [`${name}.d.ts`, `${name}_bg.wasm`, `${name}_bg.wasm.d.ts`]) {
+    for (const file of files.filter((file) => file !== `${name}.js`)) {
       await copyFile(resolve(output, file), resolve(dest, file));
     }
 
-    const outputs: Record<string, string> = {};
-    for (const file of vendored(name)) {
-      outputs[file] = (await digest(resolve(dest, file))) as string;
-    }
     await mkdir(dirname(stamp), { recursive: true });
-    await writeFile(stamp, JSON.stringify({ key, outputs } satisfies Stamp));
+    await writeFile(
+      stamp,
+      JSON.stringify({
+        key,
+        source: await hashAll(output, files),
+        vendored: await hashAll(dest, files),
+      } satisfies Stamp)
+    );
   }
 }


### PR DESCRIPTION
TL;DR:


Summary:
- Fingerprint every `wasm-pack` module over its real inputs (the crates, the workspace manifest's release profiles, the toolchain, `RUSTFLAGS`, the build scripts) and skip the build when nothing moved. A `target/` restored from cache is re-vendored rather than re-optimized, since the cost is `wasm-opt`, not the copy.
- Collapse the three duplicated wasm passes in the demo deploy into one. The workflow's separate `Build packages` step is gone: the demo's own prebuild already builds the wasm and every workspace package it needs, and the demo asset scripts have no package or wasm dependencies to order around.
- Stamp workspace packages with the hash of the tree as it settles *after* the build. The wasm builds vendor their output back into the hashed tree, so a key taken beforehand could never match again and a fresh checkout rebuilt all nine packages twice.
- Skip `packages/*` directories without a `package.json` instead of throwing on them.
- Cache the optimized wasm modules under a key covering the toolchain and the crates, and install `wasm-pack` from its GitHub release instead of compiling it from source in three workflows.
- Raise the deploy timeout to 45 minutes as headroom rather than as the fix.
- Fold the three near-identical wasm build scripts onto one shared driver.
- Fix the inside-borders assertion that turned red on main: an inserted table now arrives fully gridded, and a cell's interior edges answer to `insideH`/`insideV` rather than to the side keys, so the test has to strip all six before measuring what the button paints.

Test plan:
- [ ] CI is green, including the generated-declaration and demo-asset gates
- [ ] A dispatched `Deploy demo` finishes well inside the timeout, and the deployed demo loads a docx, an xlsx and a pptx
- [ ] `bun scripts/build-pptx-wasm.ts` twice in a row builds then reports up to date; deleting the vendored `.wasm` makes the next run vendor from the cached build without invoking `wasm-pack`
- [ ] `bun scripts/build-stale-packages.ts` twice in a row reports every package up to date on the second run
