### PR TITLE
fix(docx): keep the note number mark when a note is saved

### DIFF
--- a/.changeset/docx-note-ref-mark.md
+++ b/.changeset/docx-note-ref-mark.md
@@ -3,4 +3,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Edited footnotes and endnotes keep their `w:footnoteRef` / `w:endnoteRef` mark on save, so Word still shows the note number in front of the note text.
+Edited footnotes and endnotes keep their `w:footnoteRef` / `w:endnoteRef` mark on save, so Word still shows the note number in front of the note text. A footnote or endnote reference now counts as one position everywhere, so bookmarks and comments around a reference whose id has more than one digit no longer shift or disappear.

--- a/.changeset/docx-note-ref-mark.md
+++ b/.changeset/docx-note-ref-mark.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Edited footnotes and endnotes keep their `w:footnoteRef` / `w:endnoteRef` mark on save, so Word still shows the note number in front of the note text.

--- a/crates/docx-edit/src/bridge/mod.rs
+++ b/crates/docx-edit/src/bridge/mod.rs
@@ -403,6 +403,14 @@ fn lower_story<T: ReadTxn>(
                     paragraph_pm_units += label_width;
                     at_block_boundary = false;
                 }
+                // The note number itself is prepended by `apply_note_presentation`.
+                Out::YMap(mark)
+                    if shared_map_string(&mark, txn, "_kind").as_deref() == Some("noteRefMark") =>
+                {
+                    story_index += 1;
+                    paragraph_pm_units += 1;
+                    at_block_boundary = false;
+                }
                 Out::YMap(field)
                     if shared_map_string(&field, txn, "_kind").as_deref() == Some("field") =>
                 {
@@ -3544,6 +3552,46 @@ mod tests {
 
         let footnote = yrs_doc_to_layout_blocks(&doc, "fn:5", &RenderEnv::default()).unwrap();
         assert_eq!(footnote.len(), 1);
+    }
+
+    #[test]
+    fn native_note_ref_mark_occupies_one_position_without_a_run() {
+        let doc = EditingDoc::new(44);
+        doc.create_story("fn:5", "", "Normal", "left").unwrap();
+        doc.apply_raw_ops(
+            "fn:5",
+            vec![
+                RawOp::Delete { index: 0, len: 1 },
+                RawOp::InsertEmbed {
+                    index: 0,
+                    kind: "noteRefMark".to_owned(),
+                    payload: vec![("noteType".to_owned(), Any::from("footnote"))],
+                    attrs: Attrs::new(),
+                },
+                RawOp::Insert {
+                    index: 1,
+                    text: " Footnote text".to_owned(),
+                    attrs: Attrs::new(),
+                },
+                RawOp::InsertEmbed {
+                    index: 15,
+                    kind: "pilcrow".to_owned(),
+                    payload: vec![("paraId".to_owned(), Any::from("fn-p"))],
+                    attrs: Attrs::new(),
+                },
+            ],
+            &EditCtx::local("", DATE),
+        )
+        .unwrap();
+
+        let footnote = serde_json::to_value(
+            yrs_doc_to_layout_blocks(&doc, "fn:5", &RenderEnv::default()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(footnote[0]["runs"].as_array().map(Vec::len), Some(1));
+        assert_eq!(footnote[0]["runs"][0]["text"], json!(" Footnote text"));
+        assert_eq!(footnote[0]["runs"][0]["pmStart"], json!(2.0));
+        assert_eq!(footnote[0]["pmEnd"], json!(17.0));
     }
 
     #[test]

--- a/crates/docx-edit/src/bridge/mod.rs
+++ b/crates/docx-edit/src/bridge/mod.rs
@@ -25,9 +25,9 @@
 //! Positions come out in two coordinate systems. Story offsets are the UTF-16
 //! indices above; the `pm_*` fields carry the paragraph-node positions that
 //! [`pm_position`] derives, in which every paragraph adds two positions for
-//! its own open and close. They usually track each other, and diverge where
-//! one story unit displays as several characters — a `noteRef` embed occupies
-//! one unit but shows a multi-digit number.
+//! its own open and close. Inline content occupies the same width in both, so
+//! an embed that displays as several characters — a `noteRef` showing a
+//! multi-digit number — still spans exactly one position.
 //!
 //! Values the story cannot supply — theme colors, the default tab stop, the
 //! page content height, and the mapping from yrs ids to the numeric ids the
@@ -388,25 +388,15 @@ fn lower_story<T: ReadTxn>(
                     if !comment_ids.is_empty() {
                         formatting.comment_ids = Some(comment_ids);
                     }
-                    let label = note_ref_label(id);
-                    let label_width = utf16_len(&label);
                     paragraph_runs.push(RawRun {
-                        kind: RawRunKind::Text(label),
+                        kind: RawRunKind::Text(note_ref_label(id)),
                         formatting,
                         story_start: story_index,
                         story_end: story_index + 1,
                         pm_start: paragraph_pm_units,
-                        pm_end: paragraph_pm_units + label_width,
+                        pm_end: paragraph_pm_units + 1,
                         inline_sdt_widget: None,
                     });
-                    story_index += 1;
-                    paragraph_pm_units += label_width;
-                    at_block_boundary = false;
-                }
-                // The note number itself is prepended by `apply_note_presentation`.
-                Out::YMap(mark)
-                    if shared_map_string(&mark, txn, "_kind").as_deref() == Some("noteRefMark") =>
-                {
                     story_index += 1;
                     paragraph_pm_units += 1;
                     at_block_boundary = false;
@@ -1476,21 +1466,17 @@ fn lower_inline_sdt_values(
                     } else {
                         formatting.endnote_ref_id = Some(id);
                     }
-                    let label = note_ref_label(id);
-                    let width = utf16_len(&label);
                     runs.push(RawRun {
-                        kind: RawRunKind::Text(label),
+                        kind: RawRunKind::Text(note_ref_label(id)),
                         formatting,
                         story_start: story_index,
                         story_end: story_index + 1,
                         pm_start: child_pm_start,
-                        pm_end: child_pm_start + width,
+                        pm_end: child_pm_start + 1,
                         inline_sdt_widget: widget.clone(),
                     });
-                    width
-                } else {
-                    1
                 }
+                1
             }
             "sdt" => payload.map_or(2, |payload| {
                 lower_inline_sdt_values(
@@ -1652,10 +1638,8 @@ struct RawRun {
     /// Story-global UTF-16 bounds of the source content.
     story_start: u32,
     story_end: u32,
-    /// Rendered bounds relative to the paragraph's content start. Usually the
-    /// same width as the story bounds; they diverge where one story unit
-    /// displays as several characters, as a `noteRef` does when its id has
-    /// more than one digit.
+    /// Rendered bounds relative to the paragraph's content start, always the
+    /// same width as the story bounds.
     pm_start: u32,
     pm_end: u32,
     /// Checkbox chrome inherited from the nearest editable inline SDT.
@@ -3555,43 +3539,51 @@ mod tests {
     }
 
     #[test]
-    fn native_note_ref_mark_occupies_one_position_without_a_run() {
+    fn native_multi_digit_note_ref_occupies_one_position() {
         let doc = EditingDoc::new(44);
-        doc.create_story("fn:5", "", "Normal", "left").unwrap();
+        doc.create_story("body", "", "Normal", "left").unwrap();
         doc.apply_raw_ops(
-            "fn:5",
+            "body",
             vec![
                 RawOp::Delete { index: 0, len: 1 },
-                RawOp::InsertEmbed {
+                RawOp::Insert {
                     index: 0,
-                    kind: "noteRefMark".to_owned(),
-                    payload: vec![("noteType".to_owned(), Any::from("footnote"))],
+                    text: "A".to_owned(),
+                    attrs: Attrs::new(),
+                },
+                RawOp::InsertEmbed {
+                    index: 1,
+                    kind: "noteRef".to_owned(),
+                    payload: vec![("footnoteRefId".to_owned(), Any::Number(12.0))],
                     attrs: Attrs::new(),
                 },
                 RawOp::Insert {
-                    index: 1,
-                    text: " Footnote text".to_owned(),
+                    index: 2,
+                    text: "B".to_owned(),
                     attrs: Attrs::new(),
                 },
                 RawOp::InsertEmbed {
-                    index: 15,
+                    index: 3,
                     kind: "pilcrow".to_owned(),
-                    payload: vec![("paraId".to_owned(), Any::from("fn-p"))],
+                    payload: vec![("paraId".to_owned(), Any::from("body-p"))],
                     attrs: Attrs::new(),
                 },
             ],
             &EditCtx::local("", DATE),
         )
         .unwrap();
+        replace_story_with_paragraph(&doc, "fn:12", "fn-p", "Footnote text");
 
-        let footnote = serde_json::to_value(
-            yrs_doc_to_layout_blocks(&doc, "fn:5", &RenderEnv::default()).unwrap(),
+        let body = serde_json::to_value(
+            yrs_doc_to_layout_blocks(&doc, "body", &RenderEnv::default()).unwrap(),
         )
         .unwrap();
-        assert_eq!(footnote[0]["runs"].as_array().map(Vec::len), Some(1));
-        assert_eq!(footnote[0]["runs"][0]["text"], json!(" Footnote text"));
-        assert_eq!(footnote[0]["runs"][0]["pmStart"], json!(2.0));
-        assert_eq!(footnote[0]["pmEnd"], json!(17.0));
+        assert_eq!(body[0]["runs"][1]["text"], json!("12"));
+        assert_eq!(body[0]["runs"][1]["pmStart"], json!(2.0));
+        assert_eq!(body[0]["runs"][1]["pmEnd"], json!(3.0));
+        assert_eq!(body[0]["runs"][2]["text"], json!("B"));
+        assert_eq!(body[0]["runs"][2]["pmStart"], json!(3.0));
+        assert_eq!(body[0]["pmEnd"], json!(5.0));
     }
 
     #[test]

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -2728,6 +2728,19 @@ mod tests {
             .doc()
             .create_story("fn:5", "Footnote text", "Normal", "left")
             .unwrap();
+        engine
+            .doc()
+            .apply_raw_ops(
+                "fn:5",
+                vec![crate::RawOp::InsertEmbed {
+                    index: 0,
+                    kind: "noteRefMark".to_owned(),
+                    payload: vec![("noteType".to_owned(), Any::from("footnote"))],
+                    attrs: Attrs::new(),
+                }],
+                &crate::EditCtx::local("", "2026-07-18T00:00:00Z"),
+            )
+            .unwrap();
         let request = serde_json::json!({
             "bodyStory": "body",
             "regions": {
@@ -2761,7 +2774,9 @@ mod tests {
             serde_json::json!([5.0])
         );
         assert_eq!(note["displayLabel"], "1");
+        assert_eq!(note["blocks"][0]["runs"].as_array().map(Vec::len), Some(2));
         assert_eq!(note["blocks"][0]["runs"][0]["text"], "1  ");
+        assert_eq!(note["blocks"][0]["runs"][1]["text"], "Footnote text");
         assert!(note["height"].as_f64().unwrap() > 0.0);
         assert!(
             output["layout"]["pages"][0]["footnoteReservedHeight"]

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -2728,19 +2728,6 @@ mod tests {
             .doc()
             .create_story("fn:5", "Footnote text", "Normal", "left")
             .unwrap();
-        engine
-            .doc()
-            .apply_raw_ops(
-                "fn:5",
-                vec![crate::RawOp::InsertEmbed {
-                    index: 0,
-                    kind: "noteRefMark".to_owned(),
-                    payload: vec![("noteType".to_owned(), Any::from("footnote"))],
-                    attrs: Attrs::new(),
-                }],
-                &crate::EditCtx::local("", "2026-07-18T00:00:00Z"),
-            )
-            .unwrap();
         let request = serde_json::json!({
             "bodyStory": "body",
             "regions": {
@@ -2774,9 +2761,7 @@ mod tests {
             serde_json::json!([5.0])
         );
         assert_eq!(note["displayLabel"], "1");
-        assert_eq!(note["blocks"][0]["runs"].as_array().map(Vec::len), Some(2));
         assert_eq!(note["blocks"][0]["runs"][0]["text"], "1  ");
-        assert_eq!(note["blocks"][0]["runs"][1]["text"], "Footnote text");
         assert!(note["height"].as_f64().unwrap() > 0.0);
         assert!(
             output["layout"]["pages"][0]["footnoteReservedHeight"]

--- a/crates/docx-edit/src/seed.rs
+++ b/crates/docx-edit/src/seed.rs
@@ -1213,16 +1213,6 @@ fn note_ref_unit(
         }),
         &all_marks,
         comment_id,
-        utf16_len(&js_string(id)),
-    )
-}
-
-fn note_ref_mark_unit(note_type: &str, marks: &[Mark], comment_id: Option<String>) -> InlineUnit {
-    embed_unit(
-        "noteRefMark",
-        map_from_value(json!({ "noteType": note_type })),
-        marks,
-        comment_id,
         1,
     )
 }
@@ -1332,8 +1322,6 @@ fn run_content_to_units(
             .map(|id| note_ref_unit(id, "endnote", marks, comment_id))
             .into_iter()
             .collect(),
-        "footnoteRefMark" => vec![note_ref_mark_unit("footnote", marks, comment_id)],
-        "endnoteRefMark" => vec![note_ref_mark_unit("endnote", marks, comment_id)],
         _ => vec![],
     }
 }
@@ -1578,6 +1566,21 @@ fn paragraph_style_formatting(
     merge_text_formatting(style.as_ref(), extra)
 }
 
+/// Note number marks carry no story unit, so the run boundary cache is the only
+/// place a saved paragraph can learn they were there.
+fn note_ref_mark_types(run: &Value) -> Vec<Value> {
+    array(field(Some(run), "content"))
+        .iter()
+        .filter_map(
+            |content| match string(field(Some(content), "type")).unwrap_or_default() {
+                "footnoteRefMark" => Some(Value::String("footnote".to_owned())),
+                "endnoteRefMark" => Some(Value::String("endnote".to_owned())),
+                _ => None,
+            },
+        )
+        .collect()
+}
+
 fn run_boundary(
     run: &Value,
     style_formatting: Option<&Value>,
@@ -1585,9 +1588,10 @@ fn run_boundary(
     source: &BTreeMap<String, String>,
 ) -> Option<Value> {
     let units = run_to_units(run, style_formatting, styles, None, &[], source);
-    if units.iter().any(|unit| {
-        matches!(&unit.content, UnitContent::Embed { kind, .. } if kind != "noteRef" && kind != "noteRefMark")
-    }) {
+    if units
+        .iter()
+        .any(|unit| matches!(&unit.content, UnitContent::Embed { kind, .. } if kind != "noteRef"))
+    {
         return None;
     }
     let keys: Vec<_> = units.iter().map(|unit| marks_key(&unit.marks)).collect();
@@ -1601,7 +1605,6 @@ fn run_boundary(
         .iter()
         .map(|unit| match &unit.content {
             UnitContent::Text(text) => text.clone(),
-            UnitContent::Embed { kind, .. } if kind == "noteRefMark" => String::new(),
             UnitContent::Embed { payload, .. } => payload
                 .get("footnoteRefId")
                 .or_else(|| payload.get("endnoteRefId"))
@@ -1609,16 +1612,11 @@ fn run_boundary(
                 .unwrap_or_default(),
         })
         .collect::<String>();
-    let note_mark = units.iter().find_map(|unit| match &unit.content {
-        UnitContent::Embed { kind, payload } if kind == "noteRefMark" => {
-            payload.get("noteType").cloned()
-        }
-        _ => None,
-    });
+    let note_marks = note_ref_mark_types(run);
     let mut boundary = Map::new();
     boundary.insert("text".to_owned(), Value::String(text));
-    if let Some(note_mark) = note_mark {
-        boundary.insert("noteMark".to_owned(), note_mark);
+    if !note_marks.is_empty() {
+        boundary.insert("noteMarks".to_owned(), Value::Array(note_marks));
     }
     if let Some(key) = keys.first() {
         boundary.insert("marksKey".to_owned(), Value::String(key.clone()));
@@ -3171,36 +3169,43 @@ mod tests {
     }
 
     #[test]
-    fn note_ref_marks_seed_as_embeds_that_keep_their_run_marks() {
-        let marks = vec![mark(
-            "runStyle",
-            ordered_object([("styleId", Value::String("FootnoteReference".into()))]),
-        )];
+    fn note_ref_marks_seed_no_story_unit_and_land_in_the_run_boundary() {
+        let styles = StyleResolver::new(None);
         for (content_type, note_type) in [
             ("footnoteRefMark", "footnote"),
             ("endnoteRefMark", "endnote"),
         ] {
-            let units = run_content_to_units(
-                &json!({ "type": content_type }),
-                &marks,
-                None,
-                &BTreeMap::new(),
-            );
-            assert_eq!(units.len(), 1);
-            let UnitContent::Embed { kind, payload } = &units[0].content else {
-                panic!("{content_type} must seed an embed");
-            };
-            assert_eq!(kind, "noteRefMark");
+            let run = json!({
+                "type": "run",
+                "formatting": { "styleId": "FootnoteReference" },
+                "content": [{ "type": content_type }, { "type": content_type }],
+            });
+            assert!(run_to_units(&run, None, &styles, None, &[], &BTreeMap::new()).is_empty());
+            let boundary = run_boundary(&run, None, &styles, &BTreeMap::new()).unwrap();
             assert_eq!(
-                payload.get("noteType"),
-                Some(&Value::String(note_type.into()))
+                boundary.get("noteMarks"),
+                Some(&json!([note_type, note_type]))
             );
-            assert_eq!(units[0].pm_size, 1);
-            assert_eq!(
-                units[0].attrs.get("runStyle"),
-                Some(&json!({ "styleId": "FootnoteReference" }))
-            );
+            assert_eq!(boundary.get("text"), Some(&Value::String(String::new())));
         }
+    }
+
+    #[test]
+    fn multi_digit_note_references_seed_one_position() {
+        let styles = StyleResolver::new(None);
+        let units = run_to_units(
+            &json!({
+                "type": "run",
+                "content": [{ "type": "footnoteRef", "id": 12 }],
+            }),
+            None,
+            &styles,
+            None,
+            &[],
+            &BTreeMap::new(),
+        );
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].pm_size, 1);
     }
 
     #[test]

--- a/crates/docx-edit/src/seed.rs
+++ b/crates/docx-edit/src/seed.rs
@@ -1217,6 +1217,16 @@ fn note_ref_unit(
     )
 }
 
+fn note_ref_mark_unit(note_type: &str, marks: &[Mark], comment_id: Option<String>) -> InlineUnit {
+    embed_unit(
+        "noteRefMark",
+        map_from_value(json!({ "noteType": note_type })),
+        marks,
+        comment_id,
+        1,
+    )
+}
+
 fn run_content_to_units(
     content: &Value,
     marks: &[Mark],
@@ -1322,6 +1332,8 @@ fn run_content_to_units(
             .map(|id| note_ref_unit(id, "endnote", marks, comment_id))
             .into_iter()
             .collect(),
+        "footnoteRefMark" => vec![note_ref_mark_unit("footnote", marks, comment_id)],
+        "endnoteRefMark" => vec![note_ref_mark_unit("endnote", marks, comment_id)],
         _ => vec![],
     }
 }
@@ -1573,10 +1585,9 @@ fn run_boundary(
     source: &BTreeMap<String, String>,
 ) -> Option<Value> {
     let units = run_to_units(run, style_formatting, styles, None, &[], source);
-    if units
-        .iter()
-        .any(|unit| matches!(&unit.content, UnitContent::Embed { kind, .. } if kind != "noteRef"))
-    {
+    if units.iter().any(|unit| {
+        matches!(&unit.content, UnitContent::Embed { kind, .. } if kind != "noteRef" && kind != "noteRefMark")
+    }) {
         return None;
     }
     let keys: Vec<_> = units.iter().map(|unit| marks_key(&unit.marks)).collect();
@@ -1590,6 +1601,7 @@ fn run_boundary(
         .iter()
         .map(|unit| match &unit.content {
             UnitContent::Text(text) => text.clone(),
+            UnitContent::Embed { kind, .. } if kind == "noteRefMark" => String::new(),
             UnitContent::Embed { payload, .. } => payload
                 .get("footnoteRefId")
                 .or_else(|| payload.get("endnoteRefId"))
@@ -1597,8 +1609,17 @@ fn run_boundary(
                 .unwrap_or_default(),
         })
         .collect::<String>();
+    let note_mark = units.iter().find_map(|unit| match &unit.content {
+        UnitContent::Embed { kind, payload } if kind == "noteRefMark" => {
+            payload.get("noteType").cloned()
+        }
+        _ => None,
+    });
     let mut boundary = Map::new();
     boundary.insert("text".to_owned(), Value::String(text));
+    if let Some(note_mark) = note_mark {
+        boundary.insert("noteMark".to_owned(), note_mark);
+    }
     if let Some(key) = keys.first() {
         boundary.insert("marksKey".to_owned(), Value::String(key.clone()));
     }
@@ -3147,6 +3168,39 @@ mod tests {
             Some(Value::Bool(false)),
             "a direct off overrides a style that turns the toggle back on"
         );
+    }
+
+    #[test]
+    fn note_ref_marks_seed_as_embeds_that_keep_their_run_marks() {
+        let marks = vec![mark(
+            "runStyle",
+            ordered_object([("styleId", Value::String("FootnoteReference".into()))]),
+        )];
+        for (content_type, note_type) in [
+            ("footnoteRefMark", "footnote"),
+            ("endnoteRefMark", "endnote"),
+        ] {
+            let units = run_content_to_units(
+                &json!({ "type": content_type }),
+                &marks,
+                None,
+                &BTreeMap::new(),
+            );
+            assert_eq!(units.len(), 1);
+            let UnitContent::Embed { kind, payload } = &units[0].content else {
+                panic!("{content_type} must seed an embed");
+            };
+            assert_eq!(kind, "noteRefMark");
+            assert_eq!(
+                payload.get("noteType"),
+                Some(&Value::String(note_type.into()))
+            );
+            assert_eq!(units[0].pm_size, 1);
+            assert_eq!(
+                units[0].attrs.get("runStyle"),
+                Some(&json!({ "styleId": "FootnoteReference" }))
+            );
+        }
     }
 
     #[test]

--- a/packages/docx/src/yrs/documentToYrs.ts
+++ b/packages/docx/src/yrs/documentToYrs.ts
@@ -574,6 +574,10 @@ function runContentToUnits(
       return [noteRefUnit(content.id, 'footnote', marks, commentId)];
     case 'endnoteRef':
       return [noteRefUnit(content.id, 'endnote', marks, commentId)];
+    case 'footnoteRefMark':
+      return [embedUnit('noteRefMark', { noteType: 'footnote' }, marks, commentId)];
+    case 'endnoteRefMark':
+      return [embedUnit('noteRefMark', { noteType: 'endnote' }, marks, commentId)];
     default:
       return [];
   }
@@ -725,12 +729,21 @@ function runBoundary(
   styleResolver: StyleResolver | null
 ): Attrs | null {
   const units = runToUnits(run, styleFormatting, styleResolver);
-  if (units.some((unit) => unit.kind !== 'text' && unit.embedKind !== 'noteRef')) return null;
+  if (
+    units.some(
+      (unit) =>
+        unit.kind !== 'text' && unit.embedKind !== 'noteRef' && unit.embedKind !== 'noteRefMark'
+    )
+  ) {
+    return null;
+  }
   const keys = units.map((unit) => marksKey(unit.marks));
   if (keys.some((key) => key !== keys[0])) return null;
+  const mark = units.find((unit) => unit.kind === 'embed' && unit.embedKind === 'noteRefMark');
   const text = units
     .map((unit) => {
       if (unit.kind === 'text') return unit.text;
+      if (unit.embedKind === 'noteRefMark') return '';
       const id = unit.payload.footnoteRefId ?? unit.payload.endnoteRefId;
       return String(id ?? '');
     })
@@ -738,6 +751,7 @@ function runBoundary(
   const key = keys[0];
   return {
     text,
+    ...(mark?.kind === 'embed' ? { noteMark: mark.payload.noteType } : {}),
     ...(key !== undefined ? { marksKey: key } : {}),
     ...(run.formatting ? { formatting: run.formatting } : {}),
     ...(run.propertyChanges ? { propertyChanges: run.propertyChanges } : {}),

--- a/packages/docx/src/yrs/documentToYrs.ts
+++ b/packages/docx/src/yrs/documentToYrs.ts
@@ -508,8 +508,7 @@ function noteRefUnit(
     'noteRef',
     noteType === 'endnote' ? { endnoteRefId: id } : { footnoteRefId: id },
     allMarks,
-    commentId,
-    String(id).length
+    commentId
   );
 }
 
@@ -574,10 +573,6 @@ function runContentToUnits(
       return [noteRefUnit(content.id, 'footnote', marks, commentId)];
     case 'endnoteRef':
       return [noteRefUnit(content.id, 'endnote', marks, commentId)];
-    case 'footnoteRefMark':
-      return [embedUnit('noteRefMark', { noteType: 'footnote' }, marks, commentId)];
-    case 'endnoteRefMark':
-      return [embedUnit('noteRefMark', { noteType: 'endnote' }, marks, commentId)];
     default:
       return [];
   }
@@ -723,27 +718,32 @@ function paragraphStyleFormatting(
   return mergeTextFormatting(styleFormatting, extraRunFormatting);
 }
 
+/**
+ * Note number marks carry no story unit, so the run boundary cache is the only
+ * place a saved paragraph can learn they were there.
+ */
+function noteRefMarkTypes(run: Run): string[] {
+  const marks: string[] = [];
+  for (const content of run.content) {
+    if (content.type === 'footnoteRefMark') marks.push('footnote');
+    else if (content.type === 'endnoteRefMark') marks.push('endnote');
+  }
+  return marks;
+}
+
 function runBoundary(
   run: Run,
   styleFormatting: TextFormatting | undefined,
   styleResolver: StyleResolver | null
 ): Attrs | null {
   const units = runToUnits(run, styleFormatting, styleResolver);
-  if (
-    units.some(
-      (unit) =>
-        unit.kind !== 'text' && unit.embedKind !== 'noteRef' && unit.embedKind !== 'noteRefMark'
-    )
-  ) {
-    return null;
-  }
+  if (units.some((unit) => unit.kind !== 'text' && unit.embedKind !== 'noteRef')) return null;
   const keys = units.map((unit) => marksKey(unit.marks));
   if (keys.some((key) => key !== keys[0])) return null;
-  const mark = units.find((unit) => unit.kind === 'embed' && unit.embedKind === 'noteRefMark');
+  const marks = noteRefMarkTypes(run);
   const text = units
     .map((unit) => {
       if (unit.kind === 'text') return unit.text;
-      if (unit.embedKind === 'noteRefMark') return '';
       const id = unit.payload.footnoteRefId ?? unit.payload.endnoteRefId;
       return String(id ?? '');
     })
@@ -751,7 +751,7 @@ function runBoundary(
   const key = keys[0];
   return {
     text,
-    ...(mark?.kind === 'embed' ? { noteMark: mark.payload.noteType } : {}),
+    ...(marks.length > 0 ? { noteMarks: marks } : {}),
     ...(key !== undefined ? { marksKey: key } : {}),
     ...(run.formatting ? { formatting: run.formatting } : {}),
     ...(run.propertyChanges ? { propertyChanges: run.propertyChanges } : {}),

--- a/packages/docx/src/yrs/noteSave.test.ts
+++ b/packages/docx/src/yrs/noteSave.test.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import { parseDocx } from '../docx';
 import { repackDocx } from '../docx/rezip';
 import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
+import { readDocxContainer } from '../docx/zipContainer';
 import type { BlockContent, Document, Endnote, Footnote } from '../types/document';
 import { preloadEditWasm } from '../wasm/edit';
 import { createYrsSession, type YrsSession } from './index';
@@ -21,6 +22,7 @@ const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <Override PartName="/word/styles.xml" ContentType="${OFFICE_DOC}.wordprocessingml.styles+xml"/>
   <Override PartName="/word/footnotes.xml" ContentType="${OFFICE_DOC}.wordprocessingml.footnotes+xml"/>
   <Override PartName="/word/endnotes.xml" ContentType="${OFFICE_DOC}.wordprocessingml.endnotes+xml"/>
+  <Override PartName="/word/comments.xml" ContentType="${OFFICE_DOC}.wordprocessingml.comments+xml"/>
 </Types>`;
 
 const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -33,6 +35,7 @@ const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
   <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>
   <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/>
+  <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="comments.xml"/>
 </Relationships>`;
 
 const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -56,15 +59,32 @@ const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <w:style w:type="character" w:styleId="EndnoteReference"><w:name w:val="endnote reference"/><w:rPr><w:vertAlign w:val="superscript"/></w:rPr></w:style>
 </w:styles>`;
 
-const FOOTNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+const FOOTNOTE_BODY = `<w:r><w:t xml:space="preserve"> Footnote body.</w:t></w:r>`;
+
+const COMMENTED_FOOTNOTE_BODY = `<w:r><w:t xml:space="preserve"> Footnote </w:t></w:r>
+      <w:commentRangeStart w:id="1"/>
+      <w:r><w:t>body</w:t></w:r>
+      <w:commentRangeEnd w:id="1"/>
+      <w:r><w:t>.</w:t></w:r>`;
+
+const REVISED_FOOTNOTE_BODY = `<w:r>
+        <w:rPr><w:rPrChange w:id="7" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:rPr><w:b/></w:rPr></w:rPrChange></w:rPr>
+        <w:t xml:space="preserve"> Footnote body.</w:t>
+      </w:r>`;
+
+const MARK_RUN = `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>`;
+
+const DOUBLE_MARK_RUN = `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/><w:footnoteRef/></w:r>`;
+
+const footnotesXml = (body: string, markRun: string): string => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:footnote w:id="-1" w:type="separator"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
   <w:footnote w:id="0" w:type="continuationSeparator"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
   <w:footnote w:id="2">
     <w:p>
       <w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>
-      <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>
-      <w:r><w:t xml:space="preserve"> Footnote body.</w:t></w:r>
+      ${markRun}
+      ${body}
     </w:p>
   </w:footnote>
 </w:footnotes>`;
@@ -82,23 +102,49 @@ const ENDNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   </w:endnote>
 </w:endnotes>`;
 
-function fixture(): Uint8Array {
+const COMMENTS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:comment w:id="1" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:p><w:r><w:t>Note comment</w:t></w:r></w:p></w:comment>
+</w:comments>`;
+
+function fixture(footnoteBody = FOOTNOTE_BODY, markRun = MARK_RUN): Uint8Array {
   const parts: PartsMap = new Map();
   parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
   parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
   parts.set('word/_rels/document.xml.rels', toBytes(DOCUMENT_RELS));
   parts.set('word/document.xml', toBytes(DOCUMENT));
   parts.set('word/styles.xml', toBytes(STYLES));
-  parts.set('word/footnotes.xml', toBytes(FOOTNOTES));
+  parts.set('word/footnotes.xml', toBytes(footnotesXml(footnoteBody, markRun)));
   parts.set('word/endnotes.xml', toBytes(ENDNOTES));
+  parts.set('word/comments.xml', toBytes(COMMENTS));
   return new Uint8Array(rezipPartsToArrayBuffer(parts));
+}
+
+/** Seed `bytes`, run `edit`, and return the repacked footnote 2 XML plus the reopened document. */
+async function saveFootnote(
+  bytes: Uint8Array,
+  edit: (session: YrsSession) => void
+): Promise<{ xml: string; reopened: Document }> {
+  const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+  const session = await createYrsSession({ clientId: 53003 });
+  let saved: Document;
+  try {
+    session.seedFromDocx(bytes);
+    edit(session);
+    saved = yrsToDocument(session, parsed);
+  } finally {
+    session.destroy();
+  }
+  const repacked = await repackDocx(saved);
+  const xml = noteXml(readDocxContainer(repacked).text('word/footnotes.xml') ?? '', 'footnote', 2);
+  return { xml, reopened: await parseDocx(repacked, { preloadFonts: false }) };
 }
 
 /** Type at the end of a note story, the way the editor would. */
 function appendToNote(session: YrsSession, story: string, text: string): void {
-  const paragraphs = session.paragraphs(story);
-  const last = paragraphs[paragraphs.length - 1];
-  session.insertText({ story, paraId: last.paraId, offset: last.text.length }, text);
+  const spans = session.paragraphSpans(story);
+  const last = spans[spans.length - 1];
+  session.insertText({ story, paraId: last.paraId, offset: last.length }, text);
 }
 
 function blocksText(blocks: readonly BlockContent[]): string {
@@ -122,6 +168,11 @@ function noteText(notes: readonly (Footnote | Endnote)[] | undefined, id: number
   return note ? blocksText(note.content) : '';
 }
 
+function noteXml(xml: string, tag: 'footnote' | 'endnote', id: number): string {
+  const match = new RegExp(`<w:${tag} w:id="${id}"[^>]*>([\\s\\S]*?)</w:${tag}>`).exec(xml);
+  return match?.[1] ?? '';
+}
+
 describe('note story save projection', () => {
   beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
 
@@ -140,8 +191,67 @@ describe('note story save projection', () => {
       session.destroy();
     }
 
-    const reopened = await parseDocx(await repackDocx(saved), { preloadFonts: false });
+    const repacked = await repackDocx(saved);
+    const reopened = await parseDocx(repacked, { preloadFonts: false });
     expect(noteText(reopened.package.footnotes, 2)).toContain('Typed into the footnote.');
     expect(noteText(reopened.package.endnotes, 2)).toContain('Typed into the endnote.');
+
+    const parts = readDocxContainer(repacked);
+    const footnote = noteXml(parts.text('word/footnotes.xml') ?? '', 'footnote', 2);
+    expect(footnote).toContain('<w:footnoteRef');
+    expect(footnote).toMatch(/<w:rStyle w:val="FootnoteReference"\/>[\s\S]*?<w:footnoteRef/);
+    expect(footnote).toContain(' Footnote body. Typed into the footnote.');
+    const endnote = noteXml(parts.text('word/endnotes.xml') ?? '', 'endnote', 2);
+    expect(endnote).toContain('<w:endnoteRef');
+    expect(endnote).toMatch(/<w:rStyle w:val="EndnoteReference"\/>[\s\S]*?<w:endnoteRef/);
+    expect(endnote).toContain(' Endnote body. Typed into the endnote.');
+  });
+
+  it('keeps the note mark inside a suggested deletion', async () => {
+    const { xml, reopened } = await saveFootnote(fixture(), (session) => {
+      const [{ paraId }] = session.paragraphSpans('fn:2');
+      session.deleteRange(
+        { story: 'fn:2', start: { paraId, offset: 0 }, end: { paraId, offset: 1 } },
+        { name: 'Reviewer', date: '2026-08-16T00:00:00Z' }
+      );
+    });
+
+    expect(xml).toMatch(/<w:del [^>]*>(?:(?!<\/w:del>)[\s\S])*<w:footnoteRef\/>[\s\S]*?<\/w:del>/);
+    expect(xml).toContain(' Footnote body.');
+    const paragraph = reopened.package.footnotes?.find((note) => note.id === 2)?.content[0];
+    const deletion = paragraph?.type === 'paragraph' ? paragraph.content[0] : undefined;
+    expect(deletion?.type).toBe('deletion');
+    expect(
+      deletion?.type === 'deletion' &&
+        deletion.content.some(
+          (run) => run.type === 'run' && run.content.some((c) => c.type === 'footnoteRefMark')
+        )
+    ).toBe(true);
+  });
+
+  it('places note comment ranges after the mark on the right characters', async () => {
+    const { xml } = await saveFootnote(fixture(COMMENTED_FOOTNOTE_BODY), (session) => {
+      appendToNote(session, 'fn:2', ' Typed.');
+    });
+
+    expect(xml).toContain('<w:footnoteRef');
+    expect(xml).toMatch(
+      /<w:commentRangeStart w:id="1"\/><w:r>(?:<w:rPr>[\s\S]*?<\/w:rPr>)?<w:t>body<\/w:t><\/w:r><w:commentRangeEnd w:id="1"\/>/
+    );
+  });
+
+  it('saves a note whose run holds more than one mark', async () => {
+    const { xml } = await saveFootnote(fixture(FOOTNOTE_BODY, DOUBLE_MARK_RUN), () => {});
+
+    expect(xml.match(/<w:footnoteRef\/>/g)?.length).toBe(2);
+    expect(xml).toContain(' Footnote body.');
+  });
+
+  it('restores original note runs with their property changes when the text is untouched', async () => {
+    const { xml } = await saveFootnote(fixture(REVISED_FOOTNOTE_BODY), () => {});
+
+    expect(xml).toContain('<w:footnoteRef');
+    expect(xml).toMatch(/<w:rPrChange [^>]*w:id="7"/);
+    expect(xml).toContain(' Footnote body.');
   });
 });

--- a/packages/docx/src/yrs/noteSave.test.ts
+++ b/packages/docx/src/yrs/noteSave.test.ts
@@ -8,6 +8,7 @@ import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/p
 import { readDocxContainer } from '../docx/zipContainer';
 import type { BlockContent, Document, Endnote, Footnote } from '../types/document';
 import { preloadEditWasm } from '../wasm/edit';
+import { documentToYrs } from './documentToYrs';
 import { createYrsSession, type YrsSession } from './index';
 import { yrsToDocument } from './yrsToDocument';
 
@@ -38,14 +39,25 @@ const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="comments.xml"/>
 </Relationships>`;
 
-const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:body>
-    <w:p>
+const BODY = `<w:p>
       <w:r><w:t xml:space="preserve">Body text</w:t></w:r>
       <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="2"/></w:r>
       <w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteReference w:id="2"/></w:r>
-    </w:p>
+    </w:p>`;
+
+/** `A`, a reference to note `id`, `B`, with a bookmark closing right after the reference. */
+const bookmarkedBody = (id: number, trailing: string): string => `<w:p>
+      <w:r><w:t>A</w:t></w:r>
+      <w:bookmarkStart w:id="5" w:name="span"/>
+      <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="${id}"/></w:r>
+      <w:bookmarkEnd w:id="5"/>
+      ${trailing}
+    </w:p>`;
+
+const documentXml = (body: string): string => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    ${body}
     <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
   </w:body>
 </w:document>`;
@@ -74,13 +86,25 @@ const REVISED_FOOTNOTE_BODY = `<w:r>
 
 const MARK_RUN = `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>`;
 
-const DOUBLE_MARK_RUN = `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/><w:footnoteRef/></w:r>`;
+const DOUBLE_MARK_RUN = `<w:r>
+        <w:rPr><w:rStyle w:val="FootnoteReference"/><w:rPrChange w:id="9" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:rPr><w:b/></w:rPr></w:rPrChange></w:rPr>
+        <w:footnoteRef/><w:footnoteRef/>
+      </w:r>`;
 
-const footnotesXml = (body: string, markRun: string): string => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+const REVISED_MARK_RUN = `<w:r>
+        <w:rPr><w:rStyle w:val="FootnoteReference"/><w:rPrChange w:id="8" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:rPr><w:i/></w:rPr></w:rPrChange></w:rPr>
+        <w:footnoteRef/>
+      </w:r>`;
+
+const DELETED_MARK_RUN = `<w:del w:id="6" w:author="Reviewer" w:date="2026-08-16T00:00:00Z">
+        <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>
+      </w:del>`;
+
+const footnotesXml = (body: string, markRun: string, noteId: number): string => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:footnote w:id="-1" w:type="separator"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
   <w:footnote w:id="0" w:type="continuationSeparator"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
-  <w:footnote w:id="2">
+  <w:footnote w:id="${noteId}">
     <w:p>
       <w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>
       ${markRun}
@@ -107,37 +131,72 @@ const COMMENTS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <w:comment w:id="1" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:p><w:r><w:t>Note comment</w:t></w:r></w:p></w:comment>
 </w:comments>`;
 
-function fixture(footnoteBody = FOOTNOTE_BODY, markRun = MARK_RUN): Uint8Array {
+interface FixtureOptions {
+  footnoteBody?: string;
+  markRun?: string;
+  body?: string;
+  noteId?: number;
+}
+
+function fixture(options: FixtureOptions = {}): Uint8Array {
+  const {
+    footnoteBody = FOOTNOTE_BODY,
+    markRun = MARK_RUN,
+    body = BODY,
+    noteId = 2,
+  } = options;
   const parts: PartsMap = new Map();
   parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
   parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
   parts.set('word/_rels/document.xml.rels', toBytes(DOCUMENT_RELS));
-  parts.set('word/document.xml', toBytes(DOCUMENT));
+  parts.set('word/document.xml', toBytes(documentXml(body)));
   parts.set('word/styles.xml', toBytes(STYLES));
-  parts.set('word/footnotes.xml', toBytes(footnotesXml(footnoteBody, markRun)));
+  parts.set('word/footnotes.xml', toBytes(footnotesXml(footnoteBody, markRun, noteId)));
   parts.set('word/endnotes.xml', toBytes(ENDNOTES));
   parts.set('word/comments.xml', toBytes(COMMENTS));
   return new Uint8Array(rezipPartsToArrayBuffer(parts));
 }
 
-/** Seed `bytes`, run `edit`, and return the repacked footnote 2 XML plus the reopened document. */
-async function saveFootnote(
-  bytes: Uint8Array,
-  edit: (session: YrsSession) => void
-): Promise<{ xml: string; reopened: Document }> {
+interface SaveOptions {
+  seeder?: 'native' | 'projected';
+  noteId?: number;
+  edit?: (session: YrsSession) => void;
+}
+
+interface SaveResult {
+  /** Inner XML of the saved footnote. */
+  xml: string;
+  /** Saved `word/document.xml`. */
+  body: string;
+  /** What a peer sees on the wire for the note story. */
+  segments: ReturnType<YrsSession['storySegments']>;
+  reopened: Document;
+}
+
+/** Seed `bytes`, run the edit, and repack. */
+async function saveFootnote(bytes: Uint8Array, options: SaveOptions = {}): Promise<SaveResult> {
+  const { seeder = 'native', noteId = 2, edit } = options;
   const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
   const session = await createYrsSession({ clientId: 53003 });
   let saved: Document;
+  let segments: SaveResult['segments'];
   try {
-    session.seedFromDocx(bytes);
-    edit(session);
+    if (seeder === 'native') session.seedFromDocx(bytes);
+    else documentToYrs(session, parsed);
+    edit?.(session);
+    segments = session.storySegments(`fn:${noteId}`);
     saved = yrsToDocument(session, parsed);
   } finally {
     session.destroy();
   }
   const repacked = await repackDocx(saved);
-  const xml = noteXml(readDocxContainer(repacked).text('word/footnotes.xml') ?? '', 'footnote', 2);
-  return { xml, reopened: await parseDocx(repacked, { preloadFonts: false }) };
+  const parts = readDocxContainer(repacked);
+  return {
+    xml: noteXml(parts.text('word/footnotes.xml') ?? '', 'footnote', noteId),
+    body: parts.text('word/document.xml') ?? '',
+    segments,
+    reopened: await parseDocx(repacked, { preloadFonts: false }),
+  };
 }
 
 /** Type at the end of a note story, the way the editor would. */
@@ -207,31 +266,38 @@ describe('note story save projection', () => {
     expect(endnote).toContain(' Endnote body. Typed into the endnote.');
   });
 
-  it('keeps the note mark inside a suggested deletion', async () => {
-    const { xml, reopened } = await saveFootnote(fixture(), (session) => {
-      const [{ paraId }] = session.paragraphSpans('fn:2');
-      session.deleteRange(
-        { story: 'fn:2', start: { paraId, offset: 0 }, end: { paraId, offset: 1 } },
-        { name: 'Reviewer', date: '2026-08-16T00:00:00Z' }
-      );
+  it('keeps the note mark when the reviewer suggests deleting the note text', async () => {
+    const { xml, reopened } = await saveFootnote(fixture(), {
+      edit: (session) => {
+        const [{ paraId, length }] = session.paragraphSpans('fn:2');
+        session.deleteRange(
+          { story: 'fn:2', start: { paraId, offset: 0 }, end: { paraId, offset: length } },
+          { name: 'Reviewer', date: '2026-08-16T00:00:00Z' }
+        );
+      },
     });
 
-    expect(xml).toMatch(/<w:del [^>]*>(?:(?!<\/w:del>)[\s\S])*<w:footnoteRef\/>[\s\S]*?<\/w:del>/);
-    expect(xml).toContain(' Footnote body.');
+    expect(xml).toContain('<w:footnoteRef/>');
+    expect(xml).toMatch(/<w:del [^>]*>[\s\S]*?Footnote body\.[\s\S]*?<\/w:del>/);
     const paragraph = reopened.package.footnotes?.find((note) => note.id === 2)?.content[0];
-    const deletion = paragraph?.type === 'paragraph' ? paragraph.content[0] : undefined;
-    expect(deletion?.type).toBe('deletion');
+    const mark = paragraph?.type === 'paragraph' ? paragraph.content[0] : undefined;
     expect(
-      deletion?.type === 'deletion' &&
-        deletion.content.some(
-          (run) => run.type === 'run' && run.content.some((c) => c.type === 'footnoteRefMark')
-        )
+      mark?.type === 'run' && mark.content.some((entry) => entry.type === 'footnoteRefMark')
     ).toBe(true);
   });
 
+  it('keeps a note mark the source file already had inside a suggested deletion', async () => {
+    const { xml } = await saveFootnote(fixture({ markRun: DELETED_MARK_RUN }), {
+      edit: (session) => appendToNote(session, 'fn:2', ' Typed.'),
+    });
+
+    expect(xml).toMatch(/<w:del [^>]*>(?:(?!<\/w:del>)[\s\S])*<w:footnoteRef\/>[\s\S]*?<\/w:del>/);
+    expect(xml).toContain(' Footnote body. Typed.');
+  });
+
   it('places note comment ranges after the mark on the right characters', async () => {
-    const { xml } = await saveFootnote(fixture(COMMENTED_FOOTNOTE_BODY), (session) => {
-      appendToNote(session, 'fn:2', ' Typed.');
+    const { xml } = await saveFootnote(fixture({ footnoteBody: COMMENTED_FOOTNOTE_BODY }), {
+      edit: (session) => appendToNote(session, 'fn:2', ' Typed.'),
     });
 
     expect(xml).toContain('<w:footnoteRef');
@@ -240,18 +306,62 @@ describe('note story save projection', () => {
     );
   });
 
-  it('saves a note whose run holds more than one mark', async () => {
-    const { xml } = await saveFootnote(fixture(FOOTNOTE_BODY, DOUBLE_MARK_RUN), () => {});
-
-    expect(xml.match(/<w:footnoteRef\/>/g)?.length).toBe(2);
-    expect(xml).toContain(' Footnote body.');
-  });
-
   it('restores original note runs with their property changes when the text is untouched', async () => {
-    const { xml } = await saveFootnote(fixture(REVISED_FOOTNOTE_BODY), () => {});
+    const { xml } = await saveFootnote(fixture({ footnoteBody: REVISED_FOOTNOTE_BODY }));
 
     expect(xml).toContain('<w:footnoteRef');
     expect(xml).toMatch(/<w:rPrChange [^>]*w:id="7"/);
     expect(xml).toContain(' Footnote body.');
   });
+
+  for (const seeder of ['native', 'projected'] as const) {
+    it(`[${seeder}] leaves the note number mark off the wire`, async () => {
+      const { segments, xml } = await saveFootnote(fixture(), { seeder });
+
+      expect(segments.filter((segment) => segment.kind === 'embed')).toEqual([]);
+      expect(segments[0]).toMatchObject({ kind: 'text', text: ' Footnote body.' });
+      expect(xml).toContain('<w:footnoteRef/>');
+    });
+
+    it(`[${seeder}] keeps both marks of a run and the run's property change`, async () => {
+      const { xml } = await saveFootnote(fixture({ markRun: DOUBLE_MARK_RUN }), { seeder });
+
+      expect(xml.match(/<w:footnoteRef\/>/g)?.length).toBe(2);
+      expect(xml).toMatch(/<w:rPrChange [^>]*w:id="9"/);
+      expect(xml).toContain(' Footnote body.');
+    });
+
+    it(`[${seeder}] keeps a mark run's property change on that run once the text is edited`, async () => {
+      const { xml } = await saveFootnote(fixture({ markRun: REVISED_MARK_RUN }), {
+        seeder,
+        edit: (session) => appendToNote(session, 'fn:2', ' Typed.'),
+      });
+
+      expect(xml).toContain(' Footnote body. Typed.');
+      const runs = xml.match(/<w:r>[\s\S]*?<\/w:r>/g) ?? [];
+      expect(runs.filter((run) => /<w:rPrChange [^>]*w:id="8"/.test(run))).toEqual([
+        expect.stringContaining('<w:footnoteRef/>'),
+      ]);
+    });
+
+    it(`[${seeder}] closes a bookmark right after a multi-digit note reference`, async () => {
+      const { body } = await saveFootnote(
+        fixture({ body: bookmarkedBody(12, '<w:r><w:t>B</w:t></w:r>'), noteId: 12 }),
+        { seeder, noteId: 12 }
+      );
+
+      expect(body).toMatch(
+        /<w:footnoteReference w:id="12"\/><\/w:r><w:bookmarkEnd w:id="5"\/><w:r><w:t>B<\/w:t>/
+      );
+    });
+
+    it(`[${seeder}] keeps a bookmark that closes on a trailing note reference`, async () => {
+      const { body } = await saveFootnote(
+        fixture({ body: bookmarkedBody(12, ''), noteId: 12 }),
+        { seeder, noteId: 12 }
+      );
+
+      expect(body).toContain('<w:bookmarkEnd w:id="5"/>');
+    });
+  }
 });

--- a/packages/docx/src/yrs/yrsToDocument.ts
+++ b/packages/docx/src/yrs/yrsToDocument.ts
@@ -203,6 +203,7 @@ interface BookmarkBoundary extends CommentBoundary {
 
 interface OriginalRunBoundary {
   text: string;
+  noteMark?: 'footnote' | 'endnote';
   marksKey?: string;
   formatting?: TextFormatting;
   propertyChanges?: Run['propertyChanges'];
@@ -840,6 +841,15 @@ function commentReferenceFromPayload(payload: Attrs): Run | null {
   };
 }
 
+function noteRefMarkRun(item: EmbedItem): Run {
+  const formatting = attrsToTextFormatting(formattingAttrs(item.attributes));
+  return {
+    type: 'run',
+    ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
+    content: [{ type: item.payload.noteType === 'endnote' ? 'endnoteRefMark' : 'footnoteRefMark' }],
+  };
+}
+
 function ordinaryContentForItem(item: InlineItem): ParagraphContent | null {
   if (item.kind === 'text') return createTextRun(item.text, item.attributes);
   switch (item.embedKind) {
@@ -871,6 +881,8 @@ function ordinaryContentForItem(item: InlineItem): ParagraphContent | null {
         ],
       };
     }
+    case 'noteRefMark':
+      return noteRefMarkRun(item);
     default:
       return null;
   }
@@ -881,6 +893,7 @@ function trackedContentForItem(item: InlineItem, info: TrackedChangeInfo): Parag
   if (item.kind === 'embed' && item.embedKind === 'image') run = imageRunFromPayload(item.payload);
   else if (item.kind === 'embed' && item.embedKind === 'shape')
     run = shapeRunFromPayload(item.payload);
+  else if (item.kind === 'embed' && item.embedKind === 'noteRefMark') run = noteRefMarkRun(item);
   else if (item.kind === 'text') {
     const formatting = attrsToTextFormatting(formattingAttrs(item.attributes));
     run = {
@@ -921,6 +934,8 @@ function addToHyperlink(hyperlink: Hyperlink, item: InlineItem): void {
     else (hyperlink.structuredChildren ??= [...hyperlink.children]).push(child);
   } else if (item.embedKind === 'math') {
     (hyperlink.structuredChildren ??= [...hyperlink.children]).push(mathFromPayload(item.payload));
+  } else if (item.embedKind === 'noteRefMark') {
+    hyperlink.children.push(noteRefMarkRun(item));
   }
 }
 
@@ -1033,9 +1048,20 @@ function restoreOriginalRuns(
   if (
     !boundaries?.length ||
     !content.every(
-      (child) => child.type === 'run' && child.content.every((entry) => entry.type === 'text')
+      (child) =>
+        child.type === 'run' &&
+        child.content.every(
+          (entry) =>
+            entry.type === 'text' ||
+            entry.type === 'footnoteRefMark' ||
+            entry.type === 'endnoteRefMark'
+        )
     ) ||
-    items.some((item) => item.kind !== 'text' || item.attributes.hyperlink)
+    items.some(
+      (item) =>
+        item.attributes.hyperlink || (item.kind !== 'text' && item.embedKind !== 'noteRefMark')
+    ) ||
+    boundaries.some((boundary) => boundary.noteMark && boundary.text.length > 0)
   ) {
     return content;
   }
@@ -1046,13 +1072,27 @@ function restoreOriginalRuns(
   let itemOffset = 0;
   const restoredAttrs: Attrs[] = [];
   for (const boundary of boundaries) {
+    if (boundary.noteMark) {
+      const item = items[itemIndex];
+      if (
+        item?.kind !== 'embed' ||
+        item.embedKind !== 'noteRefMark' ||
+        item.payload.noteType !== boundary.noteMark ||
+        itemOffset !== 0
+      ) {
+        return content;
+      }
+      restoredAttrs.push(formattingAttrs(item.attributes));
+      itemIndex += 1;
+      continue;
+    }
     const expected = marksKeyToYrsAttrs(boundary.marksKey);
     if (!expected) return content;
     restoredAttrs.push(expected);
     let remaining = boundary.text.length;
     while (remaining > 0) {
-      const item = items[itemIndex] as TextItem | undefined;
-      if (!item) return content;
+      const item = items[itemIndex];
+      if (item?.kind !== 'text') return content;
       if (stableStringify(formattingAttrs(item.attributes)) !== stableStringify(expected)) {
         return content;
       }
@@ -1067,7 +1107,19 @@ function restoreOriginalRuns(
     }
   }
 
+  if (itemIndex !== items.length || itemOffset !== 0) return content;
+
   return boundaries.map((boundary, index) => {
+    if (boundary.noteMark) {
+      const markFormatting = attrsToTextFormatting(restoredAttrs[index]);
+      const markRun: Run = {
+        type: 'run',
+        content: [{ type: boundary.noteMark === 'endnote' ? 'endnoteRefMark' : 'footnoteRefMark' }],
+      };
+      if (Object.keys(markFormatting).length > 0) markRun.formatting = markFormatting;
+      if (boundary.propertyChanges?.length) markRun.propertyChanges = boundary.propertyChanges;
+      return markRun;
+    }
     // restoreOriginalRuns restores the original segmentation/property-change
     // cache, but non-empty runs keep formatting reconstructed from their live
     // marks. Only empty runs have no node and therefore take cached formatting.
@@ -1093,7 +1145,11 @@ function runTextLength(run: Run): number {
     if (
       content.type === 'tab' ||
       content.type === 'softHyphen' ||
-      content.type === 'noBreakHyphen'
+      content.type === 'noBreakHyphen' ||
+      content.type === 'footnoteRef' ||
+      content.type === 'endnoteRef' ||
+      content.type === 'footnoteRefMark' ||
+      content.type === 'endnoteRefMark'
     ) {
       return length + 1;
     }

--- a/packages/docx/src/yrs/yrsToDocument.ts
+++ b/packages/docx/src/yrs/yrsToDocument.ts
@@ -203,7 +203,7 @@ interface BookmarkBoundary extends CommentBoundary {
 
 interface OriginalRunBoundary {
   text: string;
-  noteMark?: 'footnote' | 'endnote';
+  noteMarks?: string[];
   marksKey?: string;
   formatting?: TextFormatting;
   propertyChanges?: Run['propertyChanges'];
@@ -841,15 +841,6 @@ function commentReferenceFromPayload(payload: Attrs): Run | null {
   };
 }
 
-function noteRefMarkRun(item: EmbedItem): Run {
-  const formatting = attrsToTextFormatting(formattingAttrs(item.attributes));
-  return {
-    type: 'run',
-    ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
-    content: [{ type: item.payload.noteType === 'endnote' ? 'endnoteRefMark' : 'footnoteRefMark' }],
-  };
-}
-
 function ordinaryContentForItem(item: InlineItem): ParagraphContent | null {
   if (item.kind === 'text') return createTextRun(item.text, item.attributes);
   switch (item.embedKind) {
@@ -881,8 +872,6 @@ function ordinaryContentForItem(item: InlineItem): ParagraphContent | null {
         ],
       };
     }
-    case 'noteRefMark':
-      return noteRefMarkRun(item);
     default:
       return null;
   }
@@ -893,7 +882,6 @@ function trackedContentForItem(item: InlineItem, info: TrackedChangeInfo): Parag
   if (item.kind === 'embed' && item.embedKind === 'image') run = imageRunFromPayload(item.payload);
   else if (item.kind === 'embed' && item.embedKind === 'shape')
     run = shapeRunFromPayload(item.payload);
-  else if (item.kind === 'embed' && item.embedKind === 'noteRefMark') run = noteRefMarkRun(item);
   else if (item.kind === 'text') {
     const formatting = attrsToTextFormatting(formattingAttrs(item.attributes));
     run = {
@@ -934,8 +922,6 @@ function addToHyperlink(hyperlink: Hyperlink, item: InlineItem): void {
     else (hyperlink.structuredChildren ??= [...hyperlink.children]).push(child);
   } else if (item.embedKind === 'math') {
     (hyperlink.structuredChildren ??= [...hyperlink.children]).push(mathFromPayload(item.payload));
-  } else if (item.embedKind === 'noteRefMark') {
-    hyperlink.children.push(noteRefMarkRun(item));
   }
 }
 
@@ -1040,6 +1026,14 @@ function marksKeyToYrsAttrs(marksKey: string | undefined): Attrs | null {
   return attrs;
 }
 
+/** Rebuilds the note number marks a run held; they occupy no story unit. */
+function noteMarkContent(boundary: OriginalRunBoundary): RunContent[] | null {
+  if (!boundary.noteMarks?.length) return null;
+  return boundary.noteMarks.map((mark) => ({
+    type: mark === 'endnote' ? 'endnoteRefMark' : 'footnoteRefMark',
+  }));
+}
+
 function restoreOriginalRuns(
   content: ParagraphContent[],
   items: InlineItem[],
@@ -1048,20 +1042,10 @@ function restoreOriginalRuns(
   if (
     !boundaries?.length ||
     !content.every(
-      (child) =>
-        child.type === 'run' &&
-        child.content.every(
-          (entry) =>
-            entry.type === 'text' ||
-            entry.type === 'footnoteRefMark' ||
-            entry.type === 'endnoteRefMark'
-        )
+      (child) => child.type === 'run' && child.content.every((entry) => entry.type === 'text')
     ) ||
-    items.some(
-      (item) =>
-        item.attributes.hyperlink || (item.kind !== 'text' && item.embedKind !== 'noteRefMark')
-    ) ||
-    boundaries.some((boundary) => boundary.noteMark && boundary.text.length > 0)
+    items.some((item) => item.kind !== 'text' || item.attributes.hyperlink) ||
+    boundaries.some((boundary) => boundary.noteMarks?.length && boundary.text.length > 0)
   ) {
     return content;
   }
@@ -1072,20 +1056,6 @@ function restoreOriginalRuns(
   let itemOffset = 0;
   const restoredAttrs: Attrs[] = [];
   for (const boundary of boundaries) {
-    if (boundary.noteMark) {
-      const item = items[itemIndex];
-      if (
-        item?.kind !== 'embed' ||
-        item.embedKind !== 'noteRefMark' ||
-        item.payload.noteType !== boundary.noteMark ||
-        itemOffset !== 0
-      ) {
-        return content;
-      }
-      restoredAttrs.push(formattingAttrs(item.attributes));
-      itemIndex += 1;
-      continue;
-    }
     const expected = marksKeyToYrsAttrs(boundary.marksKey);
     if (!expected) return content;
     restoredAttrs.push(expected);
@@ -1110,16 +1080,6 @@ function restoreOriginalRuns(
   if (itemIndex !== items.length || itemOffset !== 0) return content;
 
   return boundaries.map((boundary, index) => {
-    if (boundary.noteMark) {
-      const markFormatting = attrsToTextFormatting(restoredAttrs[index]);
-      const markRun: Run = {
-        type: 'run',
-        content: [{ type: boundary.noteMark === 'endnote' ? 'endnoteRefMark' : 'footnoteRefMark' }],
-      };
-      if (Object.keys(markFormatting).length > 0) markRun.formatting = markFormatting;
-      if (boundary.propertyChanges?.length) markRun.propertyChanges = boundary.propertyChanges;
-      return markRun;
-    }
     // restoreOriginalRuns restores the original segmentation/property-change
     // cache, but non-empty runs keep formatting reconstructed from their live
     // marks. Only empty runs have no node and therefore take cached formatting.
@@ -1129,7 +1089,7 @@ function restoreOriginalRuns(
         : attrsToTextFormatting(restoredAttrs[index]);
     const run: Run = {
       type: 'run',
-      content: runContentForText(boundary.text, formatting ?? {}),
+      content: noteMarkContent(boundary) ?? runContentForText(boundary.text, formatting ?? {}),
     };
     if (formatting && Object.keys(formatting).length > 0) run.formatting = formatting;
     if (boundary.propertyChanges?.length) run.propertyChanges = boundary.propertyChanges;
@@ -1147,9 +1107,7 @@ function runTextLength(run: Run): number {
       content.type === 'softHyphen' ||
       content.type === 'noBreakHyphen' ||
       content.type === 'footnoteRef' ||
-      content.type === 'endnoteRef' ||
-      content.type === 'footnoteRefMark' ||
-      content.type === 'endnoteRefMark'
+      content.type === 'endnoteRef'
     ) {
       return length + 1;
     }
@@ -1594,6 +1552,51 @@ function pageBreakParagraph(): Paragraph {
   };
 }
 
+/** A note number mark run, or a tracked-change wrapper holding only those. */
+function isNoteMark(content: ParagraphContent): boolean {
+  if (
+    content.type === 'insertion' ||
+    content.type === 'deletion' ||
+    content.type === 'moveFrom' ||
+    content.type === 'moveTo'
+  ) {
+    return content.content.length > 0 && content.content.every(isNoteMark);
+  }
+  return (
+    content.type === 'run' &&
+    content.content.length > 0 &&
+    content.content.every(
+      (entry) => entry.type === 'footnoteRefMark' || entry.type === 'endnoteRefMark'
+    )
+  );
+}
+
+function hasNoteMark(blocks: readonly BlockContent[]): boolean {
+  return blocks.some((block) => block.type === 'paragraph' && block.content.some(isNoteMark));
+}
+
+/**
+ * Reinstates the `w:footnoteRef` / `w:endnoteRef` number mark on a projected
+ * note. The mark carries no story unit, so an edit that invalidates the run
+ * boundary cache would otherwise drop it; the source note is the only record.
+ */
+function restoreNoteMarks(
+  projected: BlockContent[],
+  base: readonly BlockContent[]
+): BlockContent[] {
+  if (hasNoteMark(projected)) return projected;
+  const opening = base.find((block) => block.type === 'paragraph')?.content ?? [];
+  const end = opening.findIndex((child) => !isNoteMark(child));
+  const marks = opening.slice(0, end < 0 ? opening.length : end);
+  if (marks.length === 0) return projected;
+  const index = projected.findIndex((block) => block.type === 'paragraph');
+  if (index < 0) return projected;
+  const target = projected[index] as Paragraph;
+  const restored = [...projected];
+  restored[index] = { ...target, content: [...marks, ...target.content] };
+  return restored;
+}
+
 function collectBaseParagraphs(document: Document): Map<string, Paragraph> {
   const paragraphs = new Map<string, Paragraph>();
   const visit = (blocks: readonly BlockContent[]): void => {
@@ -1870,7 +1873,11 @@ export function yrsToDocument(
     return notes?.map((note) => {
       const storyId = `${prefix}${note.id}`;
       return context.storyIds.has(storyId) && shouldProject(storyId)
-        ? { ...note, content: context.storyToBlocks(storyId), verbatimXml: undefined }
+        ? {
+            ...note,
+            content: restoreNoteMarks(context.storyToBlocks(storyId), note.content),
+            verbatimXml: undefined,
+          }
         : note;
     });
   };


### PR DESCRIPTION
TL;DR:


Repro file:
`packages/docx/src/yrs/noteSave.test.ts` — seeds a DOCX whose footnote and endnote carry `<w:footnoteRef/>` / `<w:endnoteRef/>`, types into both, and saves. Before this change the saved note has no auto-number mark, so Word renders it without its leading number.

Summary:
- Fixes #193. A projected footnote or endnote keeps its `<w:footnoteRef/>` / `<w:endnoteRef/>` mark on save.
- The mark occupies no story unit. The original-run cache records every mark in a run and the save rebuilds them; when an edit invalidates that cache, the marks are reinstated from the source note. Nothing new goes over the wire, so a peer on an older build lowers and saves the note exactly as it does today.
- A note reference counts as one position in both seeders, the saver, and the layout bridge (both the paragraph and inline-SDT paths). Bookmarks and comments around a reference with a multi-digit id no longer shift, and a bookmark ending after a trailing reference no longer disappears.
- The original-run cache keeps a mark run's `w:rPrChange` through the round trip, including a run holding two marks.
- Save round-trip tests for the mark, a tracked deletion of the note text, a source mark already inside `w:del`, note comment ranges, run property changes on the mark run, two marks in one run, and multi-digit references in the middle and at the end of a paragraph, on both seeders.

Notes for the reviewer:
- The mark is not caret-addressable, so it cannot be tracked-deleted on its own. Word does not allow that either.
- Follow-ups, pre-existing on `main` and out of scope here: `ArrowRight` / forward `Delete` are off by one in any paragraph containing an inline embed; `Backspace` can delete a note's mark; the DOCX editing schema has no version, so any future story item breaks lowering on older peers.

Test plan:
- [x] `bun run build:docx-wasm`
- [x] `bun test packages/docx/src/yrs/noteSave.test.ts`
- [x] `bun test packages/docx/src/`
- [x] `bun test packages/docx-react/src/`
- [x] `bun run typecheck:packages`
- [x] `cargo test -p betteroffice-docx-edit && cargo test -p betteroffice-docx-parse`
- [x] `cargo clippy -p betteroffice-docx-edit --all-targets -- -D warnings && cargo fmt --check`
- [ ] Open a .docx with a footnote and an endnote, type in both, save, reopen in Word: both notes still show their number.
