### PR TITLE
fix(docx): open a local file into its own session

### DIFF
--- a/apps/demo/app/collab/CollaborationControls.tsx
+++ b/apps/demo/app/collab/CollaborationControls.tsx
@@ -9,6 +9,8 @@ interface CollaborationControlsProps {
   synced: boolean;
   peerCount: number | null;
   error: string | null;
+  /** False for a locally opened document, which no link can reach. */
+  shared?: boolean;
 }
 
 export function CollaborationControls({
@@ -16,6 +18,7 @@ export function CollaborationControls({
   synced,
   peerCount,
   error,
+  shared = true,
 }: CollaborationControlsProps) {
   const [copied, setCopied] = useState(false);
 
@@ -25,17 +28,19 @@ export function CollaborationControls({
     return () => clearTimeout(timer);
   }, [copied]);
 
-  const label = [
-    error ? "error" : status,
-    synced ? "synced" : null,
-    peerCount === null
-      ? null
-      : `${peerCount} ${peerCount === 1 ? "peer" : "peers"}`,
-  ]
-    .filter(Boolean)
-    .join(" · ");
+  const label = shared
+    ? [
+        error ? "error" : status,
+        synced ? "synced" : null,
+        peerCount === null
+          ? null
+          : `${peerCount} ${peerCount === 1 ? "peer" : "peers"}`,
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : "not shared";
 
-  const indicator = error ? "error" : status;
+  const indicator = shared ? (error ? "error" : status) : "disconnected";
 
   return (
     <div className="inline-flex flex-none items-center gap-2 font-mono text-[11px] leading-none">
@@ -58,17 +63,19 @@ export function CollaborationControls({
         />
         {label}
       </span>
-      <button
-        className="min-h-7 cursor-pointer rounded-[5px] border border-hairline-strong bg-white px-[9px] whitespace-nowrap text-fg hover:bg-surface max-[760px]:hidden"
-        type="button"
-        onClick={() => {
-          void navigator.clipboard
-            .writeText(window.location.href)
-            .then(() => setCopied(true));
-        }}
-      >
-        {copied ? "Copied" : "Copy collaboration link"}
-      </button>
+      {shared && (
+        <button
+          className="min-h-7 cursor-pointer rounded-[5px] border border-hairline-strong bg-white px-[9px] whitespace-nowrap text-fg hover:bg-surface max-[760px]:hidden"
+          type="button"
+          onClick={() => {
+            void navigator.clipboard
+              .writeText(window.location.href)
+              .then(() => setCopied(true));
+          }}
+        >
+          {copied ? "Copied" : "Copy collaboration link"}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/demo/app/collab/index.ts
+++ b/apps/demo/app/collab/index.ts
@@ -5,6 +5,7 @@ export {
   useCollabRoom,
   useDemoIdentity,
   useDemoRoom,
+  useLeaveRoom,
 } from "./useCollabRoom";
 export type { DemoCollaborationUser } from "./useCollabRoom";
 export type {

--- a/apps/demo/app/collab/useCollabRoom.ts
+++ b/apps/demo/app/collab/useCollabRoom.ts
@@ -76,7 +76,8 @@ export function useDemoIdentity(): DemoCollaborationUser | null {
   return user;
 }
 
-export function useDemoRoom(): string | null {
+/** `enabled` false while the tab holds an unshared document: no room, none minted. */
+export function useDemoRoom(enabled = true): string | null {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -84,14 +85,28 @@ export function useDemoRoom(): string | null {
   const generatedRoom = useRef<string | null>(null);
 
   useEffect(() => {
-    if (room) return;
+    if (!enabled || room) return;
     generatedRoom.current ??= crypto.randomUUID();
     const next = new URLSearchParams(searchParams.toString());
     next.set("room", generatedRoom.current);
     router.replace(`${pathname}?${next.toString()}`, { scroll: false });
-  }, [pathname, room, router, searchParams]);
+  }, [enabled, pathname, room, router, searchParams]);
 
-  return room;
+  return enabled ? room : null;
+}
+
+/** Drops the room from the URL, so the link stops advertising a document it no longer shows. */
+export function useLeaveRoom(): () => void {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  return useCallback(() => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("room");
+    const query = next.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
 }
 
 export interface CollabRoomState<
@@ -122,7 +137,9 @@ export function useCollabRoom<Provider extends CollaborationProvider>(
   const transportRef = useRef<RoomTransport | null>(null);
   const cleanupRef = useRef<Array<() => void>>([]);
 
-  useEffect(() => setClientId(createClientId()), []);
+  // Per room: a client id only identifies a replica within one room, and
+  // carrying one across rooms collides with item ids the new peers already hold.
+  useEffect(() => setClientId(roomId ? createClientId() : null), [roomId]);
 
   const teardown = useCallback(() => {
     for (const cleanup of cleanupRef.current.splice(0)) cleanup();

--- a/apps/demo/app/docx/DocxDemoClient.tsx
+++ b/apps/demo/app/docx/DocxDemoClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import type { BundledFontProvider } from "@betteroffice/docx-react";
@@ -18,9 +18,11 @@ import {
   useCollabRoom,
   useDemoIdentity,
   useDemoRoom,
+  useLeaveRoom,
   type CollaborationReplica,
   type CollaborationTransport,
 } from "../collab";
+import { planDemoSession } from "../../lib/demoSession";
 
 // The editor is browser-only (canvas + wasm + worker); keep it out of SSR.
 const DocxEditor = dynamic(
@@ -30,10 +32,19 @@ const DocxEditor = dynamic(
 
 const SHOWCASE = { url: "/betteroffice-demo.docx", name: "betteroffice-demo.docx" };
 
+/** `id` keys the editor, so each loaded document gets its own session. */
+interface DemoSource {
+  id: number;
+  buffer: ArrayBuffer;
+  name: string;
+  seed: Uint8Array | null;
+}
+
 export function DocxDemoClient() {
-  const [buffer, setBuffer] = useState<ArrayBuffer | null>(null);
-  const [seed, setSeed] = useState<Uint8Array | null>(null);
-  const room = useDemoRoom();
+  const [source, setSource] = useState<DemoSource | null>(null);
+  const openSequence = useRef(0);
+  const room = useDemoRoom(source ? source.seed !== null : true);
+  const leaveRoom = useLeaveRoom();
   const user = useDemoIdentity();
   const createProvider = useCallback(
     (replica: CollaborationReplica, transport: CollaborationTransport) =>
@@ -85,9 +96,13 @@ export function DocxDemoClient() {
         ]);
       })
       .then(([documentBytes, seedBytes]) => {
-        if (cancelled) return;
-        setBuffer(documentBytes);
-        setSeed(new Uint8Array(seedBytes));
+        if (cancelled || openSequence.current !== 0) return;
+        setSource({
+          id: 0,
+          buffer: documentBytes,
+          name: SHOWCASE.name,
+          seed: new Uint8Array(seedBytes),
+        });
       })
       .catch((e: unknown) => {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
@@ -97,18 +112,48 @@ export function DocxDemoClient() {
     };
   }, []);
 
+  const session = useMemo(
+    () =>
+      planDemoSession({
+        document: source,
+        room,
+        clientId: collab.clientId,
+        identified: user !== null,
+      }),
+    [collab.clientId, room, source, user],
+  );
+
   const collaboration = useMemo(
     () =>
-      room && seed && collab.clientId && user
+      session.status === "shared" && source?.seed && user
         ? {
-            clientId: collab.clientId,
-            initialUpdate: seed,
+            clientId: session.clientId,
+            initialUpdate: source.seed,
             user,
             onReplica: collab.onReplica,
             presence: collab.provider ?? undefined,
           }
         : undefined,
-    [collab.clientId, collab.onReplica, collab.provider, room, seed, user],
+    [collab.onReplica, collab.provider, session, source, user],
+  );
+
+  // Ordered by selection, not by completion: a slower earlier pick must not
+  // land on top of a later one.
+  const handleOpen = useCallback(
+    async (file: File) => {
+      const sequence = (openSequence.current += 1);
+      try {
+        const buffer = await file.arrayBuffer();
+        if (sequence !== openSequence.current) return;
+        leaveRoom();
+        setError(null);
+        setSource({ id: sequence, buffer, name: file.name, seed: null });
+      } catch (cause) {
+        if (sequence !== openSequence.current) return;
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    },
+    [leaveRoom],
   );
 
   return (
@@ -129,9 +174,9 @@ export function DocxDemoClient() {
 
         <div className="flex-1" />
 
-        {buffer && (
+        {source && (
           <span className="max-w-[180px] overflow-hidden text-[12.5px] text-ellipsis whitespace-nowrap text-mute">
-            {SHOWCASE.name}
+            {source.name}
           </span>
         )}
 
@@ -141,6 +186,7 @@ export function DocxDemoClient() {
             synced={collab.synced}
             peerCount={collab.peerCount}
             error={collab.error}
+            shared={session.status === "shared"}
           />
           <a
             className="inline-flex size-8 items-center justify-center rounded-[5px] text-mute transition-colors duration-[140ms] ease-[ease] hover:bg-surface hover:text-fg"
@@ -170,11 +216,15 @@ export function DocxDemoClient() {
           <p className="m-auto text-mute" role="alert">
             Failed to load the demo document: {error}
           </p>
-        ) : buffer ? (
+        ) : source && session.status !== "loading" ? (
           <DocxEditor
-            documentBuffer={buffer}
+            key={source.id}
+            documentBuffer={source.buffer}
             collaboration={collaboration}
             measurementFontProvider={measurementFontProvider}
+            documentName={source.name}
+            onOpen={handleOpen}
+            onError={(cause) => setError(cause.message)}
             showToolbar
             showRuler
             showZoomControl

--- a/apps/demo/lib/demoSession.test.ts
+++ b/apps/demo/lib/demoSession.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { planDemoSession, type DemoSessionInputs } from './demoSession';
+
+const ROOM = 'room-1';
+const seeded = { seed: Uint8Array.of(1, 2) };
+const local = { seed: null };
+
+describe('planDemoSession', () => {
+  test('withholds the editor until a document is loaded', () => {
+    expect(
+      planDemoSession({ document: null, room: ROOM, clientId: 7, identified: true })
+    ).toEqual({ status: 'loading' });
+  });
+
+  test('mounts a seeded document with its room', () => {
+    expect(
+      planDemoSession({ document: seeded, room: ROOM, clientId: 7, identified: true })
+    ).toEqual({ status: 'shared', room: ROOM, clientId: 7 });
+  });
+
+  const incomplete: Array<[string, Omit<DemoSessionInputs, 'document'>]> = [
+    ['no room', { room: null, clientId: 7, identified: true }],
+    ['no client id', { room: ROOM, clientId: null, identified: true }],
+    ['no identity', { room: ROOM, clientId: 7, identified: false }],
+  ];
+
+  for (const [missing, rest] of incomplete) {
+    test(`holds a seeded document back with ${missing} rather than mounting it unshared`, () => {
+      expect(planDemoSession({ document: seeded, ...rest })).toEqual({ status: 'loading' });
+    });
+  }
+
+  test('a locally opened file is never shared', () => {
+    expect(
+      planDemoSession({ document: local, room: ROOM, clientId: 7, identified: true })
+    ).toEqual({ status: 'local' });
+  });
+
+  test('a locally opened file stays local while a room lingers in the URL', () => {
+    expect(
+      planDemoSession({ document: local, room: 'stale-room', clientId: 9, identified: true })
+    ).toEqual({ status: 'local' });
+  });
+});

--- a/apps/demo/lib/demoSession.ts
+++ b/apps/demo/lib/demoSession.ts
@@ -1,0 +1,38 @@
+/**
+ * The loaded document. `seed` is the room state it hydrates from; a locally
+ * opened file has none. The relay never retains a first peer's document, so
+ * such a file cannot be rejoined or reloaded and is therefore not shared.
+ */
+export interface DemoDocument {
+  seed: Uint8Array | null;
+}
+
+export interface DemoSessionInputs {
+  document: DemoDocument | null;
+  room: string | null;
+  clientId: number | null;
+  identified: boolean;
+}
+
+/** `loading` withholds the editor entirely; only `shared` may collaborate. */
+export type DemoSession =
+  | { status: 'loading' }
+  | { status: 'local' }
+  | { status: 'shared'; room: string; clientId: number };
+
+/**
+ * The one gate deciding how the editor mounts. A seeded document waits for its
+ * whole room rather than mounting unshared, which would seed the room's
+ * document into an independent replica.
+ */
+export function planDemoSession({
+  document,
+  room,
+  clientId,
+  identified,
+}: DemoSessionInputs): DemoSession {
+  if (!document) return { status: 'loading' };
+  if (document.seed === null) return { status: 'local' };
+  if (!room || clientId === null || !identified) return { status: 'loading' };
+  return { status: 'shared', room, clientId };
+}

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "types": ["bun", "node"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Closes #187.

Summary:
- File → Open in the demo did not load the chosen document. Across 300 real-world documents, **181 (60%) hard-failed** — stuck on "Loading document…" with `Resident font preflight error: story "hf:rIdN" was not found` — and the other **40% silently rendered the built-in showcase instead of the opened file**, with no error at all. After the fix: **0 of 300 broken**.
- Root cause: `session.openDocx(bytes, !initialUpdate)` passes `seedStories = false` whenever a collaboration `initialUpdate` exists, and in the demo that prop is constant. So every open after the first skipped seeding the new file and re-hydrated the room's original seed, leaving the session holding the showcase's header/footer stories while the layout request described the newly parsed file. Traced to already-merged #96; reproduces on `main`.
- **Opening a local file now leaves the room.** A room is a shared document; opening a different document is not an edit to it. The demo drops `?room=` from the URL, does not mint a replacement, shows a "not shared" status, and does not offer a collaboration link. This removes the hybrid-document path where a reload or a joiner would have combined showcase package metadata with the local file's CRDT stories (the relay deliberately excludes SyncStep1 from retention, so a first peer's document is never persisted).
- Session/room decisions moved into `apps/demo/lib/demoSession.ts` — one gate instead of two racing conditions, and inside the CI test glob so the invariants are actually covered.
- Opens are now ordered by selection rather than completion; `file.arrayBuffer()` is guarded; the editor receives `onError`, so read and editor failures surface instead of being swallowed.

Test plan:
- [x] `bun test packages apps/web/app apps/demo/lib scripts` — 571 pass, 1 skip, 0 fail
- [x] Demo typecheck (`tsc --noEmit`) clean
- [x] Six corpus documents opened consecutively — 1/7/2/2/5/1 pages, no console errors
- [x] Two browsers in one room: opening a local file in one leaves the other's document untouched
- [x] Reloading after a local open yields a clean showcase, not a hybrid document
