### PR TITLE
fix(ci): build a workspace peer before its dependent

### DIFF
--- a/scripts/build-stale-packages.test.ts
+++ b/scripts/build-stale-packages.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { order, readTargets } from './build-stale-packages.ts';
+
+const targets = await readTargets();
+const names = order(targets).map((target) => target.name);
+const position = new Map(names.map((name, index) => [name, index]));
+
+describe('workspace build order', () => {
+  test('every workspace dependency and peer builds before its dependent', () => {
+    const late: string[] = [];
+    for (const target of targets) {
+      for (const dep of target.deps) {
+        if (!position.has(dep)) continue;
+        if (position.get(dep)! > position.get(target.name)!) {
+          late.push(`${dep} builds after ${target.name}`);
+        }
+      }
+    }
+    expect(late).toEqual([]);
+  });
+
+  // docx peer-depends on fonts, which peer-depends on fonts-cjk. Reading only
+  // `dependencies` left docx first and its dts build could not resolve fonts.
+  test('a workspace peer is a build dependency', () => {
+    expect(targets.find((target) => target.name === '@betteroffice/docx')?.deps).toContain(
+      '@betteroffice/fonts'
+    );
+    expect(targets.find((target) => target.name === '@betteroffice/fonts')?.deps).toContain(
+      '@betteroffice/fonts-cjk'
+    );
+    expect(position.get('@betteroffice/fonts')!).toBeLessThan(position.get('@betteroffice/docx')!);
+    expect(position.get('@betteroffice/fonts-cjk')!).toBeLessThan(
+      position.get('@betteroffice/fonts')!
+    );
+  });
+
+  test('every package that builds is ordered exactly once', () => {
+    expect(names.length).toBe(targets.length);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/scripts/build-stale-packages.ts
+++ b/scripts/build-stale-packages.ts
@@ -19,7 +19,7 @@ interface Target {
   deps: string[];
 }
 
-async function readTargets(): Promise<Target[]> {
+export async function readTargets(): Promise<Target[]> {
   const packages = resolve(root, 'packages');
   const entries = await readdir(packages, { withFileTypes: true });
   const targets: Target[] = [];
@@ -30,7 +30,9 @@ async function readTargets(): Promise<Target[]> {
     if (!packaged) continue;
     const manifest = JSON.parse(packaged);
     if (!manifest.scripts?.build) continue;
-    const deps = Object.entries<string>(manifest.dependencies ?? {})
+    // A workspace peer still has to be built first: its types resolve to dist/.
+    const deps = [manifest.dependencies, manifest.peerDependencies]
+      .flatMap((group) => Object.entries<string>(group ?? {}))
       .filter(([, range]) => range.startsWith('workspace:'))
       .map(([name]) => name);
     targets.push({ name: manifest.name, dir, deps });
@@ -38,7 +40,7 @@ async function readTargets(): Promise<Target[]> {
   return targets;
 }
 
-function order(targets: Target[]): Target[] {
+export function order(targets: Target[]): Target[] {
   const byName = new Map(targets.map((target) => [target.name, target]));
   const sorted: Target[] = [];
   const seen = new Set<string>();
@@ -78,37 +80,39 @@ async function hashInputs(dir: string): Promise<string> {
   return hash.digest('hex');
 }
 
-const targets = order(await readTargets());
-const keys = new Map<string, string>();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const targets = order(await readTargets());
+  const keys = new Map<string, string>();
 
-async function keyOf(target: Target): Promise<string> {
-  return createHash('sha256')
-    .update(await hashInputs(target.dir))
-    .update(target.deps.map((dep) => keys.get(dep) ?? '').join('\0'))
-    .digest('hex');
-}
-
-for (const target of targets) {
-  const key = await keyOf(target);
-  keys.set(target.name, key);
-
-  const stamp = resolve(target.dir, 'dist', STAMP);
-  const current = await readFile(stamp, 'utf8').catch(() => null);
-  if (current === key) {
-    console.log(`${target.name}: up to date`);
-    continue;
+  async function keyOf(target: Target): Promise<string> {
+    return createHash('sha256')
+      .update(await hashInputs(target.dir))
+      .update(target.deps.map((dep) => keys.get(dep) ?? '').join('\0'))
+      .digest('hex');
   }
 
-  console.log(`${target.name}: building`);
-  const build = spawnSync('bun', ['run', '--filter', target.name, 'build'], {
-    cwd: root,
-    stdio: 'inherit',
-  });
-  if (build.status !== 0) process.exit(build.status ?? 1);
+  for (const target of targets) {
+    const key = await keyOf(target);
+    keys.set(target.name, key);
 
-  // The wasm builds vendor their output back into the hashed tree, so a key
-  // taken beforehand never matches again; stamp the tree as it settled.
-  const settled = await keyOf(target);
-  keys.set(target.name, settled);
-  await writeFile(stamp, settled);
+    const stamp = resolve(target.dir, 'dist', STAMP);
+    const current = await readFile(stamp, 'utf8').catch(() => null);
+    if (current === key) {
+      console.log(`${target.name}: up to date`);
+      continue;
+    }
+
+    console.log(`${target.name}: building`);
+    const build = spawnSync('bun', ['run', '--filter', target.name, 'build'], {
+      cwd: root,
+      stdio: 'inherit',
+    });
+    if (build.status !== 0) process.exit(build.status ?? 1);
+
+    // The wasm builds vendor their output back into the hashed tree, so a key
+    // taken beforehand never matches again; stamp the tree as it settled.
+    const settled = await keyOf(target);
+    keys.set(target.name, settled);
+    await writeFile(stamp, settled);
+  }
 }


### PR DESCRIPTION
TL;DR:


Summary:

- `build-stale-packages.ts` read workspace dependencies from `dependencies` only, so a package depended on through `peerDependencies` was never ordered before its dependent. `@betteroffice/docx` peer-depends on `@betteroffice/fonts`, which peer-depends on `@betteroffice/fonts-cjk`; with no edge between them the order fell back to directory order, `docx` built first, and its dts pass could not resolve `@betteroffice/fonts`. That failed the demo deploy.
- Ordering now follows workspace peers as well as dependencies.
- `readTargets` and `order` are exported and the run is guarded, so the ordering is testable without executing a build.
- Adds a test that every workspace dependency and peer precedes its dependent, and that each package is ordered exactly once.

Notes for review:

- Only the demo hit this. Root `build:packages` hardcodes `build:fonts && build:xlsx && build:docx && build:pptx`, so it never consulted the graph.
- Reproduced both directions from a wiped `dist/`: before, `bun run build:deps` exits 1 with `error TS2307: Cannot find module '@betteroffice/fonts'`; after, it exits 0 with none. Removing the peer edge again fails the new test.
- The guard uses the `process.argv[1] === fileURLToPath(import.meta.url)` form already used by `scripts/python-bindings.mjs`. Confirmed it resolves true when invoked the way the demo does, `bun ../../scripts/build-stale-packages.ts`, so the script still runs.

Test plan:

- [ ] `bun test scripts` passes
- [ ] from a wiped `packages/*/dist`, `bun run build:deps` in `apps/demo` exits 0
- [ ] the deploy workflow's demo job succeeds
