### PR TITLE
fix(deps): take the patched nanoid

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -276,6 +276,7 @@
     "fast-uri": "^3.1.5",
     "ip-address": "^10.4.0",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
     "postcss": "^8.5.23",
     "sharp": "^0.35.0",
     "undici": "^7.29.0",
@@ -1801,7 +1802,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 minimumReleaseAge = 604800
 # Per-advisory exemptions; remove each after its pinned version clears the release-age window.
-minimumReleaseAgeExcludes = ["fast-uri", "postcss", "brace-expansion", "ip-address"]
+minimumReleaseAgeExcludes = ["fast-uri", "postcss", "brace-expansion", "ip-address", "nanoid"]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sharp": "^0.35.0",
     "brace-expansion": "^5.0.9",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
     "undici": "^7.29.0",
     "ip-address": "^10.4.0"
   },


### PR DESCRIPTION
TL;DR:


Summary:
- Take the patched `nanoid` (3.3.18). GHSA-2v37-7h3g-55p8 rates `nanoid <3.3.17` high and it failed the audit gate on main at 8d728a5.
- It arrives through `postcss`, which already allows `^3.3.16`, so this is only a floor in `overrides` rather than a forced upgrade.
- The patched line is two days old and the repo requires seven, so `nanoid` joins the four packages already listed in `minimumReleaseAgeExcludes` for the same reason. Remove it once 3.3.18 clears the window.

Test plan:
- [ ] `bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj` exits 0
- [ ] The docs and web apps still build, since `postcss` is what pulls `nanoid`
- [ ] The full test suite passes
