### PR TITLE
fix(docx): project endnote stories on save

### DIFF
--- a/.changeset/docx-endnote-save-projection.md
+++ b/.changeset/docx-endnote-save-projection.md
@@ -1,0 +1,8 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/docx-react": patch
+---
+
+Edits made in an endnote now reach the saved file. Endnote stories were seeded into the collaborative document as `en:{id}` alongside the footnotes' `fn:{id}`, but the save projection never read them back: it collected base stories for the body, header/footer parts and footnotes only, and rebuilt just those parts of the package. An endnote story was therefore write-only — every edit in it was silently replaced by the imported text on save.
+
+Both note families now project through one path, so a footnote and an endnote round-trip the same way, and a projected note drops its `verbatimXml` so the modeled content is what gets written rather than the original XML. The editor's dirty-story tracking follows: direct input in an `en:` story marks that story for projection instead of falling back to the body, which is what gated the partial (changed-stories-only) save.

--- a/.changeset/docx-endnote-save-projection.md
+++ b/.changeset/docx-endnote-save-projection.md
@@ -3,6 +3,4 @@
 "@betteroffice/docx-react": patch
 ---
 
-Edits made in an endnote now reach the saved file. Endnote stories were seeded into the collaborative document as `en:{id}` alongside the footnotes' `fn:{id}`, but the save projection never read them back: it collected base stories for the body, header/footer parts and footnotes only, and rebuilt just those parts of the package. An endnote story was therefore write-only — every edit in it was silently replaced by the imported text on save.
-
-Both note families now project through one path, so a footnote and an endnote round-trip the same way, and a projected note drops its `verbatimXml` so the modeled content is what gets written rather than the original XML. The editor's dirty-story tracking follows: direct input in an `en:` story marks that story for projection instead of falling back to the body, which is what gated the partial (changed-stories-only) save.
+Edits made in an endnote now reach the saved file. Endnote stories were seeded into the collaborative document but never projected back on save, so every endnote edit was silently replaced by the imported text; footnotes and endnotes now project through one path, and typing in an endnote marks it for the changed-stories-only save.

--- a/.changeset/docx-endnote-save-projection.md
+++ b/.changeset/docx-endnote-save-projection.md
@@ -3,4 +3,4 @@
 "@betteroffice/docx-react": patch
 ---
 
-Edits made in an endnote now reach the saved file. Endnote stories were seeded into the collaborative document but never projected back on save, so every endnote edit was silently replaced by the imported text; footnotes and endnotes now project through one path, and typing in an endnote marks it for the changed-stories-only save.
+Edits made in an endnote now reach the saved file. Endnote stories were seeded into the collaborative document but never projected back on save, so every endnote edit was silently replaced by the imported text; footnotes and endnotes now project through one path, and typing in a note or header — including a table cell inside one — marks its root story for the changed-stories-only save.

--- a/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.test.ts
@@ -242,4 +242,10 @@ describe('dirtyProjectionStory', () => {
   test('falls back to the body for a table cell nested in it', () => {
     expect(dirtyProjectionStory('body:t0:r0c0')).toBe('body');
   });
+
+  test('marks the note or header root for a table cell nested in it', () => {
+    expect(dirtyProjectionStory('hf:rId5:t0:r0c0')).toBe('hf:rId5');
+    expect(dirtyProjectionStory('fn:2:t0:r0c0')).toBe('fn:2');
+    expect(dirtyProjectionStory('en:2:t0:r0c0:sdt0')).toBe('en:2');
+  });
 });

--- a/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { Document } from '@betteroffice/docx/types/document';
 import type { YrsDocxHost, YrsSession } from '@betteroffice/docx/yrs';
 import {
+  dirtyProjectionStory,
   mergeDocxHostMetadata,
   seedYrsSession,
   warmCompatibilityBase,
@@ -228,5 +229,17 @@ describe('warmCompatibilityBase', () => {
     warmCompatibilityBase({ materializeDocx: () => expect.unreachable() }, compatibilityBase);
 
     expect(compatibilityBase.current).toBe(projected);
+  });
+});
+
+describe('dirtyProjectionStory', () => {
+  test('marks the note story itself for header, footer, footnote and endnote input', () => {
+    expect(dirtyProjectionStory('hf:rId5')).toBe('hf:rId5');
+    expect(dirtyProjectionStory('fn:2')).toBe('fn:2');
+    expect(dirtyProjectionStory('en:2')).toBe('en:2');
+  });
+
+  test('falls back to the body for a table cell nested in it', () => {
+    expect(dirtyProjectionStory('body:t0:r0c0')).toBe('body');
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
@@ -149,10 +149,10 @@ export function warmCompatibilityBase(
   }
 }
 
-/** Story a direct-input edit dirties: hf/note stories themselves, everything else the body. */
+/** Story a direct-input edit dirties: the hf/note root it sits in, everything else the body. */
 export function dirtyProjectionStory(activeStory: string): string {
   return ['hf:', 'fn:', 'en:'].some((prefix) => activeStory.startsWith(prefix))
-    ? activeStory
+    ? activeStory.split(':', 2).join(':')
     : 'body';
 }
 

--- a/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
@@ -149,6 +149,17 @@ export function warmCompatibilityBase(
   }
 }
 
+/**
+ * The story a direct-input edit dirties. Header/footer and note stories project
+ * on their own; everything else — the body, and the table cells nested in it —
+ * republishes through the body.
+ */
+export function dirtyProjectionStory(activeStory: string): string {
+  return ['hf:', 'fn:', 'en:'].some((prefix) => activeStory.startsWith(prefix))
+    ? activeStory
+    : 'body';
+}
+
 export function useYrsCoreSession(
   enabled: boolean,
   document: Document | null,
@@ -330,9 +341,7 @@ export function useYrsCoreSession(
     if (!live || !live.storyIds().includes('body')) return;
     inputPositionMapsRef.current.clear();
     const activeStory = live.selection()?.head.story ?? 'body';
-    projectionStoriesRef.current.add(
-      activeStory.startsWith('hf:') || activeStory.startsWith('fn:') ? activeStory : 'body'
-    );
+    projectionStoriesRef.current.add(dirtyProjectionStory(activeStory));
   }, []);
 
   return {

--- a/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
@@ -149,11 +149,7 @@ export function warmCompatibilityBase(
   }
 }
 
-/**
- * The story a direct-input edit dirties. Header/footer and note stories project
- * on their own; everything else — the body, and the table cells nested in it —
- * republishes through the body.
- */
+/** Story a direct-input edit dirties: hf/note stories themselves, everything else the body. */
 export function dirtyProjectionStory(activeStory: string): string {
   return ['hf:', 'fn:', 'en:'].some((prefix) => activeStory.startsWith(prefix))
     ? activeStory

--- a/packages/docx/src/yrs/noteSave.test.ts
+++ b/packages/docx/src/yrs/noteSave.test.ts
@@ -1,0 +1,147 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parseDocx } from '../docx';
+import { repackDocx } from '../docx/rezip';
+import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
+import type { BlockContent, Document, Endnote, Footnote } from '../types/document';
+import { preloadEditWasm } from '../wasm/edit';
+import { createYrsSession, type YrsSession } from './index';
+import { yrsToDocument } from './yrsToDocument';
+
+const WASM = resolve(import.meta.dir, '../wasm/generated/edit/docx_edit_bg.wasm');
+const OFFICE_DOC = 'application/vnd.openxmlformats-officedocument';
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="${OFFICE_DOC}.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="${OFFICE_DOC}.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="${OFFICE_DOC}.wordprocessingml.footnotes+xml"/>
+  <Override PartName="/word/endnotes.xml" ContentType="${OFFICE_DOC}.wordprocessingml.endnotes+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPkg1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/>
+</Relationships>`;
+
+const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r><w:t xml:space="preserve">Body text</w:t></w:r>
+      <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="2"/></w:r>
+      <w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteReference w:id="2"/></w:r>
+    </w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="FootnoteText"><w:name w:val="footnote text"/><w:basedOn w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="EndnoteText"><w:name w:val="endnote text"/><w:basedOn w:val="Normal"/></w:style>
+  <w:style w:type="character" w:styleId="FootnoteReference"><w:name w:val="footnote reference"/><w:rPr><w:vertAlign w:val="superscript"/></w:rPr></w:style>
+  <w:style w:type="character" w:styleId="EndnoteReference"><w:name w:val="endnote reference"/><w:rPr><w:vertAlign w:val="superscript"/></w:rPr></w:style>
+</w:styles>`;
+
+const FOOTNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:footnote w:id="-1" w:type="separator"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
+  <w:footnote w:id="0" w:type="continuationSeparator"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+  <w:footnote w:id="2">
+    <w:p>
+      <w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>
+      <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>
+      <w:r><w:t xml:space="preserve"> Footnote body.</w:t></w:r>
+    </w:p>
+  </w:footnote>
+</w:footnotes>`;
+
+const ENDNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:endnote w:id="-1" w:type="separator"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>
+  <w:endnote w:id="0" w:type="continuationSeparator"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>
+  <w:endnote w:id="2">
+    <w:p>
+      <w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr>
+      <w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteRef/></w:r>
+      <w:r><w:t xml:space="preserve"> Endnote body.</w:t></w:r>
+    </w:p>
+  </w:endnote>
+</w:endnotes>`;
+
+function fixture(): Uint8Array {
+  const parts: PartsMap = new Map();
+  parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
+  parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
+  parts.set('word/_rels/document.xml.rels', toBytes(DOCUMENT_RELS));
+  parts.set('word/document.xml', toBytes(DOCUMENT));
+  parts.set('word/styles.xml', toBytes(STYLES));
+  parts.set('word/footnotes.xml', toBytes(FOOTNOTES));
+  parts.set('word/endnotes.xml', toBytes(ENDNOTES));
+  return new Uint8Array(rezipPartsToArrayBuffer(parts));
+}
+
+/** Type at the end of a note story, the way the editor would. */
+function appendToNote(session: YrsSession, story: string, text: string): void {
+  const paragraphs = session.paragraphs(story);
+  const last = paragraphs[paragraphs.length - 1];
+  session.insertText({ story, paraId: last.paraId, offset: last.text.length }, text);
+}
+
+function blocksText(blocks: readonly BlockContent[]): string {
+  return blocks
+    .map((block) =>
+      block.type === 'paragraph'
+        ? block.content
+            .map((item) =>
+              item.type === 'run'
+                ? item.content.map((run) => (run.type === 'text' ? run.text : '')).join('')
+                : ''
+            )
+            .join('')
+        : ''
+    )
+    .join('');
+}
+
+function noteText(notes: readonly (Footnote | Endnote)[] | undefined, id: number): string {
+  const note = notes?.find((candidate) => candidate.id === id);
+  return note ? blocksText(note.content) : '';
+}
+
+describe('note story save projection', () => {
+  beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
+
+  it('round-trips text typed into a footnote and into an endnote', async () => {
+    const bytes = fixture();
+    const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+    const session = await createYrsSession({ clientId: 53002 });
+
+    let saved: Document;
+    try {
+      session.seedFromDocx(bytes);
+      appendToNote(session, 'fn:2', ' Typed into the footnote.');
+      appendToNote(session, 'en:2', ' Typed into the endnote.');
+      saved = yrsToDocument(session, parsed);
+    } finally {
+      session.destroy();
+    }
+
+    const reopened = await parseDocx(await repackDocx(saved), { preloadFonts: false });
+    expect(noteText(reopened.package.footnotes, 2)).toContain('Typed into the footnote.');
+    expect(noteText(reopened.package.endnotes, 2)).toContain('Typed into the endnote.');
+  });
+});

--- a/packages/docx/src/yrs/yrsToDocument.ts
+++ b/packages/docx/src/yrs/yrsToDocument.ts
@@ -41,6 +41,8 @@ import type {
   InlineSdt,
   SdtProperties,
   Comment,
+  Footnote,
+  Endnote,
 } from '../types/document';
 import type { YrsSession } from './index';
 
@@ -1577,6 +1579,7 @@ function collectBaseStories(document: Document): Map<string, readonly BlockConte
   for (const [rId, part] of document.package.headers ?? []) visit(`hf:${rId}`, part.content);
   for (const [rId, part] of document.package.footers ?? []) visit(`hf:${rId}`, part.content);
   for (const note of document.package.footnotes ?? []) visit(`fn:${note.id}`, note.content);
+  for (const note of document.package.endnotes ?? []) visit(`en:${note.id}`, note.content);
   return stories;
 }
 
@@ -1800,17 +1803,23 @@ export function yrsToDocument(
     );
   }
 
-  const shouldProjectFootnotes =
-    options.storyIds === undefined ||
-    base.package.footnotes?.some((note) => shouldProject(`fn:${note.id}`));
-  const footnotes = shouldProjectFootnotes
-    ? base.package.footnotes?.map((note) => {
-        const storyId = `fn:${note.id}`;
-        return context.storyIds.has(storyId) && shouldProject(storyId)
-          ? { ...note, content: context.storyToBlocks(storyId), verbatimXml: undefined }
-          : note;
-      })
-    : base.package.footnotes;
+  const projectNotes = <T extends Footnote | Endnote>(
+    notes: T[] | undefined,
+    prefix: string
+  ): T[] | undefined => {
+    const shouldProjectNotes =
+      options.storyIds === undefined ||
+      notes?.some((note) => shouldProject(`${prefix}${note.id}`));
+    if (!shouldProjectNotes) return notes;
+    return notes?.map((note) => {
+      const storyId = `${prefix}${note.id}`;
+      return context.storyIds.has(storyId) && shouldProject(storyId)
+        ? { ...note, content: context.storyToBlocks(storyId), verbatimXml: undefined }
+        : note;
+    });
+  };
+  const footnotes = projectNotes(base.package.footnotes, 'fn:');
+  const endnotes = projectNotes(base.package.endnotes, 'en:');
 
   return {
     ...base,
@@ -1823,6 +1832,7 @@ export function yrsToDocument(
       ...(headers ? { headers } : {}),
       ...(footers ? { footers } : {}),
       ...(footnotes ? { footnotes } : {}),
+      ...(endnotes ? { endnotes } : {}),
     },
   };
 }


### PR DESCRIPTION
TL;DR:


Repro file:
`packages/docx/src/yrs/noteSave.test.ts` — builds a DOCX with one footnote and one endnote, types into both stories, and saves. Before this change the endnote assertion fails with the imported text (` Endnote body.`) instead of the typed text.

Summary:
- Endnote stories (`en:{id}`) are now collected and projected by the save projection, so an edit made in an endnote reaches the saved file instead of being replaced by the imported text.
- Footnote and endnote projection share one path; a projected note drops its `verbatimXml` so the modeled content is written rather than the original XML.
- Direct input in an `en:` story now marks that story dirty for projection instead of falling back to the body, which gated the changed-stories-only save.
- Adds a save round-trip test covering both note families, and a unit test for the dirty-story selection.

Test plan:
- [ ] `bun run typecheck:packages`
- [ ] `bun test packages/docx/src/yrs/noteSave.test.ts`
- [ ] `bun test packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.test.ts`
- [ ] `bun run test`
