### PR TITLE
fix(xlsx): support chart moves in collaborative sessions

### DIFF
--- a/.changeset/xlsx-collaborative-chart-move.md
+++ b/.changeset/xlsx-collaborative-chart-move.md
@@ -1,0 +1,16 @@
+---
+"@betteroffice/xlsx": minor
+"@betteroffice/rust-crates": minor
+---
+
+Dragging a chart works in a collaborative session. It used to fail outright with "structural operations are unavailable in collaborative mode", because repinning a chart sat in the structural list beside inserting a row — so the feature could not work at all in the mode the collaborative demo runs in.
+
+A chart anchor is not workbook structure. What is frozen is now what a chart *is*: the drawing anchor it sits at, the part behind it, the references it reads, and the shape of that anchor — its kind, its `editAs` mode, a one-cell extent, an absolute position. Where a grid-anchored chart sits travels through the shared document like any other edit, and a peer picks it up the same way it picks up a cell.
+
+Two things follow from letting an anchor merge, and both are worth knowing.
+
+An arriving anchor is judged only on what is true of it whatever grid it sits over: offsets in range, corners in order, extents positive. Whether it resolves to a rectangle with room to draw depends on the column widths it spans, and those are replicated too — so that question is settled where the chart is drawn, not where the update arrives. Collapsing the columns under a chart while someone else drags it leaves both replicas holding the same workbook; the chart simply has nowhere to render, which is what collapsing those columns asked for.
+
+One drawing anchor is one element however many sheets point at it, so a drag repins every sheet holding it, and a workbook read back from the shared document always shows them agreeing. Where two sheets have been written separately, the first in sheet order supplies the anchor.
+
+Chart state is one value per sheet, so two people dragging different charts on the same sheet keep only one of the two drags. The replicas agree on which; nothing is corrupted and no one is disconnected. Dragging the same chart at once already resolves to a single anchor.

--- a/crates/betteroffice-xlsx/Cargo.toml
+++ b/crates/betteroffice-xlsx/Cargo.toml
@@ -31,4 +31,3 @@ yrs = "0.27.3"
 
 [dev-dependencies]
 png = "0.18"
-yrs = "0.27.3"

--- a/crates/betteroffice-xlsx/Cargo.toml
+++ b/crates/betteroffice-xlsx/Cargo.toml
@@ -31,3 +31,4 @@ yrs = "0.27.3"
 
 [dev-dependencies]
 png = "0.18"
+yrs = "0.27.3"

--- a/crates/betteroffice-xlsx/src/authority.rs
+++ b/crates/betteroffice-xlsx/src/authority.rs
@@ -762,19 +762,15 @@ impl WorkbookAuthority {
         self.apply_history_change(true)
     }
 
-    /// Puts the document back when a history step turns out to be unreadable.
-    /// A peer can hide a malformed value behind a concurrent local one, so
-    /// undoing that local write can expose state no replica materializes;
-    /// leaving it in place would strand the authority ahead of the model the
-    /// caller still holds, with no update to send anyone.
+    /// Moves the document and both stacks. Every failure here leaves that half
+    /// done, so the caller holds a checkpoint and puts it back — one checkpoint
+    /// for the whole step rather than one here and another there, since this
+    /// runs on a keystroke and each costs a copy of the document.
     fn apply_history_change(
         &mut self,
         redo: bool,
     ) -> Result<Option<HistoryUpdate>, AuthorityError> {
         let state_vector = self.doc.transact().state_vector();
-        let restore = self.encode_state_as_update_v1();
-        let undo_stack = self.undo_stack.clone();
-        let redo_stack = self.redo_stack.clone();
         let mut undo =
             build_undo_manager(&self.doc, self.undo_stack.clone(), self.redo_stack.clone())
                 .map_err(AuthorityError::InvalidState)?;
@@ -789,13 +785,9 @@ impl WorkbookAuthority {
         if !applied {
             return Ok(None);
         }
-        let (model, structure) = match self.strict_materialize() {
-            Ok(materialized) => materialized,
-            Err(error) => {
-                self.rollback(&restore, undo_stack, redo_stack)?;
-                return Err(AuthorityError::InvalidState(error));
-            }
-        };
+        let (model, structure) = self
+            .strict_materialize()
+            .map_err(AuthorityError::InvalidState)?;
         let update = self.doc.transact().encode_diff_v1(&state_vector);
         Ok(Some(HistoryUpdate {
             model,
@@ -804,10 +796,10 @@ impl WorkbookAuthority {
         }))
     }
 
-    /// Rebuilds the document from a state captured before a failed step. The
-    /// GUID is carried over because a history entry names the document it came
-    /// from: a fresh one orphans every restored entry, and the undo manager
-    /// discards orphans silently, one whole stack at a time.
+    /// Rebuilds the document from a checkpoint. The GUID is carried over
+    /// because a history entry names the document it came from: a fresh one
+    /// orphans every restored entry, and the undo manager discards orphans
+    /// silently, one whole stack at a time.
     fn rollback(
         &mut self,
         restore: &[u8],
@@ -2691,6 +2683,11 @@ fn materialize_sheet<T: ReadTxn>(
 /// in: refusing it would make integration depend on delivery order, and the
 /// replicas would never meet again. Sheet order is shared, so first-in-order
 /// wins is the same answer everywhere.
+///
+/// Removing a sheet is structural and refused while collaborative. Were that
+/// ever allowed, dropping the donor would hand the frame to whatever the
+/// surviving sheet's blob holds — which may be a value this has been quietly
+/// covering for, and which nothing has checked since it arrived.
 fn project_shared_frame_anchors(sheets: &mut [Sheet]) {
     let mut chosen = BTreeMap::new();
     for sheet in sheets.iter() {
@@ -4065,6 +4062,74 @@ mod tests {
         let update = peer_chart_update(&authority, 44, slid);
         let staged = authority.stage_updates_v1(&[&update]).unwrap();
         assert_eq!(staged.structure, frozen);
+    }
+
+    /// A checkpoint has to put back everything a history step moves: the
+    /// document, both stacks, and the identity the stacks name. Restoring into
+    /// a fresh document would look right and leave the history unusable — the
+    /// undo manager drops entries belonging to a document it does not know,
+    /// silently, a whole stack at a time — so the proof is that undo still
+    /// works afterwards.
+    #[test]
+    fn a_restored_checkpoint_brings_back_a_working_history() {
+        let model = sliding_model();
+        let mut authority = WorkbookAuthority::from_model_with_client_id(&model, 61).unwrap();
+        let commit = |authority: &mut WorkbookAuthority, to| {
+            let ops = [Op::SetChartAnchor {
+                sheet: SheetId(0),
+                frame: "xl/drawings/drawing1.xml#0".to_owned(),
+                part: "xl/charts/chart1.xml".to_owned(),
+                from: authority.materialize().unwrap().sheets[0].charts[0].anchor,
+                to,
+            }];
+            let staged = authority
+                .stage_local_ops_v1(&ops, SyncOrigin::User)
+                .unwrap();
+            authority
+                .apply_local_update_v1(&staged.update, SyncOrigin::User)
+                .unwrap();
+        };
+
+        commit(&mut authority, slid_anchor(2));
+        let checkpoint = authority.checkpoint();
+        let vector = authority.encode_state_vector_v1();
+        let anchor = authority.materialize().unwrap().sheets[0].charts[0].anchor;
+        let depth = authority.undo_depth();
+        assert!(depth > 0);
+
+        commit(&mut authority, slid_anchor(5));
+        assert_ne!(
+            authority.materialize().unwrap().sheets[0].charts[0].anchor,
+            anchor
+        );
+
+        authority.restore(checkpoint).unwrap();
+        assert_eq!(
+            authority.materialize().unwrap().sheets[0].charts[0].anchor,
+            anchor,
+            "restore must bring the document back"
+        );
+        assert_eq!(
+            authority.encode_state_vector_v1(),
+            vector,
+            "restore must wind the document back, not forward"
+        );
+        assert_eq!(
+            authority.undo_depth(),
+            depth,
+            "restore must bring back the stacks"
+        );
+
+        // the history still belongs to this document, so it can still be spent
+        let undone = authority
+            .undo()
+            .expect("a restored history must still apply")
+            .expect("the entry is on the stack");
+        assert_eq!(
+            undone.model.sheets[0].charts[0].anchor,
+            model.sheets[0].charts[0].anchor
+        );
+        assert_eq!(authority.undo_depth(), depth - 1);
     }
 
     /// A peer's chart write can lose the merge to a concurrent local one and

--- a/crates/betteroffice-xlsx/src/authority.rs
+++ b/crates/betteroffice-xlsx/src/authority.rs
@@ -1024,6 +1024,7 @@ impl WorkbookAuthority {
                 },
             )?);
         }
+        project_shared_frame_anchors(&mut model.sheets);
         let active = keys.iter().cloned().collect::<BTreeSet<_>>();
         let all_keys = sheets
             .keys(&txn)
@@ -2681,6 +2682,29 @@ fn materialize_sheet<T: ReadTxn>(
         _ => return Err("sheet is missing merges".to_string()),
     };
     Ok(sheet)
+}
+
+/// One drawing anchor is one element however many sheets point at it, but each
+/// sheet's chart state is assigned on its own. Two replicas can each write a
+/// legal value for a different sheet and only disagree once the two are merged,
+/// so the disagreement is settled on the way out rather than refused on the way
+/// in: refusing it would make integration depend on delivery order, and the
+/// replicas would never meet again. Sheet order is shared, so first-in-order
+/// wins is the same answer everywhere.
+fn project_shared_frame_anchors(sheets: &mut [Sheet]) {
+    let mut chosen = BTreeMap::new();
+    for sheet in sheets.iter() {
+        for chart in &sheet.charts {
+            chosen.entry(chart.frame_id()).or_insert(chart.anchor);
+        }
+    }
+    for sheet in sheets.iter_mut() {
+        for chart in &mut sheet.charts {
+            if let Some(anchor) = chosen.get(&chart.frame_id()) {
+                chart.anchor = *anchor;
+            }
+        }
+    }
 }
 
 fn nested_map<T: ReadTxn>(parent: &MapRef, txn: &T, key: &str) -> Result<MapRef, String> {

--- a/crates/betteroffice-xlsx/src/authority.rs
+++ b/crates/betteroffice-xlsx/src/authority.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use crate::sheet_json::{decode_charts, decode_hyperlinks};
 use sha2::{Digest, Sha256};
 use xlsx_model::{
-    Cell, CellFormat, CellRange, CellRef, CellValue, DateSystem, DefinedName, ErrorValue,
-    FreezePane, Hyperlink, MAX_COLS, MAX_ROWS, Sheet, SheetChart, SheetId, Stylesheet,
-    Workbook as WorkbookModel,
+    AnchorEditAs, AnchorExtent, AnchorPos, Cell, CellFormat, CellRange, CellRef, CellValue,
+    ChartAnchor, ChartRef, DateSystem, DefinedName, ErrorValue, FreezePane, Hyperlink, MAX_COLS,
+    MAX_ROWS, Sheet, SheetChart, SheetId, Stylesheet, Workbook as WorkbookModel,
 };
 use xlsx_ops::Op;
 use yrs::block::{
@@ -22,7 +22,7 @@ use yrs::undo::{Options as UndoOptions, StackItem, UndoManager};
 use yrs::updates::decoder::{Decode, Decoder, DecoderV1};
 use yrs::updates::encoder::{Encoder, EncoderV1};
 use yrs::{
-    Any, Array, ArrayRef, BranchID, Doc, ID, Map, MapPrelim, MapRef, Origin, Out, ReadTxn,
+    Any, Array, ArrayRef, BranchID, Doc, ID, Map, MapPrelim, MapRef, Options, Origin, Out, ReadTxn,
     StateVector, Transact, TransactionMut, Update, WriteTxn,
 };
 
@@ -190,6 +190,61 @@ impl WorkbookBase {
     }
 }
 
+/// The part of an anchor no move may rewrite: its kind, plus whatever the
+/// drawing writer cannot patch. Only the grid markers a save writes whole stay
+/// free, so this mirrors `only_grid_position_moved` in the writer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum AnchorShape {
+    TwoCell {
+        edit_as: AnchorEditAs,
+    },
+    OneCell {
+        extent: AnchorExtent,
+    },
+    Absolute {
+        pos: AnchorPos,
+        extent: AnchorExtent,
+    },
+}
+
+impl AnchorShape {
+    fn of(anchor: &ChartAnchor) -> Self {
+        match anchor {
+            ChartAnchor::TwoCell { edit_as, .. } => Self::TwoCell { edit_as: *edit_as },
+            ChartAnchor::OneCell { extent, .. } => Self::OneCell { extent: *extent },
+            ChartAnchor::Absolute { pos, extent } => Self::Absolute {
+                pos: *pos,
+                extent: *extent,
+            },
+        }
+    }
+}
+
+/// What the freeze pins about a chart: which drawing anchors which part, what
+/// the part reads, and the shape of that anchor. Only where a grid-anchored
+/// chart sits is replicated content, so a peer may slide one without changing
+/// the structure this describes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ChartIdentity {
+    part: String,
+    drawing: String,
+    anchor_index: usize,
+    refs: Vec<ChartRef>,
+    anchor: AnchorShape,
+}
+
+impl ChartIdentity {
+    fn of(chart: &SheetChart) -> Self {
+        Self {
+            part: chart.part.clone(),
+            drawing: chart.drawing.clone(),
+            anchor_index: chart.anchor_index,
+            refs: chart.refs.clone(),
+            anchor: AnchorShape::of(&chart.anchor),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WorkbookStructure {
     generation: i64,
@@ -197,7 +252,7 @@ pub(crate) struct WorkbookStructure {
     sheet_names: Vec<String>,
     freeze_panes: Vec<Option<FreezePane>>,
     hyperlinks: Vec<Vec<Hyperlink>>,
-    charts: Vec<Vec<SheetChart>>,
+    charts: Vec<Vec<ChartIdentity>>,
     merges: Vec<Vec<CellRange>>,
     shared_types: BTreeMap<String, SheetSharedTypes>,
 }
@@ -251,6 +306,12 @@ pub(crate) struct StagedLocalUpdate {
     pub(crate) state_vector_entries: usize,
     pub(crate) structure: WorkbookStructure,
     pub(crate) update: Vec<u8>,
+}
+
+pub(crate) struct AuthorityCheckpoint {
+    state: Vec<u8>,
+    undo_stack: Vec<StackItem<()>>,
+    redo_stack: Vec<StackItem<()>>,
 }
 
 pub(crate) struct HistoryUpdate {
@@ -671,6 +732,28 @@ impl WorkbookAuthority {
         self.redo_stack.len()
     }
 
+    /// The document and history as they stand, so a caller that rejects what a
+    /// history step produced can put the authority back. The step itself is
+    /// only half the change: the caller validates the other half.
+    pub(crate) fn checkpoint(&self) -> AuthorityCheckpoint {
+        AuthorityCheckpoint {
+            state: self.encode_state_as_update_v1(),
+            undo_stack: self.undo_stack.clone(),
+            redo_stack: self.redo_stack.clone(),
+        }
+    }
+
+    pub(crate) fn restore(
+        &mut self,
+        checkpoint: AuthorityCheckpoint,
+    ) -> Result<(), AuthorityError> {
+        self.rollback(
+            &checkpoint.state,
+            checkpoint.undo_stack,
+            checkpoint.redo_stack,
+        )
+    }
+
     pub(crate) fn undo(&mut self) -> Result<Option<HistoryUpdate>, AuthorityError> {
         self.apply_history_change(false)
     }
@@ -679,11 +762,19 @@ impl WorkbookAuthority {
         self.apply_history_change(true)
     }
 
+    /// Puts the document back when a history step turns out to be unreadable.
+    /// A peer can hide a malformed value behind a concurrent local one, so
+    /// undoing that local write can expose state no replica materializes;
+    /// leaving it in place would strand the authority ahead of the model the
+    /// caller still holds, with no update to send anyone.
     fn apply_history_change(
         &mut self,
         redo: bool,
     ) -> Result<Option<HistoryUpdate>, AuthorityError> {
         let state_vector = self.doc.transact().state_vector();
+        let restore = self.encode_state_as_update_v1();
+        let undo_stack = self.undo_stack.clone();
+        let redo_stack = self.redo_stack.clone();
         let mut undo =
             build_undo_manager(&self.doc, self.undo_stack.clone(), self.redo_stack.clone())
                 .map_err(AuthorityError::InvalidState)?;
@@ -698,15 +789,40 @@ impl WorkbookAuthority {
         if !applied {
             return Ok(None);
         }
-        let (model, structure) = self
-            .strict_materialize()
-            .map_err(AuthorityError::InvalidState)?;
+        let (model, structure) = match self.strict_materialize() {
+            Ok(materialized) => materialized,
+            Err(error) => {
+                self.rollback(&restore, undo_stack, redo_stack)?;
+                return Err(AuthorityError::InvalidState(error));
+            }
+        };
         let update = self.doc.transact().encode_diff_v1(&state_vector);
         Ok(Some(HistoryUpdate {
             model,
             structure,
             update,
         }))
+    }
+
+    /// Rebuilds the document from a state captured before a failed step. The
+    /// GUID is carried over because a history entry names the document it came
+    /// from: a fresh one orphans every restored entry, and the undo manager
+    /// discards orphans silently, one whole stack at a time.
+    fn rollback(
+        &mut self,
+        restore: &[u8],
+        undo_stack: Vec<StackItem<()>>,
+        redo_stack: Vec<StackItem<()>>,
+    ) -> Result<(), AuthorityError> {
+        let doc = Doc::with_options(Options::with_guid_and_client_id(
+            self.doc.guid().clone(),
+            self.doc.client_id(),
+        ));
+        hydrate_doc(&doc, restore).map_err(AuthorityError::InvalidState)?;
+        self.doc = doc;
+        self.undo_stack = undo_stack;
+        self.redo_stack = redo_stack;
+        Ok(())
     }
 
     pub(crate) fn clear_history(&mut self) {
@@ -861,6 +977,7 @@ impl WorkbookAuthority {
         let mut model = self.base.workbook();
         model.styles = styles;
         let expected_sheet_keys = sheet_schema_keys(version);
+        let optional_sheet_keys = sheet_schema_optional_keys(version);
         for key in keys.iter() {
             if !seen.insert(key.clone()) {
                 return Err(format!("duplicate sheet key {key}"));
@@ -870,10 +987,11 @@ impl WorkbookAuthority {
                 .and_then(|value| value.cast::<MapRef>().ok())
                 .ok_or_else(|| format!("missing sheet {key}"))?;
             if strict {
-                require_map_keys(
+                require_map_keys_with_optional(
                     &sheet_map,
                     &txn,
                     expected_sheet_keys,
+                    optional_sheet_keys,
                     &format!("sheet {key}"),
                 )?;
             }
@@ -918,10 +1036,11 @@ impl WorkbookAuthority {
                 .and_then(|value| value.cast::<MapRef>().ok())
                 .ok_or_else(|| format!("sheet {key} is not a map"))?;
             if strict && !active.contains(&key) {
-                require_map_keys(
+                require_map_keys_with_optional(
                     &sheet_map,
                     &txn,
                     expected_sheet_keys,
+                    optional_sheet_keys,
                     &format!("inactive sheet {key}"),
                 )?;
                 materialize_sheet(
@@ -951,7 +1070,7 @@ impl WorkbookAuthority {
             charts: model
                 .sheets
                 .iter()
-                .map(|sheet| sheet.charts.clone())
+                .map(|sheet| sheet.charts.iter().map(ChartIdentity::of).collect())
                 .collect(),
             merges: model
                 .sheets
@@ -1285,7 +1404,6 @@ pub(crate) fn is_structural_op(op: &Op) -> bool {
             | Op::RenameSheet { .. }
             | Op::RestoreSheet { .. }
             | Op::SetCharts { .. }
-            | Op::SetChartAnchor { .. }
             | Op::SetDefinedNames { .. }
     )
 }
@@ -2556,7 +2674,6 @@ fn materialize_sheet<T: ReadTxn>(
         (CHARTS_SCHEMA_VERSION.., Some(_)) => {
             return Err("sheet charts are not a string".to_string());
         }
-        (CHARTS_SCHEMA_VERSION.., None) => return Err("sheet is missing charts".to_string()),
         _ => fallbacks.charts.to_vec(),
     };
     sheet.merges = match sheet_map.get(txn, MERGES) {
@@ -2665,7 +2782,6 @@ fn sheet_schema_keys(version: i64) -> &'static [&'static str] {
         STYLES,
     ];
     const V6: &[&str] = &[
-        CHARTS,
         COL_WIDTHS,
         CONTENTS,
         FREEZE_PANE,
@@ -2680,6 +2796,20 @@ fn sheet_schema_keys(version: i64) -> &'static [&'static str] {
         FREEZE_PANE_SCHEMA_VERSION => V4,
         HYPERLINK_SCHEMA_VERSION => V5,
         _ => V6,
+    }
+}
+
+/// Chart state is the one sheet key two replicas can assign at once, because
+/// repinning a chart is an ordinary edit. Undoing the assignment that won
+/// deletes the key outright, so it reads as absent and falls back to what the
+/// source package holds rather than failing the whole workbook.
+fn sheet_schema_optional_keys(version: i64) -> &'static [&'static str] {
+    const NONE: &[&str] = &[];
+    const V6: &[&str] = &[CHARTS];
+    if version >= CHARTS_SCHEMA_VERSION {
+        V6
+    } else {
+        NONE
     }
 }
 
@@ -2705,12 +2835,33 @@ fn require_map_keys<T: ReadTxn>(
     expected: &[&str],
     label: &str,
 ) -> Result<(), String> {
+    require_map_keys_with_optional(map, txn, expected, &[], label)
+}
+
+/// `optional` keys may be present or absent. A key two replicas assign at once
+/// is deleted outright when the winning assignment is undone, so any such key
+/// has to read as absent rather than as a broken document.
+fn require_map_keys_with_optional<T: ReadTxn>(
+    map: &MapRef,
+    txn: &T,
+    expected: &[&str],
+    optional: &[&str],
+    label: &str,
+) -> Result<(), String> {
     let actual = map.keys(txn).map(str::to_string).collect::<BTreeSet<_>>();
     let expected = expected
         .iter()
         .map(|key| (*key).to_string())
         .collect::<BTreeSet<_>>();
-    if actual == expected {
+    let optional = optional
+        .iter()
+        .map(|key| (*key).to_string())
+        .collect::<BTreeSet<_>>();
+    if expected.is_subset(&actual)
+        && actual
+            .difference(&expected)
+            .all(|key| optional.contains(key))
+    {
         Ok(())
     } else {
         Err(format!("{label} keys do not match the schema"))
@@ -3429,6 +3580,11 @@ mod tests {
     /// on the current version instead reads the newest schema as pre-chart the
     /// moment the current version moves past it, which is how a released
     /// snapshot came to be unreadable in the first place.
+    ///
+    /// The key is optional rather than required, because repinning is an
+    /// ordinary edit and undoing the assignment that won a race deletes it. An
+    /// absent key falls back to the source package, so the schema gate is what
+    /// decides whether the document's own chart state is read at all.
     #[test]
     fn chart_state_is_gated_on_the_schema_that_introduced_it() {
         const { assert!(CHARTS_SCHEMA_VERSION <= SCHEMA_VERSION) };
@@ -3437,6 +3593,30 @@ mod tests {
         let mut model = WorkbookModel::default();
         model.sheets.push(charted("Report", "Report!$A$1"));
         let authority = WorkbookAuthority::from_model_with_client_id(&model, 140).unwrap();
+
+        // present: the document's own chart state wins over the fallback.
+        let mut moved = model.sheets[0].charts.clone();
+        moved[0].refs[0].formula = "Report!$B$9".to_owned();
+        {
+            let mut txn = authority.doc.transact_mut_with("test:charts-gate");
+            let sheets = txn.get_map(SHEETS).unwrap();
+            let sheet = sheets
+                .get(&txn, "sheet:0")
+                .and_then(|value| value.cast::<MapRef>().ok())
+                .unwrap();
+            sheet.try_update(
+                &mut txn,
+                CHARTS,
+                serde_json::to_string(&moved).unwrap().as_str(),
+            );
+        }
+        assert_eq!(
+            authority.materialize().unwrap().sheets[0].charts[0].refs[0].formula,
+            "Report!$B$9",
+            "a document at the chart schema must read its own chart state"
+        );
+
+        // absent: the source package answers, and the chart is still there.
         {
             let mut txn = authority.doc.transact_mut_with("test:charts-gate");
             let sheets = txn.get_map(SHEETS).unwrap();
@@ -3446,12 +3626,17 @@ mod tests {
                 .unwrap();
             sheet.remove(&mut txn, CHARTS);
         }
-        assert!(
-            authority.materialize().is_err(),
-            "a document at the chart schema must carry its own chart state"
-        );
-        assert!(sheet_schema_keys(CHARTS_SCHEMA_VERSION).contains(&CHARTS));
-        assert!(!sheet_schema_keys(CHARTS_SCHEMA_VERSION - 1).contains(&CHARTS));
+        let fallen_back = authority
+            .materialize()
+            .expect("an absent chart key must read as absent, not as a broken workbook");
+        assert_eq!(fallen_back.sheets[0].charts, model.sheets[0].charts);
+
+        let gated = |version: i64| {
+            sheet_schema_keys(version).contains(&CHARTS)
+                || sheet_schema_optional_keys(version).contains(&CHARTS)
+        };
+        assert!(gated(CHARTS_SCHEMA_VERSION));
+        assert!(!gated(CHARTS_SCHEMA_VERSION - 1));
     }
 
     #[test]
@@ -3720,5 +3905,204 @@ mod tests {
         let (restored, structure) = authority.strict_materialize().unwrap();
         assert_eq!(restored, model);
         assert_eq!(structure.shared_types["sheet:1"], retained);
+    }
+
+    fn sliding_chart(name: &str) -> Sheet {
+        let mut sheet = Sheet::new(name);
+        sheet.charts.push(SheetChart {
+            part: "xl/charts/chart1.xml".to_owned(),
+            drawing: "xl/drawings/drawing1.xml".to_owned(),
+            anchor_index: 0,
+            anchor: ChartAnchor::TwoCell {
+                from: xlsx_model::AnchorCell::default(),
+                to: xlsx_model::AnchorCell {
+                    col: 4,
+                    col_off: 0,
+                    row: 8,
+                    row_off: 0,
+                },
+                edit_as: AnchorEditAs::TwoCell,
+            },
+            refs: vec![ChartRef {
+                kind: xlsx_model::ChartRefKind::Values,
+                formula: "Data!$A$1:$A$2".to_owned(),
+            }],
+        });
+        sheet
+    }
+
+    fn sliding_model() -> WorkbookModel {
+        let mut model = WorkbookModel::default();
+        model.sheets.push(sliding_chart("Report"));
+        model
+    }
+
+    /// An update that assigns a sheet's chart state without touching the
+    /// structure generation, as a peer forked from `authority`'s state.
+    fn peer_chart_update(authority: &WorkbookAuthority, client_id: u64, charts: &str) -> Vec<u8> {
+        let peer = Doc::with_client_id(client_id);
+        hydrate_doc(&peer, &authority.encode_state_as_update_v1()).unwrap();
+        let before = peer.transact().state_vector();
+        {
+            let mut txn = peer.transact_mut_with("test:peer-charts");
+            let sheets = txn.get_map(SHEETS).unwrap();
+            let sheet = sheets
+                .get(&txn, "sheet:0")
+                .and_then(|value| value.cast::<MapRef>().ok())
+                .unwrap();
+            sheet.try_update(&mut txn, CHARTS, charts);
+        }
+        peer.transact().encode_diff_v1(&before)
+    }
+
+    fn slid_anchor(cols: i64) -> ChartAnchor {
+        ChartAnchor::TwoCell {
+            from: xlsx_model::AnchorCell {
+                col: cols as u32,
+                ..xlsx_model::AnchorCell::default()
+            },
+            to: xlsx_model::AnchorCell {
+                col: 4 + cols as u32,
+                col_off: 0,
+                row: 8,
+                row_off: 0,
+            },
+            edit_as: AnchorEditAs::TwoCell,
+        }
+    }
+
+    /// The freeze pins what a chart *is*, so a peer cannot pass a remap off as
+    /// a move. The structure generation is untouched here, which is what makes
+    /// this the identity check rather than the generation counter.
+    #[test]
+    fn a_peer_cannot_disguise_a_chart_remap_as_a_move() {
+        let model = sliding_model();
+        let authority = WorkbookAuthority::from_model_with_client_id(&model, 41).unwrap();
+        let frozen = authority.structure().unwrap();
+        let generation = frozen.generation;
+
+        for (label, charts) in [
+            (
+                "refs",
+                r#"[{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{"kind":"twoCell","from":{"col":0,"colOff":0,"row":0,"rowOff":0},"to":{"col":4,"colOff":0,"row":8,"rowOff":0},"edit_as":"twoCell"},"refs":[{"kind":"values","formula":"Hijacked!$A$1"}]}]"#,
+            ),
+            (
+                "part",
+                r#"[{"part":"xl/charts/other.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{"kind":"twoCell","from":{"col":0,"colOff":0,"row":0,"rowOff":0},"to":{"col":4,"colOff":0,"row":8,"rowOff":0},"edit_as":"twoCell"},"refs":[{"kind":"values","formula":"Data!$A$1:$A$2"}]}]"#,
+            ),
+            (
+                "anchorIndex",
+                r#"[{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":3,"anchor":{"kind":"twoCell","from":{"col":0,"colOff":0,"row":0,"rowOff":0},"to":{"col":4,"colOff":0,"row":8,"rowOff":0},"edit_as":"twoCell"},"refs":[{"kind":"values","formula":"Data!$A$1:$A$2"}]}]"#,
+            ),
+        ] {
+            let update = peer_chart_update(&authority, 42, charts);
+            let staged = authority.stage_updates_v1(&[&update]).unwrap();
+            assert_eq!(
+                staged.structure.generation, generation,
+                "{label} must not move the generation, or it proves nothing"
+            );
+            assert_ne!(
+                staged.structure, frozen,
+                "a rewritten {label} must change the frozen structure"
+            );
+        }
+    }
+
+    /// A move may slide a grid-anchored chart and nothing else. The drawing
+    /// writer refuses a changed kind, `editAs` mode or one-cell extent, so the
+    /// freeze has to refuse them too rather than accept a workbook that can no
+    /// longer be saved.
+    #[test]
+    fn a_peer_cannot_reshape_an_anchor_a_save_can_only_slide() {
+        let model = sliding_model();
+        let authority = WorkbookAuthority::from_model_with_client_id(&model, 43).unwrap();
+        let frozen = authority.structure().unwrap();
+
+        for (label, charts) in [
+            (
+                "editAs",
+                r#"[{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{"kind":"twoCell","from":{"col":0,"colOff":0,"row":0,"rowOff":0},"to":{"col":4,"colOff":0,"row":8,"rowOff":0},"edit_as":"oneCell"},"refs":[{"kind":"values","formula":"Data!$A$1:$A$2"}]}]"#,
+            ),
+            (
+                "kind",
+                r#"[{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{"kind":"oneCell","from":{"col":0,"colOff":0,"row":0,"rowOff":0},"extent":{"cx":100000,"cy":100000}},"refs":[{"kind":"values","formula":"Data!$A$1:$A$2"}]}]"#,
+            ),
+        ] {
+            let update = peer_chart_update(&authority, 44, charts);
+            let staged = authority.stage_updates_v1(&[&update]).unwrap();
+            assert_ne!(
+                staged.structure, frozen,
+                "a rewritten anchor {label} must change the frozen structure"
+            );
+        }
+
+        // sliding the same anchor across the grid is the one accepted change.
+        let slid = r#"[{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{"kind":"twoCell","from":{"col":2,"colOff":0,"row":0,"rowOff":0},"to":{"col":6,"colOff":0,"row":8,"rowOff":0},"edit_as":"twoCell"},"refs":[{"kind":"values","formula":"Data!$A$1:$A$2"}]}]"#;
+        let update = peer_chart_update(&authority, 44, slid);
+        let staged = authority.stage_updates_v1(&[&update]).unwrap();
+        assert_eq!(staged.structure, frozen);
+    }
+
+    /// A peer's chart write can lose the merge to a concurrent local one and
+    /// sit in the document unseen. Undoing the local write must not strand the
+    /// authority on state it cannot read: the step is refused and the replica
+    /// stays exactly as usable as it was.
+    #[test]
+    fn a_hidden_chart_conflict_leaves_the_replica_usable() {
+        let model = sliding_model();
+        let mut authority = WorkbookAuthority::from_model_with_client_id(&model, 304).unwrap();
+        let frozen = authority.structure().unwrap();
+        let hostile = peer_chart_update(
+            &authority,
+            111,
+            r#"[{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{"kind":"twoCell","from":{"col":0,"colOff":0,"row":0,"rowOff":0},"to":{"col":4,"colOff":0,"row":8,"rowOff":0},"edit_as":"twoCell"},"refs":[{"kind":"values","formula":"Hijacked!$A$1"}]}]"#,
+        );
+
+        let ops = [Op::SetChartAnchor {
+            sheet: SheetId(0),
+            frame: "xl/drawings/drawing1.xml#0".to_owned(),
+            part: "xl/charts/chart1.xml".to_owned(),
+            from: model.sheets[0].charts[0].anchor,
+            to: slid_anchor(2),
+        }];
+        let local = authority
+            .stage_local_ops_v1(&ops, SyncOrigin::User)
+            .unwrap();
+        authority
+            .apply_local_update_v1(&local.update, SyncOrigin::User)
+            .unwrap();
+
+        // the hostile value loses the merge, so the freeze sees only the move.
+        let staged = authority.stage_updates_v1(&[&hostile]).unwrap();
+        assert_eq!(staged.structure, frozen);
+        authority.apply_update_v1(&staged.commit_update).unwrap();
+        let merged = authority.materialize().unwrap();
+        assert_eq!(
+            merged.sheets[0].charts[0].refs,
+            model.sheets[0].charts[0].refs
+        );
+
+        // undoing the move succeeds, takes the anchor back, and never lets the
+        // hidden remap through.
+        let undone = authority
+            .undo()
+            .expect("a hidden conflict must not fail the undo")
+            .expect("the move is on the stack, so undo must do something");
+        assert_eq!(undone.structure, frozen);
+        let after = authority.materialize().unwrap();
+        assert_eq!(
+            after.sheets[0].charts[0].refs,
+            model.sheets[0].charts[0].refs
+        );
+        assert_eq!(
+            after.sheets[0].charts[0].anchor, model.sheets[0].charts[0].anchor,
+            "undo must put the chart back where it started"
+        );
+        assert_eq!(authority.structure().unwrap(), frozen);
+        assert!(
+            !authority.can_undo(),
+            "one undo must consume exactly the one entry, not drain a longer stack"
+        );
+        let _ = merged;
     }
 }

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, hash_map::Entry};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::{Arc, Mutex, Weak};
 
@@ -167,6 +167,10 @@ pub struct Workbook {
     proposals: ProposalSet,
     last_calculation: CalculationResult,
     update_observers: Arc<Mutex<UpdateObservers>>,
+    /// Where each chart frame sat in the source package, by `frame_id`. Every
+    /// replica opens the same bytes, so this is the one anchor baseline they
+    /// all agree on however far their own editing has since diverged.
+    opened_anchors: BTreeMap<String, ChartAnchor>,
 }
 
 impl Workbook {
@@ -277,6 +281,12 @@ impl Workbook {
         }
         let model = authority.materialize().map_err(authority_error)?;
         validate_model(&model)?;
+        let opened_anchors = model
+            .sheets
+            .iter()
+            .flat_map(|sheet| &sheet.charts)
+            .map(|chart| (chart.frame_id(), chart.anchor))
+            .collect();
         let graph = build_graph.then(|| DepGraph::build(&model));
         let mode = match client_id {
             Some(_) => WorkbookMode::Collaborative {
@@ -315,6 +325,7 @@ impl Workbook {
             proposals: ProposalSet::new(),
             last_calculation: CalculationResult::default(),
             update_observers: Arc::new(Mutex::new(UpdateObservers::default())),
+            opened_anchors,
         })
     }
 
@@ -414,8 +425,7 @@ impl Workbook {
             return Err(Error::CollaborativeStructureChanged);
         }
         let mut model = candidate.materialize().map_err(authority_error)?;
-        validate_model(&model)?;
-        validate_chart_source(&model, self.source_package.is_some())
+        self.gate_incoming(&model)
             .map_err(|error| Error::CollaborativeState(error.to_string()))?;
         let migrated = candidate.encode_state_as_update_v1();
         validate_collaboration_state(migrated.len(), candidate.state_vector_entries())?;
@@ -424,7 +434,7 @@ impl Workbook {
         calculation.changed = changed_cells_between(&self.model, &model);
         self.authority = candidate;
         self.preserved.resize(model.sheets.len());
-        self.model = model;
+        self.install_model(model)?;
         self.graph = Some(graph);
         self.last_calculation = calculation;
         self.mode = WorkbookMode::Collaborative { structure };
@@ -449,10 +459,42 @@ impl Workbook {
             .stage_updates_v1(updates)
             .map_err(authority_error)?;
         validate_collaboration_state(staged.state_bytes, staged.state_vector_entries)?;
-        validate_model(&staged.model)
-            .and_then(|()| validate_chart_source(&staged.model, self.source_package.is_some()))
+        self.gate_incoming(&staged.model)
             .map_err(|error| Error::CollaborativeState(error.to_string()))?;
         Ok(staged)
+    }
+
+    /// Everything a model arriving from outside must satisfy before this
+    /// replica takes it on, whichever door it came through: a staged update and
+    /// an adopted snapshot are the same foreign bytes and get the same answer.
+    fn gate_incoming(&self, model: &WorkbookModel) -> Result<()> {
+        validate_model(model)?;
+        validate_chart_source(model, self.source_package.is_some())?;
+        self.validate_incoming_anchors(model)
+    }
+
+    /// A repinned chart has to land somewhere a save can write and a viewport
+    /// can draw. What the source package already held is exempt, however odd,
+    /// because refusing it would reject the workbook every replica opened —
+    /// and an undo may legitimately put it back. The exemption is the opened
+    /// baseline rather than the current projection: every replica agrees on
+    /// the former, so they all reach the same verdict on the same bytes.
+    fn validate_incoming_anchors(&self, staged: &WorkbookModel) -> Result<()> {
+        for sheet in &staged.sheets {
+            let geometry = GridGeometry::new(sheet);
+            for chart in &sheet.charts {
+                if self.opened_anchors.get(&chart.frame_id()) == Some(&chart.anchor) {
+                    continue;
+                }
+                resolve_chart_anchor(chart.anchor, &geometry, 0, 0).map_err(|error| {
+                    Error::InvalidOperation(format!(
+                        "remote update repins {} to an anchor that cannot be resolved: {error}",
+                        chart.part
+                    ))
+                })?;
+            }
+        }
+        Ok(())
     }
 
     fn resolve_pending_remote_updates(
@@ -531,7 +573,7 @@ impl Workbook {
         self.authority
             .apply_update_v1(&commit_update)
             .map_err(authority_error)?;
-        self.model = model;
+        self.install_model(model)?;
         self.graph = Some(graph);
         self.last_calculation = calculation.clone();
         self.undo.clear();
@@ -1018,8 +1060,9 @@ impl Workbook {
             validate_op(&preview, op)?;
             validate_insert_capacity(&preview, op)?;
             xlsx_ops::apply(&mut preview, op)?;
-            validate_model(&preview)?;
+            validate_model_sheets(&preview)?;
         }
+        validate_shared_drawings(&preview)?;
         if preview == self.model {
             return Ok(MutationResult::default());
         }
@@ -1077,8 +1120,7 @@ impl Workbook {
 
     pub fn undo(&mut self, options: CalculationOptions) -> Result<MutationResult> {
         if self.is_collaborative() {
-            let history = self.authority.undo().map_err(authority_error)?;
-            return self.apply_collaborative_history(history, options);
+            return self.collaborative_history_step(options, false);
         }
         let active_name = self.active_sheet_name();
         let Some(ops) = self.undo.next_undo().map(<[Op]>::to_vec) else {
@@ -1116,8 +1158,7 @@ impl Workbook {
 
     pub fn redo(&mut self, options: CalculationOptions) -> Result<MutationResult> {
         if self.is_collaborative() {
-            let history = self.authority.redo().map_err(authority_error)?;
-            return self.apply_collaborative_history(history, options);
+            return self.collaborative_history_step(options, true);
         }
         let active_name = self.active_sheet_name();
         let Some(ops) = self.undo.next_redo().map(<[Op]>::to_vec) else {
@@ -1153,6 +1194,33 @@ impl Workbook {
         })
     }
 
+    /// A history step moves the shared document before anyone can see what it
+    /// produced, so a rejected result has to put that document back. Leaving it
+    /// advanced would publish an undo the workbook itself refused: peers would
+    /// stage later updates onto state this replica does not hold.
+    fn collaborative_history_step(
+        &mut self,
+        options: CalculationOptions,
+        redo: bool,
+    ) -> Result<MutationResult> {
+        let checkpoint = self.authority.checkpoint();
+        let history = if redo {
+            self.authority.redo()
+        } else {
+            self.authority.undo()
+        }
+        .map_err(authority_error)?;
+        match self.apply_collaborative_history(history, options) {
+            Ok(result) => Ok(result),
+            Err(error) => {
+                self.authority
+                    .restore(checkpoint)
+                    .map_err(authority_error)?;
+                Err(error)
+            }
+        }
+    }
+
     fn apply_collaborative_history(
         &mut self,
         history: Option<HistoryUpdate>,
@@ -1170,7 +1238,7 @@ impl Workbook {
         }
         let active_name = self.active_sheet_name();
         let before = self.model.clone();
-        self.model = history.model;
+        self.install_model(history.model)?;
         self.edited_since_open = true;
         self.restore_active_sheet(active_name.as_deref());
         self.preserved.forget_shared_strings();
@@ -1428,6 +1496,10 @@ impl Workbook {
     /// Slide the chart frame `frame` names — a `ChartRegion` id — by `dx`/`dy`
     /// content pixels, clamped to the grid. One undo step; the new anchor is
     /// written back on save.
+    ///
+    /// A frame is one element in one drawing part, and two sheets may both
+    /// anchor it. Every sheet holding it is repinned together, or the save
+    /// would refuse a drawing its sheets no longer agree on.
     pub fn move_chart(
         &mut self,
         sheet: SheetId,
@@ -1442,9 +1514,8 @@ impl Workbook {
             .iter()
             .find(|chart| chart.frame_id() == frame)
             .ok_or_else(|| chart_frame_not_found(frame))?;
-        let (part, from) = (chart.part.clone(), chart.anchor);
         let to = moved_chart_anchor(
-            from,
+            chart.anchor,
             &GridGeometry::new(sheet_ref),
             f64::from(dx),
             f64::from(dy),
@@ -1454,16 +1525,26 @@ impl Workbook {
                 "chart {frame} is pinned to the sheet and cannot be moved"
             ))
         })?;
-        self.apply_ops(
-            vec![Op::SetChartAnchor {
-                sheet,
-                frame: frame.to_owned(),
-                part,
-                from,
-                to,
-            }],
-            options,
-        )
+        let ops = self
+            .model
+            .sheets
+            .iter()
+            .enumerate()
+            .flat_map(|(index, sheet)| {
+                sheet
+                    .charts
+                    .iter()
+                    .filter(|held| held.frame_id() == frame)
+                    .map(move |held| Op::SetChartAnchor {
+                        sheet: SheetId(index as u32),
+                        frame: frame.to_owned(),
+                        part: held.part.clone(),
+                        from: held.anchor,
+                        to,
+                    })
+            })
+            .collect();
+        self.apply_ops(ops, options)
     }
 
     #[cfg(feature = "raster")]
@@ -1644,7 +1725,7 @@ impl Workbook {
                 .map_err(authority_error)?;
             let mut model = self.authority.materialize().map_err(authority_error)?;
             retain_formula_caches(&self.model, &mut model);
-            self.model = model;
+            self.install_model(model)?;
             self.emit_update(UpdateEvent {
                 update: staged.update,
                 origin: UpdateOrigin::Local,
@@ -1684,7 +1765,7 @@ impl Workbook {
                 .map_err(authority_error)?;
             let mut model = self.authority.materialize().map_err(authority_error)?;
             retain_formula_caches(&self.model, &mut model);
-            self.model = model;
+            self.install_model(model)?;
             self.emit_update(UpdateEvent {
                 update: staged.update,
                 origin: UpdateOrigin::Local,
@@ -2094,6 +2175,26 @@ fn changed_cells_between(before: &WorkbookModel, after: &WorkbookModel) -> Vec<C
 }
 
 fn validate_model(model: &WorkbookModel) -> Result<()> {
+    validate_model_sheets(model)?;
+    validate_shared_drawings(model)
+}
+
+impl Workbook {
+    /// The one way a model becomes this workbook's own. An op batch, a merge
+    /// and an undo each assemble a whole model out of parts that were checked
+    /// separately, so a combination none of them produced alone is caught here
+    /// rather than at whichever door the state came through.
+    fn install_model(&mut self, model: WorkbookModel) -> Result<()> {
+        validate_shared_drawings(&model)?;
+        self.model = model;
+        Ok(())
+    }
+}
+
+/// Everything a single sheet must satisfy on its own. A batch of ops passes
+/// through states no finished model may hold, so the cross-sheet invariants
+/// are checked once the batch is whole rather than after every op.
+fn validate_model_sheets(model: &WorkbookModel) -> Result<()> {
     if model.sheets.is_empty() {
         return Err(Error::NoSheets);
     }
@@ -2190,6 +2291,31 @@ fn validate_model(model: &WorkbookModel) -> Result<()> {
                 return Err(Error::InvalidOperation(
                     "workbook contains overlapping merged ranges".to_string(),
                 ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// One anchor in one drawing is a single element, whatever number of sheets
+/// point at it. Letting them disagree builds a workbook that converges
+/// everywhere and saves nowhere, so the disagreement is refused here instead.
+fn validate_shared_drawings(model: &WorkbookModel) -> Result<()> {
+    let mut claims: HashMap<(&str, usize), ChartAnchor> = HashMap::new();
+    for sheet in &model.sheets {
+        for chart in &sheet.charts {
+            match claims.entry((chart.drawing.as_str(), chart.anchor_index)) {
+                Entry::Vacant(slot) => {
+                    slot.insert(chart.anchor);
+                }
+                Entry::Occupied(slot) => {
+                    if *slot.get() != chart.anchor {
+                        return Err(Error::InvalidOperation(format!(
+                            "anchor {} of {} is held by two sheets that disagree on where it sits",
+                            chart.anchor_index, chart.drawing
+                        )));
+                    }
+                }
             }
         }
     }

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -1197,21 +1197,29 @@ impl Workbook {
 
     /// A history step moves the shared document before anyone can see what it
     /// produced, so a rejected result has to put that document back. Leaving it
-    /// advanced would publish an undo the workbook itself refused: peers would
+    /// advanced would publish a step the workbook itself refused: peers would
     /// stage later updates onto state this replica does not hold.
+    ///
+    /// Nothing reaches the refusal today — the checks left after a step are
+    /// ones the projection settles rather than fails — so this is defensive,
+    /// and it is the only thing standing between a future check here and a
+    /// replica that has published what it would not keep.
     fn collaborative_history_step(
         &mut self,
         options: CalculationOptions,
         redo: bool,
     ) -> Result<MutationResult> {
         let checkpoint = self.authority.checkpoint();
-        let history = if redo {
+        let stepped = if redo {
             self.authority.redo()
         } else {
             self.authority.undo()
-        }
-        .map_err(authority_error)?;
-        match self.apply_collaborative_history(history, options) {
+        };
+        let outcome = match stepped {
+            Ok(history) => self.apply_collaborative_history(history, options),
+            Err(error) => Err(authority_error(error)),
+        };
+        match outcome {
             Ok(result) => Ok(result),
             Err(error) => {
                 self.authority
@@ -2443,6 +2451,10 @@ fn validate_op(model: &WorkbookModel, op: &Op) -> Result<()> {
                 });
             }
             validate_anchor_change(*from, *to, frame)?;
+            // a peer judges this anchor on its own terms, so this replica has
+            // to as well: anything it accepts that they refuse would be
+            // published and dropped, taking the rest of the session with it.
+            validate_intrinsic_anchor(*to)?;
             resolve_chart_anchor(*to, &GridGeometry::new(sheet_ref), 0, 0)
                 .map_err(|error| Error::InvalidOperation(error.to_string()))?;
         }

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -2176,17 +2176,14 @@ fn changed_cells_between(before: &WorkbookModel, after: &WorkbookModel) -> Vec<C
 }
 
 fn validate_model(model: &WorkbookModel) -> Result<()> {
-    validate_model_sheets(model)?;
-    validate_shared_drawings(model)
+    validate_model_sheets(model)
 }
 
 impl Workbook {
-    /// The one way a model becomes this workbook's own. An op batch, a merge
-    /// and an undo each assemble a whole model out of parts that were checked
-    /// separately, so a combination none of them produced alone is caught here
-    /// rather than at whichever door the state came through.
+    /// The one way a model becomes this workbook's own. Everything arriving
+    /// from the shared document is projected on the way out, so what is left to
+    /// check here is what a local batch can still get wrong.
     fn install_model(&mut self, model: WorkbookModel) -> Result<()> {
-        validate_shared_drawings(&model)?;
         self.model = model;
         Ok(())
     }
@@ -2299,8 +2296,13 @@ fn validate_model_sheets(model: &WorkbookModel) -> Result<()> {
 }
 
 /// One anchor in one drawing is a single element, whatever number of sheets
-/// point at it. Letting them disagree builds a workbook that converges
-/// everywhere and saves nowhere, so the disagreement is refused here instead.
+/// point at it. A local batch that repins only some of them would build a
+/// workbook that saves nowhere, so it is refused before it is committed.
+///
+/// This is a local decision about a local edit. It cannot be asked of an
+/// arriving update: two replicas can each hold a legal half and only disagree
+/// once merged, and a merge that can be refused is a merge that depends on
+/// delivery order. What arrives is projected instead.
 fn validate_shared_drawings(model: &WorkbookModel) -> Result<()> {
     let mut claims: HashMap<(&str, usize), ChartAnchor> = HashMap::new();
     for sheet in &model.sheets {

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -473,24 +473,25 @@ impl Workbook {
         self.validate_incoming_anchors(model)
     }
 
-    /// A repinned chart has to land somewhere a save can write and a viewport
-    /// can draw. What the source package already held is exempt, however odd,
-    /// because refusing it would reject the workbook every replica opened —
-    /// and an undo may legitimately put it back. The exemption is the opened
-    /// baseline rather than the current projection: every replica agrees on
-    /// the former, so they all reach the same verdict on the same bytes.
+    /// A merge verdict may only rest on what is true of the anchor itself.
+    /// Whether it resolves to a drawable rectangle is a question about the
+    /// anchor *and* the column widths it spans, and widths are replicated
+    /// independently — so one replica can hold a combination the other does
+    /// not, and each would reject what the other accepted. Where a chart ends
+    /// up drawing is settled at the point of use instead.
+    ///
+    /// What the source package already held is exempt however odd, because
+    /// refusing it would reject the workbook every replica opened, and an undo
+    /// may legitimately put it back. The exemption is the opened baseline, not
+    /// the current projection: every replica agrees on the former.
     fn validate_incoming_anchors(&self, staged: &WorkbookModel) -> Result<()> {
         for sheet in &staged.sheets {
-            let geometry = GridGeometry::new(sheet);
             for chart in &sheet.charts {
                 if self.opened_anchors.get(&chart.frame_id()) == Some(&chart.anchor) {
                     continue;
                 }
-                resolve_chart_anchor(chart.anchor, &geometry, 0, 0).map_err(|error| {
-                    Error::InvalidOperation(format!(
-                        "remote update repins {} to an anchor that cannot be resolved: {error}",
-                        chart.part
-                    ))
+                validate_intrinsic_anchor(chart.anchor).map_err(|error| {
+                    Error::InvalidOperation(format!("remote update repins {}: {error}", chart.part))
                 })?;
             }
         }
@@ -2719,6 +2720,58 @@ fn validate_chart_anchor(anchor: ChartAnchor) -> Result<()> {
             return Err(Error::InvalidOperation(
                 "chart anchor is off the sheet grid".to_string(),
             ));
+        }
+    }
+    Ok(())
+}
+
+/// Beyond any sheet: an offset this large is not a position, it is a number
+/// that got somewhere it should not have. Bounding it keeps the pixel
+/// arithmetic downstream finite.
+const MAX_ANCHOR_OFFSET_EMU: i64 = 1 << 40;
+
+/// What an anchor must satisfy on its own, whatever grid it sits over. These
+/// are the properties a peer cannot make true or false by resizing a column,
+/// so they are the only ones a merge may be decided on — and they are what the
+/// drawing writer needs, since it writes grid markers rather than pixels.
+fn validate_intrinsic_anchor(anchor: ChartAnchor) -> Result<()> {
+    let offset = |value: i64| {
+        (0..=MAX_ANCHOR_OFFSET_EMU)
+            .contains(&value)
+            .then_some(())
+            .ok_or_else(|| Error::InvalidOperation("anchor offset is out of range".to_string()))
+    };
+    let extent = |value: i64| {
+        (1..=MAX_ANCHOR_OFFSET_EMU)
+            .contains(&value)
+            .then_some(())
+            .ok_or_else(|| Error::InvalidOperation("anchor extent is not positive".to_string()))
+    };
+    match anchor {
+        ChartAnchor::TwoCell { from, to, .. } => {
+            for cell in [from, to] {
+                offset(cell.col_off)?;
+                offset(cell.row_off)?;
+            }
+            if (to.col, to.col_off) <= (from.col, from.col_off)
+                || (to.row, to.row_off) <= (from.row, from.row_off)
+            {
+                return Err(Error::InvalidOperation(
+                    "anchor corners are inverted or coincident".to_string(),
+                ));
+            }
+        }
+        ChartAnchor::OneCell { from, extent: size } => {
+            offset(from.col_off)?;
+            offset(from.row_off)?;
+            extent(size.cx)?;
+            extent(size.cy)?;
+        }
+        ChartAnchor::Absolute { pos, extent: size } => {
+            offset(pos.x)?;
+            offset(pos.y)?;
+            extent(size.cx)?;
+            extent(size.cy)?;
         }
     }
     Ok(())

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -5434,9 +5434,11 @@ fn collapsing_columns_under_a_chart_does_not_block_a_peer_moving_it() {
     }
 }
 
-/// Sheets sharing one drawing anchor must agree on it in the model itself, not
-/// only in whatever path happened to build it. A raw op batch is a shipped API
-/// and a remote update arrives unvetted, so both have to be refused.
+/// A local batch that repins only one of two sheets sharing an anchor is
+/// refused: it is this replica's own edit and it can simply be told no. The
+/// same disagreement arriving as an update cannot be refused — a peer may hold
+/// the other half legally — so it is projected onto one anchor instead, the
+/// same way on every replica.
 #[test]
 fn sheets_sharing_a_drawing_anchor_may_not_disagree() {
     let bytes = shared_drawing_fixture();
@@ -5474,23 +5476,91 @@ fn sheets_sharing_a_drawing_anchor_may_not_disagree() {
         "{error:?}"
     );
 
-    // and the same disagreement arriving as a remote update
+    // the same disagreement arriving as an update is taken and projected
     let mut target = Workbook::open_collaborative(&bytes, 830).unwrap();
-    let before = target.model().clone();
     let charts = format!(
         r#"[{{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{},"refs":{}}}]"#,
         serde_json::to_string(&moved).unwrap(),
         CHARTED_FIXTURE_REFS
     );
     let update = peer_sheet_charts_update(&target, 831, "sheet:0", &charts);
-    let error = target
+    target
         .apply_update_v1(&update, CalculationOptions::default())
-        .expect_err("a remote half-repin must be refused");
-    assert!(
-        matches!(&error, Error::CollaborativeState(message) if message.contains("disagree")),
-        "{error:?}"
+        .expect("a half-repin from a peer must integrate rather than be refused");
+    assert_eq!(
+        target.model().sheets[0].charts[0].anchor,
+        target.model().sheets[1].charts[0].anchor,
+        "the projection must leave one anchor for the frame"
     );
-    assert_eq!(target.model(), &before);
+    assert!(
+        target.save().is_ok(),
+        "the projected workbook must still be saveable"
+    );
+}
+
+/// Three concurrent updates, the same three, delivered in two orders. A gate
+/// that can reject one of them rejects a different one on each replica —
+/// whichever arrives when the sheets happen to disagree — and the two never
+/// meet again. Integration therefore has to take all three whatever the order,
+/// and settle the disagreement on the way out.
+#[test]
+fn one_frame_converges_under_every_delivery_order_of_the_same_updates() {
+    let bytes = shared_drawing_fixture();
+    let baseline = Workbook::open_collaborative(&bytes, 880).unwrap();
+    let baseline_vector = baseline.encode_state_vector_v1();
+
+    // an engine move writes both sheets holding the frame; the handcrafted one
+    // writes a single sheet. Yrs settles a tie by client id, so these ids fix
+    // the priority at handcrafted > later move > earlier move.
+    let engine_move = |client_id: u64, dx: f32| {
+        let mut replica = Workbook::open_collaborative(&bytes, client_id).unwrap();
+        replica
+            .move_chart(
+                SheetId(0),
+                "xl/drawings/drawing1.xml#0",
+                dx,
+                0.0,
+                CalculationOptions::default(),
+            )
+            .unwrap();
+        (
+            replica.encode_diff_v1(&baseline_vector).unwrap(),
+            replica.model().sheets[0].charts[0].anchor,
+        )
+    };
+    let (update_b, anchor_b) = engine_move(881, 12.0);
+    let (update_c, _) = engine_move(890, 30.0);
+    let half = format!(
+        r#"[{{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{},"refs":{}}}]"#,
+        serde_json::to_string(&anchor_b).unwrap(),
+        CHARTED_FIXTURE_REFS
+    );
+    let update_h = peer_sheet_charts_update(&baseline, 899, "sheet:1", &half);
+
+    let settle = |order: [&Vec<u8>; 3], client_id: u64| {
+        let mut replica = Workbook::open_collaborative(&bytes, client_id).unwrap();
+        for update in order {
+            replica
+                .apply_update_v1(update, CalculationOptions::default())
+                .unwrap_or_else(|error| {
+                    panic!("integration must not depend on delivery order: {error}")
+                });
+        }
+        assert_eq!(
+            replica.model().sheets[0].charts[0].anchor,
+            replica.model().sheets[1].charts[0].anchor,
+            "one frame must end up with one anchor"
+        );
+        assert!(replica.save().is_ok(), "the settled workbook must save");
+        replica.model().clone()
+    };
+
+    let first = settle([&update_b, &update_h, &update_c], 870);
+    let second = settle([&update_h, &update_b, &update_c], 871);
+    assert_eq!(
+        first, second,
+        "the same updates in a different order must land on the same workbook"
+    );
 }
 
 /// A snapshot is foreign bytes like any update, so it answers to the same
@@ -5534,10 +5604,11 @@ fn an_adopted_snapshot_answers_to_the_same_anchor_check_as_an_update() {
     );
 }
 
-/// An undo assembles a model out of parts that each passed on their own way
-/// in. It can still land a pair no single edit produced: one sheet repinned,
-/// the sheet sharing its drawing anchor left behind. That is a workbook no
-/// replica can save, so the step is refused rather than installed.
+/// An undo assembles a model out of parts that each arrived on their own. It
+/// can land a pair no single edit produced: one sheet repinned, the sheet
+/// sharing its drawing anchor left behind. Projecting that back onto one
+/// anchor keeps the step working and the workbook saveable, and keeps the
+/// replica publishing something its peers can take.
 #[test]
 fn collaborative_undo_may_not_install_a_split_shared_drawing() {
     let bytes = shared_drawing_fixture();
@@ -5577,50 +5648,30 @@ fn collaborative_undo_may_not_install_a_split_shared_drawing() {
     assert_eq!(local.model().sheets[0].charts[0].anchor, moved);
     assert_eq!(local.model().sheets[1].charts[0].anchor, moved);
 
-    // undoing the move reverts only the sheet whose insertion survived, which
-    // is a workbook no replica could save, so the step is refused whole.
-    let vector_before = local.encode_state_vector_v1();
+    // the split the undo would leave is projected back onto one anchor
     let history_before = local.history_state();
-    let error = local
-        .undo(CalculationOptions::default())
-        .expect_err("an undo may not install two sheets disagreeing on one anchor");
     assert!(
-        matches!(&error, Error::InvalidOperation(message) if message.contains("disagree")),
-        "{error:?}"
+        local
+            .undo(CalculationOptions::default())
+            .expect("an undo must not be refused over a split a projection can settle")
+            .applied
     );
-    assert_eq!(local.model().sheets[0].charts[0].anchor, moved);
-    assert_eq!(local.model().sheets[1].charts[0].anchor, moved);
-    assert!(
-        local.save().is_ok(),
-        "a refused undo must leave a saveable workbook"
+    assert_eq!(
+        local.model().sheets[0].charts[0].anchor,
+        local.model().sheets[1].charts[0].anchor,
+        "an undo must not leave two sheets disagreeing on one drawing anchor"
     );
+    assert!(local.save().is_ok(), "an installed model must be saveable");
+    assert_ne!(local.history_state(), history_before, "the undo must count");
 
-    // the projection is only half of it. What the replica publishes has to be
-    // unchanged too, or peers pick up an undo this workbook refused — so ask a
-    // peer what the shared document now says.
-    assert_eq!(
-        local.encode_state_vector_v1(),
-        vector_before,
-        "a refused undo must not advance the shared document"
-    );
-    assert_eq!(
-        local.history_state(),
-        history_before,
-        "a refused undo must not spend a history entry"
-    );
+    // and what the replica publishes is what a peer ends up holding
     let mut peer = Workbook::open_collaborative(&bytes, 852).unwrap();
     let catch_up = local
         .encode_diff_v1(&peer.encode_state_vector_v1())
         .unwrap();
     peer.apply_update_v1(&catch_up, CalculationOptions::default())
         .expect("a peer must be able to take what this replica publishes");
-    assert_eq!(
-        peer.model().sheets[0].charts[0].anchor,
-        moved,
-        "the authority must not be publishing the refused undo"
-    );
-    assert_eq!(peer.model().sheets[1].charts[0].anchor, moved);
-
+    assert_eq!(peer.model(), local.model(), "the replicas must agree");
     assert_ne!(moved, before);
 }
 

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -5492,6 +5492,11 @@ fn sheets_sharing_a_drawing_anchor_may_not_disagree() {
         target.model().sheets[1].charts[0].anchor,
         "the projection must leave one anchor for the frame"
     );
+    assert_eq!(
+        target.model().sheets[1].charts[0].anchor,
+        moved,
+        "the first sheet in order donates the anchor, and it is the one written"
+    );
     assert!(
         target.save().is_ok(),
         "the projected workbook must still be saveable"
@@ -5563,6 +5568,90 @@ fn one_frame_converges_under_every_delivery_order_of_the_same_updates() {
     );
 }
 
+/// A replica may not accept an edit its peers will refuse. Publishing one is
+/// worse than losing it: the offending value stays the winner in every later
+/// diff, so the peer drops that update and every update after it, and the two
+/// part ways for the rest of the session. The local gate therefore has to hold
+/// the anchor to exactly what an arriving one is held to — the two once
+/// compared corners differently, one in pixels and one on the grid, and an
+/// offset large enough to cross a column told them apart.
+#[test]
+fn a_locally_accepted_repin_is_one_a_peer_can_take() {
+    let bytes = charted_fixture();
+    let mut local = Workbook::open_collaborative(&bytes, 940).unwrap();
+    let mut peer = Workbook::open_collaborative(&bytes, 941).unwrap();
+    let from = local.model().sheets[0].charts[0].anchor;
+    let ChartAnchor::TwoCell { edit_as, .. } = from else {
+        panic!("two-cell anchor");
+    };
+
+    // corners that run backwards on the grid but forwards in pixels, because
+    // the offset more than covers the column it steps back over
+    let crossed = ChartAnchor::TwoCell {
+        from: AnchorCell {
+            col: 2,
+            col_off: 12_700,
+            row: 4,
+            row_off: 0,
+        },
+        to: AnchorCell {
+            col: 1,
+            col_off: 6_000_000,
+            row: 16,
+            row_off: 0,
+        },
+        edit_as,
+    };
+    let batch = vec![
+        Op::SetCell {
+            sheet: SheetId(0),
+            at: cell("A1"),
+            cell: CellState {
+                value: CellValue::Text {
+                    value: "important".to_owned(),
+                },
+                ..CellState::default()
+            },
+        },
+        Op::SetChartAnchor {
+            sheet: SheetId(0),
+            frame: "xl/drawings/drawing1.xml#0".to_owned(),
+            part: "xl/charts/chart1.xml".to_owned(),
+            from,
+            to: crossed,
+        },
+    ];
+
+    let refused = local
+        .apply_ops(batch, CalculationOptions::default())
+        .expect_err("an anchor no peer would take must not be accepted locally");
+    assert!(
+        matches!(&refused, Error::InvalidOperation(message) if message.contains("inverted or coincident")),
+        "{refused:?}"
+    );
+
+    // nothing was kept, and the session carries on in step
+    local
+        .edit_cell(
+            SheetId(0),
+            cell("A2"),
+            "later",
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    let update = local
+        .encode_diff_v1(&peer.encode_state_vector_v1())
+        .unwrap();
+    peer.apply_update_v1(&update, CalculationOptions::default())
+        .expect("a peer must still be able to take what this replica publishes");
+    assert_eq!(
+        peer.model(),
+        local.model(),
+        "the replicas must stay in step"
+    );
+    assert_eq!(peer.cell(SheetId(0), cell("A2")).unwrap().input, "later");
+}
+
 /// A snapshot is foreign bytes like any update, so it answers to the same
 /// checks. A pristine replica adopts a whole document instead of merging it,
 /// and if that door skipped the anchor check the two replicas would take
@@ -5610,7 +5699,7 @@ fn an_adopted_snapshot_answers_to_the_same_anchor_check_as_an_update() {
 /// anchor keeps the step working and the workbook saveable, and keeps the
 /// replica publishing something its peers can take.
 #[test]
-fn collaborative_undo_may_not_install_a_split_shared_drawing() {
+fn collaborative_undo_settles_a_split_shared_drawing() {
     let bytes = shared_drawing_fixture();
     let mut local = Workbook::open_collaborative(&bytes, 850).unwrap();
     let before = local.model().sheets[0].charts[0].anchor;

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -5326,23 +5326,28 @@ fn honest_concurrent_drags_survive_undo_on_both_replicas() {
     );
 }
 
-/// A repin that no viewport can resolve would hide the chart on every replica
-/// while still saving a drawing Excel refuses. The open path must keep taking
-/// whatever real files hold, so this is refused where the update arrives.
+/// An anchor can be wrong on its own terms — a negative offset, one that is
+/// not a position at all, corners in the wrong order — and none of that
+/// depends on the grid it sits over. That is what a peer may not introduce.
+/// The open path must keep taking whatever real files carry, so this is
+/// refused where the update arrives rather than where the file is read.
 #[test]
-fn remote_updates_carrying_an_unresolvable_anchor_are_refused() {
+fn remote_updates_carrying_an_intrinsically_broken_anchor_are_refused() {
     let bytes = charted_fixture();
-    for (label, anchor) in [
+    for (label, reason, anchor) in [
         (
             "negative offset",
+            "offset is out of range",
             r#"{"kind":"twoCell","from":{"col":2,"colOff":-1,"row":4,"rowOff":0},"to":{"col":8,"colOff":0,"row":19,"rowOff":0},"edit_as":"oneCell"}"#,
         ),
         (
             "overflowing offset",
+            "offset is out of range",
             r#"{"kind":"twoCell","from":{"col":2,"colOff":9223372036854775807,"row":4,"rowOff":0},"to":{"col":8,"colOff":0,"row":19,"rowOff":0},"edit_as":"oneCell"}"#,
         ),
         (
             "inverted corners",
+            "inverted or coincident",
             r#"{"kind":"twoCell","from":{"col":20,"colOff":0,"row":4,"rowOff":0},"to":{"col":8,"colOff":0,"row":19,"rowOff":0},"edit_as":"oneCell"}"#,
         ),
     ] {
@@ -5356,10 +5361,76 @@ fn remote_updates_carrying_an_unresolvable_anchor_are_refused() {
             .apply_update_v1(&update, CalculationOptions::default())
             .expect_err(&format!("{label} must be refused"));
         assert!(
-            matches!(&error, Error::CollaborativeState(message) if message.contains("cannot be resolved")),
+            matches!(&error, Error::CollaborativeState(message) if message.contains(reason)),
             "{label}: {error:?}"
         );
         assert_eq!(target.model(), &before, "{label} must leave nothing behind");
+    }
+}
+
+/// Column widths and chart anchors are replicated independently, and both of
+/// these edits are ordinary. Collapsing the columns a chart spans leaves it
+/// with no room to draw, but that is a fact about one replica's grid, not
+/// about the anchor — so it cannot decide whether a peer's move is allowed.
+/// Judging it that way makes each replica reject what the other accepted.
+#[test]
+fn collapsing_columns_under_a_chart_does_not_block_a_peer_moving_it() {
+    let bytes = charted_fixture();
+    let collapse: Vec<Op> = (2..8)
+        .map(|col| Op::SetColWidth {
+            sheet: SheetId(0),
+            col,
+            width: Some(0.0),
+        })
+        .collect();
+
+    for forward_first in [true, false] {
+        let mut widener = Workbook::open_collaborative(&bytes, 870).unwrap();
+        let mut mover = Workbook::open_collaborative(&bytes, 871).unwrap();
+
+        widener
+            .apply_ops(collapse.clone(), CalculationOptions::default())
+            .expect("collapsing a column is an ordinary edit");
+        mover
+            .move_chart(
+                SheetId(0),
+                "xl/drawings/drawing1.xml#0",
+                24.0,
+                0.0,
+                CalculationOptions::default(),
+            )
+            .expect("moving a chart is an ordinary edit");
+
+        let to_mover = widener
+            .encode_diff_v1(&mover.encode_state_vector_v1())
+            .unwrap();
+        let to_widener = mover
+            .encode_diff_v1(&widener.encode_state_vector_v1())
+            .unwrap();
+        if forward_first {
+            mover
+                .apply_update_v1(&to_mover, CalculationOptions::default())
+                .expect("a collapsed column must not be refused by the replica that moved");
+            widener
+                .apply_update_v1(&to_widener, CalculationOptions::default())
+                .expect("a moved chart must not be refused by the replica that collapsed");
+        } else {
+            widener
+                .apply_update_v1(&to_widener, CalculationOptions::default())
+                .expect("a moved chart must not be refused by the replica that collapsed");
+            mover
+                .apply_update_v1(&to_mover, CalculationOptions::default())
+                .expect("a collapsed column must not be refused by the replica that moved");
+        }
+
+        assert_eq!(
+            widener.model(),
+            mover.model(),
+            "both edits are supported, so the replicas must converge"
+        );
+        assert_eq!(widener.model().sheets[0].col_widths.get(&2), Some(&0.0));
+        assert!(widener.save().is_ok(), "the union must be saveable");
+        assert!(mover.save().is_ok());
     }
 }
 

--- a/crates/betteroffice-xlsx/tests/workbook.rs
+++ b/crates/betteroffice-xlsx/tests/workbook.rs
@@ -3399,6 +3399,31 @@ fn charted_fixture() -> Vec<u8> {
     ooxml_opc::rezip_parts(&parts).unwrap()
 }
 
+/// The charted fixture with a second sheet pointing at the *same* drawing, so
+/// one anchor element is held by two sheets at once.
+fn shared_drawing_fixture() -> Vec<u8> {
+    let mut parts = ooxml_opc::unzip_parts(&charted_fixture()).unwrap();
+    let workbook = test_part_text(&parts, "xl/workbook.xml").replace(
+        "</sheets>",
+        r#"<sheet name="Mirror" sheetId="9" r:id="rIdMirror"/></sheets>"#,
+    );
+    set_test_part(&mut parts, "xl/workbook.xml", workbook.into_bytes());
+    let rels = test_part_text(&parts, "xl/_rels/workbook.xml.rels").replace(
+        "</Relationships>",
+        r#"<Relationship Id="rIdMirror" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/></Relationships>"#,
+    );
+    set_test_part(&mut parts, "xl/_rels/workbook.xml.rels", rels.into_bytes());
+    parts.push((
+        "xl/worksheets/sheet2.xml".to_owned(),
+        br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetData/><drawing r:id="rIdDrawing"/></worksheet>"#.to_vec(),
+    ));
+    parts.push((
+        "xl/worksheets/_rels/sheet2.xml.rels".to_owned(),
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#.to_vec(),
+    ));
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
 /// The charted fixture with a second sheet the chart plots, so removing that
 /// sheet strands a reference a chart on another sheet owns.
 fn cross_sheet_charted_fixture() -> Vec<u8> {
@@ -4920,24 +4945,93 @@ fn set_chart_anchor_refuses_what_a_save_cannot_write() {
     assert_eq!(reopened.model().sheets[0].charts[0].anchor, resized);
 }
 
-/// Chart state lives in the shared document as one blob per sheet, so repinning
-/// one is structural and a collaborative session refuses it outright — the same
-/// answer freeze panes and hyperlinks give. Moving a chart is a standalone-only
-/// edit, and nothing partial is left behind by the refusal.
+/// A chart anchor is replicated content, not workbook structure: the freeze
+/// pins which drawing anchors which part, and where that anchor sits travels
+/// through the document like any other edit.
 #[test]
-fn collaborative_sessions_refuse_a_chart_move() {
+fn collaborative_sessions_move_a_chart_and_converge() {
     let bytes = charted_fixture();
-    let mut workbook = Workbook::open_collaborative(&bytes, 303).unwrap();
-    let before = workbook.model().clone();
+    let mut left = Workbook::open_collaborative(&bytes, 303).unwrap();
+    let mut right = Workbook::open_collaborative(&bytes, 304).unwrap();
+    let before = left.model().sheets[0].charts[0].anchor;
 
-    let error = workbook
-        .move_chart(
+    assert!(
+        left.move_chart(
             SheetId(0),
             "xl/drawings/drawing1.xml#0",
             12.0,
             8.0,
             CalculationOptions::default(),
         )
+        .unwrap()
+        .applied
+    );
+    let moved = left.model().sheets[0].charts[0].anchor;
+    assert_ne!(moved, before);
+
+    let update = left
+        .encode_diff_v1(&right.encode_state_vector_v1())
+        .unwrap();
+    assert!(
+        right
+            .apply_update_v1(&update, CalculationOptions::default())
+            .unwrap()
+            .applied
+    );
+    assert_eq!(right.model().sheets[0].charts[0].anchor, moved);
+    assert_eq!(right.model(), left.model());
+
+    // the move survives a save, and a later peer edit still merges.
+    let reopened = Workbook::open(&left.save().unwrap()).unwrap();
+    assert_eq!(reopened.model().sheets[0].charts[0].anchor, moved);
+    right
+        .edit_cell(
+            SheetId(0),
+            cell("A1"),
+            "after",
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    let update = right
+        .encode_diff_v1(&left.encode_state_vector_v1())
+        .unwrap();
+    left.apply_update_v1(&update, CalculationOptions::default())
+        .unwrap();
+    assert_eq!(left.model().sheets[0].charts[0].anchor, moved);
+    assert_eq!(left.cell(SheetId(0), cell("A1")).unwrap().input, "after");
+
+    // the mover can take the drag back, and the peer follows it home.
+    assert!(left.can_undo());
+    assert!(left.undo(CalculationOptions::default()).unwrap().applied);
+    assert_eq!(left.model().sheets[0].charts[0].anchor, before);
+    let update = left
+        .encode_diff_v1(&right.encode_state_vector_v1())
+        .unwrap();
+    right
+        .apply_update_v1(&update, CalculationOptions::default())
+        .unwrap();
+    assert_eq!(right.model().sheets[0].charts[0].anchor, before);
+}
+
+/// Letting an anchor travel does not unfreeze the rest of a chart: an op that
+/// remaps what a chart reads is still structural, refused locally and refused
+/// again when a standalone peer offers it. This rides on the structure
+/// generation every structural op bumps; the identity fields themselves are
+/// pinned by `a_peer_cannot_disguise_a_chart_remap_as_a_move`, which leaves
+/// that counter alone.
+#[test]
+fn collaborative_sessions_still_refuse_a_chart_remap() {
+    let bytes = charted_fixture();
+    let mut workbook = Workbook::open_collaborative(&bytes, 305).unwrap();
+    let before = workbook.model().clone();
+    let insert_rows = Op::InsertRows {
+        sheet: SheetId(0),
+        at: 0,
+        count: 1,
+    };
+
+    let error = workbook
+        .apply_ops(vec![insert_rows.clone()], CalculationOptions::default())
         .unwrap_err();
     assert!(
         matches!(&error, Error::CollaborativeStructureOperation),
@@ -4945,20 +5039,635 @@ fn collaborative_sessions_refuse_a_chart_move() {
     );
     assert_eq!(workbook.model(), &before);
 
-    // the same move on a standalone session is accepted, so the refusal is the
-    // collaboration guard and not a broken op.
     let mut standalone = Workbook::open(&bytes).unwrap();
+    standalone
+        .apply_ops(vec![insert_rows], CalculationOptions::default())
+        .unwrap();
+    assert_ne!(
+        standalone.model().sheets[0].charts[0].refs,
+        before.sheets[0].charts[0].refs
+    );
+    let update = standalone
+        .encode_diff_v1(&workbook.encode_state_vector_v1())
+        .unwrap();
     assert!(
-        standalone
+        matches!(
+            workbook.apply_update_v1(&update, CalculationOptions::default()),
+            Err(Error::CollaborativeStructureChanged)
+        ),
+        "a chart remap must not slip past the freeze"
+    );
+    assert_eq!(workbook.model(), &before);
+}
+
+/// Two replicas dragging the same chart at once must land on one anchor, and
+/// on the same one whichever order the updates arrive in.
+#[test]
+fn concurrent_chart_moves_converge_in_either_delivery_order() {
+    let bytes = charted_fixture();
+    let settle = |first_wins: bool| {
+        let mut left = Workbook::open_collaborative(&bytes, 401).unwrap();
+        let mut right = Workbook::open_collaborative(&bytes, 402).unwrap();
+        left.move_chart(
+            SheetId(0),
+            "xl/drawings/drawing1.xml#0",
+            16.0,
+            0.0,
+            CalculationOptions::default(),
+        )
+        .unwrap();
+        right
             .move_chart(
                 SheetId(0),
                 "xl/drawings/drawing1.xml#0",
-                12.0,
-                8.0,
-                CalculationOptions::default()
+                0.0,
+                24.0,
+                CalculationOptions::default(),
+            )
+            .unwrap();
+        let to_right = left
+            .encode_diff_v1(&right.encode_state_vector_v1())
+            .unwrap();
+        let to_left = right
+            .encode_diff_v1(&left.encode_state_vector_v1())
+            .unwrap();
+        if first_wins {
+            right
+                .apply_update_v1(&to_right, CalculationOptions::default())
+                .unwrap();
+            left.apply_update_v1(&to_left, CalculationOptions::default())
+                .unwrap();
+        } else {
+            left.apply_update_v1(&to_left, CalculationOptions::default())
+                .unwrap();
+            right
+                .apply_update_v1(&to_right, CalculationOptions::default())
+                .unwrap();
+        }
+        let anchor = left.model().sheets[0].charts[0].anchor;
+        assert_eq!(
+            right.model().sheets[0].charts[0].anchor,
+            anchor,
+            "concurrent moves must converge"
+        );
+        anchor
+    };
+    assert_eq!(
+        settle(true),
+        settle(false),
+        "the winning anchor must not depend on delivery order"
+    );
+}
+
+/// One drawing anchor held by two sheets is one element in one part, so a drag
+/// repins every sheet holding it. Repinning only the dragged sheet would leave
+/// the two disagreeing and the save would refuse the drawing outright.
+#[test]
+fn a_drag_repins_every_sheet_sharing_the_drawing() {
+    let bytes = shared_drawing_fixture();
+    let mut workbook = Workbook::open_collaborative(&bytes, 403).unwrap();
+    assert_eq!(
+        workbook.model().sheets[1].charts[0].drawing,
+        workbook.model().sheets[0].charts[0].drawing,
+        "the fixture must share one drawing"
+    );
+    let before = workbook.model().sheets[0].charts[0].anchor;
+
+    assert!(
+        workbook
+            .move_chart(
+                SheetId(0),
+                "xl/drawings/drawing1.xml#0",
+                18.0,
+                9.0,
+                CalculationOptions::default(),
             )
             .unwrap()
             .applied
+    );
+    let moved = workbook.model().sheets[0].charts[0].anchor;
+    assert_ne!(moved, before);
+    assert_eq!(
+        workbook.model().sheets[1].charts[0].anchor,
+        moved,
+        "the sheet sharing the anchor must follow it"
+    );
+
+    let saved = workbook
+        .save()
+        .expect("a shared drawing both sheets agree on must save");
+    let reopened = Workbook::open(&saved).unwrap();
+    assert_eq!(reopened.model().sheets[0].charts[0].anchor, moved);
+    assert_eq!(reopened.model().sheets[1].charts[0].anchor, moved);
+
+    // one undo takes both sheets back together.
+    assert!(
+        workbook
+            .undo(CalculationOptions::default())
+            .unwrap()
+            .applied
+    );
+    assert_eq!(workbook.model().sheets[0].charts[0].anchor, before);
+    assert_eq!(workbook.model().sheets[1].charts[0].anchor, before);
+}
+
+/// The chart references `charted_fixture` parses, so a handcrafted peer update
+/// can leave the chart's identity alone and change only its anchor.
+const CHARTED_FIXTURE_REFS: &str = r#"[{"kind":"seriesName","formula":"Data!$B$1"},{"kind":"categories","formula":"Data!$A$2:$A$4"},{"kind":"values","formula":"Data!$B$2:$B$4"},{"kind":"dataLabels","formula":"Data!$C$2:$C$4"}]"#;
+
+/// A whole document, as a persisted snapshot would be, forked from `target`
+/// and carrying a handcrafted chart state on one sheet.
+fn peer_snapshot_with_charts(
+    target: &Workbook,
+    client_id: u64,
+    sheet_key: &str,
+    charts: &str,
+) -> Vec<u8> {
+    use yrs::updates::decoder::Decode;
+    use yrs::{Doc, Map, MapRef, ReadTxn, StateVector, Transact, Update};
+
+    let peer = Doc::with_client_id(client_id);
+    let update = Update::decode_v1(&target.encode_state_as_update_v1()).unwrap();
+    peer.transact_mut().apply_update(update).unwrap();
+    {
+        let mut txn = peer.transact_mut();
+        let sheets = txn.get_map("xlsx:sheets").unwrap();
+        let sheet = sheets
+            .get(&txn, sheet_key)
+            .and_then(|value| value.cast::<MapRef>().ok())
+            .unwrap();
+        sheet.try_update(&mut txn, "charts", charts);
+    }
+    peer.transact()
+        .encode_state_as_update_v1(&StateVector::default())
+}
+
+/// A drawing whose anchor runs backwards — `to` before `from`. Real files
+/// carry such things and open fine, but nothing can resolve them, so they are
+/// grandfathered rather than accepted as a new repin.
+fn unresolvable_anchor_fixture() -> Vec<u8> {
+    const INVERTED_DRAWING: &[u8] = br#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor editAs="oneCell"><xdr:from><xdr:col>8</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>19</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from><xdr:to><xdr:col>2</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>4</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to><xdr:graphicFrame><a:graphic><a:graphicData><c:chart r:id="rIdChart"/></a:graphicData></a:graphic></xdr:graphicFrame><xdr:clientData/></xdr:twoCellAnchor></xdr:wsDr>"#;
+
+    let mut parts = ooxml_opc::unzip_parts(&charted_fixture()).unwrap();
+    set_test_part(
+        &mut parts,
+        "xl/drawings/drawing1.xml",
+        INVERTED_DRAWING.to_vec(),
+    );
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// A drawing whose two anchors both point at one chart part, so a sheet holds
+/// that part twice and naming it alone cannot say which anchor is meant.
+fn two_anchor_fixture() -> Vec<u8> {
+    const TWO_ANCHOR_DRAWING: &[u8] = br#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor editAs="oneCell"><xdr:from><xdr:col>2</xdr:col><xdr:colOff>12700</xdr:colOff><xdr:row>4</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from><xdr:to><xdr:col>8</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>19</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to><xdr:graphicFrame><a:graphic><a:graphicData><c:chart r:id="rIdChart"/></a:graphicData></a:graphic></xdr:graphicFrame><xdr:clientData/></xdr:twoCellAnchor><xdr:twoCellAnchor editAs="oneCell"><xdr:from><xdr:col>10</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>4</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from><xdr:to><xdr:col>16</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>19</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to><xdr:graphicFrame><a:graphic><a:graphicData><c:chart r:id="rIdChart"/></a:graphicData></a:graphic></xdr:graphicFrame><xdr:clientData/></xdr:twoCellAnchor></xdr:wsDr>"#;
+
+    let mut parts = ooxml_opc::unzip_parts(&charted_fixture()).unwrap();
+    set_test_part(
+        &mut parts,
+        "xl/drawings/drawing1.xml",
+        TWO_ANCHOR_DRAWING.to_vec(),
+    );
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// A peer's update assigning one sheet's chart state, built by forking the
+/// target's own document. Mirrors the shared-document key names.
+fn peer_sheet_charts_update(
+    target: &Workbook,
+    client_id: u64,
+    sheet_key: &str,
+    charts: &str,
+) -> Vec<u8> {
+    use yrs::updates::decoder::Decode;
+    use yrs::{Doc, Map, MapRef, ReadTxn, Transact, Update};
+
+    let peer = Doc::with_client_id(client_id);
+    let update = Update::decode_v1(&target.encode_state_as_update_v1()).unwrap();
+    peer.transact_mut().apply_update(update).unwrap();
+    let before = peer.transact().state_vector();
+    {
+        let mut txn = peer.transact_mut();
+        let sheets = txn.get_map("xlsx:sheets").unwrap();
+        let sheet = sheets
+            .get(&txn, sheet_key)
+            .and_then(|value| value.cast::<MapRef>().ok())
+            .unwrap();
+        sheet.try_update(&mut txn, "charts", charts);
+    }
+    peer.transact().encode_diff_v1(&before)
+}
+
+/// Two people dragging the same chart is ordinary use, not an attack. Once the
+/// two moves merge, the assignment that lost is a tombstone, and undoing the
+/// one that won must not take the whole sheet's chart state with it: the loser
+/// keeps a readable workbook, the winner gets its drag back, and neither is
+/// left holding history it can no longer apply.
+#[test]
+fn honest_concurrent_drags_survive_undo_on_both_replicas() {
+    let bytes = charted_fixture();
+    let mut left = Workbook::open_collaborative(&bytes, 800).unwrap();
+    let mut right = Workbook::open_collaborative(&bytes, 801).unwrap();
+    let before = left.model().sheets[0].charts[0].anchor;
+
+    left.move_chart(
+        SheetId(0),
+        "xl/drawings/drawing1.xml#0",
+        16.0,
+        0.0,
+        CalculationOptions::default(),
+    )
+    .unwrap();
+    right
+        .move_chart(
+            SheetId(0),
+            "xl/drawings/drawing1.xml#0",
+            0.0,
+            24.0,
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    let to_right = left
+        .encode_diff_v1(&right.encode_state_vector_v1())
+        .unwrap();
+    let to_left = right
+        .encode_diff_v1(&left.encode_state_vector_v1())
+        .unwrap();
+    right
+        .apply_update_v1(&to_right, CalculationOptions::default())
+        .unwrap();
+    left.apply_update_v1(&to_left, CalculationOptions::default())
+        .unwrap();
+    let converged = left.model().sheets[0].charts[0].anchor;
+    assert_eq!(right.model().sheets[0].charts[0].anchor, converged);
+
+    // whichever replica owns the surviving assignment can take it back, and
+    // neither replica may fail the step or lose the workbook doing it.
+    for (label, workbook) in [("left", &mut left), ("right", &mut right)] {
+        let undone = workbook
+            .undo(CalculationOptions::default())
+            .unwrap_or_else(|error| {
+                panic!("{label} could not undo after a concurrent drag: {error}")
+            });
+        assert!(
+            workbook.save().is_ok(),
+            "{label} must still hold a saveable workbook"
+        );
+        assert!(
+            !workbook.model().sheets[0].charts.is_empty(),
+            "{label} must not lose its chart"
+        );
+        let _ = undone;
+    }
+    assert_eq!(
+        right.model().sheets[0].charts[0].anchor,
+        before,
+        "the replica whose drag survived the merge must get it back"
+    );
+}
+
+/// A repin that no viewport can resolve would hide the chart on every replica
+/// while still saving a drawing Excel refuses. The open path must keep taking
+/// whatever real files hold, so this is refused where the update arrives.
+#[test]
+fn remote_updates_carrying_an_unresolvable_anchor_are_refused() {
+    let bytes = charted_fixture();
+    for (label, anchor) in [
+        (
+            "negative offset",
+            r#"{"kind":"twoCell","from":{"col":2,"colOff":-1,"row":4,"rowOff":0},"to":{"col":8,"colOff":0,"row":19,"rowOff":0},"edit_as":"oneCell"}"#,
+        ),
+        (
+            "overflowing offset",
+            r#"{"kind":"twoCell","from":{"col":2,"colOff":9223372036854775807,"row":4,"rowOff":0},"to":{"col":8,"colOff":0,"row":19,"rowOff":0},"edit_as":"oneCell"}"#,
+        ),
+        (
+            "inverted corners",
+            r#"{"kind":"twoCell","from":{"col":20,"colOff":0,"row":4,"rowOff":0},"to":{"col":8,"colOff":0,"row":19,"rowOff":0},"edit_as":"oneCell"}"#,
+        ),
+    ] {
+        let mut target = Workbook::open_collaborative(&bytes, 820).unwrap();
+        let before = target.model().clone();
+        let charts = format!(
+            r#"[{{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{anchor},"refs":{CHARTED_FIXTURE_REFS}}}]"#
+        );
+        let update = peer_sheet_charts_update(&target, 821, "sheet:0", &charts);
+        let error = target
+            .apply_update_v1(&update, CalculationOptions::default())
+            .expect_err(&format!("{label} must be refused"));
+        assert!(
+            matches!(&error, Error::CollaborativeState(message) if message.contains("cannot be resolved")),
+            "{label}: {error:?}"
+        );
+        assert_eq!(target.model(), &before, "{label} must leave nothing behind");
+    }
+}
+
+/// Sheets sharing one drawing anchor must agree on it in the model itself, not
+/// only in whatever path happened to build it. A raw op batch is a shipped API
+/// and a remote update arrives unvetted, so both have to be refused.
+#[test]
+fn sheets_sharing_a_drawing_anchor_may_not_disagree() {
+    let bytes = shared_drawing_fixture();
+    let before = Workbook::open(&bytes).unwrap().model().sheets[0].charts[0].anchor;
+    let moved = {
+        let mut source = Workbook::open(&bytes).unwrap();
+        source
+            .move_chart(
+                SheetId(0),
+                "xl/drawings/drawing1.xml#0",
+                18.0,
+                9.0,
+                CalculationOptions::default(),
+            )
+            .unwrap();
+        source.model().sheets[0].charts[0].anchor
+    };
+
+    // a raw op batch that repins only one of the two sheets
+    let mut workbook = Workbook::open(&bytes).unwrap();
+    let error = workbook
+        .apply_ops(
+            vec![Op::SetChartAnchor {
+                sheet: SheetId(0),
+                frame: "xl/drawings/drawing1.xml#0".to_owned(),
+                part: "xl/charts/chart1.xml".to_owned(),
+                from: before,
+                to: moved,
+            }],
+            CalculationOptions::default(),
+        )
+        .expect_err("a half-repinned shared drawing must be refused");
+    assert!(
+        matches!(&error, Error::InvalidOperation(message) if message.contains("disagree")),
+        "{error:?}"
+    );
+
+    // and the same disagreement arriving as a remote update
+    let mut target = Workbook::open_collaborative(&bytes, 830).unwrap();
+    let before = target.model().clone();
+    let charts = format!(
+        r#"[{{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{},"refs":{}}}]"#,
+        serde_json::to_string(&moved).unwrap(),
+        CHARTED_FIXTURE_REFS
+    );
+    let update = peer_sheet_charts_update(&target, 831, "sheet:0", &charts);
+    let error = target
+        .apply_update_v1(&update, CalculationOptions::default())
+        .expect_err("a remote half-repin must be refused");
+    assert!(
+        matches!(&error, Error::CollaborativeState(message) if message.contains("disagree")),
+        "{error:?}"
+    );
+    assert_eq!(target.model(), &before);
+}
+
+/// A snapshot is foreign bytes like any update, so it answers to the same
+/// checks. A pristine replica adopts a whole document instead of merging it,
+/// and if that door skipped the anchor check the two replicas would take
+/// opposite decisions on identical bytes and drift apart for good.
+#[test]
+fn an_adopted_snapshot_answers_to_the_same_anchor_check_as_an_update() {
+    let bytes = charted_fixture();
+    let hostile = {
+        let donor = Workbook::open_collaborative(&bytes, 840).unwrap();
+        let charts = format!(
+            r#"[{{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{{"kind":"twoCell","from":{{"col":20,"colOff":0,"row":4,"rowOff":0}},"to":{{"col":8,"colOff":0,"row":19,"rowOff":0}},"edit_as":"oneCell"}},"refs":{}}}]"#,
+            CHARTED_FIXTURE_REFS
+        );
+        peer_snapshot_with_charts(&donor, 841, "sheet:0", &charts)
+    };
+
+    let mut pristine = Workbook::open_collaborative(&bytes, 842).unwrap();
+    let pristine_result = pristine.apply_update_v1(&hostile, CalculationOptions::default());
+
+    let mut touched = Workbook::open_collaborative(&bytes, 842).unwrap();
+    touched
+        .edit_cell(
+            SheetId(0),
+            cell("A1"),
+            "typed",
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    let touched_result = touched.apply_update_v1(&hostile, CalculationOptions::default());
+
+    assert!(
+        pristine_result.is_err(),
+        "a pristine replica must not adopt a snapshot it would reject as an update"
+    );
+    assert_eq!(
+        pristine_result.is_err(),
+        touched_result.is_err(),
+        "the same bytes must get the same answer whether or not the replica is pristine"
+    );
+}
+
+/// An undo assembles a model out of parts that each passed on their own way
+/// in. It can still land a pair no single edit produced: one sheet repinned,
+/// the sheet sharing its drawing anchor left behind. That is a workbook no
+/// replica can save, so the step is refused rather than installed.
+#[test]
+fn collaborative_undo_may_not_install_a_split_shared_drawing() {
+    let bytes = shared_drawing_fixture();
+    let mut local = Workbook::open_collaborative(&bytes, 850).unwrap();
+    let before = local.model().sheets[0].charts[0].anchor;
+
+    local
+        .move_chart(
+            SheetId(0),
+            "xl/drawings/drawing1.xml#0",
+            18.0,
+            9.0,
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    let moved = local.model().sheets[0].charts[0].anchor;
+    assert_eq!(local.model().sheets[1].charts[0].anchor, moved);
+
+    // a peer causally overwrites only the second sheet with the same anchor it
+    // already holds, tombstoning the local insertion there but not on the first
+    // same model, different bytes, so the write lands and tombstones the
+    // local insertion on this sheet only
+    let charts = format!(
+        r#"[ {{"part":"xl/charts/chart1.xml","drawing":"xl/drawings/drawing1.xml","anchorIndex":0,"anchor":{},"refs":{}}} ]"#,
+        serde_json::to_string(&moved).unwrap(),
+        CHARTED_FIXTURE_REFS
+    );
+    let update = peer_sheet_charts_update(&local, 851, "sheet:1", &charts);
+    assert!(
+        local
+            .apply_update_v1(&update, CalculationOptions::default())
+            .unwrap()
+            .applied
+            || local.model().sheets[1].charts[0].anchor == moved,
+        "the peer write must land, or the split never forms"
+    );
+    assert_eq!(local.model().sheets[0].charts[0].anchor, moved);
+    assert_eq!(local.model().sheets[1].charts[0].anchor, moved);
+
+    // undoing the move reverts only the sheet whose insertion survived, which
+    // is a workbook no replica could save, so the step is refused whole.
+    let vector_before = local.encode_state_vector_v1();
+    let history_before = local.history_state();
+    let error = local
+        .undo(CalculationOptions::default())
+        .expect_err("an undo may not install two sheets disagreeing on one anchor");
+    assert!(
+        matches!(&error, Error::InvalidOperation(message) if message.contains("disagree")),
+        "{error:?}"
+    );
+    assert_eq!(local.model().sheets[0].charts[0].anchor, moved);
+    assert_eq!(local.model().sheets[1].charts[0].anchor, moved);
+    assert!(
+        local.save().is_ok(),
+        "a refused undo must leave a saveable workbook"
+    );
+
+    // the projection is only half of it. What the replica publishes has to be
+    // unchanged too, or peers pick up an undo this workbook refused — so ask a
+    // peer what the shared document now says.
+    assert_eq!(
+        local.encode_state_vector_v1(),
+        vector_before,
+        "a refused undo must not advance the shared document"
+    );
+    assert_eq!(
+        local.history_state(),
+        history_before,
+        "a refused undo must not spend a history entry"
+    );
+    let mut peer = Workbook::open_collaborative(&bytes, 852).unwrap();
+    let catch_up = local
+        .encode_diff_v1(&peer.encode_state_vector_v1())
+        .unwrap();
+    peer.apply_update_v1(&catch_up, CalculationOptions::default())
+        .expect("a peer must be able to take what this replica publishes");
+    assert_eq!(
+        peer.model().sheets[0].charts[0].anchor,
+        moved,
+        "the authority must not be publishing the refused undo"
+    );
+    assert_eq!(peer.model().sheets[1].charts[0].anchor, moved);
+
+    assert_ne!(moved, before);
+}
+
+/// Whether an anchor is exempt from the resolvability check must be a question
+/// every replica answers the same way. Judging it against the replica's own
+/// current projection makes the answer depend on local editing history: a
+/// grandfathered source anchor reads as "unchanged" on a replica that still
+/// holds it and as "newly introduced" on one that has moved on, so an undo
+/// restoring it is accepted by one peer and refused by the other, and they
+/// never converge again.
+#[test]
+fn an_undo_restoring_a_grandfathered_anchor_is_not_judged_by_local_history() {
+    let bytes = unresolvable_anchor_fixture();
+    let mut local = Workbook::open_collaborative(&bytes, 860).unwrap();
+    let mut peer = Workbook::open_collaborative(&bytes, 861).unwrap();
+    let opened = local.model().sheets[0].charts[0].anchor;
+
+    // a repin away from it is ordinary and accepted
+    let ChartAnchor::TwoCell { from, to, edit_as } = opened else {
+        panic!("two-cell anchor");
+    };
+    let ordinary = ChartAnchor::TwoCell {
+        from: to,
+        to: from,
+        edit_as,
+    };
+    local
+        .apply_ops(
+            vec![Op::SetChartAnchor {
+                sheet: SheetId(0),
+                frame: "xl/drawings/drawing1.xml#0".to_owned(),
+                part: "xl/charts/chart1.xml".to_owned(),
+                from: opened,
+                to: ordinary,
+            }],
+            CalculationOptions::default(),
+        )
+        .unwrap();
+    let moved = local.model().sheets[0].charts[0].anchor;
+    assert_ne!(moved, opened);
+    let update = local
+        .encode_diff_v1(&peer.encode_state_vector_v1())
+        .unwrap();
+    peer.apply_update_v1(&update, CalculationOptions::default())
+        .unwrap();
+    assert_eq!(peer.model().sheets[0].charts[0].anchor, moved);
+
+    // undo puts the grandfathered anchor back and tells the peer
+    assert!(local.undo(CalculationOptions::default()).unwrap().applied);
+    assert_eq!(local.model().sheets[0].charts[0].anchor, opened);
+    let undo_update = local
+        .encode_diff_v1(&peer.encode_state_vector_v1())
+        .unwrap();
+    peer.apply_update_v1(&undo_update, CalculationOptions::default())
+        .expect("a peer must accept an undo restoring the anchor it opened with");
+    assert_eq!(
+        peer.model().sheets[0].charts[0].anchor,
+        local.model().sheets[0].charts[0].anchor,
+        "the replicas must not part ways over a grandfathered anchor"
+    );
+}
+
+/// One chart part may back two anchors in a drawing, so naming the part alone
+/// cannot say which to repin. The op carries a frame and the anchor it saw
+/// there, so the sibling sharing that part is left where it is, and a repin
+/// whose recorded anchor has moved on is refused rather than applied blind.
+#[test]
+fn a_repin_moves_only_the_frame_it_names_when_a_part_backs_two() {
+    let bytes = two_anchor_fixture();
+    let mut workbook = Workbook::open(&bytes).unwrap();
+    let charts = &workbook.model().sheets[0].charts;
+    assert_eq!(charts.len(), 2);
+    assert_eq!(
+        charts[0].part, charts[1].part,
+        "the fixture must share a part"
+    );
+    let (first, second) = (charts[0].anchor, charts[1].anchor);
+    let ChartAnchor::TwoCell { from, to, edit_as } = first else {
+        panic!("two-cell anchor");
+    };
+    let moved = ChartAnchor::TwoCell {
+        from: AnchorCell {
+            col: from.col + 1,
+            ..from
+        },
+        to: AnchorCell {
+            col: to.col + 1,
+            ..to
+        },
+        edit_as,
+    };
+    let repin = |anchor_index: usize, from: ChartAnchor, to: ChartAnchor| Op::SetChartAnchor {
+        sheet: SheetId(0),
+        frame: format!("xl/drawings/drawing1.xml#{anchor_index}"),
+        part: "xl/charts/chart1.xml".to_owned(),
+        from,
+        to,
+    };
+
+    assert!(
+        workbook
+            .apply_ops(vec![repin(0, first, moved)], CalculationOptions::default())
+            .unwrap()
+            .applied
+    );
+    assert_eq!(workbook.model().sheets[0].charts[0].anchor, moved);
+    assert_eq!(
+        workbook.model().sheets[0].charts[1].anchor,
+        second,
+        "the frame sharing the part must stay where it was"
+    );
+
+    let error = workbook
+        .apply_ops(vec![repin(0, first, moved)], CalculationOptions::default())
+        .expect_err("a repin whose recorded anchor has moved on must be refused");
+    assert!(
+        matches!(&error, Error::ChartFrameShifted { frame } if frame.ends_with("#0")),
+        "{error:?}"
     );
 }
 

--- a/packages/xlsx/src/wasm/collaboration.test.ts
+++ b/packages/xlsx/src/wasm/collaboration.test.ts
@@ -8,14 +8,23 @@ import { initWasm, openWorkbook } from './loader';
 import type { WorkbookHandle, WorkbookUpdateOrigin } from './loader';
 
 const FIXTURE = resolve(import.meta.dir, '../../test-fixtures/sample.xlsx');
+const CHART_FIXTURE = resolve(import.meta.dir, '../../test-fixtures/charts.xlsx');
 const WASM = resolve(import.meta.dir, './generated/xlsx_wasm_bg.wasm');
 
 function sampleBytes(): Uint8Array {
   return new Uint8Array(readFileSync(FIXTURE));
 }
 
+function chartBytes(): Uint8Array {
+  return new Uint8Array(readFileSync(CHART_FIXTURE));
+}
+
 function collaborative(clientId: number): WorkbookHandle {
   return openWorkbook(sampleBytes(), { collaborative: true, clientId });
+}
+
+function collaborativeCharts(clientId: number): WorkbookHandle {
+  return openWorkbook(chartBytes(), { collaborative: true, clientId });
 }
 
 function requireReplica(replica: CollaborationReplica): CollaborationReplica {
@@ -318,6 +327,27 @@ describe('wasm collaboration', () => {
     } finally {
       target.dispose();
       structuralSource.dispose();
+    }
+  });
+
+  it('drags a chart in a collaborative session and converges the peer', () => {
+    const source = collaborativeCharts(6101);
+    const target = collaborativeCharts(6102);
+    const viewport = { x: 0, y: 0, width: 800, height: 800 };
+    try {
+      const before = (source.displayList(viewport).charts ?? [])[0];
+      expect(source.moveChart(0, before.id, 24, 12).applied).toBe(true);
+
+      const moved = (source.displayList(viewport).charts ?? [])[0];
+      expect(moved.rect.x).toBeCloseTo(before.rect.x + 24, 1);
+      expect(moved.rect.y).toBeCloseTo(before.rect.y + 12, 1);
+
+      const update = source.encodeStateAsUpdate(target.encodeStateVector());
+      expect(target.applyUpdate(update).applied).toBe(true);
+      expect((target.displayList(viewport).charts ?? [])[0].rect).toEqual(moved.rect);
+    } finally {
+      source.dispose();
+      target.dispose();
     }
   });
 


### PR DESCRIPTION
TL;DR:


Repro file:
`crates/betteroffice-xlsx/tests/workbook.rs` — `collaborative_sessions_move_a_chart_and_converge` fails on `main` with `CollaborativeStructureOperation`, the same error the demo shows when you drag a chart.

Summary:
- Let a collaborative session move a chart. `Op::SetChartAnchor` was classed structural, so dragging a chart in the demo failed outright with "structural operations are unavailable in collaborative mode".
- Freeze chart *identity* — part, drawing, anchor index, refs and anchor shape — rather than the whole `SheetChart`. Where the anchor sits is replicated content, so a peer may repin a chart without changing the structure the freeze describes.
- Decide a chart-anchor merge on the anchor alone. A merge gate may only test a property that survives a merge, so intrinsic anchor properties are checked on arrival while anything derived from grid geometry moved to the point of use, where the renderer already drops a chart it cannot place.
- Settle a shared drawing rather than refusing it: every sheet pointing at one frame takes the anchor of the first sheet in order, computed identically on every replica, instead of rejecting updates that disagree.
- Hold a local repin to what a peer will take, so a replica can never emit an anchor its peers refuse.
- Make `charts` an optional sheet key. Its absence was a hard materialization error, so a concurrent write plus an undo could delete it and leave a replica unreadable.
- Roll the authority back when an undo or redo fails to install, so a rejected step cannot advance the shared document.
- Row and column operations, sheet topology and defined names stay banned — defined names live outside the CRDT, so a collaborative replica would silently keep stale references.

Test plan:
- [ ] Drag a chart in the collaborative demo with two browsers open and confirm both converge
- [ ] Drag a chart that two sheets share and confirm both sheets follow, then save and reopen
- [ ] Collapse the columns under a chart in one session while another drags it, and confirm neither is stranded
