### PR TITLE
fix(ci): point the CJK metrics test at the fonts-cjk package

### DIFF
--- a/crates/docx-layout/tests/synthetic_metrics.rs
+++ b/crates/docx-layout/tests/synthetic_metrics.rs
@@ -9,7 +9,8 @@ const CONTENT_WIDTH: f64 = 624.0;
 const FONT_SIZE_PT: f64 = 11.0;
 const FONT_SIZE_PX: f64 = FONT_SIZE_PT * 96.0 / 72.0;
 const LIBERATION: &[u8] = include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
-const NOTO_SANS_SC: &[u8] = include_bytes!("../../../packages/fonts/assets/NotoSansSC-Regular.otf");
+const NOTO_SANS_SC: &[u8] =
+    include_bytes!("../../../packages/fonts-cjk/assets/NotoSansSC-Regular.otf");
 
 const INSERTED: &str = "Vielen Dank für Ihre Bestellung Nr. 4711. Wir freuen uns, Ihnen bestätigen zu können, dass wir Ihre Zahlung erhalten haben.";
 const DELETED: &str =


### PR DESCRIPTION
TL;DR:


Summary:
- `main` has been red since #183 merged. That PR moved `NotoSansSC-Regular.otf` into the new `@betteroffice/fonts-cjk` package, but #189's `synthetic_metrics` test still `include_bytes!`d it from `packages/fonts/assets/`, so the crate fails to compile.
- Both PRs were green on their own branches — the break only exists once both are on `main`, which per-PR CI cannot see.
- Only the CJK face moved; `NotoSansHebrew-Regular.ttf` and `NotoNaskhArabic-Regular.ttf` are still in `packages/fonts/assets` and their references are correct.

Test plan:
- [x] `cargo test --workspace` — 81 suites, 0 failures
- [x] `cargo test -p betteroffice-docx-layout --test synthetic_metrics` — 7 passed
- [x] `cargo fmt --check`
