### PR TITLE
perf(ci): key the wasm cache off the build's own fingerprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           bun-version: "1.3.14"
 
       - uses: dtolnay/rust-toolchain@stable
-        id: rust
         with:
           targets: wasm32-unknown-unknown
 
@@ -28,11 +27,15 @@ jobs:
         with:
           shared-key: wasm
 
+      - name: Fingerprint the wasm inputs
+        id: wasm
+        run: echo "key=$(bun scripts/wasm-cache-key.ts)" >> "$GITHUB_OUTPUT"
+
       # rust-cache prunes the workspace's own artifacts, and wasm-opt costs minutes per module.
       - uses: actions/cache@v4
         with:
           path: target/wasm-pack
-          key: wasm-pack-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**', 'scripts/*wasm*.ts') }}
+          key: wasm-pack-${{ steps.wasm.outputs.key }}
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,6 @@ jobs:
           bun-version: "1.3.14"
 
       - uses: dtolnay/rust-toolchain@stable
-        id: rust
         if: matrix.app == 'demo'
         with:
           targets: wasm32-unknown-unknown
@@ -38,12 +37,17 @@ jobs:
         with:
           shared-key: wasm
 
+      - name: Fingerprint the wasm inputs
+        id: wasm
+        if: matrix.app == 'demo'
+        run: echo "key=$(bun scripts/wasm-cache-key.ts)" >> "$GITHUB_OUTPUT"
+
       # rust-cache prunes the workspace's own artifacts, and wasm-opt costs minutes per module.
       - uses: actions/cache@v4
         if: matrix.app == 'demo'
         with:
           path: target/wasm-pack
-          key: wasm-pack-${{ steps.rust.outputs.cachekey }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**', 'scripts/*wasm*.ts') }}
+          key: wasm-pack-${{ steps.wasm.outputs.key }}
 
       - uses: taiki-e/install-action@v2
         if: matrix.app == 'demo'

--- a/scripts/wasm-cache-key.ts
+++ b/scripts/wasm-cache-key.ts
@@ -1,0 +1,6 @@
+// Prints the wasm fingerprint for CI to key its cache on. Deriving the key from
+// the same digest the build checks keeps an immutable cache entry from outliving
+// an input the workflow forgot to list.
+import { sourcesFingerprint } from './wasm.ts';
+
+console.log(await sourcesFingerprint());

--- a/scripts/wasm.ts
+++ b/scripts/wasm.ts
@@ -63,18 +63,35 @@ async function hashTree(hash: Hash, dir: string, prefix: string): Promise<void> 
   }
 }
 
+// Everything cargo lets you redirect codegen with from outside the manifest.
+// CARGO_ENCODED_RUSTFLAGS takes precedence over RUSTFLAGS, and any
+// CARGO_PROFILE_* override rewrites the release profile the wasm is built under.
+const CODEGEN_ENV = [
+  'RUSTFLAGS',
+  'CARGO_ENCODED_RUSTFLAGS',
+  'CARGO_BUILD_RUSTFLAGS',
+  'CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS',
+];
+
 /** Digest of every input the emitted wasm depends on: the crates, the workspace
- * manifest (release profiles), the toolchain and these scripts. */
-async function hashSources(): Promise<string> {
+ * manifest (release profiles), the toolchain, the cargo environment and these
+ * scripts. Shared by every module, so it doubles as the CI cache key. */
+export async function sourcesFingerprint(): Promise<string> {
   const hash = createHash('sha256');
   // `stable` moves, so the toolchain has to be part of the identity.
   const rustc = spawnSync('rustc', ['-vV'], { encoding: 'utf8' });
   if (rustc.status !== 0) throw new Error('rustc -vV failed');
   hash.update(rustc.stdout);
-  hash.update(`${WASM_PACK_VERSION}\0${process.env.RUSTFLAGS ?? ''}\0`);
-  for (const file of ['Cargo.toml', 'Cargo.lock']) {
+  hash.update(`${WASM_PACK_VERSION}\0`);
+  const overrides = Object.keys(process.env)
+    .filter((name) => name.startsWith('CARGO_PROFILE_'))
+    .sort();
+  for (const name of [...CODEGEN_ENV, ...overrides]) {
+    hash.update(`${name}=${process.env[name] ?? ''}\0`);
+  }
+  for (const file of ['Cargo.toml', 'Cargo.lock', '.cargo/config.toml']) {
     hash.update(`${file}\0`);
-    hash.update(await readFile(resolve(root, file)));
+    hash.update(await readFile(resolve(root, file)).catch(() => Buffer.alloc(0)));
   }
   await hashTree(hash, resolve(root, 'crates'), 'crates/');
   const scripts = resolve(root, 'scripts');
@@ -109,7 +126,7 @@ async function intact(dir: string, expected: Record<string, string> | undefined)
 /** Builds every module whose inputs or vendored output changed. */
 export async function buildWasmModules(modules: WasmModule[]): Promise<void> {
   requireWasmPack();
-  const sources = await hashSources();
+  const sources = await sourcesFingerprint();
 
   for (const { crate, name, generated, cargoArgs = [] } of modules) {
     const dest = resolve(root, generated);


### PR DESCRIPTION
TL;DR:


Summary:
- Include the cargo environment that can redirect codegen from outside the manifest in the wasm fingerprint: `CARGO_ENCODED_RUSTFLAGS` (which takes precedence over `RUSTFLAGS`), the target- and build-scoped `RUSTFLAGS` variants, any `CARGO_PROFILE_*` override, and `.cargo/config.toml`.
- Derive the Actions cache key from that same fingerprint instead of restating the inputs in YAML. GitHub cache entries are immutable, so a key that missed an input the build tracks would pin a stale entry: the build would correctly rebuild every run, the save would be skipped because the key already exists, and the wasm cache would stay permanently cold.

Test plan:
- [ ] CI is green, and the Package gate restores the wasm cache rather than rebuilding it
- [ ] `bun scripts/wasm-cache-key.ts` prints the same digest on consecutive runs, and a different one after `RUSTFLAGS=-C opt-level=1 bun scripts/wasm-cache-key.ts`
