### PR TITLE
fix(ci): install a pinned wasm-opt instead of downloading binaryen mid-build

### DIFF
--- a/.github/actions/wasm-toolchain/action.yml
+++ b/.github/actions/wasm-toolchain/action.yml
@@ -1,0 +1,43 @@
+name: Wasm toolchain
+description: Puts a pinned wasm-opt on PATH so wasm-pack never downloads binaryen mid-build, and caches its tool downloads.
+
+inputs:
+  binaryen:
+    description: Binaryen release tag.
+    default: version_132
+  sha256:
+    description: Checksum of the x86_64-linux tarball.
+    default: 195ddc94f9bc89f45abdabb0b9eea86023d727ba90eac8b35b80f2544fc30572
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v4
+      id: binaryen
+      with:
+        path: ~/.cache/binaryen/${{ inputs.binaryen }}
+        key: binaryen-${{ runner.os }}-${{ inputs.binaryen }}
+
+    - if: steps.binaryen.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        if [ "$(uname -m)" != "x86_64" ]; then
+          echo "::error::no pinned binaryen for $(uname -m); add its checksum to .github/actions/wasm-toolchain"
+          exit 1
+        fi
+        tarball="$RUNNER_TEMP/binaryen.tar.gz"
+        curl -fsSL --retry 5 --retry-all-errors -o "$tarball" \
+          "https://github.com/WebAssembly/binaryen/releases/download/${{ inputs.binaryen }}/binaryen-${{ inputs.binaryen }}-x86_64-linux.tar.gz"
+        echo "${{ inputs.sha256 }}  $tarball" | sha256sum -c -
+        mkdir -p "$HOME/.cache/binaryen/${{ inputs.binaryen }}"
+        tar -xzf "$tarball" -C "$HOME/.cache/binaryen/${{ inputs.binaryen }}" --strip-components=1
+
+    - shell: bash
+      run: echo "$HOME/.cache/binaryen/${{ inputs.binaryen }}/bin" >> "$GITHUB_PATH"
+
+    # wasm-pack's own tool cache: uncached, it recompiles the wasm-bindgen CLI every run.
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/.wasm-pack
+        key: wasm-pack-tools-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: wasm-pack-tools-${{ runner.os }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           shared-key: wasm
 
+      - uses: ./.github/actions/wasm-toolchain
+
+      # Reads `wasm-opt --version`, so it has to follow the toolchain step.
       - name: Fingerprint the wasm inputs
         id: wasm
         run: echo "key=$(bun scripts/wasm-cache-key.ts)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           shared-key: wasm
 
+      - uses: ./.github/actions/wasm-toolchain
+        if: matrix.app == 'demo'
+
+      # Reads `wasm-opt --version`, so it has to follow the toolchain step.
       - name: Fingerprint the wasm inputs
         id: wasm
         if: matrix.app == 'demo'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - uses: ./.github/actions/wasm-toolchain
+        if: steps.pending.outputs.publishing == 'true'
+
       - uses: taiki-e/install-action@v2
         if: steps.pending.outputs.publishing == 'true'
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Thanks for your interest in contributing! This guide will help you get started.
 - `wasm32-unknown-unknown` (`rustup target add wasm32-unknown-unknown`)
 - [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) 0.15.0
   (`cargo install wasm-pack --version 0.15.0 --locked`)
+- [`binaryen`](https://github.com/WebAssembly/binaryen) for `wasm-opt`
+  (`brew install binaryen` / `apt-get install binaryen`)
 
 ## Development Setup
 

--- a/apps/redact-worker/scripts/build-wasm.ts
+++ b/apps/redact-worker/scripts/build-wasm.ts
@@ -2,27 +2,15 @@ import { copyFile, mkdir, rm } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { requireWasmOpt, requireWasmPack } from "../../../scripts/wasm.ts";
 
-const WASM_PACK_VERSION = "0.15.0";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const crate = resolve(root, "crates/ooxml-opc");
 const output = resolve(root, "target/wasm-pack/redact-worker");
 const generated = resolve(root, "apps/redact-worker/src/wasm/generated");
 
-const version = spawnSync("wasm-pack", ["--version"], { encoding: "utf8" });
-const versionErrorCode =
-  version.error && "code" in version.error && typeof version.error.code === "string"
-    ? version.error.code
-    : undefined;
-if (versionErrorCode === "ENOENT") {
-  throw new Error(
-    `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`,
-  );
-}
-if (version.status !== 0) process.exit(version.status ?? 1);
-if (version.stdout.trim() !== `wasm-pack ${WASM_PACK_VERSION}`) {
-  throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version.stdout.trim()}`);
-}
+requireWasmPack();
+requireWasmOpt();
 
 await rm(output, { recursive: true, force: true });
 const build = spawnSync(

--- a/packages/docx/README.md
+++ b/packages/docx/README.md
@@ -67,7 +67,8 @@ instead of independently importing the same DOCX.
 ## Development
 
 The generated `.wasm` binaries are intentionally not committed. From the
-repository root, install `wasm-pack` 0.15.0 and run `bun run build:docx-wasm`.
+repository root, install `wasm-pack` 0.15.0 and `binaryen`, then run
+`bun run build:docx-wasm`.
 Package builds, demo startup, and CI run this step automatically.
 
 Docs: https://betteroffice.dev · Apache-2.0.

--- a/packages/pptx/README.md
+++ b/packages/pptx/README.md
@@ -73,7 +73,8 @@ provider.connect();
 ## Development
 
 The generated `.wasm` binary is intentionally not committed. From the repository
-root, install `wasm-pack` 0.15.0 and run `bun scripts/build-pptx-wasm.ts`.
+root, install `wasm-pack` 0.15.0 and `binaryen`, then run
+`bun scripts/build-pptx-wasm.ts`.
 Package builds copy the binary into `dist/generated`.
 
 Docs: https://betteroffice.dev · Apache-2.0.

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -112,7 +112,8 @@ they have stable axis identities and a Yrs-aware undo manager.
 ## Development
 
 The generated `.wasm` binary is intentionally not committed. From the repository
-root, install `wasm-pack` 0.15.0 and run `bun run build:xlsx-wasm`. Package builds,
-tests, demo startup, and CI run this step automatically.
+root, install `wasm-pack` 0.15.0 and `binaryen`, then run
+`bun run build:xlsx-wasm`. Package builds, tests, demo startup, and CI run this
+step automatically.
 
 Docs: https://betteroffice.dev · Apache-2.0.

--- a/scripts/wasm.ts
+++ b/scripts/wasm.ts
@@ -32,21 +32,35 @@ interface Stamp {
 const WASM_PACK_VERSION = '0.15.0';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-function requireWasmPack(): void {
-  const version = spawnSync('wasm-pack', ['--version'], { encoding: 'utf8' });
+/** `<tool> --version`; throws `missing` when the tool is not on PATH. */
+function toolVersion(tool: string, missing: string): string {
+  const version = spawnSync(tool, ['--version'], { encoding: 'utf8' });
   const versionErrorCode =
     version.error && 'code' in version.error && typeof version.error.code === 'string'
       ? version.error.code
       : undefined;
-  if (versionErrorCode === 'ENOENT') {
-    throw new Error(
-      `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`
-    );
-  }
+  if (versionErrorCode === 'ENOENT') throw new Error(missing);
   if (version.status !== 0) process.exit(version.status ?? 1);
-  if (version.stdout.trim() !== `wasm-pack ${WASM_PACK_VERSION}`) {
-    throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version.stdout.trim()}`);
+  return version.stdout.trim();
+}
+
+export function requireWasmPack(): void {
+  const version = toolVersion(
+    'wasm-pack',
+    `wasm-pack ${WASM_PACK_VERSION} is required; install it with cargo install wasm-pack --version ${WASM_PACK_VERSION} --locked`
+  );
+  if (version !== `wasm-pack ${WASM_PACK_VERSION}`) {
+    throw new Error(`expected wasm-pack ${WASM_PACK_VERSION}, got ${version}`);
   }
+}
+
+/** wasm-pack downloads a 91MB binaryen release mid-build whenever wasm-opt is
+ * missing, so requiring it up front is what keeps the build off the network. */
+export function requireWasmOpt(): string {
+  return toolVersion(
+    'wasm-opt',
+    'wasm-opt is required; install binaryen with `brew install binaryen`, `apt-get install binaryen`, or from https://github.com/WebAssembly/binaryen/releases'
+  );
 }
 
 async function hashTree(hash: Hash, dir: string, prefix: string): Promise<void> {
@@ -74,8 +88,8 @@ const CODEGEN_ENV = [
 ];
 
 /** Digest of every input the emitted wasm depends on: the crates, the workspace
- * manifest (release profiles), the toolchain, the cargo environment and these
- * scripts. Shared by every module, so it doubles as the CI cache key. */
+ * manifest (release profiles), the toolchain, the optimizer, the cargo environment
+ * and these scripts. Shared by every module, so it doubles as the CI cache key. */
 export async function sourcesFingerprint(): Promise<string> {
   const hash = createHash('sha256');
   // `stable` moves, so the toolchain has to be part of the identity.
@@ -83,6 +97,7 @@ export async function sourcesFingerprint(): Promise<string> {
   if (rustc.status !== 0) throw new Error('rustc -vV failed');
   hash.update(rustc.stdout);
   hash.update(`${WASM_PACK_VERSION}\0`);
+  hash.update(`${requireWasmOpt()}\0`);
   const overrides = Object.keys(process.env)
     .filter((name) => name.startsWith('CARGO_PROFILE_'))
     .sort();


### PR DESCRIPTION
TL;DR:


Summary:

- CI, deploy and release install a pinned, checksum-verified binaryen before any wasm build, so `wasm-pack` finds `wasm-opt` on `PATH` instead of downloading a 91MB binaryen release mid-build. That download is what broke the Package gate on `main` (`cb409a9`); the same URL had succeeded eight minutes earlier, so the asset was never missing.
- Adds `.github/actions/wasm-toolchain`, shared by the three workflows that run `wasm-pack`. It caches the binaryen install and, separately, `~/.cache/.wasm-pack` — wasm-pack's own tool cache, which the existing `target/wasm-pack` cache never covered, so every run was recompiling the wasm-bindgen CLI from source.
- `scripts/wasm.ts` now requires `wasm-opt` up front with an actionable install hint, and folds its version into the fingerprint that keys the wasm cache, since the optimizer is an input to the emitted binaries.
- `apps/redact-worker`'s build script shares those toolchain checks instead of duplicating them.
- Documents the binaryen prerequisite in `CONTRIBUTING.md` and the docx/pptx/xlsx READMEs.

All six wasm modules plus the redact-worker build go through the same `wasm-pack` path, so all of them were exposed; pptx only failed first because `pretest` builds it before the others run.

Pinned `version_132` rather than the `version_117` wasm-pack hardcodes. Measured on `pptx_wasm_bg.wasm`, the two optimizers are equivalent (2,873,245 vs 2,876,471 bytes), while skipping `wasm-opt` entirely would cost 783KB raw / 115KB gzipped on that module alone.

Test plan:

- [ ] Package gate passes with a cold `target/wasm-pack` cache
- [ ] CI logs show `found wasm-opt at …` for all six modules and no binaryen download
- [ ] A second run hits both the binaryen and `~/.cache/.wasm-pack` caches
- [ ] `bun run --filter './apps/redact-worker' build:wasm` still succeeds
