### PR TITLE
fix(xlsx): scope preserved-reference validation to affected ranges

### DIFF
--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -1053,15 +1053,17 @@ impl Workbook {
         }
         let invalidates_proposals = ops.iter().any(invalidates_proposals);
         let mut preview = self.model.clone();
+        let mut names = self.sheet_names();
         for op in &ops {
             if let Some(sheet) = worksheet_edit_target(op) {
                 self.ensure_worksheet_sheet(sheet)?;
             }
-            self.ensure_references_stay_valid(op)?;
+            self.ensure_references_stay_valid(&names, op)?;
             validate_op(&preview, op)?;
             validate_insert_capacity(&preview, op)?;
             xlsx_ops::apply(&mut preview, op)?;
             validate_model_sheets(&preview)?;
+            rename_sheet_view(&mut names, op);
         }
         validate_shared_drawings(&preview)?;
         if preview == self.model {
@@ -1124,6 +1126,7 @@ impl Workbook {
             return self.collaborative_history_step(options, false);
         }
         let active_name = self.active_sheet_name();
+        let names_before = self.sheet_names();
         let Some(ops) = self.undo.next_undo().map(<[Op]>::to_vec) else {
             return Ok(MutationResult::default());
         };
@@ -1136,7 +1139,7 @@ impl Workbook {
             self.preserved = history.before.clone();
             self.preserved_redo.push(history);
         } else {
-            self.apply_preserved_state_ops(&ops);
+            self.apply_preserved_state_ops(&names_before, &ops);
         }
         self.restore_active_sheet(active_name.as_deref());
         if ops.iter().any(invalidates_proposals) {
@@ -1162,6 +1165,7 @@ impl Workbook {
             return self.collaborative_history_step(options, true);
         }
         let active_name = self.active_sheet_name();
+        let names_before = self.sheet_names();
         let Some(ops) = self.undo.next_redo().map(<[Op]>::to_vec) else {
             return Ok(MutationResult::default());
         };
@@ -1174,7 +1178,7 @@ impl Workbook {
             self.preserved = history.after.clone();
             self.preserved_undo.push(history);
         } else {
-            self.apply_preserved_state_ops(&ops);
+            self.apply_preserved_state_ops(&names_before, &ops);
         }
         self.restore_active_sheet(active_name.as_deref());
         if ops.iter().any(invalidates_proposals) {
@@ -1675,32 +1679,81 @@ impl Workbook {
         validate_cell_ref(cell)
     }
 
-    /// Charts, pivot tables and external links reference sheets by name and
-    /// address, and neither this crate nor the model can rewrite them. Refuse
-    /// the ops that would strand those references rather than write a workbook
-    /// whose parts disagree.
-    fn ensure_references_stay_valid(&self, op: &Op) -> Result<()> {
-        if !matches!(
-            op,
-            Op::RenameSheet { .. }
-                | Op::RemoveSheet { .. }
-                | Op::InsertRows { .. }
-                | Op::DeleteRows { .. }
-                | Op::InsertCols { .. }
-                | Op::DeleteCols { .. }
-        ) {
-            return Ok(());
-        }
-        let Some(part) = self
-            .source_package
-            .as_ref()
-            .and_then(xlsx_parse::PreservedPackage::unpatchable_reference_part)
-        else {
+    /// Pivot caches, pivot tables and the charts the model does not cover name
+    /// sheets and cells by address, and neither this crate nor the model can
+    /// rewrite them. Refuse the ops that would move what one of them names,
+    /// rather than write a workbook whose parts disagree. An op that leaves
+    /// every named cell where it was goes through, whatever sheet it lands on.
+    ///
+    /// `names` are the sheet names as this op sees them, which in a batch is
+    /// what the ops before it left behind rather than what the workbook opened
+    /// with.
+    fn ensure_references_stay_valid(&self, names: &[String], op: &Op) -> Result<()> {
+        let Some(package) = self.source_package.as_ref() else {
             return Ok(());
         };
-        Err(Error::InvalidOperation(format!(
-            "{part} references sheets this edit would move, and it cannot be rewritten"
-        )))
+        let at = |sheet: SheetId| {
+            names
+                .get(sheet.0 as usize)
+                .ok_or(Error::SheetOutOfRange(sheet))
+        };
+        let stranded = match op {
+            Op::RenameSheet { sheet, name } => {
+                let current = at(*sheet)?;
+                (current != name)
+                    .then(|| package.reference_naming_sheet(current))
+                    .flatten()
+            }
+            Op::RemoveSheet { index } => {
+                package.reference_naming_sheet(at(SheetId(*index as u32))?)
+            }
+            Op::InsertRows { sheet, at: row, .. } | Op::DeleteRows { sheet, at: row, .. } => {
+                package.reference_moved_by_rows(at(*sheet)?, *row)
+            }
+            Op::InsertCols { sheet, at: col, .. } | Op::DeleteCols { sheet, at: col, .. } => {
+                package.reference_moved_by_cols(at(*sheet)?, *col)
+            }
+            _ => return Ok(()),
+        };
+        match stranded {
+            Some(part) => Err(Error::InvalidOperation(format!(
+                "{part} references cells this edit would move, and it cannot be rewritten"
+            ))),
+            None => Ok(()),
+        }
+    }
+
+    fn sheet_names(&self) -> Vec<String> {
+        self.model
+            .sheets
+            .iter()
+            .map(|sheet| sheet.name.clone())
+            .collect()
+    }
+
+    /// Whether an op moves cells a preserved part names and no save rewrites,
+    /// which is what a save has to be told about.
+    fn moves_referenced_cells(&self, names: &[String], op: &Op) -> bool {
+        let Some(package) = self.source_package.as_ref() else {
+            return false;
+        };
+        let (sheet, at, by_rows) = match *op {
+            Op::InsertRows { sheet, at, .. } | Op::DeleteRows { sheet, at, .. } => {
+                (sheet, at, true)
+            }
+            Op::InsertCols { sheet, at, .. } | Op::DeleteCols { sheet, at, .. } => {
+                (sheet, at, false)
+            }
+            _ => return false,
+        };
+        let Some(name) = names.get(sheet.0 as usize) else {
+            return true;
+        };
+        if by_rows {
+            package.reference_moved_by_rows(name, at).is_some()
+        } else {
+            package.reference_moved_by_cols(name, at).is_some()
+        }
     }
 
     /// Rejects edits aimed at a preserved chartsheet or dialogsheet.
@@ -1727,6 +1780,7 @@ impl Workbook {
 
     fn commit_user(&mut self, ops: &[Op]) -> Result<()> {
         let preserved_before = (!self.is_collaborative()).then(|| self.preserved.clone());
+        let names_before = self.sheet_names();
         if self.is_collaborative() {
             let staged = self.stage_local_update(ops, SyncOrigin::User)?;
             self.authority
@@ -1753,7 +1807,7 @@ impl Workbook {
                 });
             }
         }
-        self.apply_preserved_state_ops(ops);
+        self.apply_preserved_state_ops(&names_before, ops);
         if let Some(before) = preserved_before {
             self.preserved_undo.push(PreservedStateHistory {
                 before,
@@ -1767,6 +1821,7 @@ impl Workbook {
 
     fn commit_agent(&mut self, ops: &[Op], agent_id: String) -> Result<()> {
         let preserved_before = (!self.is_collaborative()).then(|| self.preserved.clone());
+        let names_before = self.sheet_names();
         if self.is_collaborative() {
             let staged = self.stage_local_update(ops, SyncOrigin::Agent)?;
             self.authority
@@ -1793,7 +1848,7 @@ impl Workbook {
                 });
             }
         }
-        self.apply_preserved_state_ops(ops);
+        self.apply_preserved_state_ops(&names_before, ops);
         if let Some(before) = preserved_before {
             self.preserved_undo.push(PreservedStateHistory {
                 before,
@@ -1890,8 +1945,15 @@ impl Workbook {
             .map(|sheet| sheet.name.clone())
     }
 
-    fn apply_preserved_state_ops(&mut self, ops: &[Op]) {
-        self.moved_references_since_open |= ops.iter().any(moves_cell_references);
+    /// `before` are the sheet names as they stood when `ops` were applied, so
+    /// each op is read against the names it actually named rather than the ones
+    /// the batch left behind.
+    fn apply_preserved_state_ops(&mut self, before: &[String], ops: &[Op]) {
+        let mut names = before.to_vec();
+        for op in ops {
+            self.moved_references_since_open |= self.moves_referenced_cells(&names, op);
+            rename_sheet_view(&mut names, op);
+        }
         for op in ops {
             match *op {
                 Op::AddSheet { index, .. } => self.preserved.insert(index),
@@ -3182,15 +3244,21 @@ fn validate_axis(axis: &str, at: u32, count: u32, limit: u32) -> Result<()> {
     Ok(())
 }
 
-/// Whether an op moves the cells preserved parts name by address.
-fn moves_cell_references(op: &Op) -> bool {
-    matches!(
-        op,
-        Op::InsertRows { .. }
-            | Op::DeleteRows { .. }
-            | Op::InsertCols { .. }
-            | Op::DeleteCols { .. }
-    )
+/// Carries a sheet-name view across one op, so the next op in a batch resolves
+/// its sheet ids the way the model will.
+fn rename_sheet_view(names: &mut Vec<String>, op: &Op) {
+    match op {
+        Op::AddSheet { index, name } => names.insert((*index).min(names.len()), name.clone()),
+        Op::RemoveSheet { index } if *index < names.len() => {
+            names.remove(*index);
+        }
+        Op::RenameSheet { sheet, name } | Op::RestoreSheet { sheet, name, .. } => {
+            if let Some(slot) = names.get_mut(sheet.0 as usize) {
+                *slot = name.clone();
+            }
+        }
+        _ => {}
+    }
 }
 
 fn invalidates_proposals(op: &Op) -> bool {

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -3809,6 +3809,179 @@ fn refuses_structural_ops_that_would_strand_pivot_references() {
     Workbook::open(&workbook.save().unwrap()).unwrap();
 }
 
+/// `Data` feeds a pivot cache over `A1:B4`, `Report` hosts the pivot table at
+/// `D1:F10`, and `Notes` is named by neither.
+fn pivoted_fixture() -> Vec<u8> {
+    let mut model = WorkbookModel::default();
+    for name in ["Data", "Report", "Notes"] {
+        model.sheets.push(Sheet::new(name));
+    }
+    let mut parts = xlsx_parse::serialize_workbook(&model).unwrap();
+    parts.push((
+        "xl/pivotCache/pivotCacheDefinition1.xml".to_owned(),
+        br#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource type="worksheet"><worksheetSource ref="A1:B4" sheet="Data"/></cacheSource></pivotCacheDefinition>"#.to_vec(),
+    ));
+    parts.push((
+        "xl/pivotTables/pivotTable1.xml".to_owned(),
+        br#"<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" cacheId="1"><location ref="D1:F10" firstHeaderRow="1" firstDataRow="1" firstDataCol="1"/></pivotTableDefinition>"#.to_vec(),
+    ));
+    parts.push((
+        "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivotTables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+    ));
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// Sheet ids in a batch mean what the ops before them left behind. A batch
+/// that drops a sheet ahead of the pivot source and then edits by the id the
+/// source has slid into must be read against the shifted list, not the one the
+/// workbook opened with.
+#[test]
+fn resolves_batched_ops_against_the_sheets_the_batch_leaves() {
+    let mut model = WorkbookModel::default();
+    for name in ["Notes", "Data", "Other"] {
+        model.sheets.push(Sheet::new(name));
+    }
+    let mut parts = xlsx_parse::serialize_workbook(&model).unwrap();
+    parts.push((
+        "xl/pivotCache/pivotCacheDefinition1.xml".to_owned(),
+        br#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource type="worksheet"><worksheetSource ref="A1:B4" sheet="Data"/></cacheSource></pivotCacheDefinition>"#.to_vec(),
+    ));
+    let original = ooxml_opc::rezip_parts(&parts).unwrap();
+
+    let mut workbook = Workbook::open(&original).unwrap();
+    let error = workbook
+        .apply_ops(
+            vec![
+                Op::RemoveSheet { index: 0 },
+                Op::InsertRows {
+                    sheet: SheetId(0),
+                    at: 0,
+                    count: 1,
+                },
+                Op::AddSheet {
+                    index: 0,
+                    name: "Scratch".to_owned(),
+                },
+            ],
+            CalculationOptions::default(),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(&error, Error::InvalidOperation(message)
+            if message.contains("pivotCacheDefinition1.xml")),
+        "the batch was allowed: {error:?}"
+    );
+}
+
+/// The veto is per reference, not per workbook: an edit a pivot's source range
+/// and its own location both survive must go through.
+#[test]
+fn allows_structural_ops_no_pivot_reference_names() {
+    for op in [
+        Op::InsertRows {
+            sheet: SheetId(2),
+            at: 0,
+            count: 1,
+        },
+        Op::DeleteRows {
+            sheet: SheetId(2),
+            at: 0,
+            count: 1,
+        },
+        Op::InsertCols {
+            sheet: SheetId(2),
+            at: 0,
+            count: 1,
+        },
+        Op::DeleteCols {
+            sheet: SheetId(2),
+            at: 0,
+            count: 1,
+        },
+        Op::RenameSheet {
+            sheet: SheetId(2),
+            name: "Scratch".to_owned(),
+        },
+        Op::RemoveSheet { index: 2 },
+        Op::InsertRows {
+            sheet: SheetId(0),
+            at: 4,
+            count: 3,
+        },
+        Op::InsertCols {
+            sheet: SheetId(0),
+            at: 2,
+            count: 1,
+        },
+        Op::InsertRows {
+            sheet: SheetId(1),
+            at: 10,
+            count: 1,
+        },
+        Op::InsertCols {
+            sheet: SheetId(1),
+            at: 6,
+            count: 1,
+        },
+    ] {
+        let mut workbook = Workbook::open(&pivoted_fixture()).unwrap();
+        workbook
+            .apply_ops(vec![op.clone()], CalculationOptions::default())
+            .unwrap_or_else(|error| panic!("{op:?} was refused: {error:?}"));
+        Workbook::open(&workbook.save().unwrap())
+            .unwrap_or_else(|error| panic!("{op:?} would not save: {error:?}"));
+    }
+}
+
+/// What the cache source and the pivot table's own location name still moves
+/// out from under a part nothing can rewrite.
+#[test]
+fn still_refuses_structural_ops_a_pivot_reference_names() {
+    for op in [
+        Op::InsertRows {
+            sheet: SheetId(0),
+            at: 0,
+            count: 1,
+        },
+        Op::DeleteRows {
+            sheet: SheetId(0),
+            at: 3,
+            count: 1,
+        },
+        Op::InsertCols {
+            sheet: SheetId(0),
+            at: 1,
+            count: 1,
+        },
+        Op::RenameSheet {
+            sheet: SheetId(0),
+            name: "Renamed".to_owned(),
+        },
+        Op::RemoveSheet { index: 0 },
+        Op::InsertRows {
+            sheet: SheetId(1),
+            at: 9,
+            count: 1,
+        },
+        Op::InsertCols {
+            sheet: SheetId(1),
+            at: 5,
+            count: 1,
+        },
+        Op::RemoveSheet { index: 1 },
+    ] {
+        let mut workbook = Workbook::open(&pivoted_fixture()).unwrap();
+        let error = workbook
+            .apply_ops(vec![op.clone()], CalculationOptions::default())
+            .unwrap_err();
+        assert!(
+            matches!(&error, Error::InvalidOperation(message) if message.contains("pivot")),
+            "{op:?} was allowed: {error:?}"
+        );
+    }
+}
+
 #[test]
 fn refuses_structural_ops_that_would_strand_unclaimed_chart_parts() {
     let mut parts = ooxml_opc::unzip_parts(&preservation_fixture()).unwrap();

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -3832,10 +3832,9 @@ fn pivoted_fixture() -> Vec<u8> {
     ooxml_opc::rezip_parts(&parts).unwrap()
 }
 
-/// The blanket veto covered a mis-pathed pivot part for free, by firing on the
-/// mere presence of one. A veto that reasons per part has to actually find it,
-/// so a cache written outside the conventional directory is typed by its
-/// `Override` and still refuses the edits that would strand it.
+/// A veto that reasons per part has to find a cache the conventional directory
+/// scan misses, so one written outside it is typed by its `Override` and still
+/// refuses the edits that would strand it.
 #[test]
 fn refuses_ops_that_would_strand_a_mis_pathed_pivot_cache() {
     let mut model = WorkbookModel::default();

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -3832,6 +3832,69 @@ fn pivoted_fixture() -> Vec<u8> {
     ooxml_opc::rezip_parts(&parts).unwrap()
 }
 
+/// The blanket veto covered a mis-pathed pivot part for free, by firing on the
+/// mere presence of one. A veto that reasons per part has to actually find it,
+/// so a cache written outside the conventional directory is typed by its
+/// `Override` and still refuses the edits that would strand it.
+#[test]
+fn refuses_ops_that_would_strand_a_mis_pathed_pivot_cache() {
+    let mut model = WorkbookModel::default();
+    for name in ["Data", "Notes"] {
+        model.sheets.push(Sheet::new(name));
+    }
+    let mut parts = xlsx_parse::serialize_workbook(&model).unwrap();
+    parts.push((
+        "xl/pivotCacheDefinition1.xml".to_owned(),
+        br#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource type="worksheet"><worksheetSource ref="A1:B4" sheet="Data"/></cacheSource></pivotCacheDefinition>"#.to_vec(),
+    ));
+    let content_types = test_part_text(&parts, "[Content_Types].xml").replace(
+        "</Types>",
+        r#"<Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#,
+    );
+    set_test_part(
+        &mut parts,
+        "[Content_Types].xml",
+        content_types.into_bytes(),
+    );
+    let original = ooxml_opc::rezip_parts(&parts).unwrap();
+
+    for op in [
+        Op::InsertRows {
+            sheet: SheetId(0),
+            at: 0,
+            count: 1,
+        },
+        Op::RenameSheet {
+            sheet: SheetId(0),
+            name: "Renamed".to_owned(),
+        },
+        Op::RemoveSheet { index: 0 },
+    ] {
+        let mut workbook = Workbook::open(&original).unwrap();
+        let error = workbook
+            .apply_ops(vec![op.clone()], CalculationOptions::default())
+            .unwrap_err();
+        assert!(
+            matches!(&error, Error::InvalidOperation(message)
+                if message.contains("pivotCacheDefinition1.xml")),
+            "{op:?} was allowed: {error:?}"
+        );
+    }
+
+    let mut workbook = Workbook::open(&original).unwrap();
+    workbook
+        .apply_ops(
+            vec![Op::InsertRows {
+                sheet: SheetId(1),
+                at: 0,
+                count: 1,
+            }],
+            CalculationOptions::default(),
+        )
+        .expect("an unrelated sheet is still free");
+    Workbook::open(&workbook.save().unwrap()).unwrap();
+}
+
 /// Sheet ids in a batch mean what the ops before them left behind. A batch
 /// that drops a sheet ahead of the pivot source and then edits by the id the
 /// source has slid into must be read against the shifted list, not the one the

--- a/crates/xlsx-parse/src/chart.rs
+++ b/crates/xlsx-parse/src/chart.rs
@@ -1206,27 +1206,46 @@ fn normalize_part_path(path: &str) -> &str {
     path.trim_start_matches('/')
 }
 
-/// Whether a part holds a chart. An `Override` is authoritative; a type a
-/// `Default` extension mapping resolved names a chart when it is a chart type
-/// and otherwise leaves the conventional layout to answer, so a package that
-/// types its charts by extension alone is still covered.
+/// Whether a part holds a chart. Monotonic over the blanket veto the way
+/// pivot discovery is: the conventional layout always answers, and conforming
+/// typing may only add parts beside it. Typing that cannot be read must never
+/// take a chart away, because a chart nobody looks at vetoes nothing.
 fn is_chart_part(path: &str, content_types: &[PartContentType]) -> bool {
     let normalized = normalize_part_path(path).to_ascii_lowercase();
-    match content_types.iter().find(|part| part.path == normalized) {
-        Some(part)
-            if CHART_CONTENT_TYPES
-                .iter()
-                .any(|known| part.content_type.eq_ignore_ascii_case(known)) =>
-        {
-            true
-        }
-        Some(part) if part.overridden => false,
-        _ => {
-            normalized.starts_with("xl/charts/chart")
-                && normalized.ends_with(".xml")
-                && !normalized.contains("/_rels/")
-        }
+    (normalized.starts_with("xl/charts/chart")
+        && normalized.ends_with(".xml")
+        && !normalized.contains("/_rels/"))
+        || content_types.iter().any(|part| {
+            part.path == normalized
+                && CHART_CONTENT_TYPES
+                    .iter()
+                    .any(|known| part.content_type.eq_ignore_ascii_case(known))
+        })
+}
+
+/// Whether every anchor in a drawing claims at most one chart. The claim is
+/// followed by taking the first `c:chart` descendant of an anchor, so a second
+/// one lets two anchors swap which chart each is taken to hold — both still
+/// claimed once, so nothing looks unknown, while an unqualified reference
+/// resolves against the wrong sheet.
+pub(crate) fn drawing_claims_are_unambiguous(root: &Element) -> bool {
+    if !root.is(NS_SPREADSHEET_DRAWING, "wsDr") {
+        return true;
     }
+    root.child_elements()
+        .filter(is_anchor)
+        .all(|anchor| chart_descendants(anchor, 0) <= 1)
+}
+
+fn chart_descendants(element: &Element, depth: usize) -> usize {
+    if depth > MAX_DEPTH {
+        return usize::MAX;
+    }
+    usize::from(element.is(NS_CHART, "chart"))
+        + element
+            .child_elements()
+            .map(|child| chart_descendants(child, depth + 1))
+            .sum::<usize>()
 }
 
 /// Whether a chart part carries a reference this crate cannot rewrite. Only a

--- a/crates/xlsx-parse/src/chart.rs
+++ b/crates/xlsx-parse/src/chart.rs
@@ -17,7 +17,9 @@ use xlsx_model::{
 };
 
 use crate::package::PartContentType;
-use crate::tree::{Edit, Element, Part, Replacement, escape_text, parse_tree};
+use crate::tree::{
+    Edit, Element, Part, Replacement, escape_text, names_are_resolvable, parse_tree,
+};
 use crate::xml::{find_part, resolve_part_path};
 use crate::{MAX_CHART_ANCHORS, MAX_CHART_REFS, MAX_DEPTH, ParseError};
 
@@ -25,7 +27,7 @@ use crate::{MAX_CHART_ANCHORS, MAX_CHART_REFS, MAX_DEPTH, ParseError};
 pub(crate) const NS_RELATIONSHIPS: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 /// the `.rels` part vocabulary itself.
-const NS_PACKAGE_RELATIONSHIPS: &str =
+pub(crate) const NS_PACKAGE_RELATIONSHIPS: &str =
     "http://schemas.openxmlformats.org/package/2006/relationships";
 /// classic `c:chartSpace`.
 const NS_CHART: &str = "http://schemas.openxmlformats.org/drawingml/2006/chart";
@@ -1111,7 +1113,10 @@ pub(crate) fn unmodelled_chart_parts(
         let claimed = owners.is_some();
         if claimed {
             let root = parse_tree(bytes)?;
-            if !unsupported_reference_form(&root, 0) && !holds_an_unrebuildable_cache(&root)? {
+            if names_are_resolvable(&root)
+                && !unsupported_reference_form(&root, 0)
+                && !holds_an_unrebuildable_cache(&root)?
+            {
                 continue;
             }
         }
@@ -1144,7 +1149,7 @@ pub(crate) fn chart_reference_areas(
     owner: Option<&str>,
 ) -> Result<Option<Vec<(String, CellRef)>>, ParseError> {
     let root = parse_tree(part)?;
-    if unsupported_reference_form(&root, 0) {
+    if !names_are_resolvable(&root) || unsupported_reference_form(&root, 0) {
         return Ok(None);
     }
     let mut areas = Vec::new();

--- a/crates/xlsx-parse/src/chart.rs
+++ b/crates/xlsx-parse/src/chart.rs
@@ -1077,7 +1077,7 @@ fn marker_markup(element: &Element, cell: AnchorCell) -> String {
 
 /// content types that carry workbook references in a chart vocabulary. the
 /// style and colour-style parts under `xl/charts/` carry none.
-const CHART_CONTENT_TYPES: [&str; 2] = [
+pub(crate) const CHART_CONTENT_TYPES: [&str; 2] = [
     "application/vnd.openxmlformats-officedocument.drawingml.chart+xml",
     "application/vnd.ms-office.chartex+xml",
 ];

--- a/crates/xlsx-parse/src/chart.rs
+++ b/crates/xlsx-parse/src/chart.rs
@@ -22,7 +22,7 @@ use crate::xml::{find_part, resolve_part_path};
 use crate::{MAX_CHART_ANCHORS, MAX_CHART_REFS, MAX_DEPTH, ParseError};
 
 /// relationship references inside a part (`r:id`).
-const NS_RELATIONSHIPS: &str =
+pub(crate) const NS_RELATIONSHIPS: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 /// the `.rels` part vocabulary itself.
 const NS_PACKAGE_RELATIONSHIPS: &str =
@@ -907,7 +907,7 @@ fn split_qualifier(source: &str) -> Option<(Option<String>, &str)> {
 }
 
 /// `$A$1:$A$5` or `$A$1` as an inclusive corner pair.
-fn parse_area(source: &str) -> Option<(CellRef, CellRef)> {
+pub(crate) fn parse_area(source: &str) -> Option<(CellRef, CellRef)> {
     let (start, end) = match source.split_once(':') {
         Some((start, end)) => (start, end),
         None => (source, source),
@@ -1083,32 +1083,88 @@ const CHART_CONTENT_TYPES: [&str; 2] = [
 /// A chart part in the package that the model does not fully cover: one no
 /// sheet claims, one that is not a classic `c:chartSpace`, one carrying a
 /// reference form the remapper cannot rewrite, or one whose cache sits beside
-/// a reference this crate cannot rebuild it from. Structural edits are refused
-/// while such a part is present, because moving cells would strand it.
-pub(crate) fn unmodelled_chart_part(
+/// a reference this crate cannot rebuild it from. Structural edits that would
+/// move what such a part names are refused, because nothing rewrites it.
+///
+/// Each part comes with the sheet an unqualified reference in it resolves
+/// against: the one sheet claiming it, absent when no sheet or several do.
+pub(crate) fn unmodelled_chart_parts(
     parts: &[(String, Vec<u8>)],
     content_types: &[PartContentType],
     workbook: &xlsx_model::Workbook,
-) -> Result<Option<String>, ParseError> {
-    let modelled = workbook
-        .sheets
-        .iter()
-        .flat_map(|sheet| sheet.charts.iter())
-        .map(|chart| normalize_part_path(&chart.part))
-        .collect::<std::collections::HashSet<_>>();
+) -> Result<Vec<UnmodelledChart>, ParseError> {
+    let mut claims: std::collections::HashMap<&str, Vec<&str>> = std::collections::HashMap::new();
+    for sheet in &workbook.sheets {
+        for chart in &sheet.charts {
+            claims
+                .entry(normalize_part_path(&chart.part))
+                .or_default()
+                .push(sheet.name.as_str());
+        }
+    }
+    let mut unmodelled = Vec::new();
     for (path, bytes) in parts {
         if !is_chart_part(path, content_types) {
             continue;
         }
-        if !modelled.contains(normalize_part_path(path)) {
-            return Ok(Some(path.clone()));
+        let owners = claims.get(normalize_part_path(path));
+        let claimed = owners.is_some();
+        if claimed {
+            let root = parse_tree(bytes)?;
+            if !unsupported_reference_form(&root, 0) && !holds_an_unrebuildable_cache(&root)? {
+                continue;
+            }
         }
-        let root = parse_tree(bytes)?;
-        if unsupported_reference_form(&root, 0) || holds_an_unrebuildable_cache(&root)? {
-            return Ok(Some(path.clone()));
-        }
+        unmodelled.push(UnmodelledChart {
+            path: path.clone(),
+            owner: owners
+                .filter(|owners| owners.len() == 1)
+                .map(|owners| owners[0].to_owned()),
+            claimed,
+        });
     }
-    Ok(None)
+    Ok(unmodelled)
+}
+
+/// A chart part no save rewrites, with the sheet its unqualified references
+/// resolve against.
+pub(crate) struct UnmodelledChart {
+    pub(crate) path: String,
+    pub(crate) owner: Option<String>,
+    /// whether a sheet anchors it. A part nothing anchors is one this crate
+    /// has not read the shape of, so what it names is not resolved from it.
+    pub(crate) claimed: bool,
+}
+
+/// The areas a chart part names, or `None` when one of its references is not a
+/// form this crate reads and every cell has to be assumed named. `owner` is the
+/// sheet an unqualified reference resolves against.
+pub(crate) fn chart_reference_areas(
+    part: &[u8],
+    owner: Option<&str>,
+) -> Result<Option<Vec<(String, CellRef)>>, ParseError> {
+    let root = parse_tree(part)?;
+    if unsupported_reference_form(&root, 0) {
+        return Ok(None);
+    }
+    let mut areas = Vec::new();
+    for site in ref_sites(&root)? {
+        let formula = site.formula.trim();
+        if formula.is_empty() || formula == ErrorValue::Ref.as_str() {
+            continue;
+        }
+        let Some((qualifier, area)) = split_qualifier(formula) else {
+            return Ok(None);
+        };
+        let (Some(sheet), Some((_, end))) = (
+            qualifier.or_else(|| owner.map(str::to_owned)),
+            parse_area(area),
+        ) else {
+            return Ok(None);
+        };
+        areas.push((sheet, end));
+    }
+    Ok(Some(areas))
 }
 
 /// Whether a cache sits beside a reference this crate could not rebuild it

--- a/crates/xlsx-parse/src/chart.rs
+++ b/crates/xlsx-parse/src/chart.rs
@@ -1234,18 +1234,33 @@ pub(crate) fn drawing_claims_are_unambiguous(root: &Element) -> bool {
     }
     root.child_elements()
         .filter(is_anchor)
-        .all(|anchor| chart_descendants(anchor, 0) <= 1)
+        .all(|anchor| chart_claims(anchor, 0) <= 1)
 }
 
-fn chart_descendants(element: &Element, depth: usize) -> usize {
+/// How many claims an anchor could be read as carrying. A `c:chart` is one; so
+/// is a second relationships-namespace `id` on it, since the claim is followed
+/// by taking the first such attribute and either could answer.
+fn chart_claims(element: &Element, depth: usize) -> usize {
     if depth > MAX_DEPTH {
         return usize::MAX;
     }
-    usize::from(element.is(NS_CHART, "chart"))
-        + element
-            .child_elements()
-            .map(|child| chart_descendants(child, depth + 1))
-            .sum::<usize>()
+    let here = if element.is(NS_CHART, "chart") {
+        element
+            .attributes
+            .iter()
+            .filter(|attribute| {
+                attribute.local_name() == "id"
+                    && attribute.namespace.as_deref() == Some(NS_RELATIONSHIPS)
+            })
+            .count()
+            .max(1)
+    } else {
+        0
+    };
+    here + element
+        .child_elements()
+        .map(|child| chart_claims(child, depth + 1))
+        .sum::<usize>()
 }
 
 /// Whether a chart part carries a reference this crate cannot rewrite. Only a

--- a/crates/xlsx-parse/src/lib.rs
+++ b/crates/xlsx-parse/src/lib.rs
@@ -4,6 +4,7 @@
 mod chart;
 mod package;
 mod read;
+mod reference;
 mod styles;
 mod tree;
 mod write;
@@ -12,6 +13,7 @@ mod xml;
 pub use chart::{chart_space, preserved_chart_space};
 pub use package::PreservedPackage;
 pub use read::{LegacySheetDimensions, SharedStringCells, parse_workbook};
+pub use reference::UnpatchableReference;
 pub use write::{
     SaveEdits, serialize_workbook, serialize_workbook_with_active_sheet,
     serialize_workbook_with_package_and_origins_after_edits,

--- a/crates/xlsx-parse/src/package.rs
+++ b/crates/xlsx-parse/src/package.rs
@@ -6,6 +6,7 @@ use quick_xml::{NsReader, Reader, Writer};
 use xlsx_model::{SheetId, Workbook};
 
 use crate::read::SharedStringCells;
+use crate::reference::UnpatchableReference;
 use crate::xml::{attr, find_part, local_name, next_event, reader, resolve_part_path, xml_err};
 use crate::{MAX_DEPTH, ParseError};
 
@@ -29,7 +30,7 @@ pub struct PreservedPackage {
     pub(crate) stylesheet_template: Option<XmlTemplate>,
     pub(crate) original_workbook: Workbook,
     pub(crate) active_sheet: SheetId,
-    pub(crate) unmodelled_chart_part: Option<String>,
+    pub(crate) unpatchable_references: Vec<UnpatchableReference>,
 }
 
 impl PreservedPackage {
@@ -136,10 +137,14 @@ impl PreservedPackage {
             .map(parse_content_types)
             .transpose()?
             .unwrap_or_default();
-        let unmodelled_chart_part = crate::chart::unmodelled_chart_part(
+        let unpatchable_references = crate::reference::unpatchable_references(
             parts,
             &part_content_types(&content_types, parts),
             workbook,
+            &sheets
+                .iter()
+                .map(|sheet| sheet.path.clone())
+                .collect::<Vec<_>>(),
         )?;
 
         Ok(Self {
@@ -163,7 +168,7 @@ impl PreservedPackage {
             stylesheet_template,
             original_workbook: workbook.clone(),
             active_sheet,
-            unmodelled_chart_part,
+            unpatchable_references,
         })
     }
 
@@ -177,20 +182,46 @@ impl PreservedPackage {
         self.sheets.len()
     }
 
+    /// Every preserved part whose references cannot be patched, with the cells
+    /// each one names.
+    #[doc(hidden)]
+    pub fn unpatchable_references(&self) -> &[UnpatchableReference] {
+        &self.unpatchable_references
+    }
+
     /// Returns a preserved part whose references cannot be patched.
     #[doc(hidden)]
     pub fn unpatchable_reference_part(&self) -> Option<&str> {
-        const REFERENCE_BEARING: [&str; 2] = ["xl/pivottables/", "xl/pivotcache/"];
-        self.parts
+        self.unpatchable_references
+            .first()
+            .map(UnpatchableReference::part)
+    }
+
+    /// Returns a preserved part that renaming, dropping or reordering `sheet`
+    /// would strand.
+    #[doc(hidden)]
+    pub fn reference_naming_sheet(&self, sheet: &str) -> Option<&str> {
+        self.stranded(|reference| reference.names_sheet(sheet))
+    }
+
+    /// Returns a preserved part that inserting or deleting rows at `at` on
+    /// `sheet` would strand.
+    #[doc(hidden)]
+    pub fn reference_moved_by_rows(&self, sheet: &str, at: u32) -> Option<&str> {
+        self.stranded(|reference| reference.moved_by_rows(sheet, at))
+    }
+
+    /// The column-wise counterpart of [`Self::reference_moved_by_rows`].
+    #[doc(hidden)]
+    pub fn reference_moved_by_cols(&self, sheet: &str, at: u32) -> Option<&str> {
+        self.stranded(|reference| reference.moved_by_cols(sheet, at))
+    }
+
+    fn stranded(&self, disturbed: impl Fn(&UnpatchableReference) -> bool) -> Option<&str> {
+        self.unpatchable_references
             .iter()
-            .find_map(|(path, _)| {
-                let normalized = path.trim_start_matches('/').to_ascii_lowercase();
-                REFERENCE_BEARING
-                    .iter()
-                    .any(|prefix| normalized.starts_with(prefix))
-                    .then_some(path.as_str())
-            })
-            .or(self.unmodelled_chart_part.as_deref())
+            .find(|reference| disturbed(reference))
+            .map(UnpatchableReference::part)
     }
 
     /// The shared-string entries a source sheet's cells were authored against.

--- a/crates/xlsx-parse/src/package.rs
+++ b/crates/xlsx-parse/src/package.rs
@@ -317,7 +317,6 @@ impl ContentTypeEntry {
 
 pub(crate) struct ResolvedContentType<'a> {
     pub(crate) value: &'a str,
-    pub(crate) overridden: bool,
 }
 
 /// Resolves a part's effective content type.
@@ -336,16 +335,8 @@ pub(crate) fn effective_content_type<'a>(
             .then(|| entry.attribute("ContentType"))
             .flatten()
         })
-        .map(|value| ResolvedContentType {
-            value,
-            overridden: true,
-        })
-        .or_else(|| {
-            default_content_type(entries, path).map(|value| ResolvedContentType {
-                value,
-                overridden: false,
-            })
-        })
+        .map(|value| ResolvedContentType { value })
+        .or_else(|| default_content_type(entries, path).map(|value| ResolvedContentType { value }))
 }
 
 fn default_content_type<'a>(entries: &'a [ContentTypeEntry], path: &str) -> Option<&'a str> {
@@ -1028,7 +1019,6 @@ fn part_content_types(
             Some(PartContentType {
                 path: normalized_part_name(path),
                 content_type: resolved.value.to_owned(),
-                overridden: resolved.overridden,
             })
         })
         .collect()
@@ -1037,7 +1027,6 @@ fn part_content_types(
 pub(crate) struct PartContentType {
     pub(crate) path: String,
     pub(crate) content_type: String,
-    pub(crate) overridden: bool,
 }
 
 struct SheetEntry {

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -11,7 +11,9 @@
 
 use std::collections::HashMap;
 
+use quick_xml::NsReader;
 use quick_xml::events::Event;
+use quick_xml::name::ResolveResult;
 use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
 use xlsx_model::{CellRef, Workbook};
 
@@ -22,12 +24,14 @@ use crate::chart::{
 };
 use crate::package::PartContentType;
 use crate::tree::{Element, parse_tree};
-use crate::write::NS_MAIN;
-use crate::xml::{find_part, local_name, next_event, reader, resolve_part_path};
+use crate::write::{NS_MAIN, NS_STRICT_MAIN};
+use crate::xml::{find_part, local_name, resolve_part_path};
 
-/// the markup-compatibility vocabulary, whose branches stand in for the element
-/// they wrap.
-const NS_MCE: &str = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+/// the spreadsheetml vocabulary a pivot part is read in. Transitional and
+/// Strict spell the same names in different namespaces and this crate reads
+/// both; an unprefixed name with no namespace at all is read as ours too,
+/// because a part that declares none is still the vocabulary it looks like.
+const OURS: [&str; 2] = [NS_MAIN, NS_STRICT_MAIN];
 
 /// A preserved part naming sheets and cells neither this crate nor the model
 /// rewrites.
@@ -197,18 +201,36 @@ fn pivot_references(
     references
 }
 
-/// The local name of a part's root element, read without building a tree so a
-/// cached-records part running to megabytes costs nothing to classify.
+/// The local name of a part's root element when the root is one of ours, read
+/// without building a tree so a cached-records part running to megabytes costs
+/// nothing to classify. A root in a foreign vocabulary — including one behind a
+/// prefix the part never declared — answers to no name, which classifies the
+/// part as one this crate does not read and leaves it naming everything.
 fn root_local_name(bytes: &[u8]) -> Option<String> {
-    let mut reader = reader(bytes);
+    let mut reader = NsReader::from_reader(bytes);
+    let config = reader.config_mut();
+    config.expand_empty_elements = true;
+    config.check_end_names = true;
     let mut buf = Vec::new();
-    let mut depth = 0;
     loop {
-        match next_event(&mut reader, &mut buf, &mut depth).ok()? {
-            Event::Start(start) => return String::from_utf8(local_name(&start)).ok(),
+        let (namespace, event) = reader.read_resolved_event_into(&mut buf).ok()?;
+        match event {
+            Event::Start(start) => {
+                let ours = match namespace {
+                    ResolveResult::Unbound => true,
+                    ResolveResult::Bound(namespace) => {
+                        OURS.contains(&String::from_utf8_lossy(namespace.as_ref()).as_ref())
+                    }
+                    ResolveResult::Unknown(_) => false,
+                };
+                return ours
+                    .then(|| String::from_utf8(local_name(&start)).ok())
+                    .flatten();
+            }
             Event::Eof => return None,
             _ => {}
         }
+        buf.clear();
     }
 }
 
@@ -233,8 +255,8 @@ fn source_areas(root: &Element) -> Option<Vec<NamedArea>> {
         return None;
     };
     match sole_attribute(source, "type")?.unwrap_or("worksheet") {
-        "worksheet" if only.answers_to(NS_MAIN, "worksheetSource") => Some(vec![named_area(only)?]),
-        "consolidation" if only.answers_to(NS_MAIN, "consolidation") => consolidated_areas(only),
+        "worksheet" if only.answers_to(&OURS, "worksheetSource") => Some(vec![named_area(only)?]),
+        "consolidation" if only.answers_to(&OURS, "consolidation") => consolidated_areas(only),
         _ => None,
     }
 }
@@ -242,14 +264,14 @@ fn source_areas(root: &Element) -> Option<Vec<NamedArea>> {
 fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
     if consolidation
         .child_elements()
-        .any(|child| !child.answers_to(NS_MAIN, "pages") && !child.answers_to(NS_MAIN, "rangeSets"))
+        .any(|child| !child.answers_to(&OURS, "pages") && !child.answers_to(&OURS, "rangeSets"))
     {
         return None;
     }
     let areas = sole_child(consolidation, "rangeSets")?
         .child_elements()
         .map(|set| {
-            set.answers_to(NS_MAIN, "rangeSet")
+            set.answers_to(&OURS, "rangeSet")
                 .then(|| named_area(set))
                 .flatten()
         })
@@ -261,9 +283,7 @@ fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
 /// instead: the schema allows exactly one of `ref` and `name`, and an `r:id`
 /// puts the range in another workbook.
 fn named_area(element: &Element) -> Option<NamedArea> {
-    if element.attributes_in(NS_MAIN, "name").next().is_some()
-        || element.attributes_in(NS_MAIN, "id").next().is_some()
-    {
+    if element.any_attribute_named("name") || element.any_attribute_named("id") {
         return None;
     }
     let sheet = sole_attribute(element, "sheet")??.to_owned();
@@ -304,7 +324,7 @@ fn page_count(location: &Element, name: &str) -> Option<u32> {
 /// attribute may default. A foreign attribute is not one of ours and so reads
 /// as absent, exactly as it does to a consumer that drops it.
 fn sole_attribute<'a>(element: &'a Element, name: &'a str) -> Option<Option<&'a str>> {
-    let mut candidates = element.attributes_in(NS_MAIN, name);
+    let mut candidates = element.attributes_in(&OURS, name);
     let Some(only) = candidates.next() else {
         return Some(None);
     };
@@ -318,7 +338,7 @@ fn sole_attribute<'a>(element: &'a Element, name: &'a str) -> Option<Option<&'a 
 /// several do. A name only a foreign node answers to is a name nothing answers
 /// to, which for a node the part cannot be read without is unresolved.
 fn sole_child<'a>(element: &'a Element, local: &'a str) -> Option<&'a Element> {
-    let mut candidates = element.children_in(NS_MAIN, local);
+    let mut candidates = element.children_in(&OURS, local);
     let only = candidates.next()?;
     candidates.next().is_none().then_some(only)
 }
@@ -327,9 +347,10 @@ fn sole_child<'a>(element: &'a Element, local: &'a str) -> Option<&'a Element> {
 /// between `mc:Choice` and `mc:Fallback` is markup-compatibility processing,
 /// and a branch can supply the very node a lookup is after, so a pivot part
 /// carrying one is read as naming everything rather than as whichever branch
-/// happens to sit first.
+/// happens to sit first. Matched by local name alone, because a branch behind a
+/// prefix the part never declared still hides whatever it wraps.
 fn carries_alternate_content(element: &Element) -> bool {
-    element.is(NS_MCE, "AlternateContent")
+    element.local_name() == "AlternateContent"
         || element.child_elements().any(carries_alternate_content)
 }
 

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -85,7 +85,7 @@ pub(crate) fn unpatchable_references(
     workbook: &Workbook,
     sheet_paths: &[String],
 ) -> Result<Vec<UnpatchableReference>, ParseError> {
-    let mut references = pivot_references(parts, workbook, sheet_paths);
+    let mut references = pivot_references(parts, content_types, workbook, sheet_paths);
     for chart in unmodelled_chart_parts(parts, content_types, workbook)? {
         let areas = match chart
             .claimed
@@ -129,19 +129,29 @@ fn names_one_sheet(workbook: &Workbook, sheet: &str) -> bool {
         == 1
 }
 
-/// The directories a pivot part lives in. A save rewrites neither the ranges a
-/// cache is built from nor the grid a pivot table is laid out on.
+/// The directories a pivot part conventionally lives in, which answer for a
+/// package that types its parts by extension alone.
 const PIVOT_DIRECTORIES: [&str; 2] = ["xl/pivottables/", "xl/pivotcache/"];
+
+/// content types that carry workbook references in a pivot vocabulary. A save
+/// rewrites neither the ranges a cache is built from nor the grid a pivot table
+/// is laid out on.
+const PIVOT_CONTENT_TYPES: [&str; 3] = [
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml",
+];
 
 fn pivot_references(
     parts: &[(String, Vec<u8>)],
+    content_types: &[PartContentType],
     workbook: &Workbook,
     sheet_paths: &[String],
 ) -> Vec<UnpatchableReference> {
     let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
     let pivot_parts = parts
         .iter()
-        .filter(|(path, _)| is_pivot_part(path))
+        .filter(|(path, _)| is_pivot_part(path, content_types))
         .map(|(path, bytes)| (path, bytes, root_local_name(bytes)))
         .collect::<Vec<_>>();
 
@@ -322,12 +332,29 @@ fn related_parts(parts: &[(String, Vec<u8>)], path: &str, relationship: &str) ->
         .collect()
 }
 
-fn is_pivot_part(path: &str) -> bool {
+/// Whether a part holds a pivot cache or pivot table. Typed the way OPC types
+/// anything: an `Override` is authoritative, and the conventional directories
+/// answer only for a part a `Default` extension mapping left untyped. A pivot
+/// part written outside those directories is still found, because a veto that
+/// reasons per part gives a part it never discovers no cover at all.
+fn is_pivot_part(path: &str, content_types: &[PartContentType]) -> bool {
     let key = part_key(path);
-    !key.contains("/_rels/")
-        && PIVOT_DIRECTORIES
+    if key.contains("/_rels/") {
+        return false;
+    }
+    match content_types.iter().find(|part| part.path == key) {
+        Some(part)
+            if PIVOT_CONTENT_TYPES
+                .iter()
+                .any(|known| part.content_type.eq_ignore_ascii_case(known)) =>
+        {
+            true
+        }
+        Some(part) if part.overridden => false,
+        _ => PIVOT_DIRECTORIES
             .iter()
-            .any(|prefix| key.starts_with(prefix))
+            .any(|prefix| key.starts_with(prefix)),
+    }
 }
 
 fn part_key(path: &str) -> String {

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -9,7 +9,7 @@
 //! sheet, which refuses everything, rather than a narrow area that would let a
 //! stranding edit through.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use quick_xml::NsReader;
 use quick_xml::events::{BytesStart, Event};
@@ -18,8 +18,8 @@ use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
 use xlsx_model::{CellRef, Workbook};
 
 use crate::chart::{
-    NS_RELATIONSHIPS, chart_reference_areas, directory_of, parse_area, parse_relationships,
-    relationship_part_path, unmodelled_chart_parts,
+    NS_PACKAGE_RELATIONSHIPS, NS_RELATIONSHIPS, chart_reference_areas, directory_of, parse_area,
+    parse_relationships, relationship_part_path, unmodelled_chart_parts,
 };
 use crate::package::PartContentType;
 use crate::tree::{Element, Unqualified, Vocabulary, owned_local_name, parse_tree};
@@ -32,6 +32,12 @@ use crate::{MAX_DEPTH, ParseError};
 /// both; an unprefixed name with no namespace at all is read as ours too,
 /// because a part that declares none is still the vocabulary it looks like.
 const OURS: [&str; 2] = [NS_MAIN, NS_STRICT_MAIN];
+
+/// the package-relationships vocabulary a `.rels` part is written in.
+const RELATIONSHIPS: [&str; 1] = [NS_PACKAGE_RELATIONSHIPS];
+
+/// the vocabulary `[Content_Types].xml` is written in.
+const CONTENT_TYPES: [&str; 1] = ["http://schemas.openxmlformats.org/package/2006/content-types"];
 
 /// A preserved part naming sheets and cells neither this crate nor the model
 /// rewrites.
@@ -157,10 +163,11 @@ fn pivot_references(
     workbook: &Workbook,
     sheet_paths: &[String],
 ) -> Vec<UnpatchableReference> {
+    let typed = content_types_are_ours(parts);
     let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
     let pivot_parts = parts
         .iter()
-        .filter(|(path, _)| is_pivot_part(path, content_types))
+        .filter(|(path, _)| is_pivot_part(path, content_types, typed))
         .map(|(path, bytes)| (path, bytes, root_local_name(bytes)))
         .collect::<Vec<_>>();
 
@@ -196,7 +203,11 @@ fn pivot_references(
                 .and_then(|root| location_areas(root, hosts.get(&part_key(path)))),
             _ => None,
         };
-        references.push(bound(path.clone(), areas, workbook));
+        references.push(bound(
+            path.clone(),
+            typed.then_some(areas).flatten(),
+            workbook,
+        ));
     }
     references
 }
@@ -224,11 +235,12 @@ fn root_local_name(bytes: &[u8]) -> Option<String> {
                 if depth > MAX_DEPTH {
                     return None;
                 }
+                let cleared = declares_empty_default(&start)?;
                 if depth == 1 {
                     if root.is_some() {
                         return None;
                     }
-                    root = Some(ours_local_name(namespace, &start)?);
+                    root = Some(ours_local_name(namespace, &start, cleared)?);
                 }
             }
             Event::End(_) => depth = depth.checked_sub(1)?,
@@ -250,7 +262,11 @@ fn root_local_name(bytes: &[u8]) -> Option<String> {
 /// decided by the same rule the tree readers use. `NsReader` reports a default
 /// declared away as `Unbound`, exactly as it reports a part that declared none,
 /// so the tag's own `xmlns` is what tells those two apart here.
-fn ours_local_name(namespace: ResolveResult<'_>, start: &BytesStart<'_>) -> Option<String> {
+fn ours_local_name(
+    namespace: ResolveResult<'_>,
+    start: &BytesStart<'_>,
+    cleared: bool,
+) -> Option<String> {
     let resolved = String::from_utf8_lossy(match namespace {
         ResolveResult::Bound(ref namespace) => namespace.as_ref(),
         _ => b"",
@@ -258,7 +274,7 @@ fn ours_local_name(namespace: ResolveResult<'_>, start: &BytesStart<'_>) -> Opti
     .into_owned();
     let vocabulary = match namespace {
         ResolveResult::Bound(_) => Vocabulary::Bound(&resolved),
-        ResolveResult::Unbound if declares_empty_default(start) => Vocabulary::Cleared,
+        ResolveResult::Unbound if cleared => Vocabulary::Cleared,
         ResolveResult::Unbound | ResolveResult::Unknown(_) => Vocabulary::Absent,
     };
     let qname = String::from_utf8(start.name().as_ref().to_vec()).ok()?;
@@ -266,12 +282,16 @@ fn ours_local_name(namespace: ResolveResult<'_>, start: &BytesStart<'_>) -> Opti
 }
 
 /// Whether a start tag carries `xmlns=""`, which takes it out of every
-/// vocabulary rather than leaving it in none by omission.
-fn declares_empty_default(start: &BytesStart<'_>) -> bool {
-    start
-        .attributes()
-        .flatten()
-        .any(|attribute| attribute.key.as_ref() == b"xmlns" && attribute.value.as_ref().is_empty())
+/// vocabulary rather than leaving it in none by omission. `None` when its
+/// attributes do not parse — quick-xml reads those lazily, so a tag only proves
+/// itself well formed once they are walked.
+fn declares_empty_default(start: &BytesStart<'_>) -> Option<bool> {
+    let mut cleared = false;
+    for attribute in start.attributes() {
+        let attribute = attribute.ok()?;
+        cleared |= attribute.key.as_ref() == b"xmlns" && attribute.value.as_ref().is_empty();
+    }
+    Some(cleared)
 }
 
 /// A pivot part as an element tree, or nothing when this crate declines to read
@@ -410,9 +430,45 @@ fn pivot_table_hosts(
     hosts
 }
 
+/// The relationships declared for `path`, when they are ones this path may be
+/// read from. [`parse_relationships`] is shared code that matches `Id`, `Type`
+/// and `Target` by local name and takes the first of each, so a foreign
+/// attribute could answer for a real one and a repeated id could shadow the
+/// relationship it names. Rather than reach into that reader, the pivot path
+/// declines the whole part when it holds either, which costs a refusal and
+/// never a wrong claim.
+fn trusted_relationships<'a>(parts: &'a [(String, Vec<u8>)], path: &str) -> Option<&'a [u8]> {
+    const NAMES: [&str; 4] = ["Id", "Type", "Target", "TargetMode"];
+    let rels = find_part(parts, &relationship_part_path(path))?;
+    let root = parse_tree(rels).ok()?;
+    let mut ids = HashSet::new();
+    for child in root
+        .child_elements()
+        .filter(|child| child.local_name() == "Relationship")
+    {
+        if !child.answers_to(&RELATIONSHIPS, "Relationship") {
+            return None;
+        }
+        for name in NAMES {
+            let mut carried = child.attributes_in(&RELATIONSHIPS, name);
+            if carried.next().is_some() != child.any_attribute_named(name)
+                || carried.next().is_some()
+            {
+                return None;
+            }
+        }
+        if let Some(id) = child.attributes_in(&RELATIONSHIPS, "Id").next()
+            && !ids.insert(id.value.as_str())
+        {
+            return None;
+        }
+    }
+    Some(rels)
+}
+
 /// The part a relationship id on `path` points at, by lookup key.
 fn related_part(parts: &[(String, Vec<u8>)], path: &str, id: &str) -> Option<String> {
-    let rels = find_part(parts, &relationship_part_path(path))?;
+    let rels = trusted_relationships(parts, path)?;
     let directory = directory_of(path).to_owned();
     parse_relationships(rels)
         .ok()?
@@ -425,7 +481,7 @@ fn related_part(parts: &[(String, Vec<u8>)], path: &str, id: &str) -> Option<Str
 /// relationships part that will not parse relates nothing, which leaves what
 /// depended on it unresolved rather than failing the open.
 fn related_parts(parts: &[(String, Vec<u8>)], path: &str, relationship: &str) -> Vec<String> {
-    let Some(rels) = find_part(parts, &relationship_part_path(path)) else {
+    let Some(rels) = trusted_relationships(parts, path) else {
         return Vec::new();
     };
     let directory = directory_of(path).to_owned();
@@ -437,15 +493,44 @@ fn related_parts(parts: &[(String, Vec<u8>)], path: &str, relationship: &str) ->
         .collect()
 }
 
+/// Whether `[Content_Types].xml` is one a pivot part may be typed from. OPC
+/// typing is shared code that matches `Override`, `PartName` and `ContentType`
+/// by local name, so a foreign one could answer for a real one and rule a pivot
+/// part out. Rather than reach into that reader, the pivot path stops trusting
+/// the typing when the part holds anything it cannot read as ours.
+fn content_types_are_ours(parts: &[(String, Vec<u8>)]) -> bool {
+    const NAMES: [&str; 3] = ["PartName", "ContentType", "Extension"];
+    let Some(bytes) = find_part(parts, "[Content_Types].xml") else {
+        return true;
+    };
+    let Ok(root) = parse_tree(bytes) else {
+        return false;
+    };
+    root.child_elements().all(|child| {
+        (child.answers_to(&CONTENT_TYPES, "Override")
+            || child.answers_to(&CONTENT_TYPES, "Default"))
+            && NAMES.iter().all(|name| {
+                child.attributes_in(&CONTENT_TYPES, name).count()
+                    == usize::from(child.any_attribute_named(name))
+            })
+    })
+}
+
 /// Whether a part holds a pivot cache or pivot table. Typed the way OPC types
 /// anything: an `Override` is authoritative, and the conventional directories
 /// answer only for a part a `Default` extension mapping left untyped. A pivot
 /// part written outside those directories is still found, because a veto that
-/// reasons per part gives a part it never discovers no cover at all.
-fn is_pivot_part(path: &str, content_types: &[PartContentType]) -> bool {
+/// reasons per part gives a part it never discovers no cover at all. Typing
+/// this path cannot trust never rules a part out; it only stops ruling one in.
+fn is_pivot_part(path: &str, content_types: &[PartContentType], typed: bool) -> bool {
     let key = part_key(path);
     if key.contains("/_rels/") {
         return false;
+    }
+    if !typed {
+        return PIVOT_DIRECTORIES
+            .iter()
+            .any(|prefix| key.starts_with(prefix));
     }
     match content_types.iter().find(|part| part.path == key) {
         Some(part)

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -39,6 +39,17 @@ const RELATIONSHIPS: [&str; 1] = [NS_PACKAGE_RELATIONSHIPS];
 /// the vocabulary `[Content_Types].xml` is written in.
 const CONTENT_TYPES: [&str; 1] = ["http://schemas.openxmlformats.org/package/2006/content-types"];
 
+/// the relationship types the pivot path follows, in both the Transitional and
+/// Strict spellings a package may use.
+const REL_PIVOT_CACHE_RECORDS: [&str; 2] = [
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords",
+    "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotCacheRecords",
+];
+const REL_PIVOT_TABLE: [&str; 2] = [
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable",
+    "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotTable",
+];
+
 /// A preserved part naming sheets and cells neither this crate nor the model
 /// rewrites.
 #[derive(Clone, Debug)]
@@ -100,10 +111,10 @@ pub(crate) fn unpatchable_references(
     workbook: &Workbook,
     sheet_paths: &[String],
 ) -> Result<Vec<UnpatchableReference>, ParseError> {
-    let mut references = pivot_references(parts, content_types, workbook, sheet_paths);
+    let conforming = package_metadata_conforms(parts, content_types, sheet_paths);
+    let mut references = pivot_references(parts, content_types, workbook, sheet_paths, conforming);
     for chart in unmodelled_chart_parts(parts, content_types, workbook)? {
-        let areas = match chart
-            .claimed
+        let areas = match (conforming && chart.claimed)
             .then(|| find_part(parts, &chart.path))
             .flatten()
         {
@@ -162,17 +173,27 @@ fn pivot_references(
     content_types: &[PartContentType],
     workbook: &Workbook,
     sheet_paths: &[String],
+    conforming: bool,
 ) -> Vec<UnpatchableReference> {
-    let typing = content_type_typing(parts);
-    let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
     let pivot_parts = parts
         .iter()
-        .filter(|(path, _)| is_pivot_part(path, content_types, &typing))
+        .filter(|(path, _)| is_pivot_part(path, content_types, conforming))
+        .collect::<Vec<_>>();
+    if !conforming {
+        return pivot_parts
+            .into_iter()
+            .map(|(path, _)| bound(path.clone(), None, workbook))
+            .collect();
+    }
+
+    let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
+    let pivot_parts = pivot_parts
+        .into_iter()
         .map(|(path, bytes)| (path, bytes, root_local_name(bytes)))
         .collect::<Vec<_>>();
 
     let mut cache_areas: HashMap<String, Option<Vec<NamedArea>>> = HashMap::new();
-    let mut record_owners: HashMap<String, String> = HashMap::new();
+    let mut record_owners: HashMap<String, Option<String>> = HashMap::new();
     for (path, bytes) in pivot_parts
         .iter()
         .filter(|(_, _, root)| root.as_deref() == Some("pivotCacheDefinition"))
@@ -183,9 +204,12 @@ fn pivot_references(
         if let Some(records) = root
             .as_ref()
             .and_then(|root| root.attribute_ns(NS_RELATIONSHIPS, "id"))
-            .and_then(|id| related_part(parts, path, id))
+            .and_then(|id| related_part(parts, path, id, &REL_PIVOT_CACHE_RECORDS))
         {
-            record_owners.insert(records, part_key(path));
+            record_owners
+                .entry(records)
+                .and_modify(|owner| *owner = None)
+                .or_insert_with(|| Some(part_key(path)));
         }
     }
 
@@ -195,6 +219,7 @@ fn pivot_references(
             Some("pivotCacheDefinition") => cache_areas.get(&part_key(path)).cloned().flatten(),
             Some("pivotCacheRecords") => record_owners
                 .get(&part_key(path))
+                .and_then(Option::as_ref)
                 .and_then(|owner| cache_areas.get(owner))
                 .cloned()
                 .flatten(),
@@ -203,7 +228,6 @@ fn pivot_references(
                 .and_then(|root| location_areas(root, hosts.get(&part_key(path)))),
             _ => None,
         };
-        let areas = matches!(typing, Typing::Trusted).then_some(areas).flatten();
         references.push(bound(path.clone(), areas, workbook));
     }
     references
@@ -420,180 +444,153 @@ fn pivot_table_hosts(
 ) -> HashMap<String, Vec<String>> {
     let mut hosts: HashMap<String, Vec<String>> = HashMap::new();
     for (sheet, path) in workbook.sheets.iter().zip(sheet_paths) {
-        for table in related_parts(parts, path, "pivotTable") {
+        for table in related_parts(parts, path, &REL_PIVOT_TABLE) {
             hosts.entry(table).or_default().push(sheet.name.clone());
         }
     }
     hosts
 }
 
-/// The relationships declared for `path`, when they are ones this path may be
-/// read from. [`parse_relationships`] is shared code that matches `Id`, `Type`
-/// and `Target` by local name and takes the first of each, so a foreign
-/// attribute could answer for a real one and a repeated id could shadow the
-/// relationship it names. Rather than reach into that reader, the pivot path
-/// declines the whole part when it holds either, which costs a refusal and
-/// never a wrong claim.
-/// Whether every attribute a reader could take for `name` is the one this path
-/// would read: at most one carries that local name, and it is ours. Counting
-/// only the ours-namespaced ones would pass a foreign attribute sitting beside
-/// a real one, which is the one the reader takes first.
-fn sole_and_ours(element: &Element, namespaces: &[&str], name: &str) -> bool {
-    element.attributes_named(name) <= 1
-        && element.attributes_in(namespaces, name).count() == element.attributes_named(name)
+/// The part a relationship id on `path` points at, under an exact type. Only
+/// reached once the package metadata has been found conforming, so the shared
+/// reader's loose matching has nothing left to be fooled by and the type can be
+/// required exactly rather than by its final segment.
+fn related_part(
+    parts: &[(String, Vec<u8>)],
+    path: &str,
+    id: &str,
+    types: &[&str],
+) -> Option<String> {
+    related(parts, path)
+        .into_iter()
+        .find(|(rel_id, kind, _)| rel_id == id && types.contains(&kind.as_str()))
+        .map(|(_, _, target)| target)
 }
 
-fn trusted_relationships<'a>(parts: &'a [(String, Vec<u8>)], path: &str) -> Option<&'a [u8]> {
-    const NAMES: [&str; 4] = ["Id", "Type", "Target", "TargetMode"];
-    let rels = find_part(parts, &relationship_part_path(path))?;
-    let root = parse_tree(rels).ok()?;
-    let mut ids = HashSet::new();
-    for child in root
-        .child_elements()
-        .filter(|child| child.local_name() == "Relationship")
-    {
-        if !child.answers_to(&RELATIONSHIPS, "Relationship") {
-            return None;
-        }
-        for name in NAMES {
-            if !sole_and_ours(child, &RELATIONSHIPS, name) {
-                return None;
-            }
-        }
-        if let Some(id) = child.attributes_in(&RELATIONSHIPS, "Id").next()
-            && !ids.insert(id.value.as_str())
-        {
-            return None;
-        }
-    }
-    Some(rels)
+/// Every part `path` relates to under an exact relationship type.
+fn related_parts(parts: &[(String, Vec<u8>)], path: &str, types: &[&str]) -> Vec<String> {
+    related(parts, path)
+        .into_iter()
+        .filter(|(_, kind, _)| types.contains(&kind.as_str()))
+        .map(|(_, _, target)| target)
+        .collect()
 }
 
-/// The part a relationship id on `path` points at, by lookup key.
-fn related_part(parts: &[(String, Vec<u8>)], path: &str, id: &str) -> Option<String> {
-    let rels = trusted_relationships(parts, path)?;
-    let directory = directory_of(path).to_owned();
-    parse_relationships(rels)
-        .ok()?
-        .iter()
-        .find(|(rel_id, _, _)| rel_id == id)
-        .map(|(_, _, target)| part_key(&resolve_part_path(&directory, target)))
-}
-
-/// Every part `path` relates to under a relationship type, by lookup key. A
-/// relationships part that will not parse relates nothing, which leaves what
-/// depended on it unresolved rather than failing the open.
-fn related_parts(parts: &[(String, Vec<u8>)], path: &str, relationship: &str) -> Vec<String> {
-    let Some(rels) = trusted_relationships(parts, path) else {
+/// The relationships declared for `path`, with targets resolved to lookup keys.
+fn related(parts: &[(String, Vec<u8>)], path: &str) -> Vec<(String, String, String)> {
+    let Some(rels) = find_part(parts, &relationship_part_path(path)) else {
         return Vec::new();
     };
     let directory = directory_of(path).to_owned();
     parse_relationships(rels)
         .unwrap_or_default()
-        .iter()
-        .filter(|(_, kind, _)| kind.rsplit('/').next() == Some(relationship))
-        .map(|(_, _, target)| part_key(&resolve_part_path(&directory, target)))
+        .into_iter()
+        .map(|(id, kind, target)| (id, kind, part_key(&resolve_part_path(&directory, &target))))
         .collect()
 }
 
-/// How far `[Content_Types].xml` may be trusted to type a pivot part.
-enum Typing {
-    /// every entry reads unambiguously, so an override may rule a part in or
-    /// out the way OPC says it does
-    Trusted,
-    /// something in it cannot be read as ours, so an override may only add a
-    /// part to look at, never take one away, and nothing it typed resolves
-    Untrusted(HashSet<String>),
+/// Whether the package metadata this path reads is exactly what OPC specifies.
+/// Narrowing the veto means trusting readers that match names loosely, and this
+/// crate cannot reconstruct that trust one hole at a time. So it asks once, of
+/// the whole package: does the content-type part conform, and does every
+/// relationships part this path follows conform? A no returns the workbook to
+/// the blanket veto that shipped before narrowing existed — safe by
+/// construction, because it is the behaviour already in people's hands.
+fn package_metadata_conforms(
+    parts: &[(String, Vec<u8>)],
+    content_types: &[PartContentType],
+    sheet_paths: &[String],
+) -> bool {
+    content_types_conform(parts)
+        && sheet_paths
+            .iter()
+            .map(String::as_str)
+            .chain(
+                parts
+                    .iter()
+                    .map(|(path, _)| path.as_str())
+                    .filter(|path| is_pivot_part(path, content_types, true)),
+            )
+            .all(|owner| relationships_conform(parts, owner))
 }
 
-/// How far the content types may be trusted, and failing that, every part any
-/// override could have been naming as a pivot. OPC typing is shared code that
-/// matches `Override`, `PartName` and `ContentType` by local name at every
-/// depth and takes the first of each, so a foreign one could answer for a real
-/// one. This gate walks what that reader walks — the whole tree, root included
-/// — rather than an approximation of it.
-fn content_type_typing(parts: &[(String, Vec<u8>)]) -> Typing {
+/// Whether every attribute a reader could take for `name` is the one this path
+/// would read: at most one carries that local name, and it is ours.
+fn sole_and_ours(element: &Element, namespaces: &[&str], name: &str) -> bool {
+    element.attributes_named(name) <= 1
+        && element.attributes_in(namespaces, name).count() == element.attributes_named(name)
+}
+
+/// Whether `[Content_Types].xml` holds only what OPC allows: a `Types` root
+/// over `Default` and `Override` entries, each carrying its required names once
+/// and unambiguously, no extension or part name typed twice.
+fn content_types_conform(parts: &[(String, Vec<u8>)]) -> bool {
     const NAMES: [&str; 3] = ["PartName", "ContentType", "Extension"];
     let Some(bytes) = find_part(parts, "[Content_Types].xml") else {
-        return Typing::Trusted;
+        return true;
     };
     let Ok(root) = parse_tree(bytes) else {
-        return Typing::Untrusted(HashSet::new());
+        return false;
     };
-    let mut entries = Vec::new();
-    collect_content_type_entries(&root, 0, &mut entries);
-    let mut typed = HashSet::new();
-    let trusted = entries.iter().all(|(depth, entry)| {
-        *depth == 1
-            && (entry.answers_to(&CONTENT_TYPES, "Override")
-                || entry.answers_to(&CONTENT_TYPES, "Default"))
+    if !root.answers_to(&CONTENT_TYPES, "Types") {
+        return false;
+    }
+    let (mut overrides, mut defaults) = (HashSet::new(), HashSet::new());
+    root.child_elements().all(|entry| {
+        entry.child_elements().next().is_none()
             && NAMES
                 .iter()
                 .all(|name| sole_and_ours(entry, &CONTENT_TYPES, name))
-    }) && entries
-        .iter()
-        .filter(|(_, entry)| entry.local_name() == "Override")
-        .all(|(_, entry)| match entry.attribute_local("PartName") {
-            Some(part) => typed.insert(part_key(part)),
-            None => true,
-        });
-    if trusted {
-        return Typing::Trusted;
-    }
-    Typing::Untrusted(pivot_candidates(&entries))
+            && entry.attribute_local("ContentType").is_some()
+            && if entry.answers_to(&CONTENT_TYPES, "Override") {
+                entry
+                    .attribute_local("PartName")
+                    .is_some_and(|part| overrides.insert(part_key(part)))
+            } else if entry.answers_to(&CONTENT_TYPES, "Default") {
+                entry
+                    .attribute_local("Extension")
+                    .is_some_and(|extension| defaults.insert(extension.to_ascii_lowercase()))
+            } else {
+                false
+            }
+    })
 }
 
-/// Every element the OPC reader would take for an entry, with its depth:
-/// matched by local name at any depth, the root included, exactly as
-/// [`crate::package`] reads them. The depth comes back because that reader
-/// honours an entry the schema only allows directly under `Types`, and one
-/// sitting anywhere else is a reading no conforming consumer shares.
-fn collect_content_type_entries<'a>(
-    element: &'a Element,
-    depth: usize,
-    out: &mut Vec<(usize, &'a Element)>,
-) {
-    if matches!(element.local_name(), "Override" | "Default") {
-        out.push((depth, element));
+/// Whether the relationships declared for a part hold only what OPC allows: a
+/// `Relationships` root over `Relationship` entries, each carrying its required
+/// names once and unambiguously, no id declared twice.
+fn relationships_conform(parts: &[(String, Vec<u8>)], owner: &str) -> bool {
+    const NAMES: [&str; 4] = ["Id", "Type", "Target", "TargetMode"];
+    let Some(bytes) = find_part(parts, &relationship_part_path(owner)) else {
+        return true;
+    };
+    let Ok(root) = parse_tree(bytes) else {
+        return false;
+    };
+    if !root.answers_to(&RELATIONSHIPS, "Relationships") {
+        return false;
     }
-    for child in element.child_elements() {
-        collect_content_type_entries(child, depth + 1, out);
-    }
-}
-
-/// Every part an override could have been typing as a pivot, however the entry
-/// spells its names. Used only when the typing is not trustworthy, where the
-/// answer has to be inclusive: a part left undiscovered vetoes nothing.
-fn pivot_candidates(entries: &[(usize, &Element)]) -> HashSet<String> {
-    entries
-        .iter()
-        .map(|(_, entry)| entry)
-        .filter(|entry| entry.local_name() == "Override")
-        .filter(|entry| {
-            entry.attributes.iter().any(|attribute| {
-                attribute.local_name() == "ContentType"
-                    && PIVOT_CONTENT_TYPES
-                        .iter()
-                        .any(|known| attribute.value.eq_ignore_ascii_case(known))
-            })
-        })
-        .flat_map(|entry| {
-            entry
-                .attributes
+    let mut ids = HashSet::new();
+    root.child_elements().all(|entry| {
+        entry.answers_to(&RELATIONSHIPS, "Relationship")
+            && entry.child_elements().next().is_none()
+            && NAMES
                 .iter()
-                .filter(|attribute| attribute.local_name() == "PartName")
-                .map(|attribute| part_key(&attribute.value))
-        })
-        .collect()
+                .all(|name| sole_and_ours(entry, &RELATIONSHIPS, name))
+            && entry.attribute_local("Type").is_some()
+            && entry.attribute_local("Target").is_some()
+            && entry
+                .attribute_local("Id")
+                .is_some_and(|id| ids.insert(id.to_owned()))
+    })
 }
 
 /// Whether a part holds a pivot cache or pivot table. Typed the way OPC types
 /// anything: an `Override` is authoritative, and the conventional directories
-/// answer only for a part a `Default` extension mapping left untyped. A pivot
-/// part written outside those directories is still found, because a veto that
-/// reasons per part gives a part it never discovers no cover at all. Typing
-/// this path cannot trust never rules a part out; it only stops ruling one in.
-fn is_pivot_part(path: &str, content_types: &[PartContentType], typing: &Typing) -> bool {
+/// answer only for a part a `Default` extension mapping left untyped. Metadata
+/// that does not conform is not read at all, leaving the conventional
+/// directories the blanket veto always used.
+fn is_pivot_part(path: &str, content_types: &[PartContentType], conforming: bool) -> bool {
     let key = part_key(path);
     if key.contains("/_rels/") {
         return false;
@@ -603,13 +600,10 @@ fn is_pivot_part(path: &str, content_types: &[PartContentType], typing: &Typing)
             .iter()
             .any(|prefix| key.starts_with(prefix))
     };
-    let typed = match typing {
-        Typing::Trusted => content_types.iter().find(|part| part.path == key),
-        Typing::Untrusted(candidates) => {
-            return conventional() || candidates.contains(&key);
-        }
-    };
-    match typed {
+    if !conforming {
+        return conventional();
+    }
+    match content_types.iter().find(|part| part.path == key) {
         Some(part)
             if PIVOT_CONTENT_TYPES
                 .iter()

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -22,7 +22,12 @@ use crate::chart::{
 };
 use crate::package::PartContentType;
 use crate::tree::{Element, parse_tree};
+use crate::write::NS_MAIN;
 use crate::xml::{find_part, local_name, next_event, reader, resolve_part_path};
+
+/// the markup-compatibility vocabulary, whose branches stand in for the element
+/// they wrap.
+const NS_MCE: &str = "http://schemas.openxmlformats.org/markup-compatibility/2006";
 
 /// A preserved part naming sheets and cells neither this crate nor the model
 /// rewrites.
@@ -207,11 +212,14 @@ fn root_local_name(bytes: &[u8]) -> Option<String> {
     }
 }
 
-/// A pivot part as an element tree. A part too large or too malformed to read
-/// resolves to nothing, which is treated as naming every cell rather than
-/// failing the open of a workbook that used to open.
+/// A pivot part as an element tree, or nothing when this crate declines to read
+/// it whole: too large or too malformed, or carrying a markup-compatibility
+/// choice it does not make. Declining is treated as naming every cell rather
+/// than failing the open of a workbook that used to open.
 fn tree(bytes: &[u8]) -> Option<Element> {
-    parse_tree(bytes).ok()
+    parse_tree(bytes)
+        .ok()
+        .filter(|root| !carries_alternate_content(root))
 }
 
 /// The worksheet ranges a pivot cache is built from. Only a source read whole
@@ -219,14 +227,14 @@ fn tree(bytes: &[u8]) -> Option<Element> {
 /// `extLst` carrying the real source among them — or a `rangeSet` it cannot
 /// read all of leaves the cache naming everything.
 fn source_areas(root: &Element) -> Option<Vec<NamedArea>> {
-    let source = root.sole_child("cacheSource")?;
+    let source = sole_child(root, "cacheSource")?;
     let children = source.child_elements().collect::<Vec<_>>();
     let [only] = children[..] else {
         return None;
     };
     match sole_attribute(source, "type")?.unwrap_or("worksheet") {
-        "worksheet" if only.local_name() == "worksheetSource" => Some(vec![named_area(only)?]),
-        "consolidation" if only.local_name() == "consolidation" => consolidated_areas(only),
+        "worksheet" if only.answers_to(NS_MAIN, "worksheetSource") => Some(vec![named_area(only)?]),
+        "consolidation" if only.answers_to(NS_MAIN, "consolidation") => consolidated_areas(only),
         _ => None,
     }
 }
@@ -234,15 +242,14 @@ fn source_areas(root: &Element) -> Option<Vec<NamedArea>> {
 fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
     if consolidation
         .child_elements()
-        .any(|child| !matches!(child.local_name(), "pages" | "rangeSets"))
+        .any(|child| !child.answers_to(NS_MAIN, "pages") && !child.answers_to(NS_MAIN, "rangeSets"))
     {
         return None;
     }
-    let areas = consolidation
-        .sole_child("rangeSets")?
+    let areas = sole_child(consolidation, "rangeSets")?
         .child_elements()
         .map(|set| {
-            (set.local_name() == "rangeSet")
+            set.answers_to(NS_MAIN, "rangeSet")
                 .then(|| named_area(set))
                 .flatten()
         })
@@ -254,7 +261,9 @@ fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
 /// instead: the schema allows exactly one of `ref` and `name`, and an `r:id`
 /// puts the range in another workbook.
 fn named_area(element: &Element) -> Option<NamedArea> {
-    if element.attributes_named("name") > 0 || element.attributes_named("id") > 0 {
+    if element.attributes_in(NS_MAIN, "name").next().is_some()
+        || element.attributes_in(NS_MAIN, "id").next().is_some()
+    {
         return None;
     }
     let sheet = sole_attribute(element, "sheet")??.to_owned();
@@ -266,7 +275,7 @@ fn named_area(element: &Element) -> Option<NamedArea> {
 /// body; the filter area sits beside it, so its page counts are padded onto the
 /// far corner rather than trusting `ref` to be the whole block.
 fn location_areas(root: &Element, hosts: Option<&Vec<String>>) -> Option<Vec<NamedArea>> {
-    let location = root.sole_child("location")?;
+    let location = sole_child(root, "location")?;
     let (_, end) = parse_area(sole_attribute(location, "ref")??)?;
     let end = CellRef::new(
         end.row
@@ -289,17 +298,39 @@ fn page_count(location: &Element, name: &str) -> Option<u32> {
     }
 }
 
-/// An attribute read by a name only one of them may answer to. The outer
-/// `None` is ambiguity — several attributes carry that local name, so markup
-/// compatibility could be hiding the real one behind an ignored prefix and a
-/// lookup would be choosing by authoring order — and the inner `None` is a
-/// plain absence, which an optional attribute may default.
-fn sole_attribute<'a>(element: &'a Element, name: &str) -> Option<Option<&'a str>> {
-    match element.attributes_named(name) {
-        0 => Some(None),
-        1 => Some(element.attribute_local(name)),
-        _ => None,
-    }
+/// An attribute read by a name only one of ours may answer to. The outer `None`
+/// is ambiguity — several carry that name, so a lookup would be choosing by
+/// authoring order — and the inner `None` is absence, which an optional
+/// attribute may default. A foreign attribute is not one of ours and so reads
+/// as absent, exactly as it does to a consumer that drops it.
+fn sole_attribute<'a>(element: &'a Element, name: &'a str) -> Option<Option<&'a str>> {
+    let mut candidates = element.attributes_in(NS_MAIN, name);
+    let Some(only) = candidates.next() else {
+        return Some(None);
+    };
+    candidates
+        .next()
+        .is_none()
+        .then_some(Some(only.value.as_str()))
+}
+
+/// The one child answering to a name, or `None` when none of ours does or
+/// several do. A name only a foreign node answers to is a name nothing answers
+/// to, which for a node the part cannot be read without is unresolved.
+fn sole_child<'a>(element: &'a Element, local: &'a str) -> Option<&'a Element> {
+    let mut candidates = element.children_in(NS_MAIN, local);
+    let only = candidates.next()?;
+    candidates.next().is_none().then_some(only)
+}
+
+/// Whether a part hands a consumer a choice this crate does not make. Choosing
+/// between `mc:Choice` and `mc:Fallback` is markup-compatibility processing,
+/// and a branch can supply the very node a lookup is after, so a pivot part
+/// carrying one is read as naming everything rather than as whichever branch
+/// happens to sit first.
+fn carries_alternate_content(element: &Element) -> bool {
+    element.is(NS_MCE, "AlternateContent")
+        || element.child_elements().any(carries_alternate_content)
 }
 
 /// The sheets each pivot table part is laid out on, followed from the worksheet

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -1,0 +1,335 @@
+//! What the preserved parts no save rewrites — pivot caches, pivot tables and
+//! the charts the model does not cover — actually name, so a structural edit is
+//! refused only when it would move one of those cells rather than whenever such
+//! a part is anywhere in the package.
+//!
+//! Every resolution here is all or nothing. A source this crate does not read
+//! whole, a sheet the workbook does not hold exactly one of, a relationships
+//! part that will not parse: each leaves the part naming every cell of every
+//! sheet, which refuses everything, rather than a narrow area that would let a
+//! stranding edit through.
+
+use std::collections::HashMap;
+
+use quick_xml::events::Event;
+use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
+use xlsx_model::{CellRef, Workbook};
+
+use crate::ParseError;
+use crate::chart::{
+    NS_RELATIONSHIPS, chart_reference_areas, directory_of, parse_area, parse_relationships,
+    relationship_part_path, unmodelled_chart_parts,
+};
+use crate::package::PartContentType;
+use crate::tree::{Element, parse_tree};
+use crate::xml::{find_part, local_name, next_event, reader, resolve_part_path};
+
+/// A preserved part naming sheets and cells neither this crate nor the model
+/// rewrites.
+#[derive(Clone, Debug)]
+pub struct UnpatchableReference {
+    part: String,
+    /// the areas it names, or `None` when it did not resolve whole and every
+    /// cell of every sheet has to be assumed named.
+    areas: Option<Vec<ReferenceArea>>,
+}
+
+/// One area a part names, kept as its far corner: an insert or delete at or
+/// before that corner moves what the area covers, and one past it does not.
+#[derive(Clone, Debug)]
+struct ReferenceArea {
+    sheet: String,
+    end: CellRef,
+}
+
+impl UnpatchableReference {
+    /// The package path of the part.
+    pub fn part(&self) -> &str {
+        &self.part
+    }
+
+    /// Whether renaming, dropping or reordering `sheet` would strand it.
+    pub fn names_sheet(&self, sheet: &str) -> bool {
+        self.strands(|area| area.sheet.eq_ignore_ascii_case(sheet))
+    }
+
+    /// Whether inserting or deleting rows at `at` on `sheet` would move a cell
+    /// it names. Everything from `at` down moves, so an area ending above it is
+    /// left where it was.
+    pub fn moved_by_rows(&self, sheet: &str, at: u32) -> bool {
+        self.strands(|area| area.sheet.eq_ignore_ascii_case(sheet) && area.end.row >= at)
+    }
+
+    /// The column-wise counterpart of [`Self::moved_by_rows`].
+    pub fn moved_by_cols(&self, sheet: &str, at: u32) -> bool {
+        self.strands(|area| area.sheet.eq_ignore_ascii_case(sheet) && area.end.col >= at)
+    }
+
+    fn strands(&self, disturbed: impl Fn(&ReferenceArea) -> bool) -> bool {
+        match &self.areas {
+            None => true,
+            Some(areas) => areas.iter().any(disturbed),
+        }
+    }
+}
+
+/// An area before it is bound to the workbook: a sheet name as the part spells
+/// it, and the far corner of what it covers there.
+type NamedArea = (String, CellRef);
+
+/// Every preserved part a save cannot rewrite, with what each one names.
+/// `sheet_paths` is the source part of each of `workbook`'s sheets, in order.
+pub(crate) fn unpatchable_references(
+    parts: &[(String, Vec<u8>)],
+    content_types: &[PartContentType],
+    workbook: &Workbook,
+    sheet_paths: &[String],
+) -> Result<Vec<UnpatchableReference>, ParseError> {
+    let mut references = pivot_references(parts, workbook, sheet_paths);
+    for chart in unmodelled_chart_parts(parts, content_types, workbook)? {
+        let areas = match chart
+            .claimed
+            .then(|| find_part(parts, &chart.path))
+            .flatten()
+        {
+            Some(bytes) => chart_reference_areas(bytes, chart.owner.as_deref())?,
+            None => None,
+        };
+        references.push(bound(chart.path, areas, workbook));
+    }
+    Ok(references)
+}
+
+/// Binds resolved areas to the workbook. A sheet it does not hold exactly one
+/// of is one this crate cannot reason about — a reference into it would rebind
+/// the moment some other sheet took that name — so the part is left naming
+/// everything.
+fn bound(part: String, areas: Option<Vec<NamedArea>>, workbook: &Workbook) -> UnpatchableReference {
+    let areas = areas
+        .filter(|areas| {
+            areas
+                .iter()
+                .all(|(sheet, _)| names_one_sheet(workbook, sheet))
+        })
+        .map(|areas| {
+            areas
+                .into_iter()
+                .map(|(sheet, end)| ReferenceArea { sheet, end })
+                .collect()
+        });
+    UnpatchableReference { part, areas }
+}
+
+fn names_one_sheet(workbook: &Workbook, sheet: &str) -> bool {
+    workbook
+        .sheets
+        .iter()
+        .filter(|candidate| candidate.name.eq_ignore_ascii_case(sheet))
+        .count()
+        == 1
+}
+
+/// The directories a pivot part lives in. A save rewrites neither the ranges a
+/// cache is built from nor the grid a pivot table is laid out on.
+const PIVOT_DIRECTORIES: [&str; 2] = ["xl/pivottables/", "xl/pivotcache/"];
+
+fn pivot_references(
+    parts: &[(String, Vec<u8>)],
+    workbook: &Workbook,
+    sheet_paths: &[String],
+) -> Vec<UnpatchableReference> {
+    let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
+    let pivot_parts = parts
+        .iter()
+        .filter(|(path, _)| is_pivot_part(path))
+        .map(|(path, bytes)| (path, bytes, root_local_name(bytes)))
+        .collect::<Vec<_>>();
+
+    let mut cache_areas: HashMap<String, Option<Vec<NamedArea>>> = HashMap::new();
+    let mut record_owners: HashMap<String, String> = HashMap::new();
+    for (path, bytes) in pivot_parts
+        .iter()
+        .filter(|(_, _, root)| root.as_deref() == Some("pivotCacheDefinition"))
+        .map(|(path, bytes, _)| (path, bytes))
+    {
+        let root = tree(bytes);
+        cache_areas.insert(part_key(path), root.as_ref().and_then(source_areas));
+        if let Some(records) = root
+            .as_ref()
+            .and_then(|root| root.attribute_ns(NS_RELATIONSHIPS, "id"))
+            .and_then(|id| related_part(parts, path, id))
+        {
+            record_owners.insert(records, part_key(path));
+        }
+    }
+
+    let mut references = Vec::new();
+    for (path, bytes, root) in pivot_parts {
+        let areas = match root.as_deref() {
+            Some("pivotCacheDefinition") => cache_areas.get(&part_key(path)).cloned().flatten(),
+            Some("pivotCacheRecords") => record_owners
+                .get(&part_key(path))
+                .and_then(|owner| cache_areas.get(owner))
+                .cloned()
+                .flatten(),
+            Some("pivotTableDefinition") => tree(bytes)
+                .as_ref()
+                .and_then(|root| location_areas(root, hosts.get(&part_key(path)))),
+            _ => None,
+        };
+        references.push(bound(path.clone(), areas, workbook));
+    }
+    references
+}
+
+/// The local name of a part's root element, read without building a tree so a
+/// cached-records part running to megabytes costs nothing to classify.
+fn root_local_name(bytes: &[u8]) -> Option<String> {
+    let mut reader = reader(bytes);
+    let mut buf = Vec::new();
+    let mut depth = 0;
+    loop {
+        match next_event(&mut reader, &mut buf, &mut depth).ok()? {
+            Event::Start(start) => return String::from_utf8(local_name(&start)).ok(),
+            Event::Eof => return None,
+            _ => {}
+        }
+    }
+}
+
+/// A pivot part as an element tree. A part too large or too malformed to read
+/// resolves to nothing, which is treated as naming every cell rather than
+/// failing the open of a workbook that used to open.
+fn tree(bytes: &[u8]) -> Option<Element> {
+    parse_tree(bytes).ok()
+}
+
+/// The worksheet ranges a pivot cache is built from. Only a source read whole
+/// resolves: an unhandled `type`, a child this crate does not model — an
+/// `extLst` carrying the real source among them — or a `rangeSet` it cannot
+/// read all of leaves the cache naming everything.
+fn source_areas(root: &Element) -> Option<Vec<NamedArea>> {
+    let source = root.child("cacheSource")?;
+    let children = source.child_elements().collect::<Vec<_>>();
+    let [only] = children[..] else {
+        return None;
+    };
+    match source.attribute_local("type").unwrap_or("worksheet") {
+        "worksheet" if only.local_name() == "worksheetSource" => Some(vec![named_area(only)?]),
+        "consolidation" if only.local_name() == "consolidation" => consolidated_areas(only),
+        _ => None,
+    }
+}
+
+fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
+    if consolidation
+        .child_elements()
+        .any(|child| !matches!(child.local_name(), "pages" | "rangeSets"))
+    {
+        return None;
+    }
+    let areas = consolidation
+        .child("rangeSets")?
+        .child_elements()
+        .map(|set| {
+            (set.local_name() == "rangeSet")
+                .then(|| named_area(set))
+                .flatten()
+        })
+        .collect::<Option<Vec<_>>>()?;
+    (!areas.is_empty()).then_some(areas)
+}
+
+/// A `sheet`/`ref` pair. Refused when anything else could be naming the source
+/// instead: the schema allows exactly one of `ref` and `name`, and an `r:id`
+/// puts the range in another workbook.
+fn named_area(element: &Element) -> Option<NamedArea> {
+    if element.attribute_local("name").is_some() || element.attribute_local("id").is_some() {
+        return None;
+    }
+    let sheet = element.attribute_local("sheet")?.to_owned();
+    let (_, end) = parse_area(element.attribute_local("ref")?)?;
+    Some((sheet, end))
+}
+
+/// The grid a pivot table occupies on each sheet hosting it. `ref` covers the
+/// body; the filter area sits beside it, so its page counts are padded onto the
+/// far corner rather than trusting `ref` to be the whole block.
+fn location_areas(root: &Element, hosts: Option<&Vec<String>>) -> Option<Vec<NamedArea>> {
+    let location = root.child("location")?;
+    let (_, end) = parse_area(location.attribute_local("ref")?)?;
+    let end = CellRef::new(
+        end.row
+            .saturating_add(page_count(location, "rowPageCount")?)
+            .min(MAX_ROWS - 1),
+        end.col
+            .saturating_add(page_count(location, "colPageCount")?)
+            .min(MAX_COLS - 1),
+    );
+    let hosts = hosts?;
+    (!hosts.is_empty()).then(|| hosts.iter().map(|host| (host.clone(), end)).collect())
+}
+
+/// How far the filter area reaches past `ref`. Absent is none; anything that is
+/// not a count leaves the pivot table unresolved.
+fn page_count(location: &Element, name: &str) -> Option<u32> {
+    match location.attribute_local(name) {
+        None => Some(0),
+        Some(value) => value.trim().parse().ok(),
+    }
+}
+
+/// The sheets each pivot table part is laid out on, followed from the worksheet
+/// relationships that anchor it. A part two sheets anchor is laid out on both.
+fn pivot_table_hosts(
+    parts: &[(String, Vec<u8>)],
+    workbook: &Workbook,
+    sheet_paths: &[String],
+) -> HashMap<String, Vec<String>> {
+    let mut hosts: HashMap<String, Vec<String>> = HashMap::new();
+    for (sheet, path) in workbook.sheets.iter().zip(sheet_paths) {
+        for table in related_parts(parts, path, "pivotTable") {
+            hosts.entry(table).or_default().push(sheet.name.clone());
+        }
+    }
+    hosts
+}
+
+/// The part a relationship id on `path` points at, by lookup key.
+fn related_part(parts: &[(String, Vec<u8>)], path: &str, id: &str) -> Option<String> {
+    let rels = find_part(parts, &relationship_part_path(path))?;
+    let directory = directory_of(path).to_owned();
+    parse_relationships(rels)
+        .ok()?
+        .iter()
+        .find(|(rel_id, _, _)| rel_id == id)
+        .map(|(_, _, target)| part_key(&resolve_part_path(&directory, target)))
+}
+
+/// Every part `path` relates to under a relationship type, by lookup key. A
+/// relationships part that will not parse relates nothing, which leaves what
+/// depended on it unresolved rather than failing the open.
+fn related_parts(parts: &[(String, Vec<u8>)], path: &str, relationship: &str) -> Vec<String> {
+    let Some(rels) = find_part(parts, &relationship_part_path(path)) else {
+        return Vec::new();
+    };
+    let directory = directory_of(path).to_owned();
+    parse_relationships(rels)
+        .unwrap_or_default()
+        .iter()
+        .filter(|(_, kind, _)| kind.rsplit('/').next() == Some(relationship))
+        .map(|(_, _, target)| part_key(&resolve_part_path(&directory, target)))
+        .collect()
+}
+
+fn is_pivot_part(path: &str) -> bool {
+    let key = part_key(path);
+    !key.contains("/_rels/")
+        && PIVOT_DIRECTORIES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+}
+
+fn part_key(path: &str) -> String {
+    path.trim_start_matches('/').to_ascii_lowercase()
+}

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -18,9 +18,9 @@ use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
 use xlsx_model::{CellRef, Workbook};
 
 use crate::chart::{
-    NS_PACKAGE_RELATIONSHIPS, NS_RELATIONSHIPS, chart_reference_areas, directory_of,
-    drawing_claims_are_unambiguous, parse_area, parse_relationships, relationship_part_path,
-    unmodelled_chart_parts,
+    CHART_CONTENT_TYPES, NS_PACKAGE_RELATIONSHIPS, NS_RELATIONSHIPS, chart_reference_areas,
+    directory_of, drawing_claims_are_unambiguous, parse_area, parse_relationships,
+    relationship_part_path, unmodelled_chart_parts,
 };
 use crate::package::PartContentType;
 use crate::tree::{
@@ -127,10 +127,16 @@ pub(crate) fn unpatchable_references(
         // decided it cannot trust, so here it stops being a function of any
         // reader: every part names everything. Nothing can drop out of a set
         // that is the whole package, whatever a future reader does with it.
-        return Ok(parts
-            .iter()
-            .map(|(path, _)| bound(path.clone(), None, workbook))
-            .collect());
+        // A package holding nothing reference-bearing has nothing to strand,
+        // and gets the veto it always got: none.
+        return Ok(if package_bears_references(parts) {
+            parts
+                .iter()
+                .map(|(path, _)| bound(path.clone(), None, workbook))
+                .collect()
+        } else {
+            Vec::new()
+        });
     }
     let mut references = pivot_references(parts, content_types, workbook, sheet_paths);
     for chart in unmodelled_chart_parts(parts, content_types, workbook)? {
@@ -145,6 +151,37 @@ pub(crate) fn unpatchable_references(
         references.push(bound(chart.path, areas, workbook));
     }
     Ok(references)
+}
+
+/// Whether the package holds anything a save could strand. Read as loosely as
+/// it can be: a conventional directory, or a content type named by any
+/// attribute anywhere in the typing part. Over-reading a trigger only ever
+/// vetoes more, and reading it this loosely is what stops a decoy attribute
+/// from hiding a real part behind a reader that takes the first match.
+fn package_bears_references(parts: &[(String, Vec<u8>)]) -> bool {
+    const DIRECTORIES: [&str; 3] = ["xl/pivottables/", "xl/pivotcache/", "xl/charts/"];
+    if parts.iter().any(|(path, _)| {
+        let key = part_key(path);
+        DIRECTORIES.iter().any(|prefix| key.starts_with(prefix))
+    }) {
+        return true;
+    }
+    let Some(bytes) = find_part(parts, "[Content_Types].xml") else {
+        return false;
+    };
+    parse_tree(bytes).is_ok_and(|root| names_a_reference_bearing_type(&root, 0))
+}
+
+fn names_a_reference_bearing_type(element: &Element, depth: usize) -> bool {
+    depth <= MAX_DEPTH
+        && (element.attributes.iter().any(|attribute| {
+            PIVOT_CONTENT_TYPES
+                .iter()
+                .chain(CHART_CONTENT_TYPES.iter())
+                .any(|known| attribute.value.eq_ignore_ascii_case(known))
+        }) || element
+            .child_elements()
+            .any(|child| names_a_reference_bearing_type(child, depth + 1)))
 }
 
 /// Binds resolved areas to the workbook. A sheet it does not hold exactly one

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -22,9 +22,9 @@ use crate::chart::{
     relationship_part_path, unmodelled_chart_parts,
 };
 use crate::package::PartContentType;
-use crate::tree::{Element, parse_tree};
+use crate::tree::{Element, Unqualified, Vocabulary, owned_local_name, parse_tree};
 use crate::write::{NS_MAIN, NS_STRICT_MAIN};
-use crate::xml::{find_part, local_name, resolve_part_path};
+use crate::xml::{find_part, resolve_part_path};
 use crate::{MAX_DEPTH, ParseError};
 
 /// the spreadsheetml vocabulary a pivot part is read in. Transitional and
@@ -232,6 +232,12 @@ fn root_local_name(bytes: &[u8]) -> Option<String> {
                 }
             }
             Event::End(_) => depth = depth.checked_sub(1)?,
+            Event::Text(text) if depth == 0 => {
+                if !text.iter().all(u8::is_ascii_whitespace) {
+                    return None;
+                }
+            }
+            Event::CData(_) | Event::GeneralRef(_) if depth == 0 => return None,
             Event::Eof => break,
             _ => {}
         }
@@ -240,19 +246,32 @@ fn root_local_name(bytes: &[u8]) -> Option<String> {
     (depth == 0).then_some(root).flatten()
 }
 
-/// The local name of a start tag whose expanded name is in our vocabulary.
+/// The local name of a start tag whose expanded name is in our vocabulary,
+/// decided by the same rule the tree readers use. `NsReader` reports a default
+/// declared away as `Unbound`, exactly as it reports a part that declared none,
+/// so the tag's own `xmlns` is what tells those two apart here.
 fn ours_local_name(namespace: ResolveResult<'_>, start: &BytesStart<'_>) -> Option<String> {
-    let ours = match namespace {
-        ResolveResult::Unbound => true,
-        ResolveResult::Bound(namespace) => {
-            OURS.contains(&String::from_utf8_lossy(namespace.as_ref()).as_ref())
-        }
-        ResolveResult::Unknown(_) => false,
+    let resolved = String::from_utf8_lossy(match namespace {
+        ResolveResult::Bound(ref namespace) => namespace.as_ref(),
+        _ => b"",
+    })
+    .into_owned();
+    let vocabulary = match namespace {
+        ResolveResult::Bound(_) => Vocabulary::Bound(&resolved),
+        ResolveResult::Unbound if declares_empty_default(start) => Vocabulary::Cleared,
+        ResolveResult::Unbound | ResolveResult::Unknown(_) => Vocabulary::Absent,
     };
-    let name = String::from_utf8(start.name().as_ref().to_vec()).ok()?;
-    (ours && name.matches(':').count() <= 1)
-        .then(|| String::from_utf8(local_name(start)).ok())
+    let qname = String::from_utf8(start.name().as_ref().to_vec()).ok()?;
+    owned_local_name(&qname, vocabulary, &OURS, Unqualified::Owned).map(str::to_owned)
+}
+
+/// Whether a start tag carries `xmlns=""`, which takes it out of every
+/// vocabulary rather than leaving it in none by omission.
+fn declares_empty_default(start: &BytesStart<'_>) -> bool {
+    start
+        .attributes()
         .flatten()
+        .any(|attribute| attribute.key.as_ref() == b"xmlns" && attribute.value.as_ref().is_empty())
 }
 
 /// A pivot part as an element tree, or nothing when this crate declines to read

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -122,10 +122,20 @@ pub(crate) fn unpatchable_references(
     workbook: &Workbook,
     sheet_paths: &[String],
 ) -> Result<Vec<UnpatchableReference>, ParseError> {
-    let conforming = package_metadata_conforms(parts, content_types, sheet_paths);
-    let mut references = pivot_references(parts, content_types, workbook, sheet_paths, conforming);
+    if !package_metadata_conforms(parts, content_types, sheet_paths) {
+        // Discovery must not be a function of a reader this path has just
+        // decided it cannot trust, so here it stops being a function of any
+        // reader: every part names everything. Nothing can drop out of a set
+        // that is the whole package, whatever a future reader does with it.
+        return Ok(parts
+            .iter()
+            .map(|(path, _)| bound(path.clone(), None, workbook))
+            .collect());
+    }
+    let mut references = pivot_references(parts, content_types, workbook, sheet_paths);
     for chart in unmodelled_chart_parts(parts, content_types, workbook)? {
-        let areas = match (conforming && chart.claimed)
+        let areas = match chart
+            .claimed
             .then(|| find_part(parts, &chart.path))
             .flatten()
         {
@@ -184,22 +194,11 @@ fn pivot_references(
     content_types: &[PartContentType],
     workbook: &Workbook,
     sheet_paths: &[String],
-    conforming: bool,
 ) -> Vec<UnpatchableReference> {
+    let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
     let pivot_parts = parts
         .iter()
         .filter(|(path, _)| is_pivot_part(path, content_types))
-        .collect::<Vec<_>>();
-    if !conforming {
-        return pivot_parts
-            .into_iter()
-            .map(|(path, _)| bound(path.clone(), None, workbook))
-            .collect();
-    }
-
-    let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
-    let pivot_parts = pivot_parts
-        .into_iter()
         .map(|(path, bytes)| (path, bytes, root_local_name(bytes)))
         .collect::<Vec<_>>();
 
@@ -670,18 +669,42 @@ fn sheet_relationships_are_unambiguous(parts: &[(String, Vec<u8>)]) -> bool {
         return false;
     };
     let Some(sheets) = sole_child(&root, "sheets") else {
-        return true;
+        return false;
     };
-    sheets.child_elements().all(|sheet| {
-        !sheet.answers_to(&OURS, "sheet")
-            || (sheet.attributes_named("id") == 1
-                && sheet
-                    .attributes_in(&[NS_RELATIONSHIPS], "id")
-                    .next()
-                    .is_some()
-                && sole_and_ours(sheet, &OURS, "name")
-                && sole_and_ours(sheet, &OURS, "sheetId"))
+    let canonical = sheets
+        .child_elements()
+        .filter(|sheet| sheet.local_name() == "sheet")
+        .collect::<Vec<_>>();
+    // The model is built by a streaming reader that takes every `sheet` by
+    // local name wherever it sits, while the sheet-to-part mapping records only
+    // these children. One more anywhere else shifts the two out of step, and a
+    // pivot table is then attributed to whichever sheet moved into its slot.
+    if named_sheet_elements(&root, 0) != canonical.len() {
+        return false;
+    }
+    canonical.iter().all(|sheet| {
+        sheet.answers_to(&OURS, "sheet")
+            && sheet.attributes_named("id") == 1
+            && sheet
+                .attributes_in(&[NS_RELATIONSHIPS], "id")
+                .next()
+                .is_some()
+            && sole_and_ours(sheet, &OURS, "name")
+            && sole_and_ours(sheet, &OURS, "sheetId")
     })
+}
+
+/// How many elements the streaming model reader would take for a sheet: local
+/// name `sheet`, at any depth.
+fn named_sheet_elements(element: &Element, depth: usize) -> usize {
+    if depth > MAX_DEPTH {
+        return usize::MAX;
+    }
+    usize::from(element.local_name() == "sheet")
+        + element
+            .child_elements()
+            .map(|child| named_sheet_elements(child, depth + 1))
+            .sum::<usize>()
 }
 
 /// Whether a relationship type is one the shared readers follow. Those match
@@ -709,12 +732,15 @@ fn followed_type_is_exact(kind: &str) -> bool {
 /// vetoes nothing, which is the one outcome worse than a spurious refusal.
 fn is_pivot_part(path: &str, content_types: &[PartContentType]) -> bool {
     let key = part_key(path);
-    if key.contains("/_rels/") {
-        return false;
-    }
-    PIVOT_DIRECTORIES
-        .iter()
-        .any(|prefix| key.starts_with(prefix))
+    // A `.rels` part names parts, never cells. The blanket scan swept the ones
+    // under these directories in, but only ever to veto a workbook that holds
+    // the pivot part they describe — which is itself conventional, so leaving
+    // them out here cannot lose a veto. An explicitly typed part is a pivot
+    // part wherever it sits.
+    (!key.contains("/_rels/")
+        && PIVOT_DIRECTORIES
+            .iter()
+            .any(|prefix| key.starts_with(prefix)))
         || content_types.iter().any(|part| {
             part.path == key
                 && PIVOT_CONTENT_TYPES

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -12,12 +12,11 @@
 use std::collections::HashMap;
 
 use quick_xml::NsReader;
-use quick_xml::events::Event;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::name::ResolveResult;
 use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
 use xlsx_model::{CellRef, Workbook};
 
-use crate::ParseError;
 use crate::chart::{
     NS_RELATIONSHIPS, chart_reference_areas, directory_of, parse_area, parse_relationships,
     relationship_part_path, unmodelled_chart_parts,
@@ -26,6 +25,7 @@ use crate::package::PartContentType;
 use crate::tree::{Element, parse_tree};
 use crate::write::{NS_MAIN, NS_STRICT_MAIN};
 use crate::xml::{find_part, local_name, resolve_part_path};
+use crate::{MAX_DEPTH, ParseError};
 
 /// the spreadsheetml vocabulary a pivot part is read in. Transitional and
 /// Strict spell the same names in different namespaces and this crate reads
@@ -201,37 +201,58 @@ fn pivot_references(
     references
 }
 
-/// The local name of a part's root element when the root is one of ours, read
-/// without building a tree so a cached-records part running to megabytes costs
-/// nothing to classify. A root in a foreign vocabulary — including one behind a
-/// prefix the part never declared — answers to no name, which classifies the
-/// part as one this crate does not read and leaves it naming everything.
+/// The local name of a part's root element when the root is one of ours and the
+/// part parses whole. Streamed rather than built into a tree, so a cached-
+/// records part running to megabytes costs one pass and no memory — but the
+/// whole pass, because the first tag says nothing about whether the rest of the
+/// document closes. A foreign root, a root behind a prefix the part never
+/// declared, an element left open, or anything beside the root answers to no
+/// name, which leaves the part naming everything.
 fn root_local_name(bytes: &[u8]) -> Option<String> {
     let mut reader = NsReader::from_reader(bytes);
     let config = reader.config_mut();
     config.expand_empty_elements = true;
     config.check_end_names = true;
     let mut buf = Vec::new();
+    let mut depth = 0usize;
+    let mut root = None;
     loop {
         let (namespace, event) = reader.read_resolved_event_into(&mut buf).ok()?;
         match event {
             Event::Start(start) => {
-                let ours = match namespace {
-                    ResolveResult::Unbound => true,
-                    ResolveResult::Bound(namespace) => {
-                        OURS.contains(&String::from_utf8_lossy(namespace.as_ref()).as_ref())
+                depth += 1;
+                if depth > MAX_DEPTH {
+                    return None;
+                }
+                if depth == 1 {
+                    if root.is_some() {
+                        return None;
                     }
-                    ResolveResult::Unknown(_) => false,
-                };
-                return ours
-                    .then(|| String::from_utf8(local_name(&start)).ok())
-                    .flatten();
+                    root = Some(ours_local_name(namespace, &start)?);
+                }
             }
-            Event::Eof => return None,
+            Event::End(_) => depth = depth.checked_sub(1)?,
+            Event::Eof => break,
             _ => {}
         }
         buf.clear();
     }
+    (depth == 0).then_some(root).flatten()
+}
+
+/// The local name of a start tag whose expanded name is in our vocabulary.
+fn ours_local_name(namespace: ResolveResult<'_>, start: &BytesStart<'_>) -> Option<String> {
+    let ours = match namespace {
+        ResolveResult::Unbound => true,
+        ResolveResult::Bound(namespace) => {
+            OURS.contains(&String::from_utf8_lossy(namespace.as_ref()).as_ref())
+        }
+        ResolveResult::Unknown(_) => false,
+    };
+    let name = String::from_utf8(start.name().as_ref().to_vec()).ok()?;
+    (ours && name.matches(':').count() <= 1)
+        .then(|| String::from_utf8(local_name(start)).ok())
+        .flatten()
 }
 
 /// A pivot part as an element tree, or nothing when this crate declines to read

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -163,11 +163,11 @@ fn pivot_references(
     workbook: &Workbook,
     sheet_paths: &[String],
 ) -> Vec<UnpatchableReference> {
-    let typed = content_types_are_ours(parts);
+    let typing = content_type_typing(parts);
     let hosts = pivot_table_hosts(parts, workbook, sheet_paths);
     let pivot_parts = parts
         .iter()
-        .filter(|(path, _)| is_pivot_part(path, content_types, typed))
+        .filter(|(path, _)| is_pivot_part(path, content_types, &typing))
         .map(|(path, bytes)| (path, bytes, root_local_name(bytes)))
         .collect::<Vec<_>>();
 
@@ -203,11 +203,8 @@ fn pivot_references(
                 .and_then(|root| location_areas(root, hosts.get(&part_key(path)))),
             _ => None,
         };
-        references.push(bound(
-            path.clone(),
-            typed.then_some(areas).flatten(),
-            workbook,
-        ));
+        let areas = matches!(typing, Typing::Trusted).then_some(areas).flatten();
+        references.push(bound(path.clone(), areas, workbook));
     }
     references
 }
@@ -437,6 +434,15 @@ fn pivot_table_hosts(
 /// relationship it names. Rather than reach into that reader, the pivot path
 /// declines the whole part when it holds either, which costs a refusal and
 /// never a wrong claim.
+/// Whether every attribute a reader could take for `name` is the one this path
+/// would read: at most one carries that local name, and it is ours. Counting
+/// only the ours-namespaced ones would pass a foreign attribute sitting beside
+/// a real one, which is the one the reader takes first.
+fn sole_and_ours(element: &Element, namespaces: &[&str], name: &str) -> bool {
+    element.attributes_named(name) <= 1
+        && element.attributes_in(namespaces, name).count() == element.attributes_named(name)
+}
+
 fn trusted_relationships<'a>(parts: &'a [(String, Vec<u8>)], path: &str) -> Option<&'a [u8]> {
     const NAMES: [&str; 4] = ["Id", "Type", "Target", "TargetMode"];
     let rels = find_part(parts, &relationship_part_path(path))?;
@@ -450,10 +456,7 @@ fn trusted_relationships<'a>(parts: &'a [(String, Vec<u8>)], path: &str) -> Opti
             return None;
         }
         for name in NAMES {
-            let mut carried = child.attributes_in(&RELATIONSHIPS, name);
-            if carried.next().is_some() != child.any_attribute_named(name)
-                || carried.next().is_some()
-            {
+            if !sole_and_ours(child, &RELATIONSHIPS, name) {
                 return None;
             }
         }
@@ -493,27 +496,95 @@ fn related_parts(parts: &[(String, Vec<u8>)], path: &str, relationship: &str) ->
         .collect()
 }
 
-/// Whether `[Content_Types].xml` is one a pivot part may be typed from. OPC
-/// typing is shared code that matches `Override`, `PartName` and `ContentType`
-/// by local name, so a foreign one could answer for a real one and rule a pivot
-/// part out. Rather than reach into that reader, the pivot path stops trusting
-/// the typing when the part holds anything it cannot read as ours.
-fn content_types_are_ours(parts: &[(String, Vec<u8>)]) -> bool {
+/// How far `[Content_Types].xml` may be trusted to type a pivot part.
+enum Typing {
+    /// every entry reads unambiguously, so an override may rule a part in or
+    /// out the way OPC says it does
+    Trusted,
+    /// something in it cannot be read as ours, so an override may only add a
+    /// part to look at, never take one away, and nothing it typed resolves
+    Untrusted(HashSet<String>),
+}
+
+/// How far the content types may be trusted, and failing that, every part any
+/// override could have been naming as a pivot. OPC typing is shared code that
+/// matches `Override`, `PartName` and `ContentType` by local name at every
+/// depth and takes the first of each, so a foreign one could answer for a real
+/// one. This gate walks what that reader walks — the whole tree, root included
+/// — rather than an approximation of it.
+fn content_type_typing(parts: &[(String, Vec<u8>)]) -> Typing {
     const NAMES: [&str; 3] = ["PartName", "ContentType", "Extension"];
     let Some(bytes) = find_part(parts, "[Content_Types].xml") else {
-        return true;
+        return Typing::Trusted;
     };
     let Ok(root) = parse_tree(bytes) else {
-        return false;
+        return Typing::Untrusted(HashSet::new());
     };
-    root.child_elements().all(|child| {
-        (child.answers_to(&CONTENT_TYPES, "Override")
-            || child.answers_to(&CONTENT_TYPES, "Default"))
-            && NAMES.iter().all(|name| {
-                child.attributes_in(&CONTENT_TYPES, name).count()
-                    == usize::from(child.any_attribute_named(name))
+    let mut entries = Vec::new();
+    collect_content_type_entries(&root, 0, &mut entries);
+    let mut typed = HashSet::new();
+    let trusted = entries.iter().all(|(depth, entry)| {
+        *depth == 1
+            && (entry.answers_to(&CONTENT_TYPES, "Override")
+                || entry.answers_to(&CONTENT_TYPES, "Default"))
+            && NAMES
+                .iter()
+                .all(|name| sole_and_ours(entry, &CONTENT_TYPES, name))
+    }) && entries
+        .iter()
+        .filter(|(_, entry)| entry.local_name() == "Override")
+        .all(|(_, entry)| match entry.attribute_local("PartName") {
+            Some(part) => typed.insert(part_key(part)),
+            None => true,
+        });
+    if trusted {
+        return Typing::Trusted;
+    }
+    Typing::Untrusted(pivot_candidates(&entries))
+}
+
+/// Every element the OPC reader would take for an entry, with its depth:
+/// matched by local name at any depth, the root included, exactly as
+/// [`crate::package`] reads them. The depth comes back because that reader
+/// honours an entry the schema only allows directly under `Types`, and one
+/// sitting anywhere else is a reading no conforming consumer shares.
+fn collect_content_type_entries<'a>(
+    element: &'a Element,
+    depth: usize,
+    out: &mut Vec<(usize, &'a Element)>,
+) {
+    if matches!(element.local_name(), "Override" | "Default") {
+        out.push((depth, element));
+    }
+    for child in element.child_elements() {
+        collect_content_type_entries(child, depth + 1, out);
+    }
+}
+
+/// Every part an override could have been typing as a pivot, however the entry
+/// spells its names. Used only when the typing is not trustworthy, where the
+/// answer has to be inclusive: a part left undiscovered vetoes nothing.
+fn pivot_candidates(entries: &[(usize, &Element)]) -> HashSet<String> {
+    entries
+        .iter()
+        .map(|(_, entry)| entry)
+        .filter(|entry| entry.local_name() == "Override")
+        .filter(|entry| {
+            entry.attributes.iter().any(|attribute| {
+                attribute.local_name() == "ContentType"
+                    && PIVOT_CONTENT_TYPES
+                        .iter()
+                        .any(|known| attribute.value.eq_ignore_ascii_case(known))
             })
-    })
+        })
+        .flat_map(|entry| {
+            entry
+                .attributes
+                .iter()
+                .filter(|attribute| attribute.local_name() == "PartName")
+                .map(|attribute| part_key(&attribute.value))
+        })
+        .collect()
 }
 
 /// Whether a part holds a pivot cache or pivot table. Typed the way OPC types
@@ -522,17 +593,23 @@ fn content_types_are_ours(parts: &[(String, Vec<u8>)]) -> bool {
 /// part written outside those directories is still found, because a veto that
 /// reasons per part gives a part it never discovers no cover at all. Typing
 /// this path cannot trust never rules a part out; it only stops ruling one in.
-fn is_pivot_part(path: &str, content_types: &[PartContentType], typed: bool) -> bool {
+fn is_pivot_part(path: &str, content_types: &[PartContentType], typing: &Typing) -> bool {
     let key = part_key(path);
     if key.contains("/_rels/") {
         return false;
     }
-    if !typed {
-        return PIVOT_DIRECTORIES
+    let conventional = || {
+        PIVOT_DIRECTORIES
             .iter()
-            .any(|prefix| key.starts_with(prefix));
-    }
-    match content_types.iter().find(|part| part.path == key) {
+            .any(|prefix| key.starts_with(prefix))
+    };
+    let typed = match typing {
+        Typing::Trusted => content_types.iter().find(|part| part.path == key),
+        Typing::Untrusted(candidates) => {
+            return conventional() || candidates.contains(&key);
+        }
+    };
+    match typed {
         Some(part)
             if PIVOT_CONTENT_TYPES
                 .iter()
@@ -541,9 +618,7 @@ fn is_pivot_part(path: &str, content_types: &[PartContentType], typed: bool) -> 
             true
         }
         Some(part) if part.overridden => false,
-        _ => PIVOT_DIRECTORIES
-            .iter()
-            .any(|prefix| key.starts_with(prefix)),
+        _ => conventional(),
     }
 }
 

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -18,8 +18,9 @@ use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
 use xlsx_model::{CellRef, Workbook};
 
 use crate::chart::{
-    NS_PACKAGE_RELATIONSHIPS, NS_RELATIONSHIPS, chart_reference_areas, directory_of, parse_area,
-    parse_relationships, relationship_part_path, unmodelled_chart_parts,
+    NS_PACKAGE_RELATIONSHIPS, NS_RELATIONSHIPS, chart_reference_areas, directory_of,
+    drawing_claims_are_unambiguous, parse_area, parse_relationships, relationship_part_path,
+    unmodelled_chart_parts,
 };
 use crate::package::PartContentType;
 use crate::tree::{
@@ -50,6 +51,10 @@ const REL_PIVOT_CACHE_RECORDS: [&str; 2] = [
 const REL_DRAWING: [&str; 2] = [
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing",
     "http://purl.oclc.org/ooxml/officeDocument/relationships/drawing",
+];
+const REL_CHART: [&str; 2] = [
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart",
+    "http://purl.oclc.org/ooxml/officeDocument/relationships/chart",
 ];
 const REL_PIVOT_TABLE: [&str; 2] = [
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable",
@@ -183,7 +188,7 @@ fn pivot_references(
 ) -> Vec<UnpatchableReference> {
     let pivot_parts = parts
         .iter()
-        .filter(|(path, _)| is_pivot_part(path, content_types, conforming))
+        .filter(|(path, _)| is_pivot_part(path, content_types))
         .collect::<Vec<_>>();
     if !conforming {
         return pivot_parts
@@ -514,7 +519,12 @@ fn package_metadata_conforms(
         && narrowing_drawings(parts, sheet_paths)
             .iter()
             .filter_map(|drawing| find_part(parts, drawing))
-            .all(|bytes| parse_tree(bytes).is_ok_and(|root| names_are_resolvable(&root)))
+            .all(|bytes| {
+                parse_tree(bytes).is_ok_and(|root| {
+                    names_are_resolvable(&root) && drawing_claims_are_unambiguous(&root)
+                })
+            })
+        && sheet_relationships_are_unambiguous(parts)
 }
 
 /// Every part whose relationships the narrowing decision reads, transitively.
@@ -545,7 +555,7 @@ fn narrowing_relationship_owners(
         parts
             .iter()
             .map(|(path, _)| path.clone())
-            .filter(|path| is_pivot_part(path, content_types, true)),
+            .filter(|path| is_pivot_part(path, content_types)),
     );
     owners
 }
@@ -618,16 +628,20 @@ fn relationships_conform(parts: &[(String, Vec<u8>)], owner: &str) -> bool {
     let Ok(root) = parse_tree(bytes) else {
         return false;
     };
-    if !root.answers_to(&RELATIONSHIPS, "Relationships") {
+    if root.namespace() != Some(NS_PACKAGE_RELATIONSHIPS) || root.local_name() != "Relationships" {
         return false;
     }
     let mut ids = HashSet::new();
     root.child_elements().all(|entry| {
-        entry.answers_to(&RELATIONSHIPS, "Relationship")
+        entry.namespace() == Some(NS_PACKAGE_RELATIONSHIPS)
+            && entry.local_name() == "Relationship"
             && entry.child_elements().next().is_none()
             && NAMES
                 .iter()
                 .all(|name| sole_and_ours(entry, &RELATIONSHIPS, name))
+            && entry
+                .attribute_local("Type")
+                .is_some_and(followed_type_is_exact)
             && ["Type", "Target"].iter().all(|name| {
                 entry
                     .attribute_local(name)
@@ -643,35 +657,70 @@ fn relationships_conform(parts: &[(String, Vec<u8>)], owner: &str) -> bool {
     })
 }
 
-/// Whether a part holds a pivot cache or pivot table. Typed the way OPC types
-/// anything: an `Override` is authoritative, and the conventional directories
-/// answer only for a part a `Default` extension mapping left untyped. Metadata
-/// that does not conform is not read at all, leaving the conventional
-/// directories the blanket veto always used.
-fn is_pivot_part(path: &str, content_types: &[PartContentType], conforming: bool) -> bool {
+/// Whether each `<sheet>` in the workbook names its part unambiguously. The
+/// entry is read by taking the first attribute whose local name is `id`, so a
+/// foreign one before the real `r:id` swaps which part a sheet resolves to —
+/// leaving every sheet claimed while a pivot table is attributed to the wrong
+/// one, which is a narrow reading of a workbook nobody can read that way.
+fn sheet_relationships_are_unambiguous(parts: &[(String, Vec<u8>)]) -> bool {
+    let Some(bytes) = find_part(parts, "xl/workbook.xml") else {
+        return false;
+    };
+    let Ok(root) = parse_tree(bytes) else {
+        return false;
+    };
+    let Some(sheets) = sole_child(&root, "sheets") else {
+        return true;
+    };
+    sheets.child_elements().all(|sheet| {
+        !sheet.answers_to(&OURS, "sheet")
+            || (sheet.attributes_named("id") == 1
+                && sheet
+                    .attributes_in(&[NS_RELATIONSHIPS], "id")
+                    .next()
+                    .is_some()
+                && sole_and_ours(sheet, &OURS, "name")
+                && sole_and_ours(sheet, &OURS, "sheetId"))
+    })
+}
+
+/// Whether a relationship type is one the shared readers follow. Those match
+/// on the segment after the last slash, so a type merely ending in one of them
+/// steers chart ownership or a pivot claim without being the standard type this
+/// path enumerated. Such a package is not one to read relationships from.
+fn followed_type_is_exact(kind: &str) -> bool {
+    const FOLLOWED: [(&str, &[&str]); 4] = [
+        ("drawing", &REL_DRAWING),
+        ("chart", &REL_CHART),
+        ("pivotTable", &REL_PIVOT_TABLE),
+        ("pivotCacheRecords", &REL_PIVOT_CACHE_RECORDS),
+    ];
+    FOLLOWED.iter().all(|(segment, standard)| {
+        kind.rsplit('/').next() != Some(segment) || standard.contains(&kind)
+    })
+}
+
+/// Whether a part holds a pivot cache or pivot table.
+///
+/// Discovery is monotonic over the blanket veto: a part the conventional
+/// directories name is always looked at, and conforming metadata may only ADD
+/// parts beside them. Never a choice between the two — typing this path cannot
+/// read must not be able to take a part away, because a part nobody looks at
+/// vetoes nothing, which is the one outcome worse than a spurious refusal.
+fn is_pivot_part(path: &str, content_types: &[PartContentType]) -> bool {
     let key = part_key(path);
     if key.contains("/_rels/") {
         return false;
     }
-    let conventional = || {
-        PIVOT_DIRECTORIES
-            .iter()
-            .any(|prefix| key.starts_with(prefix))
-    };
-    if !conforming {
-        return conventional();
-    }
-    match content_types.iter().find(|part| part.path == key) {
-        Some(part)
-            if PIVOT_CONTENT_TYPES
-                .iter()
-                .any(|known| part.content_type.eq_ignore_ascii_case(known)) =>
-        {
-            true
-        }
-        Some(part) if part.overridden => false,
-        _ => conventional(),
-    }
+    PIVOT_DIRECTORIES
+        .iter()
+        .any(|prefix| key.starts_with(prefix))
+        || content_types.iter().any(|part| {
+            part.path == key
+                && PIVOT_CONTENT_TYPES
+                    .iter()
+                    .any(|known| part.content_type.eq_ignore_ascii_case(known))
+        })
 }
 
 fn part_key(path: &str) -> String {

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -219,12 +219,12 @@ fn tree(bytes: &[u8]) -> Option<Element> {
 /// `extLst` carrying the real source among them — or a `rangeSet` it cannot
 /// read all of leaves the cache naming everything.
 fn source_areas(root: &Element) -> Option<Vec<NamedArea>> {
-    let source = root.child("cacheSource")?;
+    let source = root.sole_child("cacheSource")?;
     let children = source.child_elements().collect::<Vec<_>>();
     let [only] = children[..] else {
         return None;
     };
-    match source.attribute_local("type").unwrap_or("worksheet") {
+    match sole_attribute(source, "type")?.unwrap_or("worksheet") {
         "worksheet" if only.local_name() == "worksheetSource" => Some(vec![named_area(only)?]),
         "consolidation" if only.local_name() == "consolidation" => consolidated_areas(only),
         _ => None,
@@ -239,7 +239,7 @@ fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
         return None;
     }
     let areas = consolidation
-        .child("rangeSets")?
+        .sole_child("rangeSets")?
         .child_elements()
         .map(|set| {
             (set.local_name() == "rangeSet")
@@ -254,11 +254,11 @@ fn consolidated_areas(consolidation: &Element) -> Option<Vec<NamedArea>> {
 /// instead: the schema allows exactly one of `ref` and `name`, and an `r:id`
 /// puts the range in another workbook.
 fn named_area(element: &Element) -> Option<NamedArea> {
-    if element.attribute_local("name").is_some() || element.attribute_local("id").is_some() {
+    if element.attributes_named("name") > 0 || element.attributes_named("id") > 0 {
         return None;
     }
-    let sheet = element.attribute_local("sheet")?.to_owned();
-    let (_, end) = parse_area(element.attribute_local("ref")?)?;
+    let sheet = sole_attribute(element, "sheet")??.to_owned();
+    let (_, end) = parse_area(sole_attribute(element, "ref")??)?;
     Some((sheet, end))
 }
 
@@ -266,8 +266,8 @@ fn named_area(element: &Element) -> Option<NamedArea> {
 /// body; the filter area sits beside it, so its page counts are padded onto the
 /// far corner rather than trusting `ref` to be the whole block.
 fn location_areas(root: &Element, hosts: Option<&Vec<String>>) -> Option<Vec<NamedArea>> {
-    let location = root.child("location")?;
-    let (_, end) = parse_area(location.attribute_local("ref")?)?;
+    let location = root.sole_child("location")?;
+    let (_, end) = parse_area(sole_attribute(location, "ref")??)?;
     let end = CellRef::new(
         end.row
             .saturating_add(page_count(location, "rowPageCount")?)
@@ -283,9 +283,22 @@ fn location_areas(root: &Element, hosts: Option<&Vec<String>>) -> Option<Vec<Nam
 /// How far the filter area reaches past `ref`. Absent is none; anything that is
 /// not a count leaves the pivot table unresolved.
 fn page_count(location: &Element, name: &str) -> Option<u32> {
-    match location.attribute_local(name) {
+    match sole_attribute(location, name)? {
         None => Some(0),
         Some(value) => value.trim().parse().ok(),
+    }
+}
+
+/// An attribute read by a name only one of them may answer to. The outer
+/// `None` is ambiguity — several attributes carry that local name, so markup
+/// compatibility could be hiding the real one behind an ignored prefix and a
+/// lookup would be choosing by authoring order — and the inner `None` is a
+/// plain absence, which an optional attribute may default.
+fn sole_attribute<'a>(element: &'a Element, name: &str) -> Option<Option<&'a str>> {
+    match element.attributes_named(name) {
+        0 => Some(None),
+        1 => Some(element.attribute_local(name)),
+        _ => None,
     }
 }
 

--- a/crates/xlsx-parse/src/reference.rs
+++ b/crates/xlsx-parse/src/reference.rs
@@ -22,7 +22,9 @@ use crate::chart::{
     parse_relationships, relationship_part_path, unmodelled_chart_parts,
 };
 use crate::package::PartContentType;
-use crate::tree::{Element, Unqualified, Vocabulary, owned_local_name, parse_tree};
+use crate::tree::{
+    Element, Unqualified, Vocabulary, names_are_resolvable, owned_local_name, parse_tree,
+};
 use crate::write::{NS_MAIN, NS_STRICT_MAIN};
 use crate::xml::{find_part, resolve_part_path};
 use crate::{MAX_DEPTH, ParseError};
@@ -44,6 +46,10 @@ const CONTENT_TYPES: [&str; 1] = ["http://schemas.openxmlformats.org/package/200
 const REL_PIVOT_CACHE_RECORDS: [&str; 2] = [
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords",
     "http://purl.oclc.org/ooxml/officeDocument/relationships/pivotCacheRecords",
+];
+const REL_DRAWING: [&str; 2] = [
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing",
+    "http://purl.oclc.org/ooxml/officeDocument/relationships/drawing",
 ];
 const REL_PIVOT_TABLE: [&str; 2] = [
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable",
@@ -502,16 +508,55 @@ fn package_metadata_conforms(
     sheet_paths: &[String],
 ) -> bool {
     content_types_conform(parts)
-        && sheet_paths
+        && narrowing_relationship_owners(parts, content_types, sheet_paths)
             .iter()
-            .map(String::as_str)
-            .chain(
-                parts
-                    .iter()
-                    .map(|(path, _)| path.as_str())
-                    .filter(|path| is_pivot_part(path, content_types, true)),
-            )
             .all(|owner| relationships_conform(parts, owner))
+        && narrowing_drawings(parts, sheet_paths)
+            .iter()
+            .filter_map(|drawing| find_part(parts, drawing))
+            .all(|bytes| parse_tree(bytes).is_ok_and(|root| names_are_resolvable(&root)))
+}
+
+/// Every part whose relationships the narrowing decision reads, transitively.
+/// Stated in one place, with why each is here, so a change that makes this path
+/// follow something new shows up as a change to this list rather than as a hole
+/// nobody notices. A part whose relationships are absent is not in doubt; one
+/// whose relationships are read is only as good as they are.
+fn narrowing_relationship_owners(
+    parts: &[(String, Vec<u8>)],
+    content_types: &[PartContentType],
+    sheet_paths: &[String],
+) -> Vec<String> {
+    // the workbook, whose relationships resolve every `<sheet r:id>` to its
+    // part, and so decide which sheet hosts a pivot table and which sheet
+    // claims a chart
+    let mut owners = vec!["xl/workbook.xml".to_owned()];
+    for sheet in sheet_paths {
+        // a sheet's relationships anchor the pivot tables laid out on it and
+        // the drawings that claim its charts
+        owners.push(sheet.clone());
+    }
+    // a drawing's relationships name the chart parts its sheet claims, which is
+    // what makes a chart modelled and gives an unqualified reference its owner
+    owners.extend(narrowing_drawings(parts, sheet_paths));
+    // a cache definition's relationships name the records part that inherits
+    // its source range
+    owners.extend(
+        parts
+            .iter()
+            .map(|(path, _)| path.clone())
+            .filter(|path| is_pivot_part(path, content_types, true)),
+    );
+    owners
+}
+
+/// The drawing parts the narrowing decision reads, whose own markup decides
+/// which sheet claims which chart.
+fn narrowing_drawings(parts: &[(String, Vec<u8>)], sheet_paths: &[String]) -> Vec<String> {
+    sheet_paths
+        .iter()
+        .flat_map(|sheet| related_parts(parts, sheet, &REL_DRAWING))
+        .collect()
 }
 
 /// Whether every attribute a reader could take for `name` is the one this path
@@ -527,7 +572,7 @@ fn sole_and_ours(element: &Element, namespaces: &[&str], name: &str) -> bool {
 fn content_types_conform(parts: &[(String, Vec<u8>)]) -> bool {
     const NAMES: [&str; 3] = ["PartName", "ContentType", "Extension"];
     let Some(bytes) = find_part(parts, "[Content_Types].xml") else {
-        return true;
+        return false;
     };
     let Ok(root) = parse_tree(bytes) else {
         return false;
@@ -541,14 +586,20 @@ fn content_types_conform(parts: &[(String, Vec<u8>)]) -> bool {
             && NAMES
                 .iter()
                 .all(|name| sole_and_ours(entry, &CONTENT_TYPES, name))
-            && entry.attribute_local("ContentType").is_some()
+            && entry
+                .attribute_local("ContentType")
+                .is_some_and(|kind| !kind.trim().is_empty())
             && if entry.answers_to(&CONTENT_TYPES, "Override") {
                 entry
                     .attribute_local("PartName")
+                    .is_some_and(|part| part.len() > 1 && part.starts_with('/'))
+                    .then(|| entry.attribute_local("PartName"))
+                    .flatten()
                     .is_some_and(|part| overrides.insert(part_key(part)))
             } else if entry.answers_to(&CONTENT_TYPES, "Default") {
                 entry
                     .attribute_local("Extension")
+                    .filter(|extension| !extension.is_empty() && !extension.contains('/'))
                     .is_some_and(|extension| defaults.insert(extension.to_ascii_lowercase()))
             } else {
                 false
@@ -577,10 +628,17 @@ fn relationships_conform(parts: &[(String, Vec<u8>)], owner: &str) -> bool {
             && NAMES
                 .iter()
                 .all(|name| sole_and_ours(entry, &RELATIONSHIPS, name))
-            && entry.attribute_local("Type").is_some()
-            && entry.attribute_local("Target").is_some()
+            && ["Type", "Target"].iter().all(|name| {
+                entry
+                    .attribute_local(name)
+                    .is_some_and(|value| !value.is_empty())
+            })
+            && entry
+                .attribute_local("TargetMode")
+                .is_none_or(|mode| matches!(mode, "Internal" | "External"))
             && entry
                 .attribute_local("Id")
+                .filter(|id| !id.is_empty())
                 .is_some_and(|id| ids.insert(id.to_owned()))
     })
 }

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2026,23 +2026,19 @@ fn does_not_take_an_overridden_non_pivot_part_for_a_pivot() {
     assert_eq!(parsed.package.unpatchable_references().len(), 0);
 }
 
-/// Markup compatibility lets a part carry attributes a conforming consumer
-/// drops. Reading by local name alone would take the ignored `u:sheet` for the
-/// real one and fence off `Notes` while `Data` moved out from under the cache,
-/// so a name several attributes answer to resolves to nothing at all.
+/// Markup compatibility lets a part carry nodes a conforming consumer drops. A
+/// foreign namespace makes a node a different one that merely spells its name
+/// the same way, so the real `sheet` and `ref` are still what the cache is read
+/// from however a decoy is ordered around them.
 #[test]
-fn refuses_a_pivot_source_a_decoy_attribute_could_shadow() {
+fn reads_past_a_pivot_source_decoy_to_the_real_one() {
     for (label, worksheet_source) in [
         (
-            "shadowed sheet and ref",
+            "decoy first",
             r#"<worksheetSource xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u" u:sheet="Report" u:ref="A1" sheet="Data" ref="A1:B4"/>"#,
         ),
         (
-            "shadowed sheet alone",
-            r#"<worksheetSource xmlns:u="urn:future" u:sheet="Report" sheet="Data" ref="A1:B4"/>"#,
-        ),
-        (
-            "real one authored first",
+            "decoy last",
             r#"<worksheetSource xmlns:u="urn:future" sheet="Data" ref="A1:B4" u:sheet="Report" u:ref="A1"/>"#,
         ),
     ] {
@@ -2055,46 +2051,182 @@ fn refuses_a_pivot_source_a_decoy_attribute_could_shadow() {
             )
             .as_bytes(),
         );
-        let parsed = parse_workbook_with_package(&parts).unwrap();
+        let package = parse_workbook_with_package(&parts).unwrap().package;
         assert!(
-            parsed.package.reference_naming_sheet("Data").is_some(),
+            package.reference_naming_sheet("Data").is_some(),
             "{label}: the cache stopped naming Data"
         );
+        assert_eq!(
+            package.reference_naming_sheet("Report"),
+            None,
+            "{label}: the decoy captured Report"
+        );
+        assert_eq!(
+            package.reference_moved_by_rows("Data", 4),
+            None,
+            "{label}: the decoy's A1 was read instead of A1:B4"
+        );
         assert!(
-            parsed
-                .package
-                .reference_moved_by_rows("Report", 999)
-                .is_some(),
-            "{label} was resolved"
+            package.reference_moved_by_rows("Data", 3).is_some(),
+            "{label}"
         );
     }
 }
 
-/// The same shadowing through an element name, which `cacheSource` and
-/// `location` are both reached by.
+/// The same, one level deeper: a name only a foreign node answers to is a name
+/// nothing answers to. Where the source cannot be read without it, that is
+/// unresolved — never the foreign node standing in for the real one.
 #[test]
-fn refuses_a_pivot_part_a_decoy_element_could_shadow() {
+fn refuses_a_pivot_source_only_a_foreign_node_answers_for() {
+    for (label, definition) in [
+        (
+            "foreign cacheSource",
+            r#"<pivotCacheDefinition xmlns:u="urn:future"><u:cacheSource><worksheetSource sheet="Report" ref="A1"/></u:cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "foreign worksheetSource",
+            r#"<pivotCacheDefinition xmlns:u="urn:future"><cacheSource><u:worksheetSource sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "foreign sheet and ref",
+            r#"<pivotCacheDefinition xmlns:u="urn:future"><cacheSource><worksheetSource u:sheet="Report" u:ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "foreign ref beside a real sheet",
+            r#"<pivotCacheDefinition xmlns:u="urn:future"><cacheSource><worksheetSource sheet="Data" u:ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            definition.as_bytes(),
+        );
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} was resolved"
+        );
+        assert!(
+            package.reference_naming_sheet("Data").is_some(),
+            "{label}: Data was left unprotected"
+        );
+    }
+}
+
+/// An `mc:AlternateContent` branch can supply the very node being read, and
+/// choosing between branches is markup-compatibility processing this crate does
+/// not do. A pivot part carrying one names everything rather than reading past
+/// it into whichever branch happens to sit first.
+#[test]
+fn refuses_a_pivot_part_carrying_alternate_content() {
+    for (label, definition) in [
+        (
+            "the source only a branch supplies",
+            r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u"><u:cacheSource><u:worksheetSource u:sheet="Report" u:ref="A1"/></u:cacheSource><mc:AlternateContent><mc:Choice Requires="u"><u:extension/></mc:Choice><mc:Fallback><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></mc:Fallback></mc:AlternateContent></pivotCacheDefinition>"#,
+        ),
+        (
+            "a branch beside a source that does resolve",
+            r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource><mc:AlternateContent><mc:Choice Requires="u"><cacheSource><worksheetSource sheet="Report" ref="A1"/></cacheSource></mc:Choice></mc:AlternateContent></pivotCacheDefinition>"#,
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            definition.as_bytes(),
+        );
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} was resolved"
+        );
+        assert!(
+            package.reference_naming_sheet("Data").is_some(),
+            "{label}: Data was left unprotected"
+        );
+    }
+}
+
+/// A foreign decoy over an optional name reads as absent, which is what it is:
+/// the default still applies rather than the whole part going unresolved.
+#[test]
+fn defaults_optional_pivot_names_only_a_foreign_node_carries() {
     let mut parts = pivoted_package();
     set_part(
         &mut parts,
         "xl/pivotcache/pivotCacheDefinition1.xml",
-        br#"<pivotCacheDefinition xmlns:u="urn:future"><u:cacheSource><worksheetSource sheet="Report" ref="A1"/></u:cacheSource><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+        br#"<pivotCacheDefinition xmlns:u="urn:future"><cacheSource u:type="external"><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
     );
-    let parsed = parse_workbook_with_package(&parts).unwrap();
+    parts.push((
+        "xl/pivottables/pivotTable1.xml".to_owned(),
+        br#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><location ref="C3:E8" u:colPageCount="9"/></pivotTableDefinition>"#.to_vec(),
+    ));
+    parts.push((
+        "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+        br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+    ));
+    let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert!(parsed.package.reference_naming_sheet("Data").is_some());
-    assert!(
-        parsed
-            .package
-            .reference_moved_by_rows("Report", 999)
-            .is_some()
+    assert!(package.reference_moved_by_rows("Data", 3).is_some());
+    assert_eq!(
+        package.reference_moved_by_rows("Data", 4),
+        None,
+        "a foreign type must read as the worksheet default, not leave the cache unresolved"
+    );
+    assert!(package.reference_moved_by_cols("Report", 4).is_some());
+    assert_eq!(
+        package.reference_moved_by_cols("Report", 5),
+        None,
+        "a foreign page count must read as none, not widen the grid"
     );
 }
 
-/// A pivot table's own grid is reached by the same two lookups, so a decoy over
-/// `location` or its `ref` has to leave it unresolved too.
+/// Real parts declare the spreadsheetml namespace and hand-built ones declare
+/// none. Both are ours, and narrowing to expanded names must not quietly stop
+/// resolving either.
 #[test]
-fn refuses_a_pivot_location_a_decoy_could_shadow() {
+fn resolves_a_pivot_source_however_the_part_declares_its_namespace() {
+    for (label, definition) in [
+        (
+            "no namespace",
+            r#"<pivotCacheDefinition><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "default namespace",
+            r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "prefixed namespace",
+            r#"<x:pivotCacheDefinition xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:cacheSource><x:worksheetSource sheet="Data" ref="A1:B4"/></x:cacheSource></x:pivotCacheDefinition>"#,
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            definition.as_bytes(),
+        );
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+        assert!(
+            package.reference_moved_by_rows("Data", 3).is_some(),
+            "{label}"
+        );
+        assert_eq!(
+            package.reference_moved_by_rows("Data", 4),
+            None,
+            "{label} stopped resolving"
+        );
+        assert_eq!(package.reference_naming_sheet("Report"), None, "{label}");
+    }
+}
+
+/// A pivot table's own grid is reached by the same lookups, so a decoy over
+/// `location` or its `ref` must not be read in place of the real one, and a
+/// `location` only a foreign node answers for leaves the table unresolved.
+#[test]
+fn reads_past_a_pivot_location_decoy_to_the_real_one() {
     let package = |definition: &str| {
         let mut parts = pivoted_package();
         parts.push((
@@ -2108,27 +2240,38 @@ fn refuses_a_pivot_location_a_decoy_could_shadow() {
         parse_workbook_with_package(&parts).unwrap().package
     };
 
-    let shadowed_ref = package(
-        r#"<pivotTableDefinition xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u" cacheId="1"><location u:ref="A1" ref="C3:E8"/></pivotTableDefinition>"#,
-    );
-    assert!(shadowed_ref.reference_moved_by_rows("Data", 999).is_some());
+    for (label, definition) in [
+        (
+            "shadowed ref",
+            r#"<pivotTableDefinition xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u" cacheId="1"><location u:ref="A1" ref="C3:E8"/></pivotTableDefinition>"#,
+        ),
+        (
+            "shadowed location",
+            r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><u:location ref="A1"/><location ref="C3:E8"/></pivotTableDefinition>"#,
+        ),
+        (
+            "shadowed page count",
+            r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><location ref="C3:E8" u:colPageCount="0" colPageCount="4"/></pivotTableDefinition>"#,
+        ),
+    ] {
+        let package = package(definition);
+        assert_eq!(
+            package.reference_moved_by_rows("Data", 999),
+            None,
+            "{label}: the pivot table stopped resolving"
+        );
+        assert!(
+            package.reference_moved_by_rows("Report", 7).is_some(),
+            "{label}"
+        );
+    }
 
-    let shadowed_location = package(
-        r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><u:location ref="A1"/><location ref="C3:E8"/></pivotTableDefinition>"#,
+    let only_foreign = package(
+        r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><u:location ref="C3:E8"/></pivotTableDefinition>"#,
     );
     assert!(
-        shadowed_location
-            .reference_moved_by_rows("Data", 999)
-            .is_some()
-    );
-
-    let shadowed_page_count = package(
-        r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><location ref="C3:E8" u:colPageCount="0" colPageCount="4"/></pivotTableDefinition>"#,
-    );
-    assert!(
-        shadowed_page_count
-            .reference_moved_by_rows("Data", 999)
-            .is_some()
+        only_foreign.reference_moved_by_rows("Data", 999).is_some(),
+        "a location only a foreign node answers for must leave the table unresolved"
     );
 }
 

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -1940,6 +1940,11 @@ fn refuses_everything_for_a_pivot_source_it_cannot_resolve() {
         (
             "another book",
             "",
+            r#"<worksheetSource xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" sheet="Data" ref="A1:B4" r:id="rIdBook"/>"#,
+        ),
+        (
+            "another book, undeclared prefix",
+            "",
             r#"<worksheetSource sheet="Data" ref="A1:B4" r:id="rIdBook"/>"#,
         ),
         (
@@ -2095,6 +2100,30 @@ fn refuses_a_pivot_source_only_a_foreign_node_answers_for() {
             "foreign ref beside a real sheet",
             r#"<pivotCacheDefinition xmlns:u="urn:future"><cacheSource><worksheetSource sheet="Data" u:ref="A1"/></cacheSource></pivotCacheDefinition>"#,
         ),
+        (
+            "undeclared cacheSource prefix",
+            r#"<pivotCacheDefinition><u:cacheSource><worksheetSource sheet="Report" ref="A1"/></u:cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "undeclared worksheetSource prefix",
+            r#"<pivotCacheDefinition><cacheSource><u:worksheetSource sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "undeclared attribute prefix",
+            r#"<pivotCacheDefinition><cacheSource><worksheetSource u:sheet="Report" u:ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "foreign root",
+            r#"<u:pivotCacheDefinition xmlns:u="urn:future"><cacheSource><worksheetSource sheet="Report" ref="A1"/></cacheSource></u:pivotCacheDefinition>"#,
+        ),
+        (
+            "undeclared root prefix",
+            r#"<u:pivotCacheDefinition><cacheSource><worksheetSource sheet="Report" ref="A1"/></cacheSource></u:pivotCacheDefinition>"#,
+        ),
+        (
+            "foreign default namespace",
+            r#"<pivotCacheDefinition xmlns="urn:future"><cacheSource><worksheetSource sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
     ] {
         let mut parts = pivoted_package();
         set_part(
@@ -2200,6 +2229,14 @@ fn resolves_a_pivot_source_however_the_part_declares_its_namespace() {
         (
             "prefixed namespace",
             r#"<x:pivotCacheDefinition xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:cacheSource><x:worksheetSource sheet="Data" ref="A1:B4"/></x:cacheSource></x:pivotCacheDefinition>"#,
+        ),
+        (
+            "strict default namespace",
+            r#"<pivotCacheDefinition xmlns="http://purl.oclc.org/ooxml/spreadsheetml/main"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "strict prefixed namespace",
+            r#"<x:pivotCacheDefinition xmlns:x="http://purl.oclc.org/ooxml/spreadsheetml/main"><x:cacheSource><x:worksheetSource x:sheet="Data" x:ref="A1:B4"/></x:cacheSource></x:pivotCacheDefinition>"#,
         ),
     ] {
         let mut parts = pivoted_package();

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2562,6 +2562,14 @@ fn refuses_records_whose_part_does_not_parse_whole() {
         ),
         ("trailing junk", "<pivotCacheRecords/></stray>"),
         ("trailing text", "<pivotCacheRecords/>garbage"),
+        (
+            "an attribute that does not parse",
+            "<pivotCacheRecords broken/>",
+        ),
+        (
+            "a broken attribute deeper in",
+            "<pivotCacheRecords><r broken/></pivotCacheRecords>",
+        ),
         ("trailing cdata", "<pivotCacheRecords/><![CDATA[garbage]]>"),
         ("leading text", "garbage<pivotCacheRecords/>"),
         (
@@ -2633,6 +2641,75 @@ fn refuses_records_a_definition_claims_through_an_invalid_qname() {
             "{label}: Data was left unprotected"
         );
     }
+}
+
+/// Relationships are read by local name by shared code this path does not own,
+/// so the pivot path checks the part before it trusts the lookup: a foreign
+/// `Id`, or two relationships answering to the same one, buys no claim.
+#[test]
+fn refuses_records_claimed_through_relationships_it_cannot_trust() {
+    for (label, relationships) in [
+        (
+            "foreign id",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship u:Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#,
+        ),
+        (
+            "duplicate ids",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="elsewhere.xml"/></Relationships>"#,
+        ),
+        (
+            "foreign target beside a real id",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" u:Target="elsewhere.xml" Target="pivotCacheRecords1.xml"/></Relationships>"#,
+        ),
+        (
+            "foreign relationship element",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><u:Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#,
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            br#"<pivotCacheDefinition xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rIdRecords"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+        );
+        parts.push((
+            "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+            b"<pivotCacheRecords/>".to_vec(),
+        ));
+        parts.push((
+            "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+            relationships.as_bytes().to_vec(),
+        ));
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} claimed the records"
+        );
+        assert!(
+            package.reference_naming_sheet("Data").is_some(),
+            "{label}: Data was left unprotected"
+        );
+    }
+}
+
+/// OPC types parts by local name, so a foreign `Override` could answer for a
+/// real one and rule a pivot part out entirely. A content-type part this path
+/// cannot trust leaves the pivot part vetoing everything, never untyped.
+#[test]
+fn refuses_a_pivot_part_a_foreign_override_would_rule_out() {
+    let mut parts = pivoted_package();
+    parts.push((
+        "[Content_Types].xml".to_owned(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><u:Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#.to_vec(),
+    ));
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert_eq!(package.unpatchable_references().len(), 1);
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "a cache typed by a part this path cannot trust must name everything"
+    );
 }
 
 /// Records the definition does not point its own `r:id` at are not its records,
@@ -3757,6 +3834,43 @@ fn resolves_what_an_unmodelled_chart_references() {
     assert!(package.reference_moved_by_cols("Data", 1).is_some());
     assert_eq!(package.reference_moved_by_cols("Data", 2), None);
     assert_eq!(package.reference_moved_by_rows("Report", 0), None);
+}
+
+/// The chart walk matches expanded names through shared code that resolves a
+/// prefix at the first colon and compares the local name after the last, so a
+/// qname carrying a second colon could be read as a `c:f`. A chart part holding
+/// one is not read at all.
+#[test]
+fn refuses_a_chart_holding_a_name_resolution_cannot_be_applied_to() {
+    for (label, chart) in [
+        (
+            "invalid reference element",
+            String::from_utf8(CHART.to_vec()).unwrap().replace(
+                "<c:f>Data!$B$2:$B$4</c:f>",
+                "<c:junk:f>Data!$B$2:$B$4</c:junk:f>",
+            ),
+        ),
+        (
+            "invalid attribute name",
+            String::from_utf8(CHART.to_vec())
+                .unwrap()
+                .replace(r#"<c:idx val="0"/>"#, r#"<c:idx c:junk:val="0"/>"#),
+        ),
+    ] {
+        let mut parts = charted_package();
+        set_part(&mut parts, "xl/charts/chart1.xml", chart.as_bytes());
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert_eq!(
+            package.unpatchable_reference_part(),
+            Some("xl/charts/chart1.xml"),
+            "{label}"
+        );
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} was read"
+        );
+    }
 }
 
 /// A `c:f` naming a sheet the workbook does not hold binds to nothing, so the

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2757,30 +2757,152 @@ fn refuses_a_pivot_part_a_foreign_override_would_rule_out() {
     }
 }
 
-/// Typing this path cannot trust must never lose a pivot part. A cache found
-/// only through its override, beside a foreign sibling that makes the typing
-/// untrustworthy, still has to be discovered — an undiscovered part vetoes
-/// nothing, which is the one outcome worse than a refusal.
+/// Narrowing the veto rests on reading the package's own metadata. When any of
+/// it is not exactly what OPC specifies, the whole workbook falls back to the
+/// blanket veto that shipped before narrowing existed, rather than this crate
+/// reconstructing trust over readers more permissive than the format.
 #[test]
-fn keeps_an_out_of_directory_pivot_when_the_typing_cannot_be_trusted() {
-    let mut parts = pivoted_package();
-    let cache = parts
-        .iter()
-        .position(|(path, _)| path == "xl/pivotcache/pivotCacheDefinition1.xml")
-        .expect("the fixture holds a cache");
-    parts[cache].0 = "xl/pivotCacheDefinition1.xml".to_owned();
+fn falls_back_to_the_blanket_veto_when_the_package_metadata_does_not_conform() {
+    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>"#;
+    const RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#;
+
+    for (label, types, rels) in [
+        (
+            "a foreign name in the content types",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default u:Extension="xml" Extension="xml" ContentType="application/xml"/></Types>"#,
+            RELS,
+        ),
+        (
+            "an element the content types should not hold",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><wrapper><Override PartName="/x.xml" ContentType="application/xml"/></wrapper></Types>"#,
+            RELS,
+        ),
+        (
+            "a content-type root that is not Types",
+            r#"<wrapper xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></wrapper>"#,
+            RELS,
+        ),
+        (
+            "two defaults for one extension",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="xml" ContentType="application/other"/></Types>"#,
+            RELS,
+        ),
+        (
+            "a default carrying no content type",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml"/></Types>"#,
+            RELS,
+        ),
+        (
+            "a relationships root that is not Relationships",
+            TYPES,
+            r#"<wrapper xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></wrapper>"#,
+        ),
+        (
+            "a relationship carrying no type",
+            TYPES,
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#,
+        ),
+        (
+            "a foreign name on a relationship",
+            TYPES,
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdRecords" u:Target="a.xml" Target="pivotCacheRecords1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords"/></Relationships>"#,
+        ),
+        (
+            "two relationships answering to one id",
+            TYPES,
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="elsewhere.xml"/></Relationships>"#,
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        parts.push(("[Content_Types].xml".to_owned(), types.as_bytes().to_vec()));
+        parts.push((
+            "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+            rels.as_bytes().to_vec(),
+        ));
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert_eq!(
+            package.unpatchable_reference_part(),
+            Some("xl/pivotcache/pivotCacheDefinition1.xml"),
+            "{label}: the pivot stopped being vetoed"
+        );
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} narrowed on metadata it could not read"
+        );
+        assert!(
+            package.reference_naming_sheet("Data").is_some(),
+            "{label}: Data was left unprotected"
+        );
+    }
+}
+
+/// The fallback is workbook-wide: an unmodelled chart stops narrowing too,
+/// exactly as it did before narrowing existed.
+#[test]
+fn falls_back_to_the_blanket_veto_for_charts_too() {
+    let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
     parts.push((
         "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/><u:Override PartName="/xl/unrelated.xml" ContentType="application/xml"/></Types>"#.to_vec(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default u:Extension="xml" Extension="xml" ContentType="application/xml"/></Types>"#.to_vec(),
     ));
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
     assert_eq!(
         package.unpatchable_reference_part(),
-        Some("xl/pivotCacheDefinition1.xml"),
-        "the pivot disappeared instead of becoming unresolved"
+        Some("xl/charts/chart1.xml")
     );
-    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "the chart narrowed on metadata this crate could not read"
+    );
+}
+
+/// A conforming package still narrows, which is the whole point of the change.
+#[test]
+fn still_narrows_when_the_package_metadata_conforms() {
+    let mut parts = pivoted_package();
+    parts.push((
+        "[Content_Types].xml".to_owned(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#.to_vec(),
+    ));
+    parts.push((
+        "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
+    ));
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(package.reference_moved_by_rows("Data", 3).is_some());
+    assert_eq!(package.reference_moved_by_rows("Data", 4), None);
+    assert_eq!(package.reference_naming_sheet("Report"), None);
+}
+
+/// A relationship claims records by its type, not by pointing at them. With
+/// conforming metadata the exact type can be required, so a relationship of
+/// another kind carrying the cache's own id claims nothing.
+#[test]
+fn refuses_records_claimed_by_a_relationship_of_another_type() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/pivotcache/pivotCacheDefinition1.xml",
+        br#"<pivotCacheDefinition xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rIdRecords"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+    );
+    parts.push((
+        "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+        b"<pivotCacheRecords/>".to_vec(),
+    ));
+    parts.push((
+        "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
+    ));
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "an image relationship handed the records a narrow range"
+    );
+    assert!(package.reference_naming_sheet("Data").is_some());
 }
 
 /// Records the definition does not point its own `r:id` at are not its records,

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -38,7 +38,6 @@ fn package(worksheet_body: &str, shared: &[&str], date1904: bool) -> Vec<(String
             worksheet.into_bytes(),
         ),
     ];
-    set_or_push_part(&mut parts, "[Content_Types].xml", CONFORMING_TYPES);
     if !shared.is_empty() {
         let items: String = shared
             .iter()
@@ -910,7 +909,6 @@ fn two_sheet_package(first_body: &str, second_body: &str) -> Vec<(String, Vec<u8
     let workbook = r#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/><sheet name="Sheet2" sheetId="2" r:id="rId2"/></sheets></workbook>"#;
     let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#;
     vec![
-        ("[Content_Types].xml".to_owned(), CONFORMING_TYPES.to_vec()),
         ("xl/workbook.xml".to_owned(), workbook.as_bytes().to_vec()),
         (
             "xl/_rels/workbook.xml.rels".to_owned(),
@@ -3088,6 +3086,49 @@ fn falls_back_to_the_blanket_veto_when_a_sheet_names_its_part_ambiguously() {
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
+/// Metadata this path cannot read costs a workbook nothing when the package
+/// holds nothing a save could strand. Such a workbook is edited and saved
+/// exactly as it was before narrowing existed — the fallback is a veto over
+/// references, not a penalty for imperfect typing.
+#[test]
+fn leaves_a_package_bearing_no_references_alone() {
+    let mut parts = two_sheet_package(r#"<sheetData/>"#, r#"<sheetData/>"#);
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default u:Extension="xml" Extension="xml" ContentType="application/xml"/></Types>"#);
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert_eq!(parsed.package.unpatchable_reference_part(), None);
+
+    let mut workbook = parsed.workbook.clone();
+    workbook.sheets[0].name = "Renamed".to_owned();
+    let saved = serialize_workbook_with_package(&workbook, &parsed.package)
+        .expect("a workbook with nothing to strand still saves a rename");
+    assert!(
+        String::from_utf8(part_bytes(&saved, "xl/workbook.xml"))
+            .unwrap()
+            .contains(r#"name="Renamed""#)
+    );
+}
+
+/// The trigger is read loosely on purpose: a decoy attribute cannot hide a
+/// reference-bearing part, because the genuine content type still answers to
+/// "any attribute anywhere".
+#[test]
+fn triggers_the_fallback_on_a_content_type_a_decoy_would_hide() {
+    let mut parts = two_sheet_package(r#"<sheetData/>"#, r#"<sheetData/>"#);
+    parts.push((
+        "custom/cache.pvt".to_owned(),
+        br#"<pivotCacheDefinition><cacheSource><worksheetSource sheet="Sheet1" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#.to_vec(),
+    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/custom/cache.pvt" u:ContentType="application/xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#);
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(
+        package.unpatchable_reference_part().is_some(),
+        "a decoy content type hid the part that should have triggered the veto"
+    );
+    assert!(package.reference_moved_by_rows("Sheet2", 999).is_some());
+}
+
 /// The fallback is workbook-wide: an unmodelled chart stops narrowing too,
 /// exactly as it did before narrowing existed.
 #[test]
@@ -4585,7 +4626,7 @@ fn encode_utf16(text: &str, big_endian: bool, bom: bool) -> Vec<u8> {
 
 /// The conforming package metadata the narrowing path requires before it will
 /// read a package's typing or relationships at all.
-const CONFORMING_TYPES: &[u8] = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/></Types>"#;
+const CONFORMING_TYPES: &[u8] = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#;
 
 fn set_or_push_part(parts: &mut Vec<(String, Vec<u8>)>, path: &str, bytes: &[u8]) {
     match parts.iter_mut().find(|(name, _)| name == path) {

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -22,9 +22,9 @@ fn package(worksheet_body: &str, shared: &[&str], date1904: bool) -> Vec<(String
         ""
     };
     let workbook = format!(
-        r#"<workbook>{pr}<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>"#
+        r#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">{pr}<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>"#
     );
-    let rels = r#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/></Relationships>"#;
+    let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml"/></Relationships>"#;
     let worksheet = format!("<worksheet>{worksheet_body}</worksheet>");
 
     let mut parts = vec![
@@ -235,7 +235,7 @@ fn parses_and_round_trips_external_and_internal_hyperlinks() {
     parts.push((
         "xl/worksheets/_rels/sheet1.xml.rels".into(),
         br#"
-            <Relationships>
+            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
                 <Relationship Id="rId7"
                     Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
                     Target="https://example.com/report?q=1&amp;lang=en"
@@ -906,8 +906,8 @@ fn ambiguous_duplicate_removal_is_refused() {
 /// Two worksheets sharing one workbook, so an edit to the second can be
 /// checked against the first.
 fn two_sheet_package(first_body: &str, second_body: &str) -> Vec<(String, Vec<u8>)> {
-    let workbook = r#"<workbook><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/><sheet name="Sheet2" sheetId="2" r:id="rId2"/></sheets></workbook>"#;
-    let rels = r#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#;
+    let workbook = r#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/><sheet name="Sheet2" sheetId="2" r:id="rId2"/></sheets></workbook>"#;
+    let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#;
     vec![
         ("xl/workbook.xml".to_owned(), workbook.as_bytes().to_vec()),
         (
@@ -1001,7 +1001,7 @@ fn keeps_worksheet_bytes_across_a_rename() {
 #[test]
 fn does_not_reattach_duplicate_defined_name_markup() {
     let workbook_xml = concat!(
-        r#"<workbook><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>"#,
+        r#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>"#,
         r#"<definedNames>"#,
         r#"<definedName name="_xlnm.Print_Area" localSheetId="0" comment="first">Sheet1!$A$1</definedName>"#,
         r#"<definedName name="_xlnm.Print_Area" localSheetId="1" comment="second">Sheet1!$B$1</definedName>"#,
@@ -1195,7 +1195,7 @@ fn overlays_hyperlinks_and_merges_the_worksheet_relationships() {
     let mut parts = package(body, &[], false);
     parts.push((
         "xl/worksheets/_rels/sheet1.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://old.example" TargetMode="External"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://old.example" TargetMode="External"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#.to_vec(),
     ));
 
     let parsed = parse_workbook_with_package(&parts).unwrap();
@@ -1458,7 +1458,7 @@ fn keeps_content_types_resolved_through_default_extensions() {
 #[test]
 fn allocates_distinct_sheet_ids_past_the_maximum() {
     let workbook_xml = format!(
-        r#"<workbook><sheets><sheet name="Sheet1" sheetId="{}" r:id="rId1"/></sheets></workbook>"#,
+        r#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="{}" r:id="rId1"/></sheets></workbook>"#,
         u32::MAX
     );
     let mut parts = package(r#"<sheetData/>"#, &[], false);
@@ -1567,7 +1567,7 @@ fn resolves_shared_strings_through_the_workbook_relationship() {
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="strings/custom.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="strings/custom.xml"/></Relationships>"#.to_vec(),
     );
     parts.push((
         "xl/strings/custom.xml".to_owned(),
@@ -1696,7 +1696,7 @@ fn charted_package() -> Vec<(String, Vec<u8>)> {
     let mut parts = package(r#"<sheetData/><drawing r:id="rIdDrawing"/>"#, &[], false);
     parts[0] = (
         "xl/workbook.xml".to_owned(),
-        br#"<workbook><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
@@ -1733,7 +1733,7 @@ fn shared_chart_package() -> Vec<(String, Vec<u8>)> {
     let mut parts = package(r#"<sheetData/><drawing r:id="rIdDrawing"/>"#, &[], false);
     parts[0] = (
         "xl/workbook.xml".to_owned(),
-        br#"<workbook><sheets><sheet name="First" sheetId="1" r:id="rId1"/><sheet name="Second" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="First" sheetId="1" r:id="rId1"/><sheet name="Second" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
@@ -1781,7 +1781,7 @@ fn pivoted_package() -> Vec<(String, Vec<u8>)> {
     let mut parts = package(r#"<sheetData/>"#, &[], false);
     parts[0] = (
         "xl/workbook.xml".to_owned(),
-        br#"<workbook><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
@@ -1803,7 +1803,7 @@ fn unclaimed_chart_package() -> Vec<(String, Vec<u8>)> {
     let mut parts = package(r#"<sheetData/>"#, &[], false);
     parts[0] = (
         "xl/workbook.xml".to_owned(),
-        br#"<workbook><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
@@ -2017,12 +2017,16 @@ fn finds_a_pivot_part_outside_the_conventional_directory() {
 /// An `Override` naming something other than a pivot is authoritative: the part
 /// is not a pivot part however it is pathed.
 #[test]
-fn does_not_take_an_overridden_non_pivot_part_for_a_pivot() {
+fn keeps_a_conventional_pivot_part_an_override_disagrees_with() {
     let mut parts = pivoted_package();
     set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#);
-    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(parsed.package.unpatchable_references().len(), 0);
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/pivotcache/pivotCacheDefinition1.xml"),
+        "typing must never take away a part the conventional scan names"
+    );
 }
 
 /// Markup compatibility lets a part carry nodes a conforming consumer drops. A
@@ -2208,7 +2212,7 @@ fn defaults_optional_pivot_names_only_a_foreign_node_carries() {
     ));
     parts.push((
         "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
     ));
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
@@ -2286,7 +2290,7 @@ fn reads_past_a_pivot_location_decoy_to_the_real_one() {
         ));
         parts.push((
             "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
-            br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+            br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
         ));
         parse_workbook_with_package(&parts).unwrap().package
     };
@@ -2427,7 +2431,7 @@ fn resolves_the_grid_a_pivot_table_is_laid_out_on() {
     ));
     parts.push((
         "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
     ));
     let parsed = parse_workbook_with_package(&parts).unwrap();
     let package = &parsed.package;
@@ -2455,7 +2459,7 @@ fn counts_the_filter_area_a_pivot_table_reserves() {
         ));
         parts.push((
             "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
-            br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+            br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
         ));
         parse_workbook_with_package(&parts).unwrap().package
     };
@@ -2481,7 +2485,7 @@ fn keeps_every_sheet_a_shared_pivot_table_is_anchored_by() {
         br#"<pivotTableDefinition cacheId="1"><location ref="C3:E8"/></pivotTableDefinition>"#
             .to_vec(),
     ));
-    let anchor = br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#;
+    let anchor = br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#;
     parts.push((
         "xl/worksheets/_rels/sheet1.xml.rels".to_owned(),
         anchor.to_vec(),
@@ -2521,7 +2525,7 @@ fn carries_a_cache_source_range_to_its_records() {
     ));
     parts.push((
         "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/><Relationship Id="rIdStale" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords9.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/><Relationship Id="rIdStale" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords9.xml"/></Relationships>"#.to_vec(),
     ));
     let parsed = parse_workbook_with_package(&parts).unwrap();
     let package = &parsed.package;
@@ -2583,7 +2587,7 @@ fn refuses_records_whose_part_does_not_parse_whole() {
         ));
         parts.push((
             "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
-            br#"<Relationships><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
+            br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
         ));
         let package = parse_workbook_with_package(&parts).unwrap().package;
 
@@ -2622,7 +2626,7 @@ fn refuses_records_a_definition_claims_through_an_invalid_qname() {
         ));
         parts.push((
             "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
-            br#"<Relationships><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
+            br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
         ));
         let package = parse_workbook_with_package(&parts).unwrap().package;
 
@@ -2890,6 +2894,45 @@ fn falls_back_to_the_blanket_veto_on_values_the_metadata_leaves_unusable() {
     }
 }
 
+/// Discovery is monotonic over the blanket veto: metadata may add parts to look
+/// at, never take one away. An out-of-directory pivot found only through its
+/// override, beside metadata that does not conform, still has to be looked at —
+/// main's scan would have vetoed it, and a part nobody looks at vetoes nothing.
+#[test]
+fn keeps_every_part_the_blanket_veto_would_have_looked_at() {
+    let mut parts = pivoted_package();
+    let cache = parts
+        .iter()
+        .position(|(path, _)| path == "xl/pivotcache/pivotCacheDefinition1.xml")
+        .expect("the fixture holds a cache");
+    parts[cache].0 = "xl/pivotCacheDefinition1.xml".to_owned();
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/><u:Override PartName="/xl/unrelated.xml" ContentType="application/xml"/></Types>"#);
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/pivotCacheDefinition1.xml"),
+        "the pivot disappeared where the blanket veto would have caught it"
+    );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+}
+
+/// The same invariant on the chart side: typing this path cannot read must not
+/// suppress a chart the conventional layout names.
+#[test]
+fn keeps_a_conventional_chart_an_untrusted_override_disagrees_with() {
+    let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/><u:Override PartName="/xl/unrelated.xml" ContentType="application/xml"/></Types>"#);
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/charts/chart1.xml"),
+        "the chart disappeared where the blanket veto would have caught it"
+    );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+}
+
 /// OPC has no package without a content-type stream, so a package missing one
 /// is not one this path may read typing from.
 #[test]
@@ -2926,23 +2969,141 @@ fn falls_back_to_the_blanket_veto_when_the_workbook_relationships_are_ambiguous(
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
-/// A drawing's relationships decide which sheet claims which chart, and so
-/// which sheet an unqualified chart reference resolves against. Every
-/// ambiguity found so far degrades to an unclaimed chart, which is already
-/// unresolved; this pins the gate rather than a narrowing that got through.
+/// A drawing's relationships decide which sheet claims which chart. Swapping
+/// two of them is a permutation, so both charts stay claimed exactly once and
+/// nothing looks unknown — while each unqualified reference resolves against
+/// the other sheet, and an edit passes on the sheet whose range was swapped
+/// away.
 #[test]
 fn falls_back_to_the_blanket_veto_when_a_drawing_relationship_is_ambiguous() {
+    let swapped = |ambiguous: bool| {
+        let mut parts = two_charted_sheets();
+        for (drawing, own, other) in [(1, 1, 2), (2, 2, 1)] {
+            let decoy = if ambiguous {
+                format!(r#" xmlns:u="urn:future" u:Target="../charts/chart{other}.xml""#)
+            } else {
+                String::new()
+            };
+            set_part(
+                &mut parts,
+                &format!("xl/drawings/_rels/drawing{drawing}.xml.rels"),
+                format!(
+                    r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart"{decoy} Target="../charts/chart{own}.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/></Relationships>"#
+                )
+                .as_bytes(),
+            );
+        }
+        parse_workbook_with_package(&parts).unwrap().package
+    };
+
+    let honest = swapped(false);
+    assert_eq!(
+        honest.reference_moved_by_rows("Data", 9),
+        None,
+        "the sheet with the small range should be free below it"
+    );
+    assert_eq!(
+        honest.reference_moved_by_rows("Data", 999),
+        None,
+        "a resolved claim leaves everything past the range free"
+    );
+
+    let ambiguous = swapped(true);
+    assert!(
+        ambiguous.reference_moved_by_rows("Data", 999).is_some(),
+        "a swapped claim was read as a range instead of falling back"
+    );
+    assert!(
+        ambiguous.reference_moved_by_rows("Report", 999).is_some(),
+        "a swapped claim was read as a range instead of falling back"
+    );
+}
+
+/// Two sheets, each anchoring its own chart through its own drawing, with
+/// ranges of different heights so a swapped claim is observable.
+fn two_charted_sheets() -> Vec<(String, Vec<u8>)> {
+    let mut parts = charted_package();
+    let chart = |reference: &str| {
+        String::from_utf8(CHART.to_vec())
+            .unwrap()
+            .replace("Data!$B$2:$B$4", reference)
+            .replace("<c:f>Data!$B$1</c:f>", "<c:f>$B$1</c:f>")
+            .replace("<c:f>Data!$A$2:$A$4</c:f>", "<c:f>$A$2:$A$4</c:f>")
+            .into_bytes()
+    };
+    set_part(&mut parts, "xl/charts/chart1.xml", &chart("$A$2:$B$4"));
+    parts.push(("xl/charts/chart2.xml".to_owned(), chart("$A$2:$B$40")));
+    set_part(
+        &mut parts,
+        "xl/worksheets/sheet2.xml",
+        br#"<worksheet xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetData/><drawing r:id="rIdDrawing"/></worksheet>"#,
+    );
+    parts.push((
+        "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing2.xml"/></Relationships>"#.to_vec(),
+    ));
+    parts.push(("xl/drawings/drawing2.xml".to_owned(), DRAWING.to_vec()));
+    parts.push((
+        "xl/drawings/_rels/drawing2.xml.rels".to_owned(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart2.xml"/></Relationships>"#.to_vec(),
+    ));
+    parts
+}
+
+/// The shared reader follows a relationship whose type merely ENDS IN the
+/// standard segment, so a type this path never enumerated can still steer chart
+/// ownership. A package carrying one is not one to read relationships from.
+#[test]
+fn falls_back_to_the_blanket_veto_on_a_relationship_type_only_the_reader_follows() {
     let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
     set_part(
         &mut parts,
-        "xl/drawings/_rels/drawing1.xml.rels",
-        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdChart" u:Target="../charts/elsewhere.xml" Target="../charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/></Relationships>"#,
+        "xl/worksheets/_rels/sheet1.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="https://example.invalid/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#,
+    );
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "a drawing reached by a non-standard type steered ownership unchecked"
+    );
+}
+
+/// The claim is followed by taking the first `c:chart` under an anchor, so a
+/// second one lets two anchors swap which chart each is taken to hold.
+#[test]
+fn falls_back_to_the_blanket_veto_when_a_drawing_anchor_claims_twice() {
+    let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
+    let drawing = String::from_utf8(DRAWING.to_vec()).unwrap().replace(
+        r#"<c:chart r:id="rIdChart"/>"#,
+        r#"<c:chart r:id="rIdChart"/><c:chart r:id="rIdOther"/>"#,
+    );
+    set_part(&mut parts, "xl/drawings/drawing1.xml", drawing.as_bytes());
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "an anchor claiming twice narrowed anyway"
+    );
+}
+
+/// A sheet resolves to its part through the first attribute whose local name is
+/// `id`, so a foreign one before the real `r:id` swaps which part a sheet is —
+/// leaving every sheet claimed while a pivot table is attributed to the wrong
+/// one.
+#[test]
+fn falls_back_to_the_blanket_veto_when_a_sheet_names_its_part_ambiguously() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/workbook.xml",
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:u="urn:future"><sheets><sheet name="Data" sheetId="1" u:id="rId2" r:id="rId1"/><sheet name="Report" sheetId="2" u:id="rId1" r:id="rId2"/></sheets></workbook>"#,
     );
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
     assert_eq!(
         package.unpatchable_reference_part(),
-        Some("xl/charts/chart1.xml")
+        Some("xl/pivotcache/pivotCacheDefinition1.xml")
     );
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
@@ -4387,11 +4548,11 @@ fn chartsheet_package() -> Vec<(String, Vec<u8>)> {
     let mut parts = package(r#"<sheetData/>"#, &[], false);
     parts[0] = (
         "xl/workbook.xml".to_owned(),
-        br#"<workbook><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Chart" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Chart" sheetId="2" r:id="rId2"/></sheets></workbook>"#.to_vec(),
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet" Target="chartsheets/sheet1.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet" Target="chartsheets/sheet1.xml"/></Relationships>"#.to_vec(),
     );
     parts.extend([
         (

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -1847,7 +1847,7 @@ fn refuses_to_strand_pivot_references_at_the_serialization_boundary() {
     let removed = crate::serialize_workbook_with_package_and_origins_after_edits(
         &workbook,
         &parsed.package,
-        &[Some(0), None],
+        &[None, Some(1)],
         &provenance,
         SaveEdits {
             changed: true,
@@ -1856,6 +1856,18 @@ fn refuses_to_strand_pivot_references_at_the_serialization_boundary() {
     )
     .unwrap_err();
     assert!(matches!(removed, ParseError::UnsupportedEdit(_)));
+
+    crate::serialize_workbook_with_package_and_origins_after_edits(
+        &workbook,
+        &parsed.package,
+        &[Some(0), None],
+        &provenance,
+        SaveEdits {
+            changed: true,
+            moved_references: false,
+        },
+    )
+    .expect("dropping a sheet the cache does not name strands nothing");
 
     let mut renamed = workbook.clone();
     renamed.sheets[0].name = "Renamed".to_owned();
@@ -1889,6 +1901,322 @@ fn refuses_to_strand_pivot_references_at_the_serialization_boundary() {
     assert!(
         matches!(&axis_edit, ParseError::UnsupportedEdit(message) if message.contains("pivotCacheDefinition1.xml")),
         "{axis_edit:?}"
+    );
+}
+
+/// The cache names one range on one sheet, and that is all a structural edit
+/// has to stay clear of.
+#[test]
+fn resolves_the_range_a_pivot_cache_is_built_from() {
+    let parsed = parse_workbook_with_package(&pivoted_package()).unwrap();
+    let package = &parsed.package;
+
+    assert!(package.reference_naming_sheet("Data").is_some());
+    assert!(package.reference_moved_by_rows("Data", 3).is_some());
+    assert!(package.reference_moved_by_cols("Data", 1).is_some());
+    assert_eq!(package.reference_naming_sheet("Report"), None);
+    assert_eq!(package.reference_moved_by_rows("Report", 0), None);
+    assert_eq!(package.reference_moved_by_rows("Data", 4), None);
+    assert_eq!(package.reference_moved_by_cols("Data", 2), None);
+}
+
+/// A cache source this crate does not read names every cell, so nothing
+/// structural gets through while one is preserved.
+#[test]
+fn refuses_everything_for_a_pivot_source_it_cannot_resolve() {
+    for (label, attributes, source) in [
+        (
+            "defined name",
+            "",
+            r#"<worksheetSource name="SalesRange"/>"#,
+        ),
+        ("no ref", "", r#"<worksheetSource sheet="Data"/>"#),
+        ("no sheet", "", r#"<worksheetSource ref="A1:B4"/>"#),
+        (
+            "ref and name",
+            "",
+            r#"<worksheetSource sheet="Data" ref="A1:B4" name="SalesRange"/>"#,
+        ),
+        (
+            "another book",
+            "",
+            r#"<worksheetSource sheet="Data" ref="A1:B4" r:id="rIdBook"/>"#,
+        ),
+        (
+            "an extension beside it",
+            "",
+            r#"<worksheetSource sheet="Data" ref="A1:B4"/><extLst><ext uri="{F1C0A1B2}"><x14:cacheSource><xm:f>Notes!A1:B100</xm:f></x14:cacheSource></ext></extLst>"#,
+        ),
+        (
+            "external",
+            r#" type="external""#,
+            r#"<worksheetSource sheet="Data" ref="A1:B4"/>"#,
+        ),
+        (
+            "scenario",
+            r#" type="scenario""#,
+            r#"<worksheetSource sheet="Data" ref="A1:B4"/>"#,
+        ),
+        (
+            "consolidation carrying an unmodelled child",
+            r#" type="consolidation""#,
+            r#"<consolidation><rangeSets><rangeSet sheet="Data" ref="A1:B4"/></rangeSets><extLst/></consolidation>"#,
+        ),
+        ("empty", "", ""),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            format!(
+                "<pivotCacheDefinition><cacheSource{attributes}>{source}</cacheSource></pivotCacheDefinition>"
+            )
+            .as_bytes(),
+        );
+        let parsed = parse_workbook_with_package(&parts).unwrap();
+        assert!(
+            parsed
+                .package
+                .reference_moved_by_rows("Report", 999)
+                .is_some(),
+            "{label} was resolved"
+        );
+    }
+}
+
+/// A consolidated cache names one range per set, and all of them resolve or
+/// none do.
+#[test]
+fn resolves_every_range_a_consolidated_cache_names() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/pivotcache/pivotCacheDefinition1.xml",
+        br#"<pivotCacheDefinition><cacheSource type="consolidation"><consolidation><rangeSets><rangeSet sheet="Data" ref="A1:B4"/><rangeSet sheet="Report" ref="A1:C2"/></rangeSets></consolidation></cacheSource></pivotCacheDefinition>"#,
+    );
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert!(package.reference_moved_by_rows("Data", 3).is_some());
+    assert_eq!(package.reference_moved_by_rows("Data", 4), None);
+    assert!(package.reference_moved_by_cols("Report", 2).is_some());
+    assert_eq!(package.reference_moved_by_cols("Report", 3), None);
+}
+
+/// A sheet the workbook does not hold exactly one of is not one a reference can
+/// be bound to: a later rename could put a different sheet under that name, so
+/// the part names everything instead.
+#[test]
+fn refuses_everything_for_a_source_sheet_the_workbook_does_not_hold() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/pivotcache/pivotCacheDefinition1.xml",
+        br#"<pivotCacheDefinition><cacheSource><worksheetSource sheet="Gone" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+    );
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert!(parsed.package.reference_naming_sheet("Report").is_some());
+    assert!(parsed.package.reference_naming_sheet("Data").is_some());
+    assert!(
+        parsed
+            .package
+            .reference_moved_by_rows("Report", 999)
+            .is_some()
+    );
+}
+
+/// A relationships part that will not parse costs the ownership it carried, not
+/// the open: the workbook still opens and whatever could not be followed names
+/// everything.
+#[test]
+fn opens_a_workbook_whose_pivot_relationships_do_not_parse() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/pivotcache/pivotCacheDefinition1.xml",
+        br#"<pivotCacheDefinition xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rIdRecords"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+    );
+    parts.push((
+        "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+        b"<pivotCacheRecords/>".to_vec(),
+    ));
+    parts.push((
+        "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+        b"<Relationships><Relationship Id=".to_vec(),
+    ));
+    parts.push((
+        "xl/pivottables/pivotTable1.xml".to_owned(),
+        br#"<pivotTableDefinition cacheId="1"><location ref="C3:E8"/></pivotTableDefinition>"#
+            .to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).expect("the workbook still opens");
+    let package = &parsed.package;
+
+    assert_eq!(package.unpatchable_references().len(), 3);
+    assert_eq!(
+        package.reference_moved_by_rows("Data", 3),
+        Some("xl/pivotcache/pivotCacheDefinition1.xml"),
+        "the cache itself still resolves"
+    );
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "records whose ownership could not be followed name everything"
+    );
+    assert!(
+        package
+            .unpatchable_references()
+            .iter()
+            .any(|reference| reference.part().ends_with("pivotTable1.xml")
+                && reference.names_sheet("Data")),
+        "a pivot table no sheet relationship anchors names everything"
+    );
+}
+
+/// A pivot table is laid out on the sheet whose relationships anchor it, and
+/// an edit above or left of that block moves it.
+#[test]
+fn resolves_the_grid_a_pivot_table_is_laid_out_on() {
+    let mut parts = pivoted_package();
+    parts.push((
+        "xl/pivottables/pivotTable1.xml".to_owned(),
+        br#"<pivotTableDefinition cacheId="1"><location ref="C3:E8"/></pivotTableDefinition>"#
+            .to_vec(),
+    ));
+    parts.push((
+        "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+        br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert_eq!(
+        package.reference_naming_sheet("Report"),
+        Some("xl/pivottables/pivotTable1.xml")
+    );
+    assert!(package.reference_moved_by_rows("Report", 7).is_some());
+    assert_eq!(package.reference_moved_by_rows("Report", 8), None);
+    assert!(package.reference_moved_by_cols("Report", 4).is_some());
+    assert_eq!(package.reference_moved_by_cols("Report", 5), None);
+}
+
+/// `ref` covers the body; the filter area sits beside it and is occupied just
+/// as much, so the page counts widen what an edit has to stay clear of.
+#[test]
+fn counts_the_filter_area_a_pivot_table_reserves() {
+    let package = |location: &str| {
+        let mut parts = pivoted_package();
+        parts.push((
+            "xl/pivottables/pivotTable1.xml".to_owned(),
+            format!(r#"<pivotTableDefinition cacheId="1">{location}</pivotTableDefinition>"#)
+                .into_bytes(),
+        ));
+        parts.push((
+            "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+            br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+        ));
+        parse_workbook_with_package(&parts).unwrap().package
+    };
+
+    let paged = package(r#"<location ref="A10:B20" rowPageCount="1" colPageCount="4"/>"#);
+    assert!(paged.reference_moved_by_cols("Report", 2).is_some());
+    assert!(paged.reference_moved_by_cols("Report", 5).is_some());
+    assert_eq!(paged.reference_moved_by_cols("Report", 6), None);
+    assert!(paged.reference_moved_by_rows("Report", 20).is_some());
+    assert_eq!(paged.reference_moved_by_rows("Report", 21), None);
+
+    let unreadable = package(r#"<location ref="A10:B20" colPageCount="lots"/>"#);
+    assert!(unreadable.reference_moved_by_cols("Report", 999).is_some());
+}
+
+/// One pivot table part two sheets anchor is laid out on both of them, and
+/// neither may quietly lose its claim to the other.
+#[test]
+fn keeps_every_sheet_a_shared_pivot_table_is_anchored_by() {
+    let mut parts = pivoted_package();
+    parts.push((
+        "xl/pivottables/pivotTable1.xml".to_owned(),
+        br#"<pivotTableDefinition cacheId="1"><location ref="C3:E8"/></pivotTableDefinition>"#
+            .to_vec(),
+    ));
+    let anchor = br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#;
+    parts.push((
+        "xl/worksheets/_rels/sheet1.xml.rels".to_owned(),
+        anchor.to_vec(),
+    ));
+    parts.push((
+        "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+        anchor.to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert!(package.reference_moved_by_rows("Report", 7).is_some());
+    assert_eq!(
+        package.reference_moved_by_rows("Data", 7),
+        Some("xl/pivottables/pivotTable1.xml")
+    );
+    assert_eq!(package.reference_moved_by_rows("Data", 8), None);
+}
+
+/// Cached records hold the source range's values, so they move with the range
+/// the definition that owns them names.
+#[test]
+fn carries_a_cache_source_range_to_its_records() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/pivotcache/pivotCacheDefinition1.xml",
+        br#"<pivotCacheDefinition xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rIdRecords"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+    );
+    parts.push((
+        "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+        b"<pivotCacheRecords/>".to_vec(),
+    ));
+    parts.push((
+        "xl/pivotcache/pivotCacheRecords9.xml".to_owned(),
+        b"<pivotCacheRecords/>".to_vec(),
+    ));
+    parts.push((
+        "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+        br#"<Relationships><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/><Relationship Id="rIdStale" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords9.xml"/></Relationships>"#.to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert_eq!(package.unpatchable_references().len(), 3);
+    assert_eq!(
+        package.reference_moved_by_rows("Data", 3),
+        Some("xl/pivotcache/pivotCacheDefinition1.xml")
+    );
+    assert_eq!(
+        package.reference_moved_by_rows("Data", 4),
+        Some("xl/pivotcache/pivotCacheRecords9.xml"),
+        "only the records the definition's own r:id names inherit its range"
+    );
+    assert_eq!(
+        package.reference_naming_sheet("Report"),
+        Some("xl/pivotcache/pivotCacheRecords9.xml")
+    );
+}
+
+/// Records the definition does not point its own `r:id` at are not its records,
+/// so they inherit nothing and name everything.
+#[test]
+fn refuses_everything_for_records_no_definition_claims() {
+    let mut parts = pivoted_package();
+    parts.push((
+        "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+        b"<pivotCacheRecords/>".to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert_eq!(parsed.package.unpatchable_references().len(), 2);
+    assert!(
+        parsed
+            .package
+            .reference_moved_by_rows("Report", 999)
+            .is_some()
     );
 }
 

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2026,6 +2026,112 @@ fn does_not_take_an_overridden_non_pivot_part_for_a_pivot() {
     assert_eq!(parsed.package.unpatchable_references().len(), 0);
 }
 
+/// Markup compatibility lets a part carry attributes a conforming consumer
+/// drops. Reading by local name alone would take the ignored `u:sheet` for the
+/// real one and fence off `Notes` while `Data` moved out from under the cache,
+/// so a name several attributes answer to resolves to nothing at all.
+#[test]
+fn refuses_a_pivot_source_a_decoy_attribute_could_shadow() {
+    for (label, worksheet_source) in [
+        (
+            "shadowed sheet and ref",
+            r#"<worksheetSource xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u" u:sheet="Report" u:ref="A1" sheet="Data" ref="A1:B4"/>"#,
+        ),
+        (
+            "shadowed sheet alone",
+            r#"<worksheetSource xmlns:u="urn:future" u:sheet="Report" sheet="Data" ref="A1:B4"/>"#,
+        ),
+        (
+            "real one authored first",
+            r#"<worksheetSource xmlns:u="urn:future" sheet="Data" ref="A1:B4" u:sheet="Report" u:ref="A1"/>"#,
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            format!(
+                "<pivotCacheDefinition><cacheSource>{worksheet_source}</cacheSource></pivotCacheDefinition>"
+            )
+            .as_bytes(),
+        );
+        let parsed = parse_workbook_with_package(&parts).unwrap();
+        assert!(
+            parsed.package.reference_naming_sheet("Data").is_some(),
+            "{label}: the cache stopped naming Data"
+        );
+        assert!(
+            parsed
+                .package
+                .reference_moved_by_rows("Report", 999)
+                .is_some(),
+            "{label} was resolved"
+        );
+    }
+}
+
+/// The same shadowing through an element name, which `cacheSource` and
+/// `location` are both reached by.
+#[test]
+fn refuses_a_pivot_part_a_decoy_element_could_shadow() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/pivotcache/pivotCacheDefinition1.xml",
+        br#"<pivotCacheDefinition xmlns:u="urn:future"><u:cacheSource><worksheetSource sheet="Report" ref="A1"/></u:cacheSource><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+    );
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert!(parsed.package.reference_naming_sheet("Data").is_some());
+    assert!(
+        parsed
+            .package
+            .reference_moved_by_rows("Report", 999)
+            .is_some()
+    );
+}
+
+/// A pivot table's own grid is reached by the same two lookups, so a decoy over
+/// `location` or its `ref` has to leave it unresolved too.
+#[test]
+fn refuses_a_pivot_location_a_decoy_could_shadow() {
+    let package = |definition: &str| {
+        let mut parts = pivoted_package();
+        parts.push((
+            "xl/pivottables/pivotTable1.xml".to_owned(),
+            definition.as_bytes().to_vec(),
+        ));
+        parts.push((
+            "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+            br#"<Relationships><Relationship Id="rIdPivot" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivottables/pivotTable1.xml"/></Relationships>"#.to_vec(),
+        ));
+        parse_workbook_with_package(&parts).unwrap().package
+    };
+
+    let shadowed_ref = package(
+        r#"<pivotTableDefinition xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:u="urn:future" mc:Ignorable="u" cacheId="1"><location u:ref="A1" ref="C3:E8"/></pivotTableDefinition>"#,
+    );
+    assert!(shadowed_ref.reference_moved_by_rows("Data", 999).is_some());
+
+    let shadowed_location = package(
+        r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><u:location ref="A1"/><location ref="C3:E8"/></pivotTableDefinition>"#,
+    );
+    assert!(
+        shadowed_location
+            .reference_moved_by_rows("Data", 999)
+            .is_some()
+    );
+
+    let shadowed_page_count = package(
+        r#"<pivotTableDefinition xmlns:u="urn:future" cacheId="1"><location ref="C3:E8" u:colPageCount="0" colPageCount="4"/></pivotTableDefinition>"#,
+    );
+    assert!(
+        shadowed_page_count
+            .reference_moved_by_rows("Data", 999)
+            .is_some()
+    );
+}
+
 /// A consolidated cache names one range per set, and all of them resolve or
 /// none do.
 #[test]

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2124,6 +2124,26 @@ fn refuses_a_pivot_source_only_a_foreign_node_answers_for() {
             "foreign default namespace",
             r#"<pivotCacheDefinition xmlns="urn:future"><cacheSource><worksheetSource sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
         ),
+        (
+            "subtree that left the default namespace",
+            r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource xmlns=""><worksheetSource sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "source that left the default namespace",
+            r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource><worksheetSource xmlns="" sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
+        (
+            "prefix bound to ours through an invalid qname",
+            r#"<x:pivotCacheDefinition xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:cacheSource><x:junk:worksheetSource sheet="Report" ref="A1"/></x:cacheSource></x:pivotCacheDefinition>"#,
+        ),
+        (
+            "invalid qname on the attributes",
+            r#"<x:pivotCacheDefinition xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:cacheSource><x:worksheetSource x:junk:sheet="Report" x:junk:ref="A1"/></x:cacheSource></x:pivotCacheDefinition>"#,
+        ),
+        (
+            "empty prefix on the source",
+            r#"<pivotCacheDefinition><cacheSource><:worksheetSource sheet="Report" ref="A1"/></cacheSource></pivotCacheDefinition>"#,
+        ),
     ] {
         let mut parts = pivoted_package();
         set_part(
@@ -2526,6 +2546,47 @@ fn carries_a_cache_source_range_to_its_records() {
         package.reference_naming_sheet("Report"),
         Some("xl/pivotcache/pivotCacheRecords9.xml")
     );
+}
+
+/// Classifying a part by its first tag says nothing about whether the rest of
+/// it parses. A records part that never closes, or that carries a second root
+/// beside the first, is not one this crate has read — it inherits nothing.
+#[test]
+fn refuses_records_whose_part_does_not_parse_whole() {
+    for (label, records) in [
+        ("unclosed root", "<pivotCacheRecords>"),
+        ("a second root", "<pivotCacheRecords/><secondRoot/>"),
+        (
+            "an unclosed child",
+            "<pivotCacheRecords><r></pivotCacheRecords>",
+        ),
+        ("trailing junk", "<pivotCacheRecords/></stray>"),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            br#"<pivotCacheDefinition xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rIdRecords"><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#,
+        );
+        parts.push((
+            "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+            records.as_bytes().to_vec(),
+        ));
+        parts.push((
+            "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+            br#"<Relationships><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
+        ));
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} inherited a narrow area"
+        );
+        assert!(
+            package.reference_naming_sheet("Data").is_some(),
+            "{label}: Data was left unprotected"
+        );
+    }
 }
 
 /// Records the definition does not point its own `r:id` at are not its records,

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -1429,10 +1429,7 @@ fn content_types_text(parts: &[(String, Vec<u8>)]) -> String {
 #[test]
 fn keeps_content_types_resolved_through_default_extensions() {
     let mut parts = package(r#"<sheetData/>"#, &[], false);
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/vnd.ms-excel.worksheet+xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.ms-excel.sheet.macroEnabled.main+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/vnd.ms-excel.worksheet+xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.ms-excel.sheet.macroEnabled.main+xml"/></Types>"#);
 
     let parsed = parse_workbook_with_package(&parts).unwrap();
     let mut workbook = parsed.workbook.clone();
@@ -1703,7 +1700,7 @@ fn charted_package() -> Vec<(String, Vec<u8>)> {
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
     );
     parts.extend([
         (
@@ -1721,6 +1718,7 @@ fn charted_package() -> Vec<(String, Vec<u8>)> {
         ),
         ("xl/charts/chart1.xml".to_owned(), CHART.to_vec()),
     ]);
+    set_or_push_part(&mut parts, "[Content_Types].xml", CONFORMING_TYPES);
     parts
 }
 
@@ -1739,7 +1737,7 @@ fn shared_chart_package() -> Vec<(String, Vec<u8>)> {
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
     );
     let sheet_rels = |drawing: &str| {
         format!(
@@ -1787,7 +1785,7 @@ fn pivoted_package() -> Vec<(String, Vec<u8>)> {
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
     );
     parts.push((
         "xl/worksheets/sheet2.xml".to_owned(),
@@ -1797,6 +1795,7 @@ fn pivoted_package() -> Vec<(String, Vec<u8>)> {
         "xl/pivotcache/pivotCacheDefinition1.xml".to_owned(),
         br#"<pivotCacheDefinition><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#.to_vec(),
     ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", CONFORMING_TYPES);
     parts
 }
 
@@ -1808,7 +1807,7 @@ fn unclaimed_chart_package() -> Vec<(String, Vec<u8>)> {
     );
     parts[1] = (
         "xl/_rels/workbook.xml.rels".to_owned(),
-        br#"<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#.to_vec(),
     );
     parts.push((
         "xl/worksheets/sheet2.xml".to_owned(),
@@ -1818,6 +1817,7 @@ fn unclaimed_chart_package() -> Vec<(String, Vec<u8>)> {
         "xl/charts/chart1.xml".to_owned(),
         br#"<chartSpace><f>Data!$A$1:$A$2</f></chartSpace>"#.to_vec(),
     ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", CONFORMING_TYPES);
     parts
 }
 
@@ -2001,10 +2001,7 @@ fn finds_a_pivot_part_outside_the_conventional_directory() {
         .position(|(path, _)| path == "xl/pivotcache/pivotCacheDefinition1.xml")
         .expect("the fixture holds a cache");
     parts[cache].0 = "xl/pivotCacheDefinition1.xml".to_owned();
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#);
     let parsed = parse_workbook_with_package(&parts).unwrap();
     let package = &parsed.package;
 
@@ -2022,10 +2019,7 @@ fn finds_a_pivot_part_outside_the_conventional_directory() {
 #[test]
 fn does_not_take_an_overridden_non_pivot_part_for_a_pivot() {
     let mut parts = pivoted_package();
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#);
     let parsed = parse_workbook_with_package(&parts).unwrap();
 
     assert_eq!(parsed.package.unpatchable_references().len(), 0);
@@ -2746,7 +2740,7 @@ fn refuses_a_pivot_part_a_foreign_override_would_rule_out() {
         ),
     ] {
         let mut parts = pivoted_package();
-        parts.push(("[Content_Types].xml".to_owned(), types.into_bytes()));
+        set_or_push_part(&mut parts, "[Content_Types].xml", types.as_bytes());
         let package = parse_workbook_with_package(&parts).unwrap().package;
 
         assert_eq!(package.unpatchable_references().len(), 1, "{label}");
@@ -2814,7 +2808,7 @@ fn falls_back_to_the_blanket_veto_when_the_package_metadata_does_not_conform() {
         ),
     ] {
         let mut parts = pivoted_package();
-        parts.push(("[Content_Types].xml".to_owned(), types.as_bytes().to_vec()));
+        set_or_push_part(&mut parts, "[Content_Types].xml", types.as_bytes());
         parts.push((
             "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
             rels.as_bytes().to_vec(),
@@ -2837,15 +2831,128 @@ fn falls_back_to_the_blanket_veto_when_the_package_metadata_does_not_conform() {
     }
 }
 
+/// A value the metadata carries but does not fill in is metadata this path
+/// cannot read either. An empty content type makes OPC typing rule a
+/// conventional pivot out, and a target mode outside the two OPC defines makes
+/// the shared reader take an external relationship for an internal one.
+#[test]
+fn falls_back_to_the_blanket_veto_on_values_the_metadata_leaves_unusable() {
+    for (label, types, rels) in [
+        (
+            "an override with no content type",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType=""/></Types>"#,
+            None,
+        ),
+        (
+            "an override with a relative part name",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/xml"/></Types>"#,
+            None,
+        ),
+        (
+            "a default with an empty extension",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="" ContentType="application/xml"/></Types>"#,
+            None,
+        ),
+        (
+            "a relationship with an empty target",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>"#,
+            Some(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target=""/></Relationships>"#,
+            ),
+        ),
+        (
+            "a target mode OPC does not define",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>"#,
+            Some(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml" TargetMode="bogus"/></Relationships>"#,
+            ),
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        set_or_push_part(&mut parts, "[Content_Types].xml", types.as_bytes());
+        if let Some(rels) = rels {
+            parts.push((
+                "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+                rels.as_bytes().to_vec(),
+            ));
+        }
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert_eq!(
+            package.unpatchable_reference_part(),
+            Some("xl/pivotcache/pivotCacheDefinition1.xml"),
+            "{label}: the pivot stopped being vetoed"
+        );
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} narrowed on a value it could not use"
+        );
+    }
+}
+
+/// OPC has no package without a content-type stream, so a package missing one
+/// is not one this path may read typing from.
+#[test]
+fn falls_back_to_the_blanket_veto_without_a_content_type_part() {
+    let mut parts = pivoted_package();
+    parts.retain(|(path, _)| path != "[Content_Types].xml");
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/pivotcache/pivotCacheDefinition1.xml")
+    );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+}
+
+/// Sheet parts come from the workbook's own relationships, so a pivot table's
+/// host is only as certain as they are. Two relationships answering to one id
+/// can swap which part a sheet resolves to, which would fence off the wrong
+/// sheet entirely.
+#[test]
+fn falls_back_to_the_blanket_veto_when_the_workbook_relationships_are_ambiguous() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/_rels/workbook.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#,
+    );
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/pivotcache/pivotCacheDefinition1.xml")
+    );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+}
+
+/// A drawing's relationships decide which sheet claims which chart, and so
+/// which sheet an unqualified chart reference resolves against. Every
+/// ambiguity found so far degrades to an unclaimed chart, which is already
+/// unresolved; this pins the gate rather than a narrowing that got through.
+#[test]
+fn falls_back_to_the_blanket_veto_when_a_drawing_relationship_is_ambiguous() {
+    let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
+    set_part(
+        &mut parts,
+        "xl/drawings/_rels/drawing1.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdChart" u:Target="../charts/elsewhere.xml" Target="../charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/></Relationships>"#,
+    );
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/charts/chart1.xml")
+    );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+}
+
 /// The fallback is workbook-wide: an unmodelled chart stops narrowing too,
 /// exactly as it did before narrowing existed.
 #[test]
 fn falls_back_to_the_blanket_veto_for_charts_too() {
     let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default u:Extension="xml" Extension="xml" ContentType="application/xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default u:Extension="xml" Extension="xml" ContentType="application/xml"/></Types>"#);
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
     assert_eq!(
@@ -2862,10 +2969,7 @@ fn falls_back_to_the_blanket_veto_for_charts_too() {
 #[test]
 fn still_narrows_when_the_package_metadata_conforms() {
     let mut parts = pivoted_package();
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#);
     parts.push((
         "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
         br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
@@ -3951,10 +4055,7 @@ fn refuses_structural_edits_while_a_chart_part_is_not_covered() {
 #[test]
 fn refuses_a_chart_typed_by_a_default_extension_mapping() {
     let mut parts = charted_package();
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="cxml" ContentType="application/vnd.ms-office.chartex+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="cxml" ContentType="application/vnd.ms-office.chartex+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#);
     parts.push((
         "xl/extras/plot1.cxml".to_owned(),
         br#"<cx:chartSpace xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex"/>"#
@@ -3973,10 +4074,7 @@ fn refuses_a_chart_typed_by_a_default_extension_mapping() {
 #[test]
 fn still_covers_a_conventional_chart_a_default_types_as_plain_xml() {
     let mut parts = charted_package();
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/></Types>"#);
     parts.push((
         "xl/charts/chart2.xml".to_owned(),
         b"<c:chartSpace xmlns:c=\"http://schemas.openxmlformats.org/drawingml/2006/chart\"/>"
@@ -4109,10 +4207,7 @@ fn refuses_everything_for_a_chart_no_sheet_claims() {
 #[test]
 fn allows_dropping_the_sheet_an_unmodelled_chart_hangs_off() {
     let mut parts = unrebuildable_chart_package(chartsheet_package(), "Data!$A$2:$B$4");
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#);
     parts.push((
         "_rels/.rels".to_owned(),
         br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdBook" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#.to_vec(),
@@ -4268,6 +4363,17 @@ fn encode_utf16(text: &str, big_endian: bool, bom: bool) -> Vec<u8> {
     out
 }
 
+/// The conforming package metadata the narrowing path requires before it will
+/// read a package's typing or relationships at all.
+const CONFORMING_TYPES: &[u8] = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#;
+
+fn set_or_push_part(parts: &mut Vec<(String, Vec<u8>)>, path: &str, bytes: &[u8]) {
+    match parts.iter_mut().find(|(name, _)| name == path) {
+        Some(slot) => slot.1 = bytes.to_vec(),
+        None => parts.push((path.to_owned(), bytes.to_vec())),
+    }
+}
+
 fn set_part(parts: &mut [(String, Vec<u8>)], path: &str, bytes: &[u8]) {
     let slot = parts
         .iter_mut()
@@ -4303,6 +4409,7 @@ fn chartsheet_package() -> Vec<(String, Vec<u8>)> {
         ),
         ("xl/charts/chart1.xml".to_owned(), CHART.to_vec()),
     ]);
+    set_or_push_part(&mut parts, "[Content_Types].xml", CONFORMING_TYPES);
     parts
 }
 
@@ -4311,10 +4418,7 @@ fn chartsheet_package() -> Vec<(String, Vec<u8>)> {
 #[test]
 fn dropping_a_charted_sheet_prunes_its_unreachable_parts() {
     let mut parts = charted_package();
-    parts.push((
-        "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#.to_vec(),
-    ));
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#);
     parts.push((
         "_rels/.rels".to_owned(),
         br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdBook" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#.to_vec(),

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2658,8 +2658,16 @@ fn refuses_records_claimed_through_relationships_it_cannot_trust() {
             r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="elsewhere.xml"/></Relationships>"#,
         ),
         (
-            "foreign target beside a real id",
-            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" u:Target="elsewhere.xml" Target="pivotCacheRecords1.xml"/></Relationships>"#,
+            "a foreign target the shared reader takes first",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" u:Target="pivotCacheRecords1.xml" Target="elsewhere.xml"/></Relationships>"#,
+        ),
+        (
+            "a foreign id the shared reader takes first",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship u:Id="rIdRecords" Id="rIdOther" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#,
+        ),
+        (
+            "a foreign type the shared reader takes first",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:u="urn:future"><Relationship Id="rIdRecords" u:Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Type="urn:not-records" Target="pivotCacheRecords1.xml"/></Relationships>"#,
         ),
         (
             "foreign relationship element",
@@ -2698,18 +2706,81 @@ fn refuses_records_claimed_through_relationships_it_cannot_trust() {
 /// cannot trust leaves the pivot part vetoing everything, never untyped.
 #[test]
 fn refuses_a_pivot_part_a_foreign_override_would_rule_out() {
+    const THEME: &str = "application/vnd.openxmlformats-officedocument.theme+xml";
+    for (label, types) in [
+        (
+            "a foreign override",
+            format!(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><u:Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="{THEME}"/></Types>"#
+            ),
+        ),
+        (
+            "a foreign part name the shared reader takes first",
+            format!(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override u:PartName="/xl/pivotcache/pivotCacheDefinition1.xml" PartName="/xl/elsewhere.xml" ContentType="{THEME}"/></Types>"#
+            ),
+        ),
+        (
+            "a foreign content type the shared reader takes first",
+            format!(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" u:ContentType="{THEME}" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#
+            ),
+        ),
+        (
+            "an override at the root, where the shared reader still reads it",
+            format!(
+                r#"<u:Override xmlns:u="urn:future" PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="{THEME}"/>"#
+            ),
+        ),
+        (
+            "an override nested where only the shared reader looks",
+            format!(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><wrapper><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="{THEME}"/></wrapper></Types>"#
+            ),
+        ),
+        (
+            "two overrides that disagree",
+            format!(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="{THEME}"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#
+            ),
+        ),
+    ] {
+        let mut parts = pivoted_package();
+        parts.push(("[Content_Types].xml".to_owned(), types.into_bytes()));
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert_eq!(package.unpatchable_references().len(), 1, "{label}");
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label}: a cache typed by a part this path cannot trust must name everything"
+        );
+    }
+}
+
+/// Typing this path cannot trust must never lose a pivot part. A cache found
+/// only through its override, beside a foreign sibling that makes the typing
+/// untrustworthy, still has to be discovered — an undiscovered part vetoes
+/// nothing, which is the one outcome worse than a refusal.
+#[test]
+fn keeps_an_out_of_directory_pivot_when_the_typing_cannot_be_trusted() {
     let mut parts = pivoted_package();
+    let cache = parts
+        .iter()
+        .position(|(path, _)| path == "xl/pivotcache/pivotCacheDefinition1.xml")
+        .expect("the fixture holds a cache");
+    parts[cache].0 = "xl/pivotCacheDefinition1.xml".to_owned();
     parts.push((
         "[Content_Types].xml".to_owned(),
-        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><u:Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#.to_vec(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/><u:Override PartName="/xl/unrelated.xml" ContentType="application/xml"/></Types>"#.to_vec(),
     ));
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(package.unpatchable_references().len(), 1);
-    assert!(
-        package.reference_moved_by_rows("Report", 999).is_some(),
-        "a cache typed by a part this path cannot trust must name everything"
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/pivotCacheDefinition1.xml"),
+        "the pivot disappeared instead of becoming unresolved"
     );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
 /// Records the definition does not point its own `r:id` at are not its records,

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -2561,6 +2561,13 @@ fn refuses_records_whose_part_does_not_parse_whole() {
             "<pivotCacheRecords><r></pivotCacheRecords>",
         ),
         ("trailing junk", "<pivotCacheRecords/></stray>"),
+        ("trailing text", "<pivotCacheRecords/>garbage"),
+        ("trailing cdata", "<pivotCacheRecords/><![CDATA[garbage]]>"),
+        ("leading text", "garbage<pivotCacheRecords/>"),
+        (
+            "a root that declared its way out",
+            r#"<pivotCacheRecords xmlns=""/>"#,
+        ),
     ] {
         let mut parts = pivoted_package();
         set_part(
@@ -2581,6 +2588,45 @@ fn refuses_records_whose_part_does_not_parse_whole() {
         assert!(
             package.reference_moved_by_rows("Report", 999).is_some(),
             "{label} inherited a narrow area"
+        );
+        assert!(
+            package.reference_naming_sheet("Data").is_some(),
+            "{label}: Data was left unprotected"
+        );
+    }
+}
+
+/// A definition claims its records through `r:id`, and a qname namespace
+/// resolution cannot be applied to is not that attribute however its prefix is
+/// bound. Records claimed only that way are not claimed at all.
+#[test]
+fn refuses_records_a_definition_claims_through_an_invalid_qname() {
+    for (label, id) in [
+        ("second colon", r#"r:junk:id="rIdRecords""#),
+        ("empty prefix", r#":id="rIdRecords""#),
+    ] {
+        let mut parts = pivoted_package();
+        set_part(
+            &mut parts,
+            "xl/pivotcache/pivotCacheDefinition1.xml",
+            format!(
+                r#"<pivotCacheDefinition xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" {id}><cacheSource><worksheetSource sheet="Data" ref="A1:B4"/></cacheSource></pivotCacheDefinition>"#
+            )
+            .as_bytes(),
+        );
+        parts.push((
+            "xl/pivotcache/pivotCacheRecords1.xml".to_owned(),
+            b"<pivotCacheRecords/>".to_vec(),
+        ));
+        parts.push((
+            "xl/pivotcache/_rels/pivotCacheDefinition1.xml.rels".to_owned(),
+            br#"<Relationships><Relationship Id="rIdRecords" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/></Relationships>"#.to_vec(),
+        ));
+        let package = parse_workbook_with_package(&parts).unwrap().package;
+
+        assert!(
+            package.reference_moved_by_rows("Report", 999).is_some(),
+            "{label} claimed the records"
         );
         assert!(
             package.reference_naming_sheet("Data").is_some(),

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -1984,6 +1984,48 @@ fn refuses_everything_for_a_pivot_source_it_cannot_resolve() {
     }
 }
 
+/// A veto that reasons per part must find every part, because one it never
+/// discovers gets no cover at all — worse than the unresolved it would get for
+/// a source it could not read. A cache written outside the conventional
+/// directory is still typed as one, so its `Override` finds it.
+#[test]
+fn finds_a_pivot_part_outside_the_conventional_directory() {
+    let mut parts = pivoted_package();
+    let cache = parts
+        .iter()
+        .position(|(path, _)| path == "xl/pivotcache/pivotCacheDefinition1.xml")
+        .expect("the fixture holds a cache");
+    parts[cache].0 = "xl/pivotCacheDefinition1.xml".to_owned();
+    parts.push((
+        "[Content_Types].xml".to_owned(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#.to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert_eq!(
+        package.reference_naming_sheet("Data"),
+        Some("xl/pivotCacheDefinition1.xml")
+    );
+    assert!(package.reference_moved_by_rows("Data", 3).is_some());
+    assert_eq!(package.reference_moved_by_rows("Data", 4), None);
+    assert_eq!(package.reference_naming_sheet("Report"), None);
+}
+
+/// An `Override` naming something other than a pivot is authoritative: the part
+/// is not a pivot part however it is pathed.
+#[test]
+fn does_not_take_an_overridden_non_pivot_part_for_a_pivot() {
+    let mut parts = pivoted_package();
+    parts.push((
+        "[Content_Types].xml".to_owned(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotcache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#.to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert_eq!(parsed.package.unpatchable_references().len(), 0);
+}
+
 /// A consolidated cache names one range per set, and all of them resolve or
 /// none do.
 #[test]
@@ -3282,6 +3324,128 @@ fn still_covers_a_conventional_chart_a_default_types_as_plain_xml() {
     assert_eq!(
         parsed.package.unpatchable_reference_part(),
         Some("xl/charts/chart2.xml")
+    );
+}
+
+/// `charted_package` with the plotted values widened to an area no save can
+/// rebuild a cache from, which is what leaves the chart part unmodelled while
+/// its `c:f` references stay perfectly readable.
+fn unrebuildable_chart_package(
+    mut parts: Vec<(String, Vec<u8>)>,
+    values: &str,
+) -> Vec<(String, Vec<u8>)> {
+    let chart = String::from_utf8(CHART.to_vec())
+        .unwrap()
+        .replace("Data!$B$2:$B$4", values);
+    set_part(&mut parts, "xl/charts/chart1.xml", chart.as_bytes());
+    parts
+}
+
+/// A chart the model does not cover is still only as wide as what its `c:f`
+/// name. The sheet it plots is fenced off to the far corner of those
+/// references; every other sheet, and everything past that corner, is free.
+#[test]
+fn resolves_what_an_unmodelled_chart_references() {
+    let parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/charts/chart1.xml")
+    );
+    assert_eq!(
+        package.reference_naming_sheet("Data"),
+        Some("xl/charts/chart1.xml")
+    );
+    assert_eq!(package.reference_naming_sheet("Report"), None);
+    assert!(package.reference_moved_by_rows("Data", 3).is_some());
+    assert_eq!(package.reference_moved_by_rows("Data", 4), None);
+    assert!(package.reference_moved_by_cols("Data", 1).is_some());
+    assert_eq!(package.reference_moved_by_cols("Data", 2), None);
+    assert_eq!(package.reference_moved_by_rows("Report", 0), None);
+}
+
+/// A `c:f` naming a sheet the workbook does not hold binds to nothing, so the
+/// chart names everything rather than a range some later rename could capture.
+#[test]
+fn refuses_everything_for_a_chart_naming_a_sheet_the_workbook_lost() {
+    let parts = unrebuildable_chart_package(charted_package(), "Gone!$A$2:$B$4");
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert!(parsed.package.reference_naming_sheet("Report").is_some());
+    assert!(
+        parsed
+            .package
+            .reference_moved_by_rows("Report", 999)
+            .is_some()
+    );
+}
+
+/// A chart part no sheet anchors is one this crate has not read the shape of —
+/// it has no owner to resolve an unqualified reference against — so it keeps
+/// the workbook-wide veto.
+#[test]
+fn refuses_everything_for_a_chart_no_sheet_claims() {
+    let mut parts = charted_package();
+    parts.push(("xl/charts/chart2.xml".to_owned(), CHART.to_vec()));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+
+    assert_eq!(
+        parsed.package.reference_naming_sheet("Report"),
+        Some("xl/charts/chart2.xml")
+    );
+    assert!(
+        parsed
+            .package
+            .reference_moved_by_cols("Report", 999)
+            .is_some()
+    );
+}
+
+/// The chart plots `Data` but hangs off the chartsheet, so nothing it names
+/// moves when that chartsheet goes. Dropping it is allowed, and the save takes
+/// the chart's whole part graph with it rather than leaving it behind.
+#[test]
+fn allows_dropping_the_sheet_an_unmodelled_chart_hangs_off() {
+    let mut parts = unrebuildable_chart_package(chartsheet_package(), "Data!$A$2:$B$4");
+    parts.push((
+        "[Content_Types].xml".to_owned(),
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#.to_vec(),
+    ));
+    parts.push((
+        "_rels/.rels".to_owned(),
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdBook" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#.to_vec(),
+    ));
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    let package = &parsed.package;
+
+    assert_eq!(
+        package.unpatchable_reference_part(),
+        Some("xl/charts/chart1.xml")
+    );
+    assert_eq!(package.reference_naming_sheet("Chart"), None);
+    assert_eq!(
+        package.reference_naming_sheet("Data"),
+        Some("xl/charts/chart1.xml")
+    );
+
+    let mut workbook = parsed.workbook.clone();
+    workbook.sheets.remove(1);
+    let saved = crate::serialize_workbook_with_package_and_origins_after_edits(
+        &workbook,
+        package,
+        &[Some(0)],
+        &[SharedStringCells::new()],
+        SaveEdits {
+            changed: true,
+            moved_references: false,
+        },
+    )
+    .expect("dropping the anchoring sheet strands nothing the chart names");
+    assert!(
+        !saved.iter().any(|(path, _)| path == "xl/charts/chart1.xml"),
+        "the chart part must not outlive the sheet that anchored it"
     );
 }
 

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -38,6 +38,7 @@ fn package(worksheet_body: &str, shared: &[&str], date1904: bool) -> Vec<(String
             worksheet.into_bytes(),
         ),
     ];
+    set_or_push_part(&mut parts, "[Content_Types].xml", CONFORMING_TYPES);
     if !shared.is_empty() {
         let items: String = shared
             .iter()
@@ -907,8 +908,9 @@ fn ambiguous_duplicate_removal_is_refused() {
 /// checked against the first.
 fn two_sheet_package(first_body: &str, second_body: &str) -> Vec<(String, Vec<u8>)> {
     let workbook = r#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/><sheet name="Sheet2" sheetId="2" r:id="rId2"/></sheets></workbook>"#;
-    let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>"#;
+    let rels = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#;
     vec![
+        ("[Content_Types].xml".to_owned(), CONFORMING_TYPES.to_vec()),
         ("xl/workbook.xml".to_owned(), workbook.as_bytes().to_vec()),
         (
             "xl/_rels/workbook.xml.rels".to_owned(),
@@ -2014,8 +2016,9 @@ fn finds_a_pivot_part_outside_the_conventional_directory() {
     assert_eq!(package.reference_naming_sheet("Report"), None);
 }
 
-/// An `Override` naming something other than a pivot is authoritative: the part
-/// is not a pivot part however it is pathed.
+/// Discovery unions the conventional scan with what the typing names, so an
+/// `Override` disagreeing about a conventionally pathed part cannot take it
+/// away — only add parts beside it.
 #[test]
 fn keeps_a_conventional_pivot_part_an_override_disagrees_with() {
     let mut parts = pivoted_package();
@@ -2399,24 +2402,11 @@ fn opens_a_workbook_whose_pivot_relationships_do_not_parse() {
     let parsed = parse_workbook_with_package(&parts).expect("the workbook still opens");
     let package = &parsed.package;
 
-    assert_eq!(package.unpatchable_references().len(), 3);
-    assert_eq!(
-        package.reference_moved_by_rows("Data", 3),
-        Some("xl/pivotcache/pivotCacheDefinition1.xml"),
-        "the cache itself still resolves"
-    );
     assert!(
         package.reference_moved_by_rows("Report", 999).is_some(),
-        "records whose ownership could not be followed name everything"
+        "a package whose relationships do not parse names everything"
     );
-    assert!(
-        package
-            .unpatchable_references()
-            .iter()
-            .any(|reference| reference.part().ends_with("pivotTable1.xml")
-                && reference.names_sheet("Data")),
-        "a pivot table no sheet relationship anchors names everything"
-    );
+    assert!(package.reference_naming_sheet("Data").is_some());
 }
 
 /// A pivot table is laid out on the sheet whose relationships anchor it, and
@@ -2747,7 +2737,7 @@ fn refuses_a_pivot_part_a_foreign_override_would_rule_out() {
         set_or_push_part(&mut parts, "[Content_Types].xml", types.as_bytes());
         let package = parse_workbook_with_package(&parts).unwrap().package;
 
-        assert_eq!(package.unpatchable_references().len(), 1, "{label}");
+        assert!(package.unpatchable_reference_part().is_some(), "{label}");
         assert!(
             package.reference_moved_by_rows("Report", 999).is_some(),
             "{label}: a cache typed by a part this path cannot trust must name everything"
@@ -2819,10 +2809,9 @@ fn falls_back_to_the_blanket_veto_when_the_package_metadata_does_not_conform() {
         ));
         let package = parse_workbook_with_package(&parts).unwrap().package;
 
-        assert_eq!(
-            package.unpatchable_reference_part(),
-            Some("xl/pivotcache/pivotCacheDefinition1.xml"),
-            "{label}: the pivot stopped being vetoed"
+        assert!(
+            package.unpatchable_reference_part().is_some(),
+            "{label}: the workbook stopped being vetoed"
         );
         assert!(
             package.reference_moved_by_rows("Report", 999).is_some(),
@@ -2882,10 +2871,9 @@ fn falls_back_to_the_blanket_veto_on_values_the_metadata_leaves_unusable() {
         }
         let package = parse_workbook_with_package(&parts).unwrap().package;
 
-        assert_eq!(
-            package.unpatchable_reference_part(),
-            Some("xl/pivotcache/pivotCacheDefinition1.xml"),
-            "{label}: the pivot stopped being vetoed"
+        assert!(
+            package.unpatchable_reference_part().is_some(),
+            "{label}: the workbook stopped being vetoed"
         );
         assert!(
             package.reference_moved_by_rows("Report", 999).is_some(),
@@ -2896,10 +2884,10 @@ fn falls_back_to_the_blanket_veto_on_values_the_metadata_leaves_unusable() {
 
 /// Discovery is monotonic over the blanket veto: metadata may add parts to look
 /// at, never take one away. An out-of-directory pivot found only through its
-/// override, beside metadata that does not conform, still has to be looked at —
-/// main's scan would have vetoed it, and a part nobody looks at vetoes nothing.
+/// override, beside metadata that does not conform, still has to be looked at:
+/// the fallback names the whole package precisely so nothing can drop out.
 #[test]
-fn keeps_every_part_the_blanket_veto_would_have_looked_at() {
+fn names_every_part_when_the_metadata_does_not_conform() {
     let mut parts = pivoted_package();
     let cache = parts
         .iter()
@@ -2909,10 +2897,12 @@ fn keeps_every_part_the_blanket_veto_would_have_looked_at() {
     set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/><u:Override PartName="/xl/unrelated.xml" ContentType="application/xml"/></Types>"#);
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(
-        package.unpatchable_reference_part(),
-        Some("xl/pivotCacheDefinition1.xml"),
-        "the pivot disappeared where the blanket veto would have caught it"
+    assert!(
+        package
+            .unpatchable_references()
+            .iter()
+            .any(|reference| reference.part() == "xl/pivotCacheDefinition1.xml"),
+        "the pivot dropped out of a set that is supposed to be every part"
     );
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
@@ -2920,17 +2910,16 @@ fn keeps_every_part_the_blanket_veto_would_have_looked_at() {
 /// The same invariant on the chart side: typing this path cannot read must not
 /// suppress a chart the conventional layout names.
 #[test]
-fn keeps_a_conventional_chart_an_untrusted_override_disagrees_with() {
+fn keeps_a_conventional_chart_an_override_disagrees_with() {
     let mut parts = unrebuildable_chart_package(charted_package(), "Data!$A$2:$B$4");
-    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/><u:Override PartName="/xl/unrelated.xml" ContentType="application/xml"/></Types>"#);
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/></Types>"#);
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
     assert_eq!(
         package.unpatchable_reference_part(),
         Some("xl/charts/chart1.xml"),
-        "the chart disappeared where the blanket veto would have caught it"
+        "typing must never take away a chart the conventional layout names"
     );
-    assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
 /// OPC has no package without a content-type stream, so a package missing one
@@ -2941,10 +2930,7 @@ fn falls_back_to_the_blanket_veto_without_a_content_type_part() {
     parts.retain(|(path, _)| path != "[Content_Types].xml");
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(
-        package.unpatchable_reference_part(),
-        Some("xl/pivotcache/pivotCacheDefinition1.xml")
-    );
+    assert!(package.unpatchable_reference_part().is_some());
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
@@ -2962,10 +2948,7 @@ fn falls_back_to_the_blanket_veto_when_the_workbook_relationships_are_ambiguous(
     );
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(
-        package.unpatchable_reference_part(),
-        Some("xl/pivotcache/pivotCacheDefinition1.xml")
-    );
+    assert!(package.unpatchable_reference_part().is_some());
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
@@ -3101,10 +3084,7 @@ fn falls_back_to_the_blanket_veto_when_a_sheet_names_its_part_ambiguously() {
     );
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(
-        package.unpatchable_reference_part(),
-        Some("xl/pivotcache/pivotCacheDefinition1.xml")
-    );
+    assert!(package.unpatchable_reference_part().is_some());
     assert!(package.reference_moved_by_rows("Report", 999).is_some());
 }
 
@@ -3116,10 +3096,7 @@ fn falls_back_to_the_blanket_veto_for_charts_too() {
     set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default u:Extension="xml" Extension="xml" ContentType="application/xml"/></Types>"#);
     let package = parse_workbook_with_package(&parts).unwrap().package;
 
-    assert_eq!(
-        package.unpatchable_reference_part(),
-        Some("xl/charts/chart1.xml")
-    );
+    assert!(package.unpatchable_reference_part().is_some());
     assert!(
         package.reference_moved_by_rows("Report", 999).is_some(),
         "the chart narrowed on metadata this crate could not read"
@@ -3140,6 +3117,88 @@ fn still_narrows_when_the_package_metadata_conforms() {
     assert!(package.reference_moved_by_rows("Data", 3).is_some());
     assert_eq!(package.reference_moved_by_rows("Data", 4), None);
     assert_eq!(package.reference_naming_sheet("Report"), None);
+}
+
+/// The typing slice is produced by a reader that keeps the first local-name
+/// `ContentType`, so a foreign one before the real one both fails conformance
+/// and misclassifies the part. Discovery must not consult that slice at all in
+/// the fallback: an unconventionally pathed pivot has to stay in the set.
+#[test]
+fn names_an_unconventionally_pathed_part_the_typing_slice_misreads() {
+    let mut parts = pivoted_package();
+    let cache = parts
+        .iter()
+        .position(|(path, _)| path == "xl/pivotcache/pivotCacheDefinition1.xml")
+        .expect("the fixture holds a cache");
+    parts[cache].0 = "xl/pivotCacheDefinition1.xml".to_owned();
+    set_or_push_part(&mut parts, "[Content_Types].xml", br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types" xmlns:u="urn:future"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/pivotCacheDefinition1.xml" u:ContentType="application/xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#);
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(
+        package
+            .unpatchable_references()
+            .iter()
+            .any(|reference| reference.part() == "xl/pivotCacheDefinition1.xml"),
+        "a part the typing slice misreads dropped out of discovery"
+    );
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+}
+
+/// The model is built by a reader that takes every local-name `sheet` wherever
+/// it sits, while the sheet-to-part mapping records only the canonical
+/// children. One more elsewhere shifts the two out of step.
+#[test]
+fn falls_back_to_the_blanket_veto_on_a_sheet_element_outside_the_canonical_list() {
+    let mut parts = pivoted_package();
+    set_part(
+        &mut parts,
+        "xl/workbook.xml",
+        br#"<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><extra><sheet name="Decoy" sheetId="9" r:id="rId1"/></extra><sheets><sheet name="Data" sheetId="1" r:id="rId1"/><sheet name="Report" sheetId="2" r:id="rId2"/></sheets></workbook>"#,
+    );
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(package.reference_moved_by_rows("Report", 999).is_some());
+    assert!(package.reference_naming_sheet("Data").is_some());
+}
+
+/// The claim is followed by taking the first relationships-namespace `id` on a
+/// `c:chart`, so two of them under different prefixes both survive a count of
+/// chart elements alone.
+#[test]
+fn falls_back_to_the_blanket_veto_when_a_chart_claim_carries_two_ids() {
+    let mut parts = two_charted_sheets();
+    for drawing in [1, 2] {
+        let other = 3 - drawing;
+        set_part(
+            &mut parts,
+            &format!("xl/drawings/_rels/drawing{drawing}.xml.rels"),
+            format!(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart{drawing}.xml"/><Relationship Id="rIdOther" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart{other}.xml"/></Relationships>"#
+            )
+            .as_bytes(),
+        );
+        set_part(
+            &mut parts,
+            &format!("xl/drawings/drawing{drawing}.xml"),
+            String::from_utf8(DRAWING.to_vec())
+                .unwrap()
+                .replace(
+                    r#"<c:chart r:id="rIdChart"/>"#,
+                    r#"<c:chart xmlns:r2="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r2:id="rIdOther" r:id="rIdChart"/>"#,
+                )
+                .as_bytes(),
+        );
+    }
+    let package = parse_workbook_with_package(&parts).unwrap().package;
+
+    assert!(
+        package.reference_moved_by_rows("Data", 999).is_some(),
+        "a claim carrying two ids was read as a range instead of falling back"
+    );
+    assert!(
+        package.reference_moved_by_rows("Report", 999).is_some(),
+        "a claim carrying two ids was read as a range instead of falling back"
+    );
 }
 
 /// A relationship claims records by its type, not by pointing at them. With
@@ -4526,7 +4585,7 @@ fn encode_utf16(text: &str, big_endian: bool, bom: bool) -> Vec<u8> {
 
 /// The conforming package metadata the narrowing path requires before it will
 /// read a package's typing or relationships at all.
-const CONFORMING_TYPES: &[u8] = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#;
+const CONFORMING_TYPES: &[u8] = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/></Types>"#;
 
 fn set_or_push_part(parts: &mut Vec<(String, Vec<u8>)>, path: &str, bytes: &[u8]) {
     match parts.iter_mut().find(|(name, _)| name == path) {

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -28,34 +28,69 @@ impl Attribute {
     pub(crate) fn local_name(&self) -> &str {
         self.name.rsplit(':').next().unwrap_or(&self.name)
     }
-}
 
-/// Whether a node belongs to one of `namespaces` for the purpose of reading it
-/// by name. Three ways to carry no namespace have to be told apart, and only
-/// the first is ours: a part that declared none at all still looks like the
-/// vocabulary it spells, a prefix that resolved to nothing names a vocabulary
-/// the part never declared, and `cleared` — an `xmlns=""` in scope — is a
-/// subtree that declared its way out of the vocabulary it was in. Resolution
-/// collapses all three to `None`, so the QName as authored and the binding in
-/// scope are what separate them.
-fn answers_for(name: &str, namespace: Option<&str>, cleared: bool, namespaces: &[&str]) -> bool {
-    if !is_namespace_valid(name) {
-        return false;
-    }
-    match namespace {
-        Some(namespace) => namespaces.contains(&namespace),
-        None => !cleared && split_prefix(name).0.is_empty(),
+    /// A default declaration never reaches an attribute, so an unprefixed one
+    /// is unqualified however its element was declared.
+    fn vocabulary(&self) -> Vocabulary<'_> {
+        match self.namespace.as_deref() {
+            Some(namespace) => Vocabulary::Bound(namespace),
+            None => Vocabulary::Absent,
+        }
     }
 }
 
-/// Whether a QName is one namespace resolution can be applied to at all: at
-/// most one colon, with neither side of it empty. Anything else is
-/// namespace-invalid, and a name that is not well formed is never ours however
-/// its prefix resolves.
-fn is_namespace_valid(name: &str) -> bool {
+/// What a name's prefix, or the default declaration over it, resolved to.
+/// Three ways to carry no namespace have to be told apart and resolution
+/// collapses all of them, so every reader reports which one it saw.
+#[derive(Clone, Copy)]
+pub(crate) enum Vocabulary<'a> {
+    Bound(&'a str),
+    /// nothing in scope declares one, which is how a part authored without
+    /// namespaces spells the vocabulary it looks like
+    Absent,
+    /// an `xmlns=""` in scope: this name declared its way out of every
+    /// vocabulary, which is not the same as never having declared one
+    Cleared,
+}
+
+/// Whether an unqualified name is read as a vocabulary's own.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum Unqualified {
+    /// spreadsheetml, whose parts are sometimes authored bare
+    Owned,
+    /// relationships and friends, where a bare `id` is a different attribute
+    /// rather than an unqualified `r:id`
+    Foreign,
+}
+
+/// The one ownership rule in this crate. Every reader of a name — tree
+/// elements, tree attributes, the streaming root sniff — decides here and
+/// nowhere else, so a reader added later cannot answer it differently. Returns
+/// the local name the QName answers to when it belongs to `namespaces`.
+pub(crate) fn owned_local_name<'a>(
+    qname: &'a str,
+    vocabulary: Vocabulary<'_>,
+    namespaces: &[&str],
+    unqualified: Unqualified,
+) -> Option<&'a str> {
+    let (prefix, local) = valid_qname(qname)?;
+    let ours = match vocabulary {
+        Vocabulary::Bound(namespace) => namespaces.contains(&namespace),
+        Vocabulary::Absent => prefix.is_empty() && unqualified == Unqualified::Owned,
+        Vocabulary::Cleared => false,
+    };
+    ours.then_some(local)
+}
+
+/// A QName namespace resolution can be applied to at all — at most one colon,
+/// with neither side of it empty — split into its prefix and local name. A
+/// name that is not well formed answers to nothing, however its prefix
+/// resolves, so no reader may derive a local name any other way.
+fn valid_qname(name: &str) -> Option<(&str, &str)> {
     match name.split_once(':') {
-        None => !name.is_empty(),
-        Some((prefix, local)) => !prefix.is_empty() && !local.is_empty() && !local.contains(':'),
+        None => (!name.is_empty()).then_some(("", name)),
+        Some((prefix, local)) => (!prefix.is_empty() && !local.is_empty() && !local.contains(':'))
+            .then_some((prefix, local)),
     }
 }
 
@@ -106,13 +141,18 @@ impl Element {
             .map(|attribute| attribute.value.as_str())
     }
 
-    /// the attribute with this expanded name, whatever prefix carries it.
+    /// the attribute with this expanded name, whatever prefix carries it. An
+    /// unqualified attribute is a different one, never this vocabulary's.
     pub(crate) fn attribute_ns(&self, namespace: &str, local: &str) -> Option<&str> {
         self.attributes
             .iter()
             .find(|attribute| {
-                attribute.namespace.as_deref() == Some(namespace)
-                    && attribute.name.rsplit(':').next() == Some(local)
+                owned_local_name(
+                    &attribute.name,
+                    attribute.vocabulary(),
+                    &[namespace],
+                    Unqualified::Foreign,
+                ) == Some(local)
             })
             .map(|attribute| attribute.value.as_str())
     }
@@ -134,13 +174,12 @@ impl Element {
         local: &'a str,
     ) -> impl Iterator<Item = &'a Attribute> {
         self.attributes.iter().filter(move |attribute| {
-            attribute.local_name() == local
-                && answers_for(
-                    &attribute.name,
-                    attribute.namespace.as_deref(),
-                    false,
-                    namespaces,
-                )
+            owned_local_name(
+                &attribute.name,
+                attribute.vocabulary(),
+                namespaces,
+                Unqualified::Owned,
+            ) == Some(local)
         })
     }
 
@@ -168,13 +207,20 @@ impl Element {
     /// counting the unqualified form a part that declares none is authored in.
     /// A foreign element spells the name the same way but is a different one.
     pub(crate) fn answers_to(&self, namespaces: &[&str], local: &str) -> bool {
-        self.local_name() == local
-            && answers_for(
-                &self.name,
-                self.namespace(),
-                self.default_cleared,
-                namespaces,
-            )
+        owned_local_name(
+            &self.name,
+            self.vocabulary(),
+            namespaces,
+            Unqualified::Owned,
+        ) == Some(local)
+    }
+
+    fn vocabulary(&self) -> Vocabulary<'_> {
+        match self.namespace() {
+            Some(namespace) => Vocabulary::Bound(namespace),
+            None if self.default_cleared => Vocabulary::Cleared,
+            None => Vocabulary::Absent,
+        }
     }
 
     pub(crate) fn child_elements(&self) -> impl Iterator<Item = &Element> {

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -30,11 +30,18 @@ impl Attribute {
     }
 }
 
-/// Whether a node belongs to `namespace` for the purpose of reading it by name.
-/// An unqualified node does: attributes are unqualified by schema, and a part
-/// that declares no namespace at all is still the vocabulary it looks like.
-fn answers_for(node: Option<&str>, namespace: &str) -> bool {
-    node.is_none_or(|node| node == namespace)
+/// Whether a node belongs to one of `namespaces` for the purpose of reading it
+/// by name. An unprefixed node carrying no namespace does: attributes are
+/// unqualified by schema, and a part that declares none at all is still the
+/// vocabulary it looks like. A prefix that resolved to nothing is not the same
+/// thing — the name comes from a vocabulary the part never declared, so it is
+/// foreign however it is spelled. `name` is the QName as authored, which is
+/// what tells the two apart once resolution has collapsed both to `None`.
+fn answers_for(name: &str, namespace: Option<&str>, namespaces: &[&str]) -> bool {
+    match namespace {
+        Some(namespace) => namespaces.contains(&namespace),
+        None => split_prefix(name).0.is_empty(),
+    }
 }
 
 pub(crate) struct Element {
@@ -104,30 +111,40 @@ impl Element {
     /// never among them.
     pub(crate) fn attributes_in<'a>(
         &'a self,
-        namespace: &'a str,
+        namespaces: &'a [&'a str],
         local: &'a str,
     ) -> impl Iterator<Item = &'a Attribute> {
         self.attributes.iter().filter(move |attribute| {
             attribute.local_name() == local
-                && answers_for(attribute.namespace.as_deref(), namespace)
+                && answers_for(&attribute.name, attribute.namespace.as_deref(), namespaces)
         })
     }
 
-    /// the child elements answering to a local name in `namespace`.
+    /// whether any attribute answers to a local name, in whatever namespace.
+    /// For a name that disqualifies rather than supplies, a foreign match costs
+    /// only a refusal while a missed real one costs correctness, so the wider
+    /// question is the safe one to ask.
+    pub(crate) fn any_attribute_named(&self, local: &str) -> bool {
+        self.attributes
+            .iter()
+            .any(|attribute| attribute.local_name() == local)
+    }
+
+    /// the child elements answering to a local name in one of `namespaces`.
     pub(crate) fn children_in<'a>(
         &'a self,
-        namespace: &'a str,
+        namespaces: &'a [&'a str],
         local: &'a str,
     ) -> impl Iterator<Item = &'a Element> {
         self.child_elements()
-            .filter(move |child| child.answers_to(namespace, local))
+            .filter(move |child| child.answers_to(namespaces, local))
     }
 
-    /// whether this element answers to a local name in `namespace`, counting
-    /// the unqualified form a part that declares no namespace is authored in.
+    /// whether this element answers to a local name in one of `namespaces`,
+    /// counting the unqualified form a part that declares none is authored in.
     /// A foreign element spells the name the same way but is a different one.
-    pub(crate) fn answers_to(&self, namespace: &str, local: &str) -> bool {
-        self.local_name() == local && answers_for(self.namespace(), namespace)
+    pub(crate) fn answers_to(&self, namespaces: &[&str], local: &str) -> bool {
+        self.local_name() == local && answers_for(&self.name, self.namespace(), namespaces)
     }
 
     pub(crate) fn child_elements(&self) -> impl Iterator<Item = &Element> {

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -86,6 +86,28 @@ impl Element {
             .map(|attribute| attribute.value.as_str())
     }
 
+    /// how many attributes answer to a local name. More than one means
+    /// [`Element::attribute_local`] is picking between them by authoring order,
+    /// which markup compatibility makes an attacker's choice.
+    pub(crate) fn attributes_named(&self, name: &str) -> usize {
+        self.attributes
+            .iter()
+            .filter(|attribute| {
+                attribute.name.rsplit(':').next().unwrap_or(&attribute.name) == name
+            })
+            .count()
+    }
+
+    /// the one child element with this local name, or `None` when several
+    /// could answer to it and a lookup would be picking by authoring order.
+    pub(crate) fn sole_child(&self, local: &str) -> Option<&Element> {
+        let mut matches = self
+            .child_elements()
+            .filter(|child| child.local_name() == local);
+        let only = matches.next()?;
+        matches.next().is_none().then_some(only)
+    }
+
     pub(crate) fn child_elements(&self) -> impl Iterator<Item = &Element> {
         self.children.iter().filter_map(|node| match node {
             Node::Element(element) => Some(element),

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -202,9 +202,17 @@ impl Element {
     /// only a refusal while a missed real one costs correctness, so the wider
     /// question is the safe one to ask.
     pub(crate) fn any_attribute_named(&self, local: &str) -> bool {
+        self.attributes_named(local) > 0
+    }
+
+    /// how many attributes answer to a local name, in whatever namespace. A
+    /// gate over a reader that matches local names counts these, because the
+    /// reader will see every one of them and take the first.
+    pub(crate) fn attributes_named(&self, local: &str) -> usize {
         self.attributes
             .iter()
-            .any(|attribute| attribute.local_name() == local)
+            .filter(|attribute| attribute.local_name() == local)
+            .count()
     }
 
     /// the child elements answering to a local name in one of `namespaces`.

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -31,16 +31,31 @@ impl Attribute {
 }
 
 /// Whether a node belongs to one of `namespaces` for the purpose of reading it
-/// by name. An unprefixed node carrying no namespace does: attributes are
-/// unqualified by schema, and a part that declares none at all is still the
-/// vocabulary it looks like. A prefix that resolved to nothing is not the same
-/// thing — the name comes from a vocabulary the part never declared, so it is
-/// foreign however it is spelled. `name` is the QName as authored, which is
-/// what tells the two apart once resolution has collapsed both to `None`.
-fn answers_for(name: &str, namespace: Option<&str>, namespaces: &[&str]) -> bool {
+/// by name. Three ways to carry no namespace have to be told apart, and only
+/// the first is ours: a part that declared none at all still looks like the
+/// vocabulary it spells, a prefix that resolved to nothing names a vocabulary
+/// the part never declared, and `cleared` — an `xmlns=""` in scope — is a
+/// subtree that declared its way out of the vocabulary it was in. Resolution
+/// collapses all three to `None`, so the QName as authored and the binding in
+/// scope are what separate them.
+fn answers_for(name: &str, namespace: Option<&str>, cleared: bool, namespaces: &[&str]) -> bool {
+    if !is_namespace_valid(name) {
+        return false;
+    }
     match namespace {
         Some(namespace) => namespaces.contains(&namespace),
-        None => split_prefix(name).0.is_empty(),
+        None => !cleared && split_prefix(name).0.is_empty(),
+    }
+}
+
+/// Whether a QName is one namespace resolution can be applied to at all: at
+/// most one colon, with neither side of it empty. Anything else is
+/// namespace-invalid, and a name that is not well formed is never ours however
+/// its prefix resolves.
+fn is_namespace_valid(name: &str) -> bool {
+    match name.split_once(':') {
+        None => !name.is_empty(),
+        Some((prefix, local)) => !prefix.is_empty() && !local.is_empty() && !local.contains(':'),
     }
 }
 
@@ -50,6 +65,10 @@ pub(crate) struct Element {
     /// the namespace the tag's prefix (or the default declaration) was bound
     /// to, so a part is read by expanded name rather than by literal prefix.
     pub(crate) namespace: Option<Rc<str>>,
+    /// whether an `xmlns=""` was in scope. Such a name carries no namespace
+    /// because its subtree declared its way out of one, which is not the same
+    /// as a part that never declared one.
+    pub(crate) default_cleared: bool,
     pub(crate) attributes: Vec<Attribute>,
     pub(crate) children: Vec<Node>,
     /// byte span of the content between the start and end tags; empty for a
@@ -116,7 +135,12 @@ impl Element {
     ) -> impl Iterator<Item = &'a Attribute> {
         self.attributes.iter().filter(move |attribute| {
             attribute.local_name() == local
-                && answers_for(&attribute.name, attribute.namespace.as_deref(), namespaces)
+                && answers_for(
+                    &attribute.name,
+                    attribute.namespace.as_deref(),
+                    false,
+                    namespaces,
+                )
         })
     }
 
@@ -144,7 +168,13 @@ impl Element {
     /// counting the unqualified form a part that declares none is authored in.
     /// A foreign element spells the name the same way but is a different one.
     pub(crate) fn answers_to(&self, namespaces: &[&str], local: &str) -> bool {
-        self.local_name() == local && answers_for(&self.name, self.namespace(), namespaces)
+        self.local_name() == local
+            && answers_for(
+                &self.name,
+                self.namespace(),
+                self.default_cleared,
+                namespaces,
+            )
     }
 
     pub(crate) fn child_elements(&self) -> impl Iterator<Item = &Element> {
@@ -215,6 +245,16 @@ impl Namespaces {
         if let Some(len) = self.scopes.pop() {
             self.bindings.truncate(len);
         }
+    }
+
+    /// whether an `xmlns=""` is in scope, taking every unprefixed name under it
+    /// out of the vocabulary rather than leaving it in none by omission.
+    fn default_cleared(&self) -> bool {
+        self.bindings
+            .iter()
+            .rev()
+            .find(|(bound, _)| bound.is_empty())
+            .is_some_and(|(_, uri)| uri.is_empty())
     }
 
     fn resolve(&self, prefix: &str) -> Option<Rc<str>> {
@@ -530,6 +570,7 @@ fn open_element(
         });
     }
     Ok(Element {
+        default_cleared: namespaces.default_cleared(),
         name,
         namespace,
         attributes,

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -82,6 +82,20 @@ pub(crate) fn owned_local_name<'a>(
     ours.then_some(local)
 }
 
+/// Whether every element and attribute name in a subtree is one namespace
+/// resolution can be applied to. [`Element::is`] and its callers resolve a
+/// prefix at the first colon while comparing a local name after the last, so a
+/// name carrying a second colon can be read as one it is not. A reader that
+/// matches expanded names that way asks this first and declines the part.
+pub(crate) fn names_are_resolvable(element: &Element) -> bool {
+    valid_qname(&element.name).is_some()
+        && element
+            .attributes
+            .iter()
+            .all(|attribute| valid_qname(&attribute.name).is_some())
+        && element.child_elements().all(names_are_resolvable)
+}
+
 /// A QName namespace resolution can be applied to at all — at most one colon,
 /// with neither side of it empty — split into its prefix and local name. A
 /// name that is not well formed answers to nothing, however its prefix

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -24,6 +24,19 @@ pub(crate) struct Attribute {
     pub(crate) value: String,
 }
 
+impl Attribute {
+    pub(crate) fn local_name(&self) -> &str {
+        self.name.rsplit(':').next().unwrap_or(&self.name)
+    }
+}
+
+/// Whether a node belongs to `namespace` for the purpose of reading it by name.
+/// An unqualified node does: attributes are unqualified by schema, and a part
+/// that declares no namespace at all is still the vocabulary it looks like.
+fn answers_for(node: Option<&str>, namespace: &str) -> bool {
+    node.is_none_or(|node| node == namespace)
+}
+
 pub(crate) struct Element {
     /// the tag as authored, prefix included.
     pub(crate) name: String,
@@ -86,26 +99,35 @@ impl Element {
             .map(|attribute| attribute.value.as_str())
     }
 
-    /// how many attributes answer to a local name. More than one means
-    /// [`Element::attribute_local`] is picking between them by authoring order,
-    /// which markup compatibility makes an attacker's choice.
-    pub(crate) fn attributes_named(&self, name: &str) -> usize {
-        self.attributes
-            .iter()
-            .filter(|attribute| {
-                attribute.name.rsplit(':').next().unwrap_or(&attribute.name) == name
-            })
-            .count()
+    /// the attributes answering to a local name in `namespace`. A foreign one
+    /// spells the name the same way but is a different attribute, so it is
+    /// never among them.
+    pub(crate) fn attributes_in<'a>(
+        &'a self,
+        namespace: &'a str,
+        local: &'a str,
+    ) -> impl Iterator<Item = &'a Attribute> {
+        self.attributes.iter().filter(move |attribute| {
+            attribute.local_name() == local
+                && answers_for(attribute.namespace.as_deref(), namespace)
+        })
     }
 
-    /// the one child element with this local name, or `None` when several
-    /// could answer to it and a lookup would be picking by authoring order.
-    pub(crate) fn sole_child(&self, local: &str) -> Option<&Element> {
-        let mut matches = self
-            .child_elements()
-            .filter(|child| child.local_name() == local);
-        let only = matches.next()?;
-        matches.next().is_none().then_some(only)
+    /// the child elements answering to a local name in `namespace`.
+    pub(crate) fn children_in<'a>(
+        &'a self,
+        namespace: &'a str,
+        local: &'a str,
+    ) -> impl Iterator<Item = &'a Element> {
+        self.child_elements()
+            .filter(move |child| child.answers_to(namespace, local))
+    }
+
+    /// whether this element answers to a local name in `namespace`, counting
+    /// the unqualified form a part that declares no namespace is authored in.
+    /// A foreign element spells the name the same way but is a different one.
+    pub(crate) fn answers_to(&self, namespace: &str, local: &str) -> bool {
+        self.local_name() == local && answers_for(self.namespace(), namespace)
     }
 
     pub(crate) fn child_elements(&self) -> impl Iterator<Item = &Element> {

--- a/crates/xlsx-parse/src/write.rs
+++ b/crates/xlsx-parse/src/write.rs
@@ -191,8 +191,10 @@ pub struct SaveEdits {
     /// the caller guarantees an untouched model, which is returned as the
     /// source bytes; true drops the now-stale calculation chain.
     pub changed: bool,
-    /// an edit moved cell addresses, so every preserved part naming them must
-    /// be one this crate can rewrite.
+    /// an edit moved cells a preserved part names but this crate cannot
+    /// rewrite. The caller resolves that against
+    /// [`PreservedPackage::unpatchable_references`], because only it knows
+    /// which edits were applied.
     pub moved_references: bool,
 }
 
@@ -653,39 +655,58 @@ fn preflight_preserved_save(
 }
 
 /// Charts, pivot caches and their friends name sheets and cells this crate
-/// never patches. Moving cells, or dropping, reordering or renaming a source
-/// sheet while one of them is preserved strands it, so the serializer refuses
-/// that here instead of trusting every caller to have checked.
+/// never patches. Dropping, reordering or renaming a sheet one of them names —
+/// or moving cells it names, which the caller reports — strands it, so the
+/// serializer refuses that here instead of trusting every caller to have
+/// checked. A sheet no preserved reference names moves freely.
 fn ensure_preserved_references_stay_valid(
     wb: &Workbook,
     package: &PreservedPackage,
     origins: &[Option<usize>],
     edits: SaveEdits,
 ) -> Result<(), ParseError> {
-    let Some(part) = package.unpatchable_reference_part() else {
-        return Ok(());
+    let refused = |part: &str| {
+        ParseError::UnsupportedEdit(format!(
+            "{part} references sheets or cells this save would move, and it cannot be rewritten"
+        ))
     };
-    let retained = origins.iter().flatten().copied().collect::<Vec<_>>();
-    let kept_in_order = retained.len() == package.sheets.len()
-        && retained
-            .iter()
-            .enumerate()
-            .all(|(position, origin)| *origin == position);
-    let renamed = origins.iter().zip(&wb.sheets).any(|(origin, sheet)| {
-        origin.is_some_and(|origin| {
-            package
-                .original_workbook
-                .sheets
-                .get(origin)
-                .is_some_and(|original| original.name != sheet.name)
-        })
-    });
-    if kept_in_order && !renamed && !edits.moved_references {
-        return Ok(());
+    if edits.moved_references
+        && let Some(part) = package.unpatchable_reference_part()
+    {
+        return Err(refused(part));
     }
-    Err(ParseError::UnsupportedEdit(format!(
-        "{part} references sheets or cells this save would move, and it cannot be rewritten"
-    )))
+    for name in displaced_source_sheets(wb, package, origins) {
+        if let Some(part) = package.reference_naming_sheet(&name) {
+            return Err(refused(part));
+        }
+    }
+    Ok(())
+}
+
+/// The names of the source sheets this save does not leave where and as they
+/// were: one that is gone, one whose rank among the survivors changed, one
+/// renamed.
+fn displaced_source_sheets(
+    wb: &Workbook,
+    package: &PreservedPackage,
+    origins: &[Option<usize>],
+) -> Vec<String> {
+    let retained = origins.iter().flatten().copied().collect::<Vec<_>>();
+    let mut ranked = retained.clone();
+    ranked.sort_unstable();
+    let mut displaced = Vec::new();
+    for (index, original) in package.original_workbook.sheets.iter().enumerate() {
+        let rank = retained.iter().position(|origin| *origin == index);
+        let kept_in_place = rank.is_some_and(|rank| ranked.get(rank) == Some(&index))
+            && origins
+                .iter()
+                .zip(&wb.sheets)
+                .any(|(origin, sheet)| *origin == Some(index) && sheet.name == original.name);
+        if !kept_in_place {
+            displaced.push(original.name.clone());
+        }
+    }
+    displaced
 }
 
 /// This crate patches chart parts in place; it can neither create one nor

--- a/crates/xlsx-parse/src/write.rs
+++ b/crates/xlsx-parse/src/write.rs
@@ -25,7 +25,7 @@ use crate::read::SharedStringCells;
 use crate::xml::{resolve_part_path, xml_err};
 
 pub(crate) const NS_MAIN: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-const NS_STRICT_MAIN: &str = "http://purl.oclc.org/ooxml/spreadsheetml/main";
+pub(crate) const NS_STRICT_MAIN: &str = "http://purl.oclc.org/ooxml/spreadsheetml/main";
 const NS_R: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 const NS_CT: &str = "http://schemas.openxmlformats.org/package/2006/content-types";
 const NS_PKG_REL: &str = "http://schemas.openxmlformats.org/package/2006/relationships";

--- a/crates/xlsx-parse/src/write.rs
+++ b/crates/xlsx-parse/src/write.rs
@@ -24,7 +24,7 @@ use crate::package::{
 use crate::read::SharedStringCells;
 use crate::xml::{resolve_part_path, xml_err};
 
-const NS_MAIN: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+pub(crate) const NS_MAIN: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
 const NS_STRICT_MAIN: &str = "http://purl.oclc.org/ooxml/spreadsheetml/main";
 const NS_R: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 const NS_CT: &str = "http://schemas.openxmlformats.org/package/2006/content-types";


### PR DESCRIPTION
TL;DR:


Repro file:
`crates/betteroffice-xlsx/tests/workbook.rs` — `allows_structural_ops_no_pivot_reference_names` fails on the pre-PR engine with `InvalidOperation("xl/pivotCache/pivotCacheDefinition1.xml references sheets this edit would move")` when inserting a row on a sheet the pivot does not name.

Summary:
- Scope the preserved-reference veto to what a reference actually names, so a pivot on one sheet no longer blocks structural edits on unrelated sheets. Resolves pivot cache source ranges, pivot table locations including the filter area, cached-record ownership, and unmodelled chart `c:f` references, and refuses only edits that would move a named cell.
- Apply the same resolution at the save boundary, so an edit that is allowed can always be saved.
- Fall back to the pre-existing workbook-wide veto whenever the package's own metadata is not exactly conforming — and only when the package holds something reference-bearing, so a workbook with no pivots or charts is never affected.
- Discovery is monotonic: a part the conventional scan names can never be taken away by a content-type reading, because a part nobody looks at vetoes nothing.

What it deliberately refuses, keeping the workbook-wide veto: pivot sources naming a defined name, table, external book or scenario; pivot tables whose host sheet cannot be followed; records with no owning definition; charts no sheet claims; ChartEx, `pivotSource`, `externalData`, `sqref`, unions and defined names in charts; any part carrying `mc:AlternateContent`; and any package whose content types or relationships do not conform.

**Residual, stated plainly.** In the conforming branch the decision consults several readers that match names loosely — content types, relationships, the workbook's sheet list, drawing claims. Each is now either matched exactly or gated, but that set is an enumeration rather than a proof of closure: review kept finding one more, at a falling rate. The underlying weakness is filed as F9–F11 — shared `parse_relationships`, `Element::is` and `parse_content_types` all match by local name and take the first match — and is not addressed here. The mitigating property is that a missed reader most likely trips conformance and lands in the fallback rather than producing a narrow wrong answer. F3–F6 and F8 also remain open.

Test plan:
- [ ] Open a real pivot workbook, insert rows on an unrelated sheet, save, reopen in Excel
- [ ] Open the same workbook, insert rows inside the pivot source range, and confirm the refusal
- [ ] Confirm a workbook with no pivots or charts is unaffected, including one with imperfect metadata
