### PR TITLE
ci(python): publish the pptx binding to pypi

### DIFF
--- a/.changeset/publish-pptx-binding.md
+++ b/.changeset/publish-pptx-binding.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/python-pptx": patch
+---
+
+`betteroffice-pptx` publishes to PyPI. The distribution joins the release train's publish matrix, and a `workflow_dispatch` workflow can publish one binding on its own — to create a PyPI project from a pending Trusted Publisher, or to fill in a wheel a release run dropped. Publishing is Trusted Publishing only; the workflow refuses to run while a repository-scoped `PYPI_API_TOKEN` exists.

--- a/.github/workflows/publish-python-binding.yml
+++ b/.github/workflows/publish-python-binding.yml
@@ -1,0 +1,76 @@
+name: Publish a Python binding
+
+# Publishes one bindings/python-* distribution at its committed version, outside
+# the release train. Use it to create a PyPI project from a pending Trusted
+# Publisher, or to fill in a wheel a release run dropped.
+on:
+  workflow_dispatch:
+    inputs:
+      binding:
+        description: The bindings/python-<binding> distribution to publish.
+        required: true
+        type: string
+      dry_run:
+        description: Build and check the artifacts without uploading.
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  dist:
+    name: Build ${{ inputs.binding }}
+    uses: ./.github/workflows/python-dist.yml
+    with:
+      binding: ${{ inputs.binding }}
+    permissions:
+      contents: read
+
+  publish:
+    name: Publish betteroffice-${{ inputs.binding }}
+    needs: dist
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Never a reusable workflow: the OIDC claim must name this file.
+    environment: pypi-${{ inputs.binding }}
+    permissions:
+      id-token: write # OIDC Trusted Publishing
+    steps:
+      - name: Require a complete build
+        uses: actions/download-artifact@v4
+        with:
+          name: built-${{ inputs.binding }}
+          path: receipt
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-${{ inputs.binding }}.*
+          path: dist
+          merge-multiple: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check the metadata renders
+        run: |
+          ls -la dist
+          python -m pip install --upgrade pip twine
+          twine check dist/*
+
+      - name: Refuse a repository-scoped PyPI token
+        env:
+          TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "::error::PYPI_API_TOKEN is set. This workflow publishes through Trusted Publishing only."
+            echo "::error::Delete it under Settings > Secrets and variables > Actions, and revoke it on PyPI."
+            exit 1
+          fi
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ !inputs.dry_run }}
+        with:
+          packages-dir: dist
+          skip-existing: true

--- a/apps/docs/content/docs/python.mdx
+++ b/apps/docs/content/docs/python.mdx
@@ -1,17 +1,17 @@
 ---
 title: Python
-description: betteroffice-xlsx on PyPI — open, recalculate, render, and save workbooks
+description: betteroffice-xlsx and betteroffice-pptx on PyPI — open, recalculate, render, and save
 ---
 
 ```bash
 pip install betteroffice-xlsx
 ```
 
-[`betteroffice-xlsx`](https://pypi.org/project/betteroffice-xlsx/) is the one
-BetterOffice distribution on PyPI today. The Rust XLSX engine is compiled into
-the wheel: no Excel, no LibreOffice subprocess, no COM. Wheels are built for
-Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows (x86_64) against the
-stable ABI for CPython 3.9 and up.
+[`betteroffice-xlsx`](https://pypi.org/project/betteroffice-xlsx/) is the
+workbook distribution. The Rust XLSX engine is compiled into the wheel: no
+Excel, no LibreOffice subprocess, no COM. Wheels are built for Linux (x86_64,
+aarch64), macOS (arm64, x86_64), and Windows (x86_64) against the stable ABI for
+CPython 3.9 and up.
 
 ## Formulas calculate
 
@@ -72,21 +72,16 @@ and the error hierarchy.
 
 ## PPTX and DOCX
 
-The PPTX binding is not on PyPI yet, so `pip` will not find it. It lives in the
-repository at
-[`bindings/python-pptx`](https://github.com/openooxml/betteroffice/tree/main/bindings/python-pptx),
-and CI builds and tests it on every change. From a checkout, with a Rust
-toolchain installed:
-
 ```bash
-pip install -e bindings/python-pptx
+pip install betteroffice-pptx
 ```
 
-It reads decks, edits shapes and text in memory, saves the edits back to
-`.pptx` bytes, and lays slides out into the same display-list contract the
-canvas paints. `render_slide` fails until `register_font` has supplied at least
-one face — no font is compiled into that wheel. A `Presentation` is also pinned
-to the thread that opened it, and must be released there.
+[`betteroffice-pptx`](https://pypi.org/project/betteroffice-pptx/) reads decks,
+edits shapes and text, saves the edits back to `.pptx` bytes, and lays slides
+out into the same display-list contract the canvas paints. `render_slide` fails
+until `register_font` has supplied at least one face — no font is compiled into
+that wheel. A `Presentation` is also pinned to the thread that opened it, and
+must be released there.
 
 There is no DOCX binding for Python. Reach for
 [`betteroffice-docx`](./rust) in Rust, or

--- a/apps/web/app/api/pypi-downloads/route.test.js
+++ b/apps/web/app/api/pypi-downloads/route.test.js
@@ -74,7 +74,9 @@ describe("PyPI downloads total", () => {
   });
 
   test("reports the count once a package has stats", async () => {
-    expect(await monthlyDownloadsTotal(async () => recent(42))).toBe(42);
+    expect(await monthlyDownloadsTotal(async () => recent(42))).toBe(
+      42 * PYPI_PACKAGES.length,
+    );
   });
 
   test("every listed package is a betteroffice distribution", () => {
@@ -88,6 +90,5 @@ describe("PyPI downloads total", () => {
     expect(PYPI_PACKAGES).toEqual(
       PYTHON_PUBLISH_NAMES.map((name) => `betteroffice-${name}`),
     );
-    expect(PYPI_PACKAGES).not.toContain("betteroffice-pptx");
   });
 });

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -51,11 +51,12 @@ The per-layer crates are published for direct use when you need one stage of the
 
 ## Python packages
 
-Published to PyPI, Apache-2.0. The Rust engine is compiled into the wheel — no Excel, no LibreOffice subprocess, no COM. Wheels cover Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows (x86_64) against the stable ABI for CPython 3.9 and up. The [Python guide](https://docs.betteroffice.dev/docs/python) carries the install line, a first example, and what is not published yet.
+Published to PyPI, Apache-2.0. The Rust engine is compiled into the wheel — no Excel, no LibreOffice subprocess, no COM. Wheels cover Linux (x86_64, aarch64), macOS (arm64, x86_64), and Windows (x86_64) against the stable ABI for CPython 3.9 and up. The [Python guide](https://docs.betteroffice.dev/docs/python) carries the install line and a first example.
 
+- [betteroffice-pptx](https://pypi.org/project/betteroffice-pptx/): `pip install betteroffice-pptx`. Read, edit, and save PPTX decks, and lay slides out into the display-list contract the canvas paints; no rasterizer yet, so it returns a scene description rather than pixels. No font ships in the wheel, so `register_font` must supply at least one face before a slide with text lays out. Yrs collaboration is exposed as byte-level primitives, and a deck is pinned to the thread that opened it.
 - [betteroffice-xlsx](https://pypi.org/project/betteroffice-xlsx/): `pip install betteroffice-xlsx`. Open, recalculate, style, render to PNG, and save XLSX workbooks; formulas are evaluated by this engine rather than read back from the file. Yrs collaboration and agent proposals are exposed as byte-level primitives, and opening, recalculating, rendering, and saving release the GIL.
 
-The PPTX binding lives in the repository at `bindings/python-pptx` and is built and tested in CI, but it has no PyPI project yet, so `pip` will not find it. There is no DOCX binding for Python.
+There is no DOCX binding for Python.
 
 ## Collaboration
 

--- a/bindings/python-pptx/README.md
+++ b/bindings/python-pptx/README.md
@@ -6,10 +6,8 @@ metrics, a display list — and merges edits across replicas, because the Rust
 [BetterOffice](https://betteroffice.dev) PPTX core is compiled into the wheel:
 no PowerPoint, no LibreOffice subprocess, no COM.
 
-Not on PyPI yet. From a checkout, with a Rust toolchain installed:
-
 ```bash
-pip install -e bindings/python-pptx
+pip install betteroffice-pptx
 ```
 
 The distribution is hyphenated, the module is not: `import betteroffice_pptx`.

--- a/scripts/python-bindings.mjs
+++ b/scripts/python-bindings.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 // CI, and wheel builds; see RELEASING.md for the PyPI side.
 // `publish: false` holds it out of the PyPI matrix until its project is ready.
 const REGISTRY = [
-  { path: 'bindings/python-pptx', publish: false },
+  { path: 'bindings/python-pptx', publish: true },
   { path: 'bindings/python-xlsx', publish: true }
 ];
 

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -32,16 +32,24 @@ describe('registry', () => {
     }
   });
 
-  test('pptx builds and versions but does not publish', () => {
+  test('pptx publishes', () => {
     expect(PYTHON_BINDINGS).toContain('bindings/python-pptx');
     expect(PYTHON_BINDING_NAMES).toContain('pptx');
-    expect(PYTHON_PUBLISH_NAMES).not.toContain('pptx');
-    expect(PYPI_DISTRIBUTIONS).not.toContain('betteroffice-pptx');
+    expect(PYTHON_PUBLISH_NAMES).toContain('pptx');
+    expect(PYPI_DISTRIBUTIONS).toContain('betteroffice-pptx');
   });
 
   test('xlsx publishes', () => {
     expect(PYTHON_PUBLISH_NAMES).toContain('xlsx');
     expect(PYPI_DISTRIBUTIONS).toContain('betteroffice-xlsx');
+  });
+
+  test('a held-back binding stays out of the publish matrix', () => {
+    const held = PYTHON_BINDING_NAMES.filter((name) => !PYTHON_PUBLISH_NAMES.includes(name));
+    for (const name of held) {
+      expect(PYPI_DISTRIBUTIONS).not.toContain(`betteroffice-${name}`);
+    }
+    expect(PYPI_DISTRIBUTIONS).toHaveLength(PYTHON_PUBLISH_NAMES.length);
   });
 
   test('the CLI reports the registry three ways', () => {


### PR DESCRIPTION
TL;DR:


Summary:

- Flips `bindings/python-pptx` to `publish: true`, so it joins the release train's publish matrix and the PyPI downloads badge picks it up. The registry stays the single source; this is one line.
- Adds `publish-python-binding.yml`, a `workflow_dispatch` that builds and publishes one binding on its own — to create a PyPI project from a pending Trusted Publisher, or to fill in a wheel a release run dropped. Defaults to a dry run.
- The one-off publishes through Trusted Publishing only. It reuses `python-dist.yml` for the wheel matrix and keeps its publish job top-level, because PyPI cannot name a reusable workflow as a Trusted Publisher. It demands the same `built-<binding>` receipt the release path does, so a partial wheel set cannot upload, and it refuses to run while a repository-scoped `PYPI_API_TOKEN` exists.
- Documents the distribution as installable: the pptx README and the Python docs page drop their "not on PyPI" instructions, and the docs page now covers both distributions.
- Replaces the test asserting pptx is held back with one asserting it publishes, plus a general test that whatever is held back stays out of the publish matrix — so the invariant survives the next binding rather than naming this one.

Notes for review:

- Supersedes #195, whose one-line README fix is folded in here to avoid two PRs editing the same file.
- Verified locally: the release simulation bumps and the bindings clippy passes under `--locked`; `actionlint` clean; 21 registry and docs tests pass; reverting the flip fails `registry > pptx publishes`, so the flip is load-bearing.

Test plan:

- [x] `pypi-pptx` environment exists on GitHub and matches the PyPI publisher's environment field
- [x] no repository-scoped `PYPI_API_TOKEN` exists
- [x] a dry run of `publish-python-binding.yml` for `pptx` builds five wheels and an sdist and passes `twine check`
- [x] the live run creates `betteroffice-pptx` on PyPI from the pending publisher
- [x] the downloads badge resolves the new distribution
