### PR TITLE
docs(pptx): drop the stale in-memory editing note

### DIFF
--- a/bindings/python-pptx/README.md
+++ b/bindings/python-pptx/README.md
@@ -6,9 +6,6 @@ metrics, a display list — and merges edits across replicas, because the Rust
 [BetterOffice](https://betteroffice.dev) PPTX core is compiled into the wheel:
 no PowerPoint, no LibreOffice subprocess, no COM.
 
-Editing is in-memory today: see [Writing](#writing) before you reach for
-`save()`.
-
 Not on PyPI yet. From a checkout, with a Rust toolchain installed:
 
 ```bash


### PR DESCRIPTION
TL;DR:


Summary:

- Removes a lead-in line claiming editing is in-memory only. It contradicted the Writing section two screens below, which correctly documents `save()` serializing every accepted edit.

Test plan:

- [ ] `save()` round-trips an edit: open, `move_shape`, save, reopen, coordinates match
