### PR TITLE
feat(docx): edit footnote and endnote text in place

### DIFF
--- a/.changeset/docx-note-editing.md
+++ b/.changeset/docx-note-editing.md
@@ -1,6 +1,6 @@
 ---
-"@betteroffice/docx": patch
-"@betteroffice/docx-react": patch
+"@betteroffice/docx": minor
+"@betteroffice/docx-react": minor
 ---
 
 Clicking a footnote or an endnote now opens it for editing. The caret lands under the pointer, typing goes into that note, and what is typed reaches the saved file. Escape or a click back in the body leaves the note.

--- a/.changeset/docx-note-editing.md
+++ b/.changeset/docx-note-editing.md
@@ -5,7 +5,7 @@
 
 Clicking a footnote or an endnote now opens it for editing. The caret lands under the pointer, typing goes into that note, and what is typed reaches the saved file. Escape leaves the note; clicking back in the body leaves it and places the body caret under the pointer.
 
-Undo tracking follows the open part, so entering a note starts a fresh undo scope.
+Undo follows the part being edited: the first edit in a newly opened part replaces the undo scope and discards the previous part's history.
 
 A note area is document text, not chrome, so a single click opens it — where a header or footer band, which repeats on every page and sits in the margin, still needs a double-click. The click that opens the note also places its caret: the position it resolved belongs to a story the editor is not on yet, so it waits for that story to become active and is discarded if the host never opens the note.
 

--- a/.changeset/docx-note-editing.md
+++ b/.changeset/docx-note-editing.md
@@ -1,0 +1,14 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/docx-react": patch
+---
+
+Clicking a footnote or an endnote now opens it for editing. The caret lands under the pointer, typing goes into that note, and what is typed reaches the saved file. Escape or a click back in the body leaves the note.
+
+A note area is document text, not chrome, so a single click opens it — where a header or footer band, which repeats on every page and sits in the margin, still needs a double-click. The click that opens the note also places its caret: the position it resolved belongs to a story the editor is not on yet, so it waits for that story to become active and is discarded if the host never opens the note.
+
+The editor could previously be in a header/footer band, and now also in a note, so the two are one value rather than a flag each: `partEdit` names the single non-body part that is open, and opening a note closes whatever was open before. That removes the state where a band and a note could both claim the caret, and folds the band's first-page variant and originating page into the same value. `PagedEditor` takes `partEdit` in place of `hfEditMode` / `hfEditRId` and reports the open part's selection through `onYrsPartSelectionChange`.
+
+Everything the body offers behind an open band was already off, and stays off behind an open note for the same reason plus one of its own: the display list indexes images, tables and hyperlinks by band, so a note area has no scope to look one up in and answering `body` would hand back something from behind the note. Selecting a picture, dragging a table edge, the row/column insert affordance and opening a link are therefore inert inside a note; caret movement, word and paragraph selection, drag-selection and Home/End are not. Arrows navigate a note the way they navigate a band — paragraph by paragraph, since the display-list vertical-move query answers body positions only — and the caret never leaves the note it is in.
+
+Selection geometry comes from the note's own story: `noteCaretRects` is the note twin of `hfCaretRects`, resolving the leading edge of the caret's position and falling back to the trailing edge of the previous one at end of line. A note paints on exactly one page, so unlike a band there is never a second candidate page to choose between. One overlay now paints the caret and highlight for whichever part is open, band or note, and it asks the queries directly — `computeHfCaretRectsFromDisplayList` and `computeHfSelectionRectsFromDisplayList`, which had that overlay as their only caller, are gone from `@betteroffice/docx/layout`.

--- a/.changeset/docx-note-editing.md
+++ b/.changeset/docx-note-editing.md
@@ -3,7 +3,9 @@
 "@betteroffice/docx-react": minor
 ---
 
-Clicking a footnote or an endnote now opens it for editing. The caret lands under the pointer, typing goes into that note, and what is typed reaches the saved file. Escape or a click back in the body leaves the note.
+Clicking a footnote or an endnote now opens it for editing. The caret lands under the pointer, typing goes into that note, and what is typed reaches the saved file. Escape leaves the note; clicking back in the body leaves it and places the body caret under the pointer.
+
+Undo tracking follows the open part, so entering a note starts a fresh undo scope.
 
 A note area is document text, not chrome, so a single click opens it — where a header or footer band, which repeats on every page and sits in the margin, still needs a double-click. The click that opens the note also places its caret: the position it resolved belongs to a story the editor is not on yet, so it waits for that story to become active and is discarded if the host never opens the note.
 

--- a/.changeset/docx-part-edit-state.md
+++ b/.changeset/docx-part-edit-state.md
@@ -1,0 +1,10 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/docx-react": patch
+---
+
+Header/footer editing state becomes one value instead of a flag per kind. `partEdit` names the single non-body part the editor has open, folding the band's first-page variant and the page it was opened from into it — three `useState`s in `DocxEditor` become one.
+
+`PagedEditor` takes `partEdit` in place of `hfEditMode` / `hfEditRId`, and reports the open part's selection through `onYrsPartSelectionChange` in place of `onYrsHfSelectionChange`. `CanvasHfSelectionOverlay` becomes `CanvasPartSelectionOverlay` and queries the display list directly, so `computeHfCaretRectsFromDisplayList` and `computeHfSelectionRectsFromDisplayList` are gone from `@betteroffice/docx/layout`.
+
+Behaviour is unchanged, with one exception: Escape moves from the header/footer chrome component to the paged area, so it now also closes a band whose chrome never mounted.

--- a/.changeset/docx-part-edit-state.md
+++ b/.changeset/docx-part-edit-state.md
@@ -1,6 +1,6 @@
 ---
-"@betteroffice/docx": patch
-"@betteroffice/docx-react": patch
+"@betteroffice/docx": minor
+"@betteroffice/docx-react": minor
 ---
 
 Header/footer editing state becomes one value instead of a flag per kind. `partEdit` names the single non-body part the editor has open, folding the band's first-page variant and the page it was opened from into it — three `useState`s in `DocxEditor` become one.

--- a/packages/docx-react/src/components/DocxEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor.tsx
@@ -636,7 +636,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
   const isDark = useIsDark(colorMode);
 
-  // The one non-body part open for editing.
+  // The one non-body part open for editing — a header/footer band or a note.
   const [partEditTarget, setPartEditTarget] = useState<PartEditTarget | null>(null);
 
   // Controlled by `commentsSidebarOpen` when provided, else editor-owned; the
@@ -1858,6 +1858,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
               partEditTarget={partEditTarget}
               setPartEditTarget={setPartEditTarget}
               onHeaderFooterDoubleClick={handleHeaderFooterDoubleClick}
+              onNoteClick={setPartEditTarget}
               onRemoveHeaderFooter={handleRemoveHeaderFooter}
               onBodyClick={handleBodyClick}
               zoom={state.zoom}

--- a/packages/docx-react/src/components/DocxEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor.tsx
@@ -48,6 +48,7 @@ import { useDocxEditorRefApi } from './DocxEditor/hooks/useDocxEditorRefApi';
 import { useControllableBoolean } from './DocxEditor/hooks/useControllableBoolean';
 import { useTableDialogs } from './DocxEditor/hooks/useTableDialogs';
 import { useHeaderFooterEditing } from './DocxEditor/hooks/useHeaderFooterEditing';
+import type { PartEditTarget } from './DocxEditor/partEdit';
 import { useDocumentLoader } from './DocxEditor/hooks/useDocumentLoader';
 import { useYrsCoreSession } from './DocxEditor/hooks/useYrsCoreSession';
 import { useContextMenus } from './DocxEditor/hooks/useContextMenus';
@@ -635,10 +636,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
   const isDark = useIsDark(colorMode);
 
-  // Header/footer editing state.
-  const [hfEditPosition, setHfEditPosition] = useState<'header' | 'footer' | null>(null);
-  const [hfEditIsFirstPage, setHfEditIsFirstPage] = useState(false);
-  const [hfEditPageIndex, setHfEditPageIndex] = useState(0);
+  // The one non-body part open for editing.
+  const [partEditTarget, setPartEditTarget] = useState<PartEditTarget | null>(null);
 
   // Controlled by `commentsSidebarOpen` when provided, else editor-owned; the
   // setter routes through `onCommentsSidebarOpenChange`. See useControllableBoolean.
@@ -820,8 +819,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     setCommentSelectionRange,
     setAddCommentYPosition,
     setFloatingCommentBtn,
-    setHfEditPosition,
-    setHfEditIsFirstPage,
+    setPartEditTarget,
     setAnchorPositions,
     clearFindReplaceMatches: useCallback(() => findReplace.setMatches([], 0), [findReplace]),
     cleanOrphanedCommentsTimerRef,
@@ -1332,11 +1330,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     pushDocument,
     initialSectionProperties,
     finalSectionProperties,
-    hfEditPosition,
-    setHfEditPosition,
-    hfEditIsFirstPage,
-    setHfEditIsFirstPage,
-    setHfEditPageIndex,
+    partEditTarget,
+    setPartEditTarget,
   });
 
   // Container styles - using overflow: auto so sticky toolbar works
@@ -1860,10 +1855,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
               footerContent={footerContent}
               firstPageHeaderContent={firstPageHeaderContent}
               firstPageFooterContent={firstPageFooterContent}
-              hfEditPosition={hfEditPosition}
-              setHfEditPosition={setHfEditPosition}
-              hfEditIsFirstPage={hfEditIsFirstPage}
-              hfEditPageIndex={hfEditPageIndex}
+              partEditTarget={partEditTarget}
+              setPartEditTarget={setPartEditTarget}
               onHeaderFooterDoubleClick={handleHeaderFooterDoubleClick}
               onRemoveHeaderFooter={handleRemoveHeaderFooter}
               onBodyClick={handleBodyClick}

--- a/packages/docx-react/src/components/DocxEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor.tsx
@@ -1162,6 +1162,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     displayListQueries: canvasRenderer.queries,
     interactionPageHostRef: canvasRenderer.canvasHostRef,
     i18n,
+    partEditOpen: partEditTarget !== null,
     onAddComment: useCallback(
       ({ from, to, yPos }: { from: number; to: number; yPos: number | null }) => {
         setCommentSelectionRange({ from, to });

--- a/packages/docx-react/src/components/DocxEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor.tsx
@@ -1006,6 +1006,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     editorContentRef,
     isAddingCommentRef,
     setFloatingCommentBtn,
+    partEditOpen: partEditTarget !== null,
     readOnly,
     isLoading: state.isLoading,
     zoom: state.zoom,

--- a/packages/docx-react/src/components/DocxEditor/ContentControlWidgets.tsx
+++ b/packages/docx-react/src/components/DocxEditor/ContentControlWidgets.tsx
@@ -199,6 +199,7 @@ export function ContentControlWidgets({
     <div
       ref={popupRef}
       className="layout-sdt-widget-popup"
+      data-docx-escape-layer="true"
       style={style}
       role={popup.kind === 'dropdown' ? 'listbox' : undefined}
       onKeyDown={handlePopupKeyDown}

--- a/packages/docx-react/src/components/DocxEditor/DocxEditorPagedArea.tsx
+++ b/packages/docx-react/src/components/DocxEditor/DocxEditorPagedArea.tsx
@@ -35,7 +35,7 @@ import type { YrsToolbarSelection } from './yrsToolbar';
 import type { TrackedChangesResult } from '@betteroffice/docx/layout/render';
 import type { DocxEditorCollaborationOptions } from './types';
 import type { YrsCoreSession } from './hooks/useYrsCoreSession';
-import { partEditStory, type PartEdit, type PartEditTarget } from './partEdit';
+import { partEditStory, type NoteEdit, type PartEdit, type PartEditTarget } from './partEdit';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 /**
@@ -68,6 +68,7 @@ export function DocxEditorPagedArea({
   partEditTarget,
   setPartEditTarget,
   onHeaderFooterDoubleClick,
+  onNoteClick,
   onRemoveHeaderFooter,
   onBodyClick,
   // Editor
@@ -145,6 +146,7 @@ export function DocxEditorPagedArea({
   partEditTarget: PartEditTarget | null;
   setPartEditTarget: React.Dispatch<React.SetStateAction<PartEditTarget | null>>;
   onHeaderFooterDoubleClick: (position: 'header' | 'footer', pageNumber?: number) => void;
+  onNoteClick: (note: NoteEdit) => void;
   onRemoveHeaderFooter: () => void;
   onBodyClick: () => void;
   zoom: number;
@@ -228,7 +230,11 @@ export function DocxEditorPagedArea({
 }) {
   const sidebarCommentIds = useMemo(() => comments.map((comment) => comment.id), [comments]);
 
-  const bandEdit = partEditTarget;
+  // The open part, split into the two shapes its consumers address it by.
+  const bandEdit =
+    partEditTarget?.kind === 'header' || partEditTarget?.kind === 'footer'
+      ? partEditTarget
+      : null;
 
   // Resolve the active HF block for the inline editor — first-page variant
   // wins when `titlePg` is set and the user double-clicked page 1.
@@ -265,19 +271,23 @@ export function DocxEditorPagedArea({
       })()
     : null;
 
-  // Memoised: consumers key effects on this identity, and a value rebuilt per
-  // render would re-run them for nothing.
+  const noteEdit =
+    partEditTarget?.kind === 'footnote' || partEditTarget?.kind === 'endnote'
+      ? partEditTarget
+      : null;
+  // Memoised: consumers key effects on this identity, and a band that rebuilt
+  // it per render would re-run them for nothing.
   const partEdit = useMemo<PartEdit | null>(
-    () => (bandEdit ? { kind: bandEdit.kind, rId: activeHfRid } : null),
-    [bandEdit, activeHfRid]
+    () => (bandEdit ? { kind: bandEdit.kind, rId: activeHfRid } : noteEdit),
+    [bandEdit, activeHfRid, noteEdit]
   );
 
   // Live Yrs selection inside that part, captured on every selection change.
   const [partSelection, setPartSelection] = useState<{ from: number; to: number } | null>(null);
   const partStory = partEditStory(partEdit);
-  // Cleared during render, not in an effect: a child effect can publish a
-  // caret in the same commit, and an effect here would run after it and wipe
-  // the very selection that was just asked for.
+  // Cleared during render, not in an effect: the click that opens a note
+  // publishes its caret from a child effect, which React flushes first, and an
+  // effect here would then wipe the very selection that click asked for.
   const [selectionStory, setSelectionStory] = useState(partStory);
   if (selectionStory !== partStory) {
     setSelectionStory(partStory);
@@ -411,6 +421,7 @@ export function DocxEditorPagedArea({
         firstPageHeaderContent={firstPageHeaderContent}
         firstPageFooterContent={firstPageFooterContent}
         onHeaderFooterDoubleClick={onHeaderFooterDoubleClick}
+        onNoteClick={onNoteClick}
         partEdit={partEdit}
         onBodyClick={onBodyClick}
         isSuggesting={isSuggesting}
@@ -503,6 +514,7 @@ export function DocxEditorPagedArea({
 
       {!canvasOverlayTarget && floatingCommentButton}
 
+      {/* Cell selection is indexed by band, so only an open band offers it. */}
       {canvasOverlayTarget &&
         displayListQueries &&
         bandEdit &&

--- a/packages/docx-react/src/components/DocxEditor/DocxEditorPagedArea.tsx
+++ b/packages/docx-react/src/components/DocxEditor/DocxEditorPagedArea.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { ReactNode } from 'react';
 import type {
@@ -23,7 +23,7 @@ import { UnifiedSidebar } from '../UnifiedSidebar';
 import { CommentMarginMarkers } from '../CommentMarginMarkers';
 import { useCanvasOverlayTarget } from './internals/useCanvasOverlayTarget';
 import { CanvasCellSelectionOverlay } from './overlays/CanvasCellSelectionOverlay';
-import { CanvasHfSelectionOverlay } from './overlays/CanvasHfSelectionOverlay';
+import { CanvasPartSelectionOverlay } from './overlays/CanvasPartSelectionOverlay';
 import { projectPageLocalRect } from './internals/canvasProjection';
 import { Tooltip } from '../ui/Tooltip';
 import { MaterialSymbol } from '../ui/Icons';
@@ -35,6 +35,8 @@ import type { YrsToolbarSelection } from './yrsToolbar';
 import type { TrackedChangesResult } from '@betteroffice/docx/layout/render';
 import type { DocxEditorCollaborationOptions } from './types';
 import type { YrsCoreSession } from './hooks/useYrsCoreSession';
+import { partEditStory, type PartEdit, type PartEditTarget } from './partEdit';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
 
 /**
  * Body of the editor: the paged editor host, its sidebar overlay
@@ -63,10 +65,8 @@ export function DocxEditorPagedArea({
   footerContent,
   firstPageHeaderContent,
   firstPageFooterContent,
-  hfEditPosition,
-  setHfEditPosition,
-  hfEditIsFirstPage,
-  hfEditPageIndex,
+  partEditTarget,
+  setPartEditTarget,
   onHeaderFooterDoubleClick,
   onRemoveHeaderFooter,
   onBodyClick,
@@ -142,10 +142,8 @@ export function DocxEditorPagedArea({
   footerContent: HeaderFooter | null | undefined;
   firstPageHeaderContent: HeaderFooter | null | undefined;
   firstPageFooterContent: HeaderFooter | null | undefined;
-  hfEditPosition: 'header' | 'footer' | null;
-  setHfEditPosition: React.Dispatch<React.SetStateAction<'header' | 'footer' | null>>;
-  hfEditIsFirstPage: boolean;
-  hfEditPageIndex: number;
+  partEditTarget: PartEditTarget | null;
+  setPartEditTarget: React.Dispatch<React.SetStateAction<PartEditTarget | null>>;
   onHeaderFooterDoubleClick: (position: 'header' | 'footer', pageNumber?: number) => void;
   onRemoveHeaderFooter: () => void;
   onBodyClick: () => void;
@@ -230,14 +228,16 @@ export function DocxEditorPagedArea({
 }) {
   const sidebarCommentIds = useMemo(() => comments.map((comment) => comment.id), [comments]);
 
+  const bandEdit = partEditTarget;
+
   // Resolve the active HF block for the inline editor — first-page variant
   // wins when `titlePg` is set and the user double-clicked page 1.
-  const activeHf = hfEditPosition
-    ? hfEditIsFirstPage
-      ? hfEditPosition === 'header'
+  const activeHf = bandEdit
+    ? bandEdit.isFirstPage
+      ? bandEdit.kind === 'header'
         ? firstPageHeaderContent
         : firstPageFooterContent
-      : hfEditPosition === 'header'
+      : bandEdit.kind === 'header'
         ? headerContent
         : footerContent
     : null;
@@ -248,14 +248,14 @@ export function DocxEditorPagedArea({
   // the user is editing page 1 of a titlePg section. This keys the region-aware
   // range-rect query so a first-page vs default variant on another page never
   // contributes stray rects.
-  const activeHfRid = hfEditPosition
+  const activeHfRid = bandEdit
     ? (() => {
         const refs =
-          hfEditPosition === 'header'
+          bandEdit.kind === 'header'
             ? finalSectionProperties?.headerReferences
             : finalSectionProperties?.footerReferences;
         if (!refs) return null;
-        const wantType = hfEditIsFirstPage ? 'first' : 'default';
+        const wantType = bandEdit.isFirstPage ? 'first' : 'default';
         const entry =
           refs.find((r) => r.type === wantType) ??
           refs.find((r) => r.type === 'default') ??
@@ -265,24 +265,39 @@ export function DocxEditorPagedArea({
       })()
     : null;
 
-  // Live HF Yrs selection, captured on every HF selection change.
-  const [hfSelection, setHfSelection] = useState<{ from: number; to: number } | null>(null);
-  useEffect(() => {
-    setHfSelection(null);
-  }, [hfEditPosition, activeHfRid]);
+  // Memoised: consumers key effects on this identity, and a value rebuilt per
+  // render would re-run them for nothing.
+  const partEdit = useMemo<PartEdit | null>(
+    () => (bandEdit ? { kind: bandEdit.kind, rId: activeHfRid } : null),
+    [bandEdit, activeHfRid]
+  );
+
+  // Live Yrs selection inside that part, captured on every selection change.
+  const [partSelection, setPartSelection] = useState<{ from: number; to: number } | null>(null);
+  const partStory = partEditStory(partEdit);
+  // Cleared during render, not in an effect: a child effect can publish a
+  // caret in the same commit, and an effect here would run after it and wipe
+  // the very selection that was just asked for.
+  const [selectionStory, setSelectionStory] = useState(partStory);
+  if (selectionStory !== partStory) {
+    setSelectionStory(partStory);
+    setPartSelection(null);
+  }
+
+  useEscapeKey(partEditTarget != null, () => setPartEditTarget(null));
 
   // UI chrome is independent of renderer readiness and always portals onto
   // the positioned editor-content host.
   const canvasOverlayTarget = useCanvasOverlayTarget(true, editorContentRef);
 
-  const activeHfPage = displayListQueries
-    ? (displayListQueries.displayList.pages[hfEditPageIndex] ??
-      displayListQueries.displayList.pages.find((page) => {
-        const band = hfEditPosition ? page[hfEditPosition] : null;
-        return band?.rId === activeHfRid;
-      }))
-    : null;
-  const activeHfBand = activeHfPage && hfEditPosition ? activeHfPage[hfEditPosition] : null;
+  const activeHfPage =
+    displayListQueries && bandEdit
+      ? (displayListQueries.displayList.pages[bandEdit.pageIndex] ??
+        displayListQueries.displayList.pages.find(
+          (page) => page[bandEdit.kind]?.rId === activeHfRid
+        ))
+      : null;
+  const activeHfBand = activeHfPage && bandEdit ? activeHfPage[bandEdit.kind] : null;
   const hfChromeRect =
     activeHfPage &&
     activeHfBand &&
@@ -396,8 +411,7 @@ export function DocxEditorPagedArea({
         firstPageHeaderContent={firstPageHeaderContent}
         firstPageFooterContent={firstPageFooterContent}
         onHeaderFooterDoubleClick={onHeaderFooterDoubleClick}
-        hfEditMode={hfEditPosition}
-        hfEditRId={activeHfRid}
+        partEdit={partEdit}
         onBodyClick={onBodyClick}
         isSuggesting={isSuggesting}
         author={author}
@@ -409,8 +423,8 @@ export function DocxEditorPagedArea({
         onYrsHistoryChange={onYrsHistoryChange}
         onSelectionChange={onPagedSelectionChange}
         onYrsSelectionChange={onYrsSelectionChange}
-        onYrsHfSelectionChange={(rId, selection) => {
-          if (rId === activeHfRid) setHfSelection(selection);
+        onYrsPartSelectionChange={(part, selection) => {
+          if (partEditStory(part) === partStory) setPartSelection(selection);
         }}
         onRenderedDomContextReady={onRenderedDomContextReady}
         pluginOverlays={pluginOverlays}
@@ -491,44 +505,44 @@ export function DocxEditorPagedArea({
 
       {canvasOverlayTarget &&
         displayListQueries &&
-        hfEditPosition &&
+        bandEdit &&
         activeHfRid &&
         canvasHostRef && (
-          <>
-            <CanvasCellSelectionOverlay
-              session={pagedEditorRef.current?.getYrsSession() ?? null}
-              positionProjection={null}
-              overlayTarget={canvasOverlayTarget}
-              canvasHostRef={canvasHostRef}
-              displayListQueries={displayListQueries}
-              region={{ kind: hfEditPosition, rId: activeHfRid }}
-              sidebarOpen={sidebarOpen}
-              zoom={zoom}
-            />
-            <CanvasHfSelectionOverlay
-              region={hfEditPosition}
-              rId={activeHfRid}
-              selection={hfSelection}
-              overlayTarget={canvasOverlayTarget}
-              canvasHostRef={canvasHostRef}
-              displayListQueries={displayListQueries}
-              activePageIndex={activeHfPage?.pageIndex}
-              sidebarOpen={sidebarOpen}
-              zoom={zoom}
-            />
-          </>
+          <CanvasCellSelectionOverlay
+            session={pagedEditorRef.current?.getYrsSession() ?? null}
+            positionProjection={null}
+            overlayTarget={canvasOverlayTarget}
+            canvasHostRef={canvasHostRef}
+            displayListQueries={displayListQueries}
+            region={{ kind: bandEdit.kind, rId: activeHfRid }}
+            sidebarOpen={sidebarOpen}
+            zoom={zoom}
+          />
         )}
 
-      {hfEditPosition &&
+      {canvasOverlayTarget && displayListQueries && partEdit && canvasHostRef && (
+        <CanvasPartSelectionOverlay
+          part={partEdit}
+          selection={partSelection}
+          overlayTarget={canvasOverlayTarget}
+          canvasHostRef={canvasHostRef}
+          displayListQueries={displayListQueries}
+          activePageIndex={activeHfPage?.pageIndex}
+          sidebarOpen={sidebarOpen}
+          zoom={zoom}
+        />
+      )}
+
+      {bandEdit &&
         activeHf &&
         hfChromeRect &&
         (() => {
           const editor = (
             <InlineHeaderFooterEditor
-              position={hfEditPosition}
+              position={bandEdit.kind}
               targetRect={hfChromeRect}
               onClose={() => {
-                setHfEditPosition(null);
+                setPartEditTarget(null);
               }}
               onRemove={onRemoveHeaderFooter}
             />

--- a/packages/docx-react/src/components/DocxEditor/DocxEditorPagedArea.tsx
+++ b/packages/docx-react/src/components/DocxEditor/DocxEditorPagedArea.tsx
@@ -353,7 +353,7 @@ export function DocxEditorPagedArea({
   );
 
   const floatingCommentButton =
-    floatingCommentBtn != null && !isAddingComment && !readOnly ? (
+    partEditTarget == null && floatingCommentBtn != null && !isAddingComment && !readOnly ? (
       <Tooltip content="Add comment" side="bottom" delayMs={300}>
         <button
           type="button"

--- a/packages/docx-react/src/components/DocxEditor/EditingModeDropdown.tsx
+++ b/packages/docx-react/src/components/DocxEditor/EditingModeDropdown.tsx
@@ -88,6 +88,7 @@ export function EditingModeDropdown({
       {isOpen && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           onMouseDown={(e) => e.preventDefault()}
           style={{
             position: 'fixed',

--- a/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
@@ -125,6 +125,7 @@ import {
   type YrsEditorCommand,
 } from './yrsCommands';
 import { YrsPositionProjection } from './internals/yrsPositionProjection';
+import { partEditStory, type PartEdit } from './partEdit';
 import type { DocxEditorCollaborationOptions } from './types';
 
 export { DEFAULT_PAGE_WIDTH };
@@ -209,11 +210,9 @@ export interface PagedEditorProps {
   pluginOverlays?: React.ReactNode;
   /** Callback when header or footer is double-clicked for editing. */
   onHeaderFooterDoubleClick?: (position: 'header' | 'footer', pageNumber?: number) => void;
-  /** Active header/footer editing mode (dims body, intercepts body clicks). */
-  hfEditMode?: 'header' | 'footer' | null;
-  /** Relationship id of the exact HF part active on the edited page. */
-  hfEditRId?: string | null;
-  /** Called when user clicks the body area while in HF editing mode. */
+  /** The one non-body part open for editing (dims body, intercepts body clicks). */
+  partEdit?: PartEdit | null;
+  /** Called when user clicks the body area while a part is open. */
   onBodyClick?: () => void;
   /** Custom class name. */
   className?: string;
@@ -268,8 +267,8 @@ export interface PagedEditorProps {
   sidebarCommentIds?: readonly (string | number)[];
   /** yrs-authoritative tracked-change list, emitted while standard yrs input is active. */
   onYrsTrackedChangesChange?: (result: TrackedChangesResult) => void;
-  /** Sticky yrs HF selection, expressed in the active HF root's display positions. */
-  onYrsHfSelectionChange?: (rId: string, selection: { from: number; to: number }) => void;
+  /** Sticky yrs selection inside the open part, in that part's display positions. */
+  onYrsPartSelectionChange?: (part: PartEdit, selection: { from: number; to: number }) => void;
   /**
    * Callback fired when the page count changes after a layout pass.
    * Parents use this to keep their own page counters (e.g. scroll indicator,
@@ -437,13 +436,12 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onYrsHistoryChange,
       onSelectionChange,
       onYrsSelectionChange,
-      onYrsHfSelectionChange,
+      onYrsPartSelectionChange,
       onReady,
       onRenderedDomContextReady,
       pluginOverlays,
       onHeaderFooterDoubleClick,
-      hfEditMode,
-      hfEditRId,
+      partEdit = null,
       onBodyClick,
       className,
       style,
@@ -519,7 +517,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         numericIds: {},
       };
     }, [_theme?.colorScheme, document?.package.settings?.defaultTabStop]);
-    const activeYrsRootStory = hfEditMode && hfEditRId ? `hf:${hfEditRId}` : 'body';
+    const activeYrsRootStory = partEditStory(partEdit);
     const yrsInputPositionMap = useCallback(
       (storyId = activeYrsRootStory) => yrsCore.inputPositionMap(storyId),
       [activeYrsRootStory, yrsCore.inputPositionMap]
@@ -563,14 +561,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // when parent passes unstable callback references
     const onSelectionChangeRef = useRef(onSelectionChange);
     const onYrsSelectionChangeRef = useRef(onYrsSelectionChange);
-    const onYrsHfSelectionChangeRef = useRef(onYrsHfSelectionChange);
+    const onYrsPartSelectionChangeRef = useRef(onYrsPartSelectionChange);
     const onYrsContentChangeRef = useRef(onYrsContentChange);
     const onYrsHistoryChangeRef = useRef(onYrsHistoryChange);
     const onReadyRef = useRef(onReady);
     // Keep refs in sync with latest props
     onSelectionChangeRef.current = onSelectionChange;
     onYrsSelectionChangeRef.current = onYrsSelectionChange;
-    onYrsHfSelectionChangeRef.current = onYrsHfSelectionChange;
+    onYrsPartSelectionChangeRef.current = onYrsPartSelectionChange;
     onYrsContentChangeRef.current = onYrsContentChange;
     onYrsHistoryChangeRef.current = onYrsHistoryChange;
     onReadyRef.current = onReady;
@@ -584,18 +582,18 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const [isFocused, setIsFocused] = useState(false);
 
     useEffect(() => {
-      if (hfEditMode) setIsFocused(false);
-    }, [hfEditMode]);
+      if (partEdit) setIsFocused(false);
+    }, [partEdit]);
 
     useEffect(() => {
       if (!isFocused) onCaretInterrupt?.();
     }, [isFocused, onCaretInterrupt]);
 
-    // Read-only / suggesting / HF-edit transitions bypass the resident input
+    // Read-only / suggesting / part-edit transitions bypass the resident input
     // path, so any painted caret line would go stale — swap to the DOM caret.
     useEffect(() => {
       onCaretInterrupt?.();
-    }, [readOnly, isSuggesting, hfEditMode, onCaretInterrupt]);
+    }, [readOnly, isSuggesting, partEdit, onCaretInterrupt]);
 
     // Image selection state — `isImageInteractingRef` lives at the parent so
     // useSelectionOverlay can read it (to gate the deferred image-info clear)
@@ -783,8 +781,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           }
         }
 
-        if (activeYrsRootStory.startsWith('hf:') && hfEditRId) {
-          onYrsHfSelectionChangeRef.current?.(hfEditRId, {
+        if (partEdit && activeYrsRootStory !== 'body') {
+          onYrsPartSelectionChangeRef.current?.(partEdit, {
             from: selection.anchor,
             to: selection.head,
           });
@@ -823,7 +821,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       [
         activeYrsRootStory,
         collaboration?.presence,
-        hfEditRId,
+        partEdit,
         refreshYrsLayout,
         updateSelectionOverlay,
         yrsCore.inputPositionMap,
@@ -1307,7 +1305,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       applyYrsCommand,
       syncYrsInputState,
       readOnly,
-      hfEditMode,
+      partEdit,
       displayListQueries,
       canvasHostRef,
       canvasOverlayTarget,
@@ -1647,7 +1645,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         <YrsInput
           ref={yrsInputRef}
           enabled
-          readOnly={readOnly || (!!hfEditMode && !hfEditRId)}
+          readOnly={readOnly || (!!partEdit && activeYrsRootStory === 'body')}
           session={yrsCore.session}
           story={activeYrsRootStory}
           isSuggesting={isSuggesting}
@@ -1688,11 +1686,11 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             canvasDisplayList &&
             (residentCaretAuthoritative || displayListQueries) && (
               <CanvasSelectionOverlay
-                selectionRects={hfEditMode ? [] : selectionRects}
+                selectionRects={partEdit ? [] : selectionRects}
                 // While the worker paints the caret into the presented frame,
                 // the DOM blink caret stays unmounted (two-mode caret).
-                caretPosition={hfEditMode || paintedCaretActive ? null : caretPosition}
-                isFocused={isFocused && !hfEditMode}
+                caretPosition={partEdit || paintedCaretActive ? null : caretPosition}
+                isFocused={isFocused && !partEdit}
                 readOnly={readOnly}
                 overlayTarget={canvasOverlayTarget}
                 canvasHostRef={interactionPageHostRef}
@@ -1723,7 +1721,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               />
             )}
 
-          {canvasOverlayTarget && displayListQueries && !hfEditMode && (
+          {canvasOverlayTarget && displayListQueries && !partEdit && (
             <CanvasCellSelectionOverlay
               session={yrsCore.session}
               positionProjection={getYrsPositionProjection('body')}
@@ -1737,8 +1735,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
           {canvasOverlayTarget && displayListQueries && (
             <CanvasImageSelectionOverlay
-              pmPos={hfEditMode ? null : canvasSelectedImagePos}
-              isFocused={isFocused && !hfEditMode}
+              pmPos={partEdit ? null : canvasSelectedImagePos}
+              isFocused={isFocused && !partEdit}
               readOnly={readOnly}
               overlayTarget={canvasOverlayTarget}
               canvasHostRef={interactionPageHostRef}
@@ -1755,7 +1753,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             />
           )}
 
-          {canvasOverlayTarget && displayListQueries && !hfEditMode && (
+          {canvasOverlayTarget && displayListQueries && !partEdit && (
             <CanvasTableResizeOverlay
               overlayTarget={canvasOverlayTarget}
               canvasHostRef={interactionPageHostRef}

--- a/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
@@ -125,7 +125,7 @@ import {
   type YrsEditorCommand,
 } from './yrsCommands';
 import { YrsPositionProjection } from './internals/yrsPositionProjection';
-import { partEditStory, type PartEdit } from './partEdit';
+import { partEditStory, type NoteEdit, type PartEdit } from './partEdit';
 import type { DocxEditorCollaborationOptions } from './types';
 
 export { DEFAULT_PAGE_WIDTH };
@@ -210,6 +210,8 @@ export interface PagedEditorProps {
   pluginOverlays?: React.ReactNode;
   /** Callback when header or footer is double-clicked for editing. */
   onHeaderFooterDoubleClick?: (position: 'header' | 'footer', pageNumber?: number) => void;
+  /** Callback when a note area is clicked for editing. */
+  onNoteClick?: (note: NoteEdit) => void;
   /** The one non-body part open for editing (dims body, intercepts body clicks). */
   partEdit?: PartEdit | null;
   /** Called when user clicks the body area while a part is open. */
@@ -441,6 +443,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onRenderedDomContextReady,
       pluginOverlays,
       onHeaderFooterDoubleClick,
+      onNoteClick,
       partEdit = null,
       onBodyClick,
       className,
@@ -534,7 +537,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         const map = yrsCore.inputPositionMap(loc.story);
         if (!map) return null;
         const local = yrsLocToLocalDisplayPosition(map, loc);
-        const rootStory = loc.story.startsWith('hf:') ? activeYrsRootStory : 'body';
+        const rootStory =
+          loc.story === 'body' || loc.story.startsWith('body:') ? 'body' : activeYrsRootStory;
         return (
           getYrsPositionProjectionRef.current(rootStory)?.positionForLoc(loc) ??
           (loc.story === rootStory ? local : null)
@@ -1313,6 +1317,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onContextMenu,
       onHyperlinkClick,
       onHeaderFooterDoubleClick,
+      onNoteClick,
       setSelectionRects,
       setCaretPosition,
       setIsFocused,

--- a/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
@@ -708,8 +708,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const lastPublishedBodySelectionKeyRef = useRef<string | null>(null);
     const lastPublishedPresenceSelectionKeyRef = useRef<string | null>(null);
     const documentChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const publishYrsDirectInput = useCallback((): void => {
-      yrsCore.publishDirectInput();
+    const publishYrsDirectInput = useCallback((dirtyStory?: string): void => {
+      yrsCore.publishDirectInput(dirtyStory);
       // Structural input can mint a paragraph before the existing projection
       // can map its new sticky caret. Invalidate first so emitSelection can
       // rebuild the projection and reach the normal layout-refresh callback.
@@ -853,11 +853,15 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     }, [collaboration?.presence, yrsCore.session]);
 
     const syncYrsInputState = useCallback(
-      (docChanged: boolean, origin: LayoutUpdateOrigin = 'local'): boolean => {
+      (
+        docChanged: boolean,
+        origin: LayoutUpdateOrigin = 'local',
+        dirtyStory?: string
+      ): boolean => {
         if (!yrsCore.session) return false;
         const displaySelection = yrsInputRef.current?.displaySelection() ?? { anchor: 0, head: 0 };
         if (docChanged) {
-          yrsCore.publishDirectInput();
+          yrsCore.publishDirectInput(dirtyStory);
         }
         handleYrsStateChange(displaySelection, docChanged, false, false, origin);
         return true;
@@ -1599,7 +1603,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       documentFromYrs: yrsCore.documentFromYrs,
       yrsSession: yrsCore.session,
       yrsLocToDisplayPosition,
-      syncYrsInputState,
+      syncYrsInputState: (docChanged, dirtyStory) =>
+        syncYrsInputState(docChanged, 'local', dirtyStory),
       applyYrsFormatting,
       applyYrsCommand,
       getYrsPositionProjection: () => getYrsPositionProjection('body'),

--- a/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor/PagedEditor.tsx
@@ -124,7 +124,10 @@ import {
   yrsTableSelectionRange,
   type YrsEditorCommand,
 } from './yrsCommands';
-import { YrsPositionProjection } from './internals/yrsPositionProjection';
+import {
+  createYrsPositionProjection,
+  type YrsPositionProjection,
+} from './internals/yrsPositionProjection';
 import { partEditStory, type NoteEdit, type PartEdit } from './partEdit';
 import type { DocxEditorCollaborationOptions } from './types';
 
@@ -1257,7 +1260,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const getYrsPositionProjection = useCallback(
       (rootStory: string): YrsPositionProjection | null => {
         const session = yrsCore.session;
-        if (!session) return null;
+        if (!session || !session.storyIds().includes(rootStory)) return null;
         const cached = yrsPositionProjectionCacheRef.current;
         if (
           cached?.version === yrsProjectionVersionRef.current &&
@@ -1266,7 +1269,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         ) {
           return cached.projection;
         }
-        const projection = new YrsPositionProjection(session, rootStory);
+        const projection = createYrsPositionProjection(session, rootStory);
+        if (!projection) return null;
         yrsPositionProjectionCacheRef.current = {
           version: yrsProjectionVersionRef.current,
           session,

--- a/packages/docx-react/src/components/DocxEditor/YrsInput.tsx
+++ b/packages/docx-react/src/components/DocxEditor/YrsInput.tsx
@@ -106,7 +106,7 @@ export interface YrsInputProps {
     residentLayoutReady?: boolean,
     residentCaretReady?: boolean
   ): void;
-  onDirectInput(): void;
+  onDirectInput(story?: string): void;
   /** One-owner body text path; false until the resident frame is initialized. */
   applyResidentInput?(text: string): Promise<ResidentFrameApplyResult | null>;
   /** One-owner collapsed delete/merge path; false until the resident frame is initialized. */
@@ -321,11 +321,11 @@ const YrsInputComponent = forwardRef<YrsInputRef, YrsInputProps>(function YrsInp
   );
 
   const finishMutation = useCallback(
-    (residentLayoutReady = false, residentCaretReady = false): void => {
+    (residentLayoutReady = false, residentCaretReady = false, dirtyStory?: string): void => {
       verticalCaretGoalRef.current.reset();
       if (!composingRef.current && textareaRef.current) textareaRef.current.value = '';
       onCaretInput?.();
-      onDirectInput();
+      onDirectInput(dirtyStory);
       emitSelection(true, residentLayoutReady, residentCaretReady);
     },
     [emitSelection, onCaretInput, onDirectInput]
@@ -726,8 +726,8 @@ const YrsInputComponent = forwardRef<YrsInputRef, YrsInputProps>(function YrsInp
     (redo: boolean): void => {
       enqueueInputOperation(() => {
         if (!session || readOnly) return;
-        const changed = performYrsHistoryAction(session, redo);
-        if (changed) finishMutation();
+        const result = performYrsHistoryAction(session, redo);
+        if (result.changed) finishMutation(false, false, result.story ?? undefined);
       });
     },
     [enqueueInputOperation, finishMutation, readOnly, session]

--- a/packages/docx-react/src/components/DocxEditor/hooks/useContextMenus.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useContextMenus.test.ts
@@ -7,10 +7,16 @@ const ownsDom = !GlobalRegistrator.isRegistered;
 if (ownsDom) GlobalRegistrator.register();
 const { act, cleanup, renderHook } = await import('@testing-library/react');
 
-function options(partEditOpen: boolean) {
+function options(
+  partEditOpen: boolean,
+  onAddComment: (range: { from: number; to: number; yPos: number | null }) => void = () => {}
+) {
   return {
     pagedEditorRef: {
-      current: { getYrsSession: () => null } as PagedEditorRef,
+      current: {
+        getYrsSession: () => null,
+        getSelectionRange: () => ({ from: 1, to: 2 }),
+      } as PagedEditorRef,
     },
     focusActiveEditor: () => {},
     openSplitCellDialog: () => {},
@@ -19,7 +25,7 @@ function options(partEditOpen: boolean) {
     interactionPageHostRef: { current: null },
     i18n: undefined,
     partEditOpen,
-    onAddComment: () => {},
+    onAddComment,
   };
 }
 
@@ -45,5 +51,25 @@ describe('selection context menu', () => {
     openSelectionMenu(result);
 
     expect(result.current.contextMenuItems.map((item) => item.action)).not.toContain('addComment');
+  });
+
+  test('rejects a displayed Comment action when a part opens before dispatch', async () => {
+    let added = 0;
+    const onAddComment = () => {
+      added += 1;
+    };
+    const { result, rerender } = renderHook(
+      ({ partEditOpen }) => useContextMenus(options(partEditOpen, onAddComment)),
+      { initialProps: { partEditOpen: false } }
+    );
+    openSelectionMenu(result);
+    expect(result.current.contextMenuItems.map((item) => item.action)).toContain('addComment');
+
+    rerender({ partEditOpen: true });
+    await act(async () => {
+      await result.current.handleContextMenuAction('addComment');
+    });
+
+    expect(added).toBe(0);
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/hooks/useContextMenus.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useContextMenus.test.ts
@@ -1,0 +1,49 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import type { PagedEditorRef } from '../PagedEditor';
+import { useContextMenus } from './useContextMenus';
+
+const ownsDom = !GlobalRegistrator.isRegistered;
+if (ownsDom) GlobalRegistrator.register();
+const { act, cleanup, renderHook } = await import('@testing-library/react');
+
+function options(partEditOpen: boolean) {
+  return {
+    pagedEditorRef: {
+      current: { getYrsSession: () => null } as PagedEditorRef,
+    },
+    focusActiveEditor: () => {},
+    openSplitCellDialog: () => {},
+    editorContentRef: { current: null },
+    displayListQueries: null,
+    interactionPageHostRef: { current: null },
+    i18n: undefined,
+    partEditOpen,
+    onAddComment: () => {},
+  };
+}
+
+function openSelectionMenu(result: { current: ReturnType<typeof useContextMenus> }): void {
+  act(() => result.current.handleContextMenu({ x: 10, y: 20, hasSelection: true }));
+}
+
+afterEach(cleanup);
+afterAll(() => {
+  if (ownsDom) GlobalRegistrator.unregister();
+});
+
+describe('selection context menu', () => {
+  test('offers Comment for a body selection', () => {
+    const { result } = renderHook(() => useContextMenus(options(false)));
+    openSelectionMenu(result);
+
+    expect(result.current.contextMenuItems.map((item) => item.action)).toContain('addComment');
+  });
+
+  test('does not offer Comment for a selection in an open note', () => {
+    const { result } = renderHook(() => useContextMenus(options(true)));
+    openSelectionMenu(result);
+
+    expect(result.current.contextMenuItems.map((item) => item.action)).not.toContain('addComment');
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/hooks/useContextMenus.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useContextMenus.ts
@@ -53,6 +53,7 @@ export function useContextMenus({
   displayListQueries,
   interactionPageHostRef,
   i18n,
+  partEditOpen,
   onAddComment,
 }: {
   pagedEditorRef: React.RefObject<PagedEditorRef | null>;
@@ -62,6 +63,7 @@ export function useContextMenus({
   displayListQueries: DisplayListQueries | null;
   interactionPageHostRef: React.RefObject<HTMLDivElement | null>;
   i18n: Translations | undefined;
+  partEditOpen: boolean;
   onAddComment: (range: { from: number; to: number; yPos: number | null }) => void;
 }) {
   const { t } = useTranslation();
@@ -250,7 +252,7 @@ export function useContextMenus({
         dividerAfter: !contextMenu.hasSelection && !contextMenu.cursorInTable,
       },
     ];
-    if (contextMenu.hasSelection) {
+    if (contextMenu.hasSelection && !partEditOpen) {
       items.push({
         action: 'addComment',
         label: 'Comment',
@@ -293,7 +295,14 @@ export function useContextMenus({
       shortcut: formatKeys(t('contextMenu.selectAllShortcut')),
     });
     return items;
-  }, [contextMenu.hasSelection, contextMenu.cursorInTable, contextMenu.tableContext, i18n, t]);
+  }, [
+    contextMenu.hasSelection,
+    contextMenu.cursorInTable,
+    contextMenu.tableContext,
+    i18n,
+    partEditOpen,
+    t,
+  ]);
 
   const handleContextMenuAction = useCallback(
     async (action: TextContextAction) => {
@@ -370,6 +379,7 @@ export function useContextMenus({
           paged.applyYrsCommand({ type: 'tableDelete' });
           break;
         case 'addComment': {
+          if (partEditOpen) break;
           const selection = paged.getSelectionRange();
           if (!selection || selection.from === selection.to) break;
           const { from, to } = selection;
@@ -403,6 +413,7 @@ export function useContextMenus({
       displayListQueries,
       interactionPageHostRef,
       onAddComment,
+      partEditOpen,
     ]
   );
 

--- a/packages/docx-react/src/components/DocxEditor/hooks/useFloatingCommentBtn.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useFloatingCommentBtn.test.ts
@@ -1,0 +1,58 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import type { SetStateAction } from 'react';
+import type { PagedEditorRef } from '../PagedEditor';
+import { useFloatingCommentBtn } from './useFloatingCommentBtn';
+
+const ownsDom = !GlobalRegistrator.isRegistered;
+if (ownsDom) GlobalRegistrator.register();
+const { act, cleanup, renderHook } = await import('@testing-library/react');
+
+afterEach(cleanup);
+afterAll(() => {
+  if (ownsDom) GlobalRegistrator.unregister();
+});
+
+describe('useFloatingCommentBtn', () => {
+  test('clears the body comment affordance while a part is open', () => {
+    let selectionReads = 0;
+    const updates: Array<{ top: number; left: number } | null> = [];
+    const setFloatingCommentBtn = (
+      next: SetStateAction<{ top: number; left: number } | null>
+    ) => {
+      const previous = updates.length > 0 ? updates[updates.length - 1] : null;
+      updates.push(typeof next === 'function' ? next(previous) : next);
+    };
+    const pagedEditorRef = {
+      current: {
+        getSelectionRange: () => {
+          selectionReads += 1;
+          return { from: 1, to: 2 };
+        },
+      } as PagedEditorRef,
+    };
+    const { result, rerender } = renderHook(
+      ({ partEditOpen }) =>
+        useFloatingCommentBtn({
+          pagedEditorRef,
+          scrollContainerRef: { current: null },
+          editorContentRef: { current: null },
+          isAddingCommentRef: { current: false },
+          setFloatingCommentBtn,
+          partEditOpen,
+          readOnly: false,
+          isLoading: false,
+          zoom: 1,
+        }),
+      { initialProps: { partEditOpen: false } }
+    );
+    const readsBeforePartOpen = selectionReads;
+
+    rerender({ partEditOpen: true });
+    expect(updates[updates.length - 1]).toBeNull();
+
+    act(() => result.current.recomputeFloatingCommentBtn());
+    expect(selectionReads).toBe(readsBeforePartOpen);
+    expect(updates[updates.length - 1]).toBeNull();
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/hooks/useFloatingCommentBtn.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useFloatingCommentBtn.ts
@@ -31,6 +31,7 @@ export function useFloatingCommentBtn({
   editorContentRef,
   isAddingCommentRef,
   setFloatingCommentBtn,
+  partEditOpen,
   readOnly,
   isLoading,
   zoom,
@@ -42,6 +43,7 @@ export function useFloatingCommentBtn({
   editorContentRef: React.RefObject<HTMLDivElement | null>;
   isAddingCommentRef: React.RefObject<boolean>;
   setFloatingCommentBtn: React.Dispatch<React.SetStateAction<{ top: number; left: number } | null>>;
+  partEditOpen: boolean;
   readOnly: boolean;
   isLoading: boolean;
   zoom: number;
@@ -52,9 +54,15 @@ export function useFloatingCommentBtn({
 }) {
   const readOnlyForFloatingBtnRef = useRef(false);
   readOnlyForFloatingBtnRef.current = readOnly;
+  const partEditOpenRef = useRef(false);
+  partEditOpenRef.current = partEditOpen;
 
   const recomputeFloatingCommentBtn = useCallback(() => {
-    if (isAddingCommentRef.current || readOnlyForFloatingBtnRef.current) {
+    if (
+      partEditOpenRef.current ||
+      isAddingCommentRef.current ||
+      readOnlyForFloatingBtnRef.current
+    ) {
       setFloatingCommentBtn(null);
       return;
     }
@@ -111,6 +119,10 @@ export function useFloatingCommentBtn({
   useEffect(() => {
     recomputeFloatingCommentBtn();
   }, [zoom, recomputeFloatingCommentBtn]);
+
+  useEffect(() => {
+    if (partEditOpen) setFloatingCommentBtn(null);
+  }, [partEditOpen, setFloatingCommentBtn]);
 
   return { recomputeFloatingCommentBtn };
 }

--- a/packages/docx-react/src/components/DocxEditor/hooks/useHeaderFooterEditing.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useHeaderFooterEditing.ts
@@ -6,12 +6,14 @@ import type {
 } from '@betteroffice/docx/types/document';
 import { resolveHeaderFooter } from '@betteroffice/docx/layout';
 
+import type { PartEditTarget } from '../partEdit';
+
 /**
- * Owns the inline header/footer editing mode: which slot is being
- * edited (`hfEditPosition`), whether the first-page variant applies
- * (`hfEditIsFirstPage`), the resolved header/footer content for the
- * current section, plus the double-click → edit, save, remove, and
- * "click out" workflows.
+ * Owns the inline header/footer editing mode: which slot is being edited and
+ * which page it was opened from (both carried by `partEditTarget`, the one
+ * value naming whatever non-body part is open), the resolved header/footer
+ * content for the current section, plus the double-click → edit, save,
+ * remove, and "click out" workflows.
  *
  * Empty headers/footers are materialised on first double-click so the
  * user can start typing — the helper writes the new HeaderFooter into
@@ -23,23 +25,17 @@ export function useHeaderFooterEditing({
   pushDocument,
   initialSectionProperties,
   finalSectionProperties,
-  hfEditPosition,
-  setHfEditPosition,
-  hfEditIsFirstPage,
-  setHfEditIsFirstPage,
-  setHfEditPageIndex,
+  partEditTarget,
+  setPartEditTarget,
 }: {
   document: Document | null;
   pushDocument: (doc: Document) => void;
   initialSectionProperties: SectionProperties | undefined;
   finalSectionProperties: SectionProperties | undefined;
-  // State + setters live in the parent so selection and canvas overlays can
-  // route to the active header/footer story.
-  hfEditPosition: 'header' | 'footer' | null;
-  setHfEditPosition: React.Dispatch<React.SetStateAction<'header' | 'footer' | null>>;
-  hfEditIsFirstPage: boolean;
-  setHfEditIsFirstPage: React.Dispatch<React.SetStateAction<boolean>>;
-  setHfEditPageIndex: React.Dispatch<React.SetStateAction<number>>;
+  // State + setter live in the parent so selection and canvas overlays can
+  // route to the open part's story.
+  partEditTarget: PartEditTarget | null;
+  setPartEditTarget: React.Dispatch<React.SetStateAction<PartEditTarget | null>>;
 }) {
   const { headerContent, footerContent, firstPageHeaderContent, firstPageFooterContent } =
     useMemo(() => {
@@ -63,7 +59,11 @@ export function useHeaderFooterEditing({
       // over THAT page's header and edits propagate visually to all others.
       const sectProps = document?.package?.document?.finalSectionProperties;
       const isFirstPage = sectProps?.titlePg === true && (pageNumber ?? 1) === 1;
-      setHfEditPageIndex(Math.max(0, (pageNumber ?? 1) - 1));
+      const opened: PartEditTarget = {
+        kind: position,
+        isFirstPage,
+        pageIndex: Math.max(0, (pageNumber ?? 1) - 1),
+      };
       const hf = isFirstPage
         ? position === 'header'
           ? firstPageHeaderContent
@@ -71,9 +71,8 @@ export function useHeaderFooterEditing({
         : position === 'header'
           ? headerContent
           : footerContent;
-      setHfEditIsFirstPage(isFirstPage);
       if (hf) {
-        setHfEditPosition(position);
+        setPartEditTarget(opened);
         return;
       }
 
@@ -136,7 +135,7 @@ export function useHeaderFooterEditing({
         },
       };
       pushDocument(newDoc);
-      setHfEditPosition(position);
+      setPartEditTarget(opened);
     },
     [
       headerContent,
@@ -145,29 +144,30 @@ export function useHeaderFooterEditing({
       firstPageFooterContent,
       document,
       pushDocument,
-      setHfEditPosition,
-      setHfEditIsFirstPage,
-      setHfEditPageIndex,
+      setPartEditTarget,
     ]
   );
 
   const handleBodyClick = useCallback(() => {
-    if (!hfEditPosition) return;
-    setHfEditPosition(null);
-  }, [hfEditPosition, setHfEditPosition]);
+    setPartEditTarget(null);
+  }, [setPartEditTarget]);
 
   const handleRemoveHeaderFooter = useCallback(() => {
-    if (!hfEditPosition || !document?.package) {
-      setHfEditPosition(null);
+    const band =
+      partEditTarget?.kind === 'header' || partEditTarget?.kind === 'footer'
+        ? partEditTarget
+        : null;
+    if (!band || !document?.package) {
+      setPartEditTarget(null);
       return;
     }
 
     const pkg = document.package;
     const sectionProps = pkg.document?.finalSectionProperties;
-    const refKey = hfEditPosition === 'header' ? 'headerReferences' : 'footerReferences';
-    const mapKey = hfEditPosition === 'header' ? 'headers' : 'footers';
+    const refKey = band.kind === 'header' ? 'headerReferences' : 'footerReferences';
+    const mapKey = band.kind === 'header' ? 'headers' : 'footers';
     const refs = sectionProps?.[refKey];
-    const delTargetType = hfEditIsFirstPage ? 'first' : 'default';
+    const delTargetType = band.isFirstPage ? 'first' : 'default';
     const activeRef =
       refs?.find((r) => r.type === delTargetType) ??
       refs?.find((r) => r.type === 'default') ??
@@ -199,8 +199,8 @@ export function useHeaderFooterEditing({
       pushDocument(newDoc);
     }
 
-    setHfEditPosition(null);
-  }, [hfEditPosition, hfEditIsFirstPage, document, pushDocument, setHfEditPosition]);
+    setPartEditTarget(null);
+  }, [partEditTarget, document, pushDocument, setPartEditTarget]);
 
   return {
     headerContent,

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagedEditorRefApi.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagedEditorRefApi.ts
@@ -22,7 +22,9 @@ interface RefApiInputs {
   documentFromYrsRef: React.MutableRefObject<() => Document | null>;
   yrsSessionRef: React.MutableRefObject<YrsSession | null>;
   yrsLocToDisplayPositionRef: React.MutableRefObject<(loc: YrsLoc) => number | null>;
-  syncYrsInputStateRef: React.MutableRefObject<(docChanged: boolean) => boolean>;
+  syncYrsInputStateRef: React.MutableRefObject<
+    (docChanged: boolean, dirtyStory?: string) => boolean
+  >;
   applyYrsFormattingRef: React.MutableRefObject<(action: FormattingAction) => boolean>;
   applyYrsCommandRef: React.MutableRefObject<(command: YrsEditorCommand) => boolean>;
   getYrsPositionProjectionRef: React.MutableRefObject<() => YrsPositionProjection | null>;
@@ -103,15 +105,19 @@ function buildRefApi(inputs: RefApiInputs): PagedEditorRef {
     isFocused: () => yrsInputRef.current?.isFocused() ?? false,
     undo: () => {
       const session = yrsSessionRef.current;
-      const changed = session ? performYrsHistoryAction(session, false) : false;
-      if (changed) syncYrsInputStateRef.current(true);
-      return changed;
+      const result = session
+        ? performYrsHistoryAction(session, false)
+        : { changed: false, story: null };
+      if (result.changed) syncYrsInputStateRef.current(true, result.story ?? undefined);
+      return result.changed;
     },
     redo: () => {
       const session = yrsSessionRef.current;
-      const changed = session ? performYrsHistoryAction(session, true) : false;
-      if (changed) syncYrsInputStateRef.current(true);
-      return changed;
+      const result = session
+        ? performYrsHistoryAction(session, true)
+        : { changed: false, story: null };
+      if (result.changed) syncYrsInputStateRef.current(true, result.story ?? undefined);
+      return result.changed;
     },
     canUndo: () => yrsSessionRef.current?.canUndo() ?? false,
     canRedo: () => yrsSessionRef.current?.canRedo() ?? false,
@@ -189,7 +195,7 @@ export interface UsePagedEditorRefApiOptions {
   documentFromYrs: () => Document | null;
   yrsSession: YrsSession | null;
   yrsLocToDisplayPosition: (loc: YrsLoc) => number | null;
-  syncYrsInputState: (docChanged: boolean) => boolean;
+  syncYrsInputState: (docChanged: boolean, dirtyStory?: string) => boolean;
   applyYrsFormatting: (action: FormattingAction) => boolean;
   applyYrsCommand: (command: YrsEditorCommand) => boolean;
   getYrsPositionProjection: () => YrsPositionProjection | null;

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.cursor.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.cursor.test.ts
@@ -10,6 +10,7 @@ import { createRef } from 'react';
 import type { DisplayListQueries } from '@betteroffice/docx/layout/render';
 import type { YrsSession } from '@betteroffice/docx/yrs';
 import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
+import type { PartEdit } from '../partEdit';
 import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
 
 // Registered only if nobody else did, and handed back at the end: a leaked
@@ -178,15 +179,15 @@ describe('pages pointer hover cursor', () => {
   test('a mode flip mid-drag waits for the release', () => {
     const options = stableOptions();
     const { rerender } = renderHook(
-      (hfEditMode: 'header' | 'footer' | null) => usePagesPointer(options({ hfEditMode })),
-      { initialProps: null as 'header' | 'footer' | null }
+      (partEdit: PartEdit | null) => usePagesPointer(options({ partEdit })),
+      { initialProps: null as PartEdit | null }
     );
 
     mouse('mousemove', 400, 500, canvasOf());
     mouse('mousedown', 400, 500, canvasOf());
 
     // the body becomes inert behind an open band editor, but not mid-gesture
-    act(() => rerender('header'));
+    act(() => rerender({ kind: 'header', rId: 'rId7' }));
     expect(host.style.cursor).toBe('text');
 
     mouse('mouseup', 400, 500, window);
@@ -215,15 +216,15 @@ describe('pages pointer hover cursor', () => {
   test('opening a header editor re-resolves a pointer that has not moved', () => {
     const options = stableOptions();
     const { rerender } = renderHook(
-      (hfEditMode: 'header' | 'footer' | null) => usePagesPointer(options({ hfEditMode })),
-      { initialProps: null as 'header' | 'footer' | null }
+      (partEdit: PartEdit | null) => usePagesPointer(options({ partEdit })),
+      { initialProps: null as PartEdit | null }
     );
 
     mouse('mousemove', 400, 500, canvasOf());
     expect(host.style.cursor).toBe('text');
 
     // the body is inert behind an open band editor, under the same pointer
-    act(() => rerender('header'));
+    act(() => rerender({ kind: 'header', rId: 'rId7' }));
     expect(host.style.cursor).toBe('default');
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
@@ -9,6 +9,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:tes
 import { createElement, createRef, useState } from 'react';
 import type { DisplayListQueries, DisplayListRegionHit } from '@betteroffice/docx/layout/render';
 import type { YrsSession } from '@betteroffice/docx/yrs';
+import { AlignmentButtons } from '../../ui/AlignmentButtons';
 import { MenuDropdown } from '../../ui/MenuDropdown';
 import { useEscapeKey } from '../../../hooks/useEscapeKey';
 import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
@@ -610,6 +611,25 @@ describe('closing an open part with Escape', () => {
     expect(closed).toBe(0);
   });
 
+  test('lets an open alignment dropdown consume Escape without closing the part', () => {
+    let closed = 0;
+    const view = render(
+      createElement(EscapeAlignmentHarness, { onEscape: () => (closed += 1) })
+    );
+    const trigger = view.getByTestId('toolbar-alignment');
+    act(() => trigger.click());
+
+    expect(view.getByTestId('alignment-left')).toBeTruthy();
+    const input = document.createElement('textarea');
+    input.className = 'paged-editor__yrs-input';
+    host.append(input);
+    dispatchEscape(input);
+
+    expect(view.queryByTestId('alignment-left')).toBeNull();
+    expect(closed).toBe(0);
+    input.remove();
+  });
+
   test('plain Escape from the editor input closes the part', () => {
     let closed = 0;
     const input = document.createElement('textarea');
@@ -667,4 +687,9 @@ function EscapeMenuHarness({ onEscape }: { onEscape: () => void }) {
     label: 'File',
     items: [{ label: 'Open', onClick: () => {} }],
   });
+}
+
+function EscapeAlignmentHarness({ onEscape }: { onEscape: () => void }) {
+  useEscapeKey(true, onEscape);
+  return createElement(AlignmentButtons);
 }

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
@@ -6,9 +6,11 @@
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { createRef, useState } from 'react';
-import type { DisplayListQueries } from '@betteroffice/docx/layout/render';
+import { createElement, createRef, useState } from 'react';
+import type { DisplayListQueries, DisplayListRegionHit } from '@betteroffice/docx/layout/render';
 import type { YrsSession } from '@betteroffice/docx/yrs';
+import { MenuDropdown } from '../../ui/MenuDropdown';
+import { useEscapeKey } from '../../../hooks/useEscapeKey';
 import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
 import type { YrsInputRef } from '../YrsInput';
 import { partEditStory, type PartEdit } from '../partEdit';
@@ -16,7 +18,7 @@ import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
 
 const ownsDom = !GlobalRegistrator.isRegistered;
 if (ownsDom) GlobalRegistrator.register();
-const { act, cleanup, renderHook } = await import('@testing-library/react');
+const { act, cleanup, render, renderHook } = await import('@testing-library/react');
 
 const PAGE = { width: 800, height: 1000 };
 /** y at or past this is the page's footnote area in the fake engine. */
@@ -25,16 +27,23 @@ const NOTE_A_ID = 1;
 const NOTE_ID = 2;
 /** what the fake engine resolves anywhere inside the note area */
 const NOTE_POSITION = 7;
+const UNATTRIBUTED_NOTE_HIT = {
+  region: 'footnote',
+  noteId: undefined,
+  pos: null,
+  target: 'none',
+} as DisplayListRegionHit;
 
 let host: HTMLDivElement;
 let selections: Array<{ anchor: number; head: number; story?: string }>;
 
-function fakeQueries(): DisplayListQueries {
+function fakeQueries(fixedHit?: DisplayListRegionHit): DisplayListQueries {
   return {
     displayList: { pages: [{ pageIndex: 0, ...PAGE, primitives: [] }] },
     pageCount: () => 1,
     pageSize: () => PAGE,
     hitTestRegions: (_pageIndex: number, x: number, y: number) => {
+      if (fixedHit) return fixedHit;
       if (y < NOTE_FROM) return { region: 'body' as const, pos: 1, target: 'text' as const };
       return x < PAGE.width / 2
         ? {
@@ -111,6 +120,17 @@ function dispatchMouse(
 
 function mouse(type: string, clientX: number, clientY: number, target: EventTarget): void {
   act(() => dispatchMouse(type, clientX, clientY, target));
+}
+
+function dispatchEscape(target: EventTarget, init: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Escape',
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  act(() => target.dispatchEvent(event));
+  return event;
 }
 
 beforeEach(() => {
@@ -399,18 +419,111 @@ describe('clicking a note', () => {
     ]);
   });
 
-  test('a click in the body leaves the note instead of typing into it', () => {
+  test('a click in the body leaves the note and places the body caret there', () => {
     let left = 0;
     const options = stableOptions();
-    renderHook(() =>
-      usePagesPointer(
-        options({ partEdit: note, yrsRootStory: `fn:${NOTE_ID}`, onBodyClick: () => (left += 1) })
-      )
-    );
+    renderHook(() => {
+      const [partEdit, setPartEdit] = useState<PartEdit | null>(note);
+      return usePagesPointer(
+        options({
+          partEdit,
+          yrsRootStory: partEditStory(partEdit),
+          onBodyClick: () => {
+            left += 1;
+            setPartEdit(null);
+          },
+        })
+      );
+    });
 
     mouse('mousedown', 400, 500, canvasOf());
 
     expect(left).toBe(1);
+    expect(selections).toEqual([{ anchor: 1, head: 1, story: 'body' }]);
+  });
+
+  test('a click in the body leaves a band and places the body caret there', () => {
+    let left = 0;
+    const options = stableOptions();
+    renderHook(() => {
+      const [partEdit, setPartEdit] = useState<PartEdit | null>({
+        kind: 'header',
+        rId: 'rId7',
+      });
+      return usePagesPointer(
+        options({
+          partEdit,
+          yrsRootStory: partEditStory(partEdit),
+          onBodyClick: () => {
+            left += 1;
+            setPartEdit(null);
+          },
+        })
+      );
+    });
+
+    mouse('mousedown', 400, 500, canvasOf());
+
+    expect(left).toBe(1);
+    expect(selections).toEqual([{ anchor: 1, head: 1, story: 'body' }]);
+  });
+
+  test('a body click can leave a note whose story vanished', () => {
+    let left = 0;
+    const options = stableOptions();
+    const projectionFor = options().getYrsPositionProjection;
+    renderHook(() => {
+      const [partEdit, setPartEdit] = useState<PartEdit | null>(note);
+      return usePagesPointer(
+        options({
+          partEdit,
+          yrsRootStory: partEditStory(partEdit),
+          getYrsPositionProjection: (story) =>
+            story === `fn:${NOTE_ID}` ? null : projectionFor(story),
+          onBodyClick: () => {
+            left += 1;
+            setPartEdit(null);
+          },
+        })
+      );
+    });
+
+    mouse('mousedown', 400, 500, canvasOf());
+
+    expect(left).toBe(1);
+    expect(selections).toEqual([{ anchor: 1, head: 1, story: 'body' }]);
+  });
+
+  test('an unattributed note-area hit is inert while the body is active', () => {
+    const options = stableOptions();
+    renderHook(() =>
+      usePagesPointer(
+        options({ displayListQueries: fakeQueries(UNATTRIBUTED_NOTE_HIT), onNoteClick: () => {} })
+      )
+    );
+
+    mouse('mousedown', 400, 950, canvasOf());
+
+    expect(selections).toEqual([]);
+  });
+
+  test('an unattributed note-area hit does not close an open note', () => {
+    let left = 0;
+    const options = stableOptions();
+    renderHook(() =>
+      usePagesPointer(
+        options({
+          partEdit: note,
+          yrsRootStory: `fn:${NOTE_ID}`,
+          displayListQueries: fakeQueries(UNATTRIBUTED_NOTE_HIT),
+          onBodyClick: () => (left += 1),
+        })
+      )
+    );
+
+    mouse('mousedown', 400, 950, canvasOf());
+
+    expect(left).toBe(0);
     expect(selections).toEqual([]);
   });
 
@@ -466,3 +579,92 @@ describe('clicking a note', () => {
     expect(contexts[0]?.image).toBeNull();
   });
 });
+
+describe('closing an open part with Escape', () => {
+  test('ignores composition Escape events', () => {
+    let closed = 0;
+    renderHook(() => useEscapeKey(true, () => (closed += 1)));
+
+    dispatchEscape(document, { isComposing: true });
+    const legacy = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(legacy, 'keyCode', { value: 229 });
+    act(() => document.dispatchEvent(legacy));
+
+    expect(closed).toBe(0);
+  });
+
+  test('lets an open menu consume Escape without closing the part', () => {
+    let closed = 0;
+    const view = render(createElement(EscapeMenuHarness, { onEscape: () => (closed += 1) }));
+    const trigger = view.getByRole('button', { name: 'File' });
+    act(() => trigger.click());
+
+    expect(view.getByText('Open')).toBeTruthy();
+    dispatchEscape(trigger);
+
+    expect(view.queryByText('Open')).toBeNull();
+    expect(closed).toBe(0);
+  });
+
+  test('plain Escape from the editor input closes the part', () => {
+    let closed = 0;
+    const input = document.createElement('textarea');
+    input.className = 'paged-editor__yrs-input';
+    host.append(input);
+    renderHook(() => useEscapeKey(true, () => (closed += 1)));
+
+    const event = dispatchEscape(input);
+
+    expect(closed).toBe(1);
+    expect(event.defaultPrevented).toBe(true);
+    input.remove();
+  });
+
+  test('ignores Escape from another input', () => {
+    let closed = 0;
+    const input = document.createElement('input');
+    host.append(input);
+    renderHook(() => useEscapeKey(true, () => (closed += 1)));
+
+    dispatchEscape(input);
+
+    expect(closed).toBe(0);
+    input.remove();
+  });
+
+  test('ignores an already prevented Escape', () => {
+    let closed = 0;
+    renderHook(() => useEscapeKey(true, () => (closed += 1)));
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    event.preventDefault();
+
+    act(() => document.dispatchEvent(event));
+
+    expect(closed).toBe(0);
+  });
+
+  test('closes an active part without mounted chrome', () => {
+    let closed = 0;
+    renderHook(() => useEscapeKey(true, () => (closed += 1)));
+
+    dispatchEscape(document);
+
+    expect(closed).toBe(1);
+  });
+});
+
+function EscapeMenuHarness({ onEscape }: { onEscape: () => void }) {
+  useEscapeKey(true, onEscape);
+  return createElement(MenuDropdown, {
+    label: 'File',
+    items: [{ label: 'Open', onClick: () => {} }],
+  });
+}

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Clicking into a footnote: the pointer path opens the note it lands in, and
+ * the caret that click asked for goes into that note's story once the editor
+ * is on it. `partEdit.test.ts` covers the mapping; this shows the wiring.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createRef } from 'react';
+import type { DisplayListQueries } from '@betteroffice/docx/layout/render';
+import type { YrsSession } from '@betteroffice/docx/yrs';
+import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
+import type { YrsInputRef } from '../YrsInput';
+import type { PartEdit } from '../partEdit';
+import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
+
+const ownsDom = !GlobalRegistrator.isRegistered;
+if (ownsDom) GlobalRegistrator.register();
+const { act, cleanup, renderHook } = await import('@testing-library/react');
+
+const PAGE = { width: 800, height: 1000 };
+/** y at or past this is the page's footnote area in the fake engine. */
+const NOTE_FROM = 900;
+const NOTE_ID = 2;
+/** what the fake engine resolves anywhere inside the note area */
+const NOTE_POSITION = 7;
+
+let host: HTMLDivElement;
+let selections: Array<{ anchor: number; head: number; story?: string }>;
+
+function fakeQueries(): DisplayListQueries {
+  return {
+    displayList: { pages: [{ pageIndex: 0, ...PAGE, primitives: [] }] },
+    pageCount: () => 1,
+    pageSize: () => PAGE,
+    hitTestRegions: (_pageIndex: number, _x: number, y: number) =>
+      y >= NOTE_FROM
+        ? { region: 'footnote' as const, noteId: NOTE_ID, pos: NOTE_POSITION, target: 'text' as const }
+        : { region: 'body' as const, pos: 1, target: 'text' as const },
+    imageAtPoint: () => null,
+  } as unknown as DisplayListQueries;
+}
+
+function stableOptions(): (overrides?: Partial<UsePagesPointerOptions>) => UsePagesPointerOptions {
+  const canvasHostRef = createRef<HTMLDivElement>() as { current: HTMLDivElement | null };
+  canvasHostRef.current = host;
+  const yrsInputRef = {
+    current: {
+      focus: () => {},
+      setSelectionFromDisplay: (anchor: number, head = anchor, story?: string) => {
+        selections.push({ anchor, head, story });
+      },
+      displaySelection: () => null,
+    } as unknown as YrsInputRef,
+  };
+  // Positions in a root story project back onto that same story, which is what
+  // the real projection does for a story with no nested children.
+  const projectionFor = (rootStory: string) =>
+    ({
+      size: 10,
+      targetAt: (position: number) => ({ story: rootStory, displayPosition: position }),
+      tableAtPosition: () => null,
+      cellPosition: () => null,
+    }) as unknown as YrsPositionProjection;
+  const base: UsePagesPointerOptions = {
+    pagesContainerRef: { current: null },
+    yrsInputRef,
+    yrsSession: null as unknown as YrsSession,
+    yrsRootStory: 'body',
+    getYrsPositionProjection: projectionFor,
+    applyYrsCommand: () => false,
+    syncYrsInputState: () => false,
+    readOnly: false,
+    displayListQueries: fakeQueries(),
+    canvasHostRef,
+    setSelectionRects: () => {},
+    setCaretPosition: () => {},
+    setIsFocused: () => {},
+    scrollToPositionImpl: () => {},
+  };
+  return (overrides = {}) => ({ ...base, ...overrides });
+}
+
+function mouse(type: string, clientX: number, clientY: number, target: EventTarget): void {
+  act(() => {
+    target.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, button: 0 })
+    );
+  });
+}
+
+beforeEach(() => {
+  selections = [];
+  host = document.createElement('div');
+  host.className = 'canvas-pages';
+  const canvas = document.createElement('canvas');
+  canvas.dataset.pageIndex = '0';
+  canvas.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: PAGE.width,
+      bottom: PAGE.height,
+      width: PAGE.width,
+      height: PAGE.height,
+    }) as DOMRect;
+  host.append(canvas);
+  document.body.append(host);
+});
+
+afterEach(() => {
+  cleanup();
+  host.remove();
+});
+
+afterAll(async () => {
+  if (ownsDom) await GlobalRegistrator.unregister();
+});
+
+const canvasOf = () => host.firstElementChild as HTMLCanvasElement;
+const note: PartEdit = { kind: 'footnote', noteId: NOTE_ID };
+
+describe('clicking a note', () => {
+  test('a click in the note area opens that note instead of moving the body caret', () => {
+    const opened: PartEdit[] = [];
+    const options = stableOptions();
+    renderHook(() => usePagesPointer(options({ onNoteClick: (hit) => opened.push(hit) })));
+
+    mouse('mousedown', 400, 950, canvasOf());
+
+    expect(opened).toEqual([note]);
+    expect(selections).toEqual([]);
+  });
+
+  test('the caret the opening click asked for lands in the note story', () => {
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (partEdit: PartEdit | null) =>
+        usePagesPointer(
+          options({ partEdit, yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body', onNoteClick: () => {} })
+        ),
+      { initialProps: null as PartEdit | null }
+    );
+
+    mouse('mousedown', 400, 950, canvasOf());
+    expect(selections).toEqual([]);
+
+    act(() => rerender(note));
+    expect(selections).toEqual([
+      { anchor: NOTE_POSITION, head: NOTE_POSITION, story: `fn:${NOTE_ID}` },
+    ]);
+  });
+
+  test('a click inside the open note selects in its own story', () => {
+    const options = stableOptions();
+    renderHook(() =>
+      usePagesPointer(options({ partEdit: note, yrsRootStory: `fn:${NOTE_ID}` }))
+    );
+
+    mouse('mousedown', 400, 950, canvasOf());
+
+    expect(selections).toEqual([
+      { anchor: NOTE_POSITION, head: NOTE_POSITION, story: `fn:${NOTE_ID}` },
+    ]);
+  });
+
+  test('a click in the body leaves the note instead of typing into it', () => {
+    let left = 0;
+    const options = stableOptions();
+    renderHook(() =>
+      usePagesPointer(
+        options({ partEdit: note, yrsRootStory: `fn:${NOTE_ID}`, onBodyClick: () => (left += 1) })
+      )
+    );
+
+    mouse('mousedown', 400, 500, canvasOf());
+
+    expect(left).toBe(1);
+    expect(selections).toEqual([]);
+  });
+
+  test('a read-only document never opens a note', () => {
+    const opened: PartEdit[] = [];
+    const options = stableOptions();
+    renderHook(() =>
+      usePagesPointer(options({ readOnly: true, onNoteClick: (hit) => opened.push(hit) }))
+    );
+
+    mouse('mousedown', 400, 950, canvasOf());
+
+    expect(opened).toEqual([]);
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
@@ -11,6 +11,9 @@ import type { DisplayListQueries, DisplayListRegionHit } from '@betteroffice/doc
 import type { YrsSession } from '@betteroffice/docx/yrs';
 import { AlignmentButtons } from '../../ui/AlignmentButtons';
 import { MenuDropdown } from '../../ui/MenuDropdown';
+import { TableStyleGallery } from '../../ui/TableStyleGallery';
+import { FootnotePropertiesDialog } from '../../dialogs/FootnotePropertiesDialog';
+import { CommentCard } from '../../sidebar/CommentCard';
 import { useEscapeKey } from '../../../hooks/useEscapeKey';
 import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
 import type { YrsInputRef } from '../YrsInput';
@@ -630,6 +633,55 @@ describe('closing an open part with Escape', () => {
     input.remove();
   });
 
+  test('lets the table style gallery consume Escape without closing the part', () => {
+    let closed = 0;
+    const view = render(
+      createElement(EscapeTableStyleHarness, { onEscape: () => (closed += 1) })
+    );
+    const trigger = view.container.querySelector('button');
+    expect(trigger).not.toBeNull();
+    act(() => trigger!.click());
+
+    expect(view.container.querySelector('[data-docx-escape-layer]')).not.toBeNull();
+    dispatchEscape(trigger!);
+
+    expect(view.container.querySelector('[data-docx-escape-layer]')).toBeNull();
+    expect(closed).toBe(0);
+  });
+
+  test('lets the footnote properties dialog consume Escape without closing the part', () => {
+    let closed = 0;
+    let dialogClosed = 0;
+    const view = render(
+      createElement(EscapeFootnotePropertiesHarness, {
+        onEscape: () => (closed += 1),
+        onClose: () => (dialogClosed += 1),
+      })
+    );
+
+    dispatchEscape(view.getByRole('dialog'));
+
+    expect(view.queryByRole('dialog')).toBeNull();
+    expect(dialogClosed).toBe(1);
+    expect(closed).toBe(0);
+  });
+
+  test('lets a comment menu consume Escape without closing the part', () => {
+    let closed = 0;
+    const view = render(
+      createElement(EscapeCommentMenuHarness, { onEscape: () => (closed += 1) })
+    );
+    const trigger = view.container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]');
+    expect(trigger).not.toBeNull();
+    act(() => trigger!.click());
+
+    expect(view.getByRole('menu')).toBeTruthy();
+    dispatchEscape(trigger!);
+
+    expect(view.queryByRole('menu')).toBeNull();
+    expect(closed).toBe(0);
+  });
+
   test('plain Escape from the editor input closes the part', () => {
     let closed = 0;
     const input = document.createElement('textarea');
@@ -692,4 +744,39 @@ function EscapeMenuHarness({ onEscape }: { onEscape: () => void }) {
 function EscapeAlignmentHarness({ onEscape }: { onEscape: () => void }) {
   useEscapeKey(true, onEscape);
   return createElement(AlignmentButtons);
+}
+
+function EscapeTableStyleHarness({ onEscape }: { onEscape: () => void }) {
+  useEscapeKey(true, onEscape);
+  return createElement(TableStyleGallery, { onAction: () => {} });
+}
+
+function EscapeFootnotePropertiesHarness({
+  onEscape,
+  onClose,
+}: {
+  onEscape: () => void;
+  onClose: () => void;
+}) {
+  useEscapeKey(true, onEscape);
+  const [open, setOpen] = useState(true);
+  return createElement(FootnotePropertiesDialog, {
+    isOpen: open,
+    onClose: () => {
+      setOpen(false);
+      onClose();
+    },
+    onApply: () => {},
+  });
+}
+
+function EscapeCommentMenuHarness({ onEscape }: { onEscape: () => void }) {
+  useEscapeKey(true, onEscape);
+  return createElement(CommentCard, {
+    comment: { id: 1, author: 'Reviewer', content: [] },
+    replies: [],
+    isExpanded: true,
+    onToggleExpand: () => {},
+    measureRef: () => {},
+  });
 }

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.note.test.ts
@@ -6,12 +6,12 @@
 
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 import type { DisplayListQueries } from '@betteroffice/docx/layout/render';
 import type { YrsSession } from '@betteroffice/docx/yrs';
 import { usePagesPointer, type UsePagesPointerOptions } from './usePagesPointer';
 import type { YrsInputRef } from '../YrsInput';
-import type { PartEdit } from '../partEdit';
+import { partEditStory, type PartEdit } from '../partEdit';
 import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
 
 const ownsDom = !GlobalRegistrator.isRegistered;
@@ -21,6 +21,7 @@ const { act, cleanup, renderHook } = await import('@testing-library/react');
 const PAGE = { width: 800, height: 1000 };
 /** y at or past this is the page's footnote area in the fake engine. */
 const NOTE_FROM = 900;
+const NOTE_A_ID = 1;
 const NOTE_ID = 2;
 /** what the fake engine resolves anywhere inside the note area */
 const NOTE_POSITION = 7;
@@ -33,10 +34,22 @@ function fakeQueries(): DisplayListQueries {
     displayList: { pages: [{ pageIndex: 0, ...PAGE, primitives: [] }] },
     pageCount: () => 1,
     pageSize: () => PAGE,
-    hitTestRegions: (_pageIndex: number, _x: number, y: number) =>
-      y >= NOTE_FROM
-        ? { region: 'footnote' as const, noteId: NOTE_ID, pos: NOTE_POSITION, target: 'text' as const }
-        : { region: 'body' as const, pos: 1, target: 'text' as const },
+    hitTestRegions: (_pageIndex: number, x: number, y: number) => {
+      if (y < NOTE_FROM) return { region: 'body' as const, pos: 1, target: 'text' as const };
+      return x < PAGE.width / 2
+        ? {
+            region: 'footnote' as const,
+            noteId: NOTE_A_ID,
+            pos: 4,
+            target: 'text' as const,
+          }
+        : {
+            region: 'footnote' as const,
+            noteId: NOTE_ID,
+            pos: NOTE_POSITION,
+            target: 'text' as const,
+          };
+    },
     imageAtPoint: () => null,
   } as unknown as DisplayListQueries;
 }
@@ -55,17 +68,20 @@ function stableOptions(): (overrides?: Partial<UsePagesPointerOptions>) => UsePa
   };
   // Positions in a root story project back onto that same story, which is what
   // the real projection does for a story with no nested children.
-  const projectionFor = (rootStory: string) =>
-    ({
+  const projectionFor = (rootStory: string) => {
+    const size = 10;
+    return {
       size: 10,
-      targetAt: (position: number) => ({ story: rootStory, displayPosition: position }),
+      targetAt: (position: number) =>
+        position >= 0 && position < size ? { story: rootStory, displayPosition: position } : null,
       tableAtPosition: () => null,
       cellPosition: () => null,
-    }) as unknown as YrsPositionProjection;
+    } as unknown as YrsPositionProjection;
+  };
   const base: UsePagesPointerOptions = {
     pagesContainerRef: { current: null },
     yrsInputRef,
-    yrsSession: null as unknown as YrsSession,
+    yrsSession: { cellSelection: () => null } as unknown as YrsSession,
     yrsRootStory: 'body',
     getYrsPositionProjection: projectionFor,
     applyYrsCommand: () => false,
@@ -81,12 +97,20 @@ function stableOptions(): (overrides?: Partial<UsePagesPointerOptions>) => UsePa
   return (overrides = {}) => ({ ...base, ...overrides });
 }
 
+function dispatchMouse(
+  type: string,
+  clientX: number,
+  clientY: number,
+  target: EventTarget,
+  init: MouseEventInit = {}
+): void {
+  target.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, button: 0, ...init })
+  );
+}
+
 function mouse(type: string, clientX: number, clientY: number, target: EventTarget): void {
-  act(() => {
-    target.dispatchEvent(
-      new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, button: 0 })
-    );
-  });
+  act(() => dispatchMouse(type, clientX, clientY, target));
 }
 
 beforeEach(() => {
@@ -134,21 +158,232 @@ describe('clicking a note', () => {
 
   test('the caret the opening click asked for lands in the note story', () => {
     const options = stableOptions();
+    renderHook(() => {
+      const [partEdit, setPartEdit] = useState<PartEdit | null>(null);
+      return usePagesPointer(
+        options({
+          partEdit,
+          yrsRootStory: partEditStory(partEdit),
+          onNoteClick: setPartEdit,
+        })
+      );
+    });
+
+    mouse('mousedown', 400, 950, canvasOf());
+    expect(selections).toEqual([
+      { anchor: NOTE_POSITION, head: NOTE_POSITION, story: `fn:${NOTE_ID}` },
+    ]);
+  });
+
+  test('the opening caret survives until React commits the requested note', async () => {
+    const options = stableOptions();
+    const actEnvironment = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    const previousActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT;
+    const { rerender } = renderHook(() => {
+      const [partEdit, setPartEdit] = useState<PartEdit | null>(null);
+      return usePagesPointer(
+        options({
+          partEdit,
+          yrsRootStory: partEditStory(partEdit),
+          onNoteClick: setPartEdit,
+        })
+      );
+    });
+
+    try {
+      actEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+      dispatchMouse('mousedown', 400, 950, canvasOf());
+      await Promise.resolve();
+      actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      act(() => rerender());
+
+      expect(selections).toEqual([
+        { anchor: NOTE_POSITION, head: NOTE_POSITION, story: `fn:${NOTE_ID}` },
+      ]);
+    } finally {
+      actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
+  test('a second note click replaces the first deferred caret', () => {
+    const options = stableOptions();
+    const noteA = { kind: 'footnote', noteId: NOTE_A_ID } as const;
     const { rerender } = renderHook(
       (partEdit: PartEdit | null) =>
         usePagesPointer(
-          options({ partEdit, yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body', onNoteClick: () => {} })
+          options({
+            partEdit,
+            yrsRootStory: partEditStory(partEdit),
+            onNoteClick: () => {},
+          })
         ),
       { initialProps: null as PartEdit | null }
     );
 
-    mouse('mousedown', 400, 950, canvasOf());
-    expect(selections).toEqual([]);
+    act(() => {
+      dispatchMouse('mousedown', 200, 950, canvasOf());
+      dispatchMouse('mousedown', 600, 950, canvasOf());
+      rerender(note);
+    });
 
-    act(() => rerender(note));
     expect(selections).toEqual([
       { anchor: NOTE_POSITION, head: NOTE_POSITION, story: `fn:${NOTE_ID}` },
     ]);
+    expect(selections).not.toContainEqual({
+      anchor: 4,
+      head: 4,
+      story: `fn:${noteA.noteId}`,
+    });
+  });
+
+  test('a later body click cancels the deferred note caret', () => {
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (partEdit: PartEdit | null) =>
+        usePagesPointer(
+          options({
+            partEdit,
+            yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body',
+            onNoteClick: () => {},
+          })
+        ),
+      { initialProps: null as PartEdit | null }
+    );
+
+    act(() => {
+      dispatchMouse('mousedown', 600, 950, canvasOf());
+      dispatchMouse('mousedown', 400, 500, canvasOf());
+      dispatchMouse('mouseup', 400, 500, window);
+      rerender(note);
+    });
+
+    expect(selections).toEqual([{ anchor: 1, head: 1, story: 'body' }]);
+  });
+
+  test('a right-click cancels the deferred note caret', () => {
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (partEdit: PartEdit | null) =>
+        usePagesPointer(
+          options({
+            partEdit,
+            yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body',
+            onNoteClick: () => {},
+          })
+        ),
+      { initialProps: null as PartEdit | null }
+    );
+
+    act(() => {
+      dispatchMouse('mousedown', 600, 950, canvasOf());
+      dispatchMouse('mousedown', 600, 950, canvasOf(), { button: 2 });
+      rerender(note);
+    });
+
+    expect(selections).toEqual([]);
+  });
+
+  test('a request the host never honours does not leak into a later note open', () => {
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (partEdit: PartEdit | null) =>
+        usePagesPointer(
+          options({
+            partEdit,
+            yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body',
+            onNoteClick: () => {},
+          })
+        ),
+      { initialProps: null as PartEdit | null }
+    );
+
+    mouse('mousedown', 600, 950, canvasOf());
+    act(() => rerender(note));
+
+    expect(selections).toEqual([]);
+  });
+
+  test('opening a different note discards the deferred note caret', () => {
+    const options = stableOptions();
+    const otherNote: PartEdit = { kind: 'footnote', noteId: NOTE_A_ID };
+    const { rerender } = renderHook(
+      ({ partEdit, story }: { partEdit: PartEdit | null; story: string }) =>
+        usePagesPointer(options({ partEdit, yrsRootStory: story, onNoteClick: () => {} })),
+      { initialProps: { partEdit: null as PartEdit | null, story: 'body' } }
+    );
+
+    act(() => {
+      dispatchMouse('mousedown', 600, 950, canvasOf());
+      rerender({ partEdit: otherNote, story: `fn:${NOTE_A_ID}` });
+    });
+    act(() => rerender({ partEdit: note, story: `fn:${NOTE_ID}` }));
+
+    expect(selections).toEqual([]);
+  });
+
+  test('a replacement session cannot inherit a deferred note caret', () => {
+    const options = stableOptions();
+    const oldSession = { cellSelection: () => null } as unknown as YrsSession;
+    const newSession = { cellSelection: () => null } as unknown as YrsSession;
+    const { rerender } = renderHook(
+      ({ partEdit, session }: { partEdit: PartEdit | null; session: YrsSession }) =>
+        usePagesPointer(
+          options({
+            partEdit,
+            yrsSession: session,
+            yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body',
+            onNoteClick: () => {},
+          })
+        ),
+      {
+        initialProps: {
+          partEdit: null as PartEdit | null,
+          session: oldSession,
+        },
+      }
+    );
+
+    act(() => {
+      dispatchMouse('mousedown', 600, 950, canvasOf());
+      rerender({ partEdit: note, session: newSession });
+    });
+
+    expect(selections).toEqual([]);
+  });
+
+  test('revalidates the deferred offset after an intervening edit', () => {
+    let size = 10;
+    const projectionFor = (rootStory: string) =>
+      ({
+        size,
+        targetAt: (position: number) =>
+          position >= 0 && position < size ? { story: rootStory, displayPosition: position } : null,
+        tableAtPosition: () => null,
+        cellPosition: () => null,
+      } as unknown as YrsPositionProjection);
+    const options = stableOptions();
+    const { rerender } = renderHook(
+      (partEdit: PartEdit | null) =>
+        usePagesPointer(
+          options({
+            partEdit,
+            yrsRootStory: partEdit ? `fn:${NOTE_ID}` : 'body',
+            getYrsPositionProjection: projectionFor,
+            onNoteClick: () => {},
+          })
+        ),
+      { initialProps: null as PartEdit | null }
+    );
+
+    act(() => {
+      dispatchMouse('mousedown', 600, 950, canvasOf());
+      size = 4;
+      rerender(note);
+    });
+
+    expect(selections).toEqual([{ anchor: 3, head: 3, story: `fn:${NOTE_ID}` }]);
   });
 
   test('a click inside the open note selects in its own story', () => {
@@ -189,5 +424,45 @@ describe('clicking a note', () => {
     mouse('mousedown', 400, 950, canvasOf());
 
     expect(opened).toEqual([]);
+  });
+
+  test('a one-unit note image selection has no image context entry', () => {
+    const contexts: Array<{ image?: { pos: number } | null }> = [];
+    const options = stableOptions();
+    const yrsInputRef = {
+      current: {
+        focus: () => {},
+        setSelectionFromDisplay: () => {},
+        displaySelection: () => ({ anchor: 3, head: 4 }),
+      } as unknown as YrsInputRef,
+    };
+    const projectionFor = (rootStory: string) =>
+      ({
+        size: 10,
+        targetAt: (position: number) => ({
+          story: rootStory,
+          displayPosition: position,
+        }),
+        nodeAt: (position: number) =>
+          position === 3 ? { kind: 'image', attrs: { wrapType: 'inline' } } : null,
+        tableAtPosition: () => null,
+        cellPosition: () => null,
+      } as unknown as YrsPositionProjection);
+    renderHook(() =>
+      usePagesPointer(
+        options({
+          partEdit: note,
+          yrsRootStory: `fn:${NOTE_ID}`,
+          yrsInputRef,
+          getYrsPositionProjection: projectionFor,
+          onContextMenu: (context) => contexts.push(context),
+        })
+      )
+    );
+
+    mouse('contextmenu', 600, 950, canvasOf());
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.image).toBeNull();
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
@@ -194,7 +194,12 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
   const isDraggingRef = useRef(false);
   const dragAnchorRef = useRef<number | null>(null);
-  const pendingNoteCaretRef = useRef<{ story: string; position: number } | null>(null);
+  const pendingNoteCaretRef = useRef<{
+    session: YrsSession;
+    story: string;
+    position: number;
+  } | null>(null);
+  const [pendingNoteCaretVersion, setPendingNoteCaretVersion] = useState(0);
   const yrsCellDragAnchorRef = useRef<YrsCellLoc | null>(null);
   const yrsCellDraggingRef = useRef(false);
   const [tableInsertButton, setTableInsertButton] = useState<TableInsertButtonState | null>(null);
@@ -332,6 +337,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
   const handlePagesMouseDown = useCallback(
     (e: React.MouseEvent) => {
+      pendingNoteCaretRef.current = null;
       const projection = getYrsPositionProjection(yrsRootStory);
       if (!projection) return;
       if (e.button === 2) {
@@ -354,9 +360,17 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       const note = noteEditFromHit(hit);
       if (note && onNoteClick && !hitBelongsToPart(partEdit, hit)) {
         e.stopPropagation();
-        pendingNoteCaretRef.current =
-          hit?.pos == null ? null : { story: partEditStory(note), position: hit.pos };
+        const pending =
+          hit?.pos == null || !yrsSession
+            ? null
+            : {
+                session: yrsSession,
+                story: partEditStory(note),
+                position: hit.pos,
+              };
+        pendingNoteCaretRef.current = pending;
         onNoteClick(note);
+        if (pending) setPendingNoteCaretVersion((version) => version + 1);
         return;
       }
       if (partEdit) {
@@ -416,19 +430,37 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       setSelectionRects,
       setTextSelection,
       yrsRootStory,
+      yrsSession,
     ]
   );
 
   // The opening click resolves a position in a story the editor is not on yet,
-  // so the caret waits for the story to become active. Keyed on the story it
-  // was resolved in, a request the host never honoured expires unused.
+  // so the caret waits for the requested part to become active in this session.
   useEffect(() => {
     const pending = pendingNoteCaretRef.current;
-    if (!pending || pending.story !== yrsRootStory) return;
+    if (!pending) return;
     pendingNoteCaretRef.current = null;
-    setTextSelection(pending.position);
+    if (
+      pending.session !== yrsSession ||
+      pending.story !== yrsRootStory ||
+      pending.story !== partEditStory(partEdit)
+    ) {
+      return;
+    }
+    const projection = getYrsPositionProjection(yrsRootStory);
+    if (!projection) return;
+    const position = Math.min(Math.max(0, pending.position), Math.max(0, projection.size - 1));
+    setTextSelection(position);
     focusInput();
-  }, [focusInput, setTextSelection, yrsRootStory]);
+  }, [
+    focusInput,
+    getYrsPositionProjection,
+    partEdit,
+    pendingNoteCaretVersion,
+    setTextSelection,
+    yrsRootStory,
+    yrsSession,
+  ]);
 
   dragExtendRef.current = (cx, cy) => {
     if (!isDraggingRef.current || dragAnchorRef.current == null) return;
@@ -738,7 +770,12 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
         if (image) imageInfo = readImageNodeAt(image.pos);
       }
       const selection = yrsInputRef.current?.displaySelection();
-      if (!imageInfo && selection && Math.abs(selection.anchor - selection.head) === 1) {
+      if (
+        !imageInfo &&
+        imageRegion &&
+        selection &&
+        Math.abs(selection.anchor - selection.head) === 1
+      ) {
         imageInfo = readImageNodeAt(Math.min(selection.anchor, selection.head));
       }
       if (imageInfo?.wrapType === 'inline' && displayListQueries && !partEdit) {

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
@@ -24,6 +24,7 @@ import {
   type CanvasHoverCursor,
 } from '../hoverCursor';
 import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
+import { hitBelongsToPart, partImageRegion, type PartEdit } from '../partEdit';
 import type { YrsEditorCommand } from '../yrsCommands';
 
 interface TableInsertButtonState {
@@ -49,7 +50,8 @@ export interface UsePagesPointerOptions {
   applyYrsCommand: (command: YrsEditorCommand) => boolean;
   syncYrsInputState: (docChanged: boolean) => boolean;
   readOnly: boolean;
-  hfEditMode?: 'header' | 'footer' | null;
+  /** the non-body part open for editing — the body is inert behind it */
+  partEdit?: PartEdit | null;
   displayListQueries?: DisplayListQueries | null;
   canvasHostRef?: React.RefObject<HTMLDivElement | null>;
   canvasOverlayTarget?: HTMLElement | null;
@@ -166,7 +168,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     applyYrsCommand,
     syncYrsInputState,
     readOnly,
-    hfEditMode,
+    partEdit = null,
     displayListQueries,
     canvasHostRef,
     canvasOverlayTarget,
@@ -237,9 +239,9 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     (clientX: number, clientY: number) => {
       hoverPointRef.current = { x: clientX, y: clientY };
       const hit = readOnly ? null : (resolveCanvasHit(clientX, clientY, false)?.hit ?? null);
-      paintHoverCursor(canvasHoverCursor({ readOnly, hfEditMode }, hit));
+      paintHoverCursor(canvasHoverCursor({ readOnly, partEdit }, hit));
     },
-    [hfEditMode, paintHoverCursor, readOnly, resolveCanvasHit]
+    [paintHoverCursor, partEdit, readOnly, resolveCanvasHit]
   );
   // A mode flip changes what is typeable under a pointer that has not moved.
   // A gesture still holds its own cursor; the release resolves the new mode.
@@ -259,10 +261,10 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     (clientX: number, clientY: number): number | null => {
       const hit = resolveCanvasHit(clientX, clientY, isDraggingRef.current)?.hit;
       if (!hit) return null;
-      if (hfEditMode) return hit.region === hfEditMode ? hit.pos : null;
+      if (partEdit) return hitBelongsToPart(partEdit, hit) ? hit.pos : null;
       return hit.region === 'body' ? hit.pos : null;
     },
-    [hfEditMode, resolveCanvasHit]
+    [partEdit, resolveCanvasHit]
   );
 
   const resolveTarget = useCallback(
@@ -332,9 +334,10 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       if (readOnly) return;
 
       const point = resolveCanvasHit(e.clientX, e.clientY, false);
-      const region = point?.hit?.region ?? null;
-      if (hfEditMode) {
-        if (region !== hfEditMode && onBodyClick) {
+      const hit = point?.hit ?? null;
+      const region = hit?.region ?? null;
+      if (partEdit) {
+        if (!hitBelongsToPart(partEdit, hit) && onBodyClick) {
           e.stopPropagation();
           onBodyClick();
           return;
@@ -348,8 +351,8 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
           point.pageIndex,
           point.x,
           point.y,
-          hfEditMode ?? 'body',
-          point.hit?.rId
+          partImageRegion(partEdit),
+          hit?.rId
         );
         if (image) {
           e.stopPropagation();
@@ -357,7 +360,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
           setSelectionRects([]);
           setCaretPosition(null);
           focusInput();
-          if (!hfEditMode) setIsFocused(true);
+          if (!partEdit) setIsFocused(true);
           return;
         }
       }
@@ -370,7 +373,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       dragAnchorRef.current = targetPos;
       setTextSelection(targetPos);
       focusInput();
-      if (!hfEditMode) setIsFocused(true);
+      if (!partEdit) setIsFocused(true);
     },
     [
       clearTableInsertTimer,
@@ -378,8 +381,8 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       focusInput,
       getPositionFromMouse,
       getYrsPositionProjection,
-      hfEditMode,
       onBodyClick,
+      partEdit,
       readOnly,
       resolveCanvasHit,
       resolveTarget,
@@ -454,7 +457,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       if (isDraggingRef.current || yrsCellDraggingRef.current) return;
       hoverPointRef.current = { x: e.clientX, y: e.clientY };
       const point = readOnly ? null : resolveCanvasHit(e.clientX, e.clientY, false);
-      paintHoverCursor(canvasHoverCursor({ readOnly, hfEditMode }, point?.hit ?? null));
+      paintHoverCursor(canvasHoverCursor({ readOnly, partEdit }, point?.hit ?? null));
       if (readOnly) return;
       const scheduleHide = () => {
         tableInsertHideTimerRef.current ??= setTimeout(() => {
@@ -474,12 +477,12 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
         return;
       }
       let region: DisplayListTableRegion = { kind: 'body' };
-      if (hfEditMode) {
-        if (point.hit?.region !== hfEditMode || !point.hit.rId) {
+      if (partEdit) {
+        if (!hitBelongsToPart(partEdit, point.hit ?? null) || !point.hit?.rId) {
           scheduleHide();
           return;
         }
-        region = { kind: hfEditMode, rId: point.hit.rId };
+        region = { kind: partEdit.kind, rId: point.hit.rId };
       } else if (point.hit?.region === 'header' || point.hit?.region === 'footer') {
         scheduleHide();
         return;
@@ -514,9 +517,9 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       clearTableInsertTimer,
       displayListQueries,
       getYrsPositionProjection,
-      hfEditMode,
       pagesContainerRef,
       paintHoverCursor,
+      partEdit,
       readOnly,
       resolveCanvasHit,
       yrsRootStory,
@@ -562,21 +565,20 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       const host = canvasHostRef?.current ?? pagesContainerRef.current;
       const point = resolveCanvasHit(e.clientX, e.clientY, false);
       if (projection && queries && host && point) {
-        const hitRegion = point.hit?.region;
-        let region: DisplayListTableRegion = { kind: 'body' };
-        if (hfEditMode && hitRegion === hfEditMode) {
-          region = { kind: hfEditMode, rId: point.hit?.rId };
-        }
-        const displayHit =
-          !hfEditMode || hitRegion === hfEditMode
-            ? findDisplayListHyperlinkAtPoint(
-                queries.displayList,
-                point.pageIndex,
-                point.x,
-                point.y,
-                region
-              )
+        const region: DisplayListTableRegion | null = !partEdit
+          ? { kind: 'body' }
+          : hitBelongsToPart(partEdit, point.hit ?? null)
+            ? { kind: partEdit.kind, rId: point.hit?.rId }
             : null;
+        const displayHit = region
+          ? findDisplayListHyperlinkAtPoint(
+              queries.displayList,
+              point.pageIndex,
+              point.x,
+              point.y,
+              region
+            )
+          : null;
         const href = sanitizeHref(displayHit?.href ?? '');
         if (href) {
           e.preventDefault();
@@ -621,7 +623,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
         }
       }
 
-      if (e.detail === 2 && !hfEditMode && onHeaderFooterDoubleClick) {
+      if (e.detail === 2 && !partEdit && onHeaderFooterDoubleClick) {
         const region = point?.hit?.region;
         if (region === 'header' || region === 'footer') {
           e.preventDefault();
@@ -649,10 +651,10 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       focusInput,
       getPositionFromMouse,
       getYrsPositionProjection,
-      hfEditMode,
       onHeaderFooterDoubleClick,
       onHyperlinkClick,
       pagesContainerRef,
+      partEdit,
       resolveCanvasHit,
       resolveTarget,
       scrollToPositionImpl,
@@ -684,7 +686,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
           point.pageIndex,
           point.x,
           point.y,
-          hfEditMode ?? 'body',
+          partImageRegion(partEdit),
           point.hit?.rId
         );
         if (image) imageInfo = readImageNodeAt(image.pos);
@@ -693,7 +695,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       if (!imageInfo && selection && Math.abs(selection.anchor - selection.head) === 1) {
         imageInfo = readImageNodeAt(Math.min(selection.anchor, selection.head));
       }
-      if (imageInfo?.wrapType === 'inline' && displayListQueries && !hfEditMode) {
+      if (imageInfo?.wrapType === 'inline' && displayListQueries && !partEdit) {
         imageInfo.inlinePositionEmu = captureInlinePositionEmuFromDisplayList(
           displayListQueries,
           imageInfo.pos
@@ -712,7 +714,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       ) {
         setTextSelection(pmPos);
         focusInput();
-        if (!hfEditMode) setIsFocused(true);
+        if (!partEdit) setIsFocused(true);
       }
       const latest = yrsInputRef.current?.displaySelection();
       onContextMenu({
@@ -727,8 +729,8 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       focusInput,
       getPositionFromMouse,
       getYrsPositionProjection,
-      hfEditMode,
       onContextMenu,
+      partEdit,
       resolveCanvasHit,
       resolveTarget,
       setIsFocused,

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
@@ -24,7 +24,14 @@ import {
   type CanvasHoverCursor,
 } from '../hoverCursor';
 import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
-import { hitBelongsToPart, partImageRegion, type PartEdit } from '../partEdit';
+import {
+  hitBelongsToPart,
+  noteEditFromHit,
+  partEditStory,
+  partImageRegion,
+  type NoteEdit,
+  type PartEdit,
+} from '../partEdit';
 import type { YrsEditorCommand } from '../yrsCommands';
 
 interface TableInsertButtonState {
@@ -69,6 +76,8 @@ export interface UsePagesPointerOptions {
     position: { top: number; left: number };
   }) => void;
   onHeaderFooterDoubleClick?: (position: 'header' | 'footer', pageNumber?: number) => void;
+  /** A single click landed in a note area — the host opens it for editing. */
+  onNoteClick?: (note: NoteEdit) => void;
   setSelectionRects: React.Dispatch<React.SetStateAction<SelectionRect[]>>;
   setCaretPosition: React.Dispatch<React.SetStateAction<CaretPosition | null>>;
   setIsFocused: React.Dispatch<React.SetStateAction<boolean>>;
@@ -176,6 +185,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     onContextMenu,
     onHyperlinkClick,
     onHeaderFooterDoubleClick,
+    onNoteClick,
     setSelectionRects,
     setCaretPosition,
     setIsFocused,
@@ -184,6 +194,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
   const isDraggingRef = useRef(false);
   const dragAnchorRef = useRef<number | null>(null);
+  const pendingNoteCaretRef = useRef<{ story: string; position: number } | null>(null);
   const yrsCellDragAnchorRef = useRef<YrsCellLoc | null>(null);
   const yrsCellDraggingRef = useRef(false);
   const [tableInsertButton, setTableInsertButton] = useState<TableInsertButtonState | null>(null);
@@ -336,6 +347,18 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       const point = resolveCanvasHit(e.clientX, e.clientY, false);
       const hit = point?.hit ?? null;
       const region = hit?.region ?? null;
+      // A note area opens on a single click, wherever the caret was before:
+      // one part is open at a time, so this both leaves the old one and picks
+      // the note up. The caret the click asked for is placed once the editor
+      // is on that note's story.
+      const note = noteEditFromHit(hit);
+      if (note && onNoteClick && !hitBelongsToPart(partEdit, hit)) {
+        e.stopPropagation();
+        pendingNoteCaretRef.current =
+          hit?.pos == null ? null : { story: partEditStory(note), position: hit.pos };
+        onNoteClick(note);
+        return;
+      }
       if (partEdit) {
         if (!hitBelongsToPart(partEdit, hit) && onBodyClick) {
           e.stopPropagation();
@@ -346,12 +369,13 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
         return;
       }
 
-      if (displayListQueries && point) {
+      const imageRegion = partImageRegion(partEdit);
+      if (displayListQueries && point && imageRegion) {
         const image = displayListQueries.imageAtPoint(
           point.pageIndex,
           point.x,
           point.y,
-          partImageRegion(partEdit),
+          imageRegion,
           hit?.rId
         );
         if (image) {
@@ -382,6 +406,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       getPositionFromMouse,
       getYrsPositionProjection,
       onBodyClick,
+      onNoteClick,
       partEdit,
       readOnly,
       resolveCanvasHit,
@@ -393,6 +418,17 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       yrsRootStory,
     ]
   );
+
+  // The opening click resolves a position in a story the editor is not on yet,
+  // so the caret waits for the story to become active. Keyed on the story it
+  // was resolved in, a request the host never honoured expires unused.
+  useEffect(() => {
+    const pending = pendingNoteCaretRef.current;
+    if (!pending || pending.story !== yrsRootStory) return;
+    pendingNoteCaretRef.current = null;
+    setTextSelection(pending.position);
+    focusInput();
+  }, [focusInput, setTextSelection, yrsRootStory]);
 
   dragExtendRef.current = (cx, cy) => {
     if (!isDraggingRef.current || dragAnchorRef.current == null) return;
@@ -476,14 +512,19 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
         scheduleHide();
         return;
       }
+      // Table affordances are indexed by band; a note carries none, so an open
+      // note has no table to offer a row/column on.
       let region: DisplayListTableRegion = { kind: 'body' };
       if (partEdit) {
-        if (!hitBelongsToPart(partEdit, point.hit ?? null) || !point.hit?.rId) {
+        const inBand =
+          (partEdit.kind === 'header' || partEdit.kind === 'footer') &&
+          hitBelongsToPart(partEdit, point.hit ?? null);
+        if (!inBand || !point.hit?.rId) {
           scheduleHide();
           return;
         }
         region = { kind: partEdit.kind, rId: point.hit.rId };
-      } else if (point.hit?.region === 'header' || point.hit?.region === 'footer') {
+      } else if (point.hit && point.hit.region !== 'body') {
         scheduleHide();
         return;
       }
@@ -565,9 +606,13 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       const host = canvasHostRef?.current ?? pagesContainerRef.current;
       const point = resolveCanvasHit(e.clientX, e.clientY, false);
       if (projection && queries && host && point) {
+        // Hyperlink primitives are indexed by band, so an open note — whose
+        // area the index does not cover — resolves none and falls through to
+        // the multi-click selection below.
+        const inOpenPart = hitBelongsToPart(partEdit, point.hit ?? null);
         const region: DisplayListTableRegion | null = !partEdit
           ? { kind: 'body' }
-          : hitBelongsToPart(partEdit, point.hit ?? null)
+          : inOpenPart && (partEdit.kind === 'header' || partEdit.kind === 'footer')
             ? { kind: partEdit.kind, rId: point.hit?.rId }
             : null;
         const displayHit = region
@@ -681,12 +726,13 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       };
       let imageInfo: ImageInfo | null = null;
       const point = resolveCanvasHit(e.clientX, e.clientY, false);
-      if (displayListQueries && point) {
+      const imageRegion = partImageRegion(partEdit);
+      if (displayListQueries && point && imageRegion) {
         const image = displayListQueries.imageAtPoint(
           point.pageIndex,
           point.x,
           point.y,
-          partImageRegion(partEdit),
+          imageRegion,
           point.hit?.rId
         );
         if (image) imageInfo = readImageNodeAt(image.pos);

--- a/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/usePagesPointer.ts
@@ -26,6 +26,7 @@ import {
 import type { YrsPositionProjection } from '../internals/yrsPositionProjection';
 import {
   hitBelongsToPart,
+  isNoteAreaHit,
   noteEditFromHit,
   partEditStory,
   partImageRegion,
@@ -194,12 +195,12 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
   const isDraggingRef = useRef(false);
   const dragAnchorRef = useRef<number | null>(null);
-  const pendingNoteCaretRef = useRef<{
+  const pendingPartCaretRef = useRef<{
     session: YrsSession;
     story: string;
     position: number;
   } | null>(null);
-  const [pendingNoteCaretVersion, setPendingNoteCaretVersion] = useState(0);
+  const [pendingPartCaretVersion, setPendingPartCaretVersion] = useState(0);
   const yrsCellDragAnchorRef = useRef<YrsCellLoc | null>(null);
   const yrsCellDraggingRef = useRef(false);
   const [tableInsertButton, setTableInsertButton] = useState<TableInsertButtonState | null>(null);
@@ -337,9 +338,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
 
   const handlePagesMouseDown = useCallback(
     (e: React.MouseEvent) => {
-      pendingNoteCaretRef.current = null;
-      const projection = getYrsPositionProjection(yrsRootStory);
-      if (!projection) return;
+      pendingPartCaretRef.current = null;
       if (e.button === 2) {
         e.preventDefault();
         return;
@@ -358,6 +357,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
       // the note up. The caret the click asked for is placed once the editor
       // is on that note's story.
       const note = noteEditFromHit(hit);
+      if (isNoteAreaHit(hit) && !note) return;
       if (note && onNoteClick && !hitBelongsToPart(partEdit, hit)) {
         e.stopPropagation();
         const pending =
@@ -368,20 +368,29 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
                 story: partEditStory(note),
                 position: hit.pos,
               };
-        pendingNoteCaretRef.current = pending;
+        pendingPartCaretRef.current = pending;
         onNoteClick(note);
-        if (pending) setPendingNoteCaretVersion((version) => version + 1);
+        if (pending) setPendingPartCaretVersion((version) => version + 1);
         return;
       }
       if (partEdit) {
         if (!hitBelongsToPart(partEdit, hit) && onBodyClick) {
           e.stopPropagation();
+          const pending =
+            hit?.region === 'body' && hit.pos != null && yrsSession
+              ? { session: yrsSession, story: 'body', position: hit.pos }
+              : null;
+          pendingPartCaretRef.current = pending;
           onBodyClick();
+          if (pending) setPendingPartCaretVersion((version) => version + 1);
           return;
         }
       } else if ((region === 'header' || region === 'footer') && e.detail !== 2) {
         return;
       }
+
+      const projection = getYrsPositionProjection(yrsRootStory);
+      if (!projection) return;
 
       const imageRegion = partImageRegion(partEdit);
       if (displayListQueries && point && imageRegion) {
@@ -434,12 +443,10 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     ]
   );
 
-  // The opening click resolves a position in a story the editor is not on yet,
-  // so the caret waits for the requested part to become active in this session.
   useEffect(() => {
-    const pending = pendingNoteCaretRef.current;
+    const pending = pendingPartCaretRef.current;
     if (!pending) return;
-    pendingNoteCaretRef.current = null;
+    pendingPartCaretRef.current = null;
     if (
       pending.session !== yrsSession ||
       pending.story !== yrsRootStory ||
@@ -456,7 +463,7 @@ export function usePagesPointer(opts: UsePagesPointerOptions): UsePagesPointerRe
     focusInput,
     getYrsPositionProjection,
     partEdit,
-    pendingNoteCaretVersion,
+    pendingPartCaretVersion,
     setTextSelection,
     yrsRootStory,
     yrsSession,

--- a/packages/docx-react/src/components/DocxEditor/hooks/useResetEditorState.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useResetEditorState.ts
@@ -2,12 +2,13 @@ import { useCallback } from 'react';
 import type { Comment } from '@betteroffice/docx/types/content';
 import type { HeadingInfo } from '@betteroffice/docx/utils';
 import { EMPTY_ANCHOR_POSITIONS } from '../commentFactories';
+import type { PartEditTarget } from '../partEdit';
 
 /**
  * Bundles the document-load reset surface — every state setter that
  * needs to clear when the user opens a new document. Twelve setters
  * fan out from one callback: comments, headings, sidebar visibility,
- * the new-comment workflow state, the floating button, H/F editing,
+ * the new-comment workflow state, the floating button, the open part,
  * anchor positions, find-replace matches, and the orphan-cleanup timer.
  *
  * Lifted out of `DocxEditor.tsx` so the orchestrator doesn't carry the
@@ -25,8 +26,7 @@ export function useResetEditorState({
   setCommentSelectionRange,
   setAddCommentYPosition,
   setFloatingCommentBtn,
-  setHfEditPosition,
-  setHfEditIsFirstPage,
+  setPartEditTarget,
   setAnchorPositions,
   clearFindReplaceMatches,
   cleanOrphanedCommentsTimerRef,
@@ -42,8 +42,7 @@ export function useResetEditorState({
   >;
   setAddCommentYPosition: React.Dispatch<React.SetStateAction<number | null>>;
   setFloatingCommentBtn: React.Dispatch<React.SetStateAction<{ top: number; left: number } | null>>;
-  setHfEditPosition: React.Dispatch<React.SetStateAction<'header' | 'footer' | null>>;
-  setHfEditIsFirstPage: React.Dispatch<React.SetStateAction<boolean>>;
+  setPartEditTarget: React.Dispatch<React.SetStateAction<PartEditTarget | null>>;
   setAnchorPositions: React.Dispatch<React.SetStateAction<Map<string, number>>>;
   clearFindReplaceMatches: () => void;
   cleanOrphanedCommentsTimerRef: React.RefObject<ReturnType<typeof setTimeout> | null>;
@@ -58,8 +57,7 @@ export function useResetEditorState({
     setCommentSelectionRange(null);
     setAddCommentYPosition(null);
     setFloatingCommentBtn(null);
-    setHfEditPosition(null);
-    setHfEditIsFirstPage(false);
+    setPartEditTarget(null);
     setAnchorPositions(EMPTY_ANCHOR_POSITIONS);
     clearFindReplaceMatches();
     if (cleanOrphanedCommentsTimerRef.current) {
@@ -76,8 +74,7 @@ export function useResetEditorState({
     setCommentSelectionRange,
     setAddCommentYPosition,
     setFloatingCommentBtn,
-    setHfEditPosition,
-    setHfEditIsFirstPage,
+    setPartEditTarget,
     setAnchorPositions,
     clearFindReplaceMatches,
     cleanOrphanedCommentsTimerRef,

--- a/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useYrsCoreSession.ts
@@ -27,7 +27,7 @@ export interface YrsCoreSession {
   displayPositionToLoc(position: number, storyId?: string): YrsLoc | null;
   locToDisplayPosition(loc: YrsLoc): number | null;
   documentFromYrs(baseDocument?: Document | null): Document | null;
-  publishDirectInput(): void;
+  publishDirectInput(storyId?: string): void;
 }
 
 interface YrsCoreSessionCallbacks {
@@ -332,11 +332,11 @@ export function useYrsCoreSession(
     }
   }, []);
 
-  const publishDirectInput = useCallback((): void => {
+  const publishDirectInput = useCallback((storyId?: string): void => {
     const live = sessionRef.current;
     if (!live || !live.storyIds().includes('body')) return;
     inputPositionMapsRef.current.clear();
-    const activeStory = live.selection()?.head.story ?? 'body';
+    const activeStory = storyId ?? live.selection()?.head.story ?? 'body';
     projectionStoriesRef.current.add(dirtyProjectionStory(activeStory));
   }, []);
 

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
@@ -37,7 +37,7 @@ describe('canvas hover cursor', () => {
   });
 
   test('editing a band makes only that band typeable', () => {
-    const mode = { readOnly: false, hfEditMode: 'header' as const };
+    const mode = { readOnly: false, partEdit: { kind: 'header', rId: 'rId7' } as const };
     expect(canvasHoverCursor(mode, hit({ region: 'header', target: 'none' }))).toBe('text');
     expect(canvasHoverCursor(mode, hit({ region: 'header', target: 'text' }))).toBe('text');
     expect(canvasHoverCursor(mode, hit({ region: 'header', target: 'image' }))).toBe('default');
@@ -46,10 +46,14 @@ describe('canvas hover cursor', () => {
     expect(canvasHoverCursor(mode, hit({ region: 'footnote', target: 'text' }))).toBe('default');
   });
 
+
   test('read-only and off-page points never type', () => {
     expect(canvasHoverCursor({ readOnly: true }, hit({ target: 'text' }))).toBe('default');
     expect(
-      canvasHoverCursor({ readOnly: true, hfEditMode: 'footer' }, hit({ region: 'footer' }))
+      canvasHoverCursor(
+        { readOnly: true, partEdit: { kind: 'footer', rId: 'rId8' } },
+        hit({ region: 'footer' })
+      )
     ).toBe('default');
     expect(canvasHoverCursor(editing, null)).toBe('default');
   });
@@ -59,7 +63,10 @@ describe('canvas hover cursor', () => {
     expect(canvasHoverCursor(editing, older)).toBe('default');
     // an open band types regardless: the whole band is its typeable area
     expect(
-      canvasHoverCursor({ readOnly: false, hfEditMode: 'header' }, { ...older, region: 'header' })
+      canvasHoverCursor(
+        { readOnly: false, partEdit: { kind: 'header', rId: 'rId7' } },
+        { ...older, region: 'header' }
+      )
     ).toBe('text');
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
@@ -46,6 +46,16 @@ describe('canvas hover cursor', () => {
     expect(canvasHoverCursor(mode, hit({ region: 'footnote', target: 'text' }))).toBe('default');
   });
 
+  test('editing a note makes only that note typeable', () => {
+    const mode = { readOnly: false, partEdit: { kind: 'footnote', noteId: 2 } as const };
+    expect(canvasHoverCursor(mode, hit({ region: 'footnote', noteId: 2, target: 'none' }))).toBe(
+      'text'
+    );
+    expect(canvasHoverCursor(mode, hit({ region: 'footnote', noteId: 3, target: 'text' }))).toBe(
+      'default'
+    );
+    expect(canvasHoverCursor(mode, hit({ region: 'body', target: 'text' }))).toBe('default');
+  });
 
   test('read-only and off-page points never type', () => {
     expect(canvasHoverCursor({ readOnly: true }, hit({ target: 'text' }))).toBe('default');

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.test.ts
@@ -27,11 +27,14 @@ describe('canvas hover cursor', () => {
     expect(canvasHoverCursor(editing, hit({ region: 'footer', target: 'none' }))).toBe('default');
   });
 
-  test('a note reads as text over its own runs', () => {
+  test('an idle note area is text unless it is an image', () => {
     expect(
       canvasHoverCursor(editing, hit({ region: 'footnote', noteId: 3, target: 'text' }))
     ).toBe('text');
     expect(canvasHoverCursor(editing, hit({ region: 'endnote', noteId: 3, target: 'none' }))).toBe(
+      'text'
+    );
+    expect(canvasHoverCursor(editing, hit({ region: 'footnote', target: 'image' }))).toBe(
       'default'
     );
   });
@@ -71,6 +74,7 @@ describe('canvas hover cursor', () => {
   test('a wasm build without the target degrades to the pre-hover behaviour', () => {
     const older: DisplayListRegionHit = { region: 'body', pos: 12 };
     expect(canvasHoverCursor(editing, older)).toBe('default');
+    expect(canvasHoverCursor(editing, { ...older, region: 'footnote' })).toBe('text');
     // an open band types regardless: the whole band is its typeable area
     expect(
       canvasHoverCursor(

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
@@ -18,7 +18,7 @@
 
 import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
 
-import { hitBelongsToPart, type PartEdit } from './partEdit';
+import { hitBelongsToPart, isNoteAreaHit, type PartEdit } from './partEdit';
 
 export type CanvasHoverCursor = 'default' | 'text';
 
@@ -39,6 +39,7 @@ export function canvasHoverCursor(
     // the whole part is typeable once open, so an absent target still types
     return hit.target === 'image' ? 'default' : 'text';
   }
+  if (isNoteAreaHit(hit)) return hit.target === 'image' ? 'default' : 'text';
   return hit.target === 'text' ? 'text' : 'default';
 }
 

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
@@ -10,7 +10,8 @@
  * An idle header/footer band deliberately DIFFERS from that stylesheet, which
  * gave the whole band a hand: here it reads as text over its own runs, since a
  * single click on an idle band is inert and only a double-click opens it for
- * editing at that word.
+ * editing at that word. Over a note area the same reading is literal — a
+ * single click there opens the note and puts the caret under the pointer.
  *
  * A wasm build predating `target` omits it, which reads as "not text".
  */
@@ -33,7 +34,7 @@ export function canvasHoverCursor(
 ): CanvasHoverCursor {
   if (mode.readOnly || !hit) return 'default';
   if (mode.partEdit) {
-    // only the open part accepts typing; the body and its siblings are inert
+    // only the open part accepts typing; the body and every sibling are inert
     if (!hitBelongsToPart(mode.partEdit, hit)) return 'default';
     // the whole part is typeable once open, so an absent target still types
     return hit.target === 'image' ? 'default' : 'text';

--- a/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
+++ b/packages/docx-react/src/components/DocxEditor/hoverCursor.ts
@@ -17,12 +17,14 @@
 
 import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
 
+import { hitBelongsToPart, type PartEdit } from './partEdit';
+
 export type CanvasHoverCursor = 'default' | 'text';
 
 export interface CanvasHoverMode {
   readOnly: boolean;
-  /** the header/footer region being edited inline, if any */
-  hfEditMode?: 'header' | 'footer' | null;
+  /** the non-body part open for editing, if any */
+  partEdit?: PartEdit | null;
 }
 
 export function canvasHoverCursor(
@@ -30,10 +32,10 @@ export function canvasHoverCursor(
   hit: DisplayListRegionHit | null
 ): CanvasHoverCursor {
   if (mode.readOnly || !hit) return 'default';
-  if (mode.hfEditMode) {
-    // only the edited band accepts typing; the body and the sibling band are inert
-    if (hit.region !== mode.hfEditMode) return 'default';
-    // the whole band is typeable once open, so an absent target still types
+  if (mode.partEdit) {
+    // only the open part accepts typing; the body and its siblings are inert
+    if (!hitBelongsToPart(mode.partEdit, hit)) return 'default';
+    // the whole part is typeable once open, so an absent target still types
     return hit.target === 'image' ? 'default' : 'text';
   }
   return hit.target === 'text' ? 'text' : 'default';

--- a/packages/docx-react/src/components/DocxEditor/internals/yrsPositionProjection.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/internals/yrsPositionProjection.test.ts
@@ -5,7 +5,7 @@ import {
   type YrsSession,
   type YrsStorySegment,
 } from '@betteroffice/docx/yrs';
-import { YrsPositionProjection } from './yrsPositionProjection';
+import { createYrsPositionProjection, YrsPositionProjection } from './yrsPositionProjection';
 
 const segments: Record<string, YrsStorySegment[]> = {
   body: [
@@ -34,6 +34,24 @@ const session = {
 } as unknown as YrsSession;
 
 describe('YrsPositionProjection', () => {
+  test('returns null without reading a missing story', () => {
+    let readStory = false;
+    const missingStorySession = {
+      storyIds: () => ['body'],
+      storySegments: () => {
+        readStory = true;
+        throw new Error('missing story');
+      },
+    } as unknown as YrsSession;
+    let projection: YrsPositionProjection | null = null;
+
+    expect(() => {
+      projection = createYrsPositionProjection(missingStorySession, 'fn:2');
+    }).not.toThrow();
+    expect(projection).toBeNull();
+    expect(readStory).toBe(false);
+  });
+
   test('maps post-table positions back to the root story input map', () => {
     const projection = new YrsPositionProjection(session, 'body');
     // `paragraph_spans` measures a paragraph from the previous pilcrow, so the

--- a/packages/docx-react/src/components/DocxEditor/internals/yrsPositionProjection.ts
+++ b/packages/docx-react/src/components/DocxEditor/internals/yrsPositionProjection.ts
@@ -55,6 +55,14 @@ export interface YrsPointerProjectionTarget {
   cell?: YrsCellLoc;
 }
 
+export function createYrsPositionProjection(
+  session: YrsSession,
+  rootStory: string
+): YrsPositionProjection | null {
+  if (!session.storyIds().includes(rootStory)) return null;
+  return new YrsPositionProjection(session, rootStory);
+}
+
 export class YrsPositionProjection {
   private readonly stories = new Map<string, StoryProjection>();
   private readonly nodes = new Map<number, YrsProjectedNode>();

--- a/packages/docx-react/src/components/DocxEditor/overlays/CanvasPartSelectionOverlay.tsx
+++ b/packages/docx-react/src/components/DocxEditor/overlays/CanvasPartSelectionOverlay.tsx
@@ -7,7 +7,7 @@ import { projectPageLocalRect } from '../internals/canvasProjection';
 import type { PartEdit } from '../partEdit';
 
 export interface CanvasPartSelectionOverlayProps {
-  /** Which band is open. */
+  /** Which part is open — a header/footer band, or one note. */
   part: PartEdit;
   /** Current selection, in the open part's own display positions, or null. */
   selection: { from: number; to: number } | null;
@@ -17,7 +17,7 @@ export interface CanvasPartSelectionOverlayProps {
   canvasHostRef: React.RefObject<HTMLDivElement | null>;
   /** Display-list queries — part geometry source + page-local → canvas scale. */
   displayListQueries: DisplayListQueries;
-  /** Exact display page whose band was activated. */
+  /** Exact display page whose band was activated. Notes paint on one page. */
   activePageIndex?: number;
   /** Sidebar open — recompute after its `translateX` transition settles. */
   sidebarOpen: boolean;
@@ -39,12 +39,21 @@ function partSelectionRects(
   from: number,
   to: number
 ): DisplayListRect[] {
-  if (!part.rId) return [];
   const start = Math.min(from, to);
   const end = Math.max(from, to);
-  return start === end
-    ? queries.hfCaretRects(part.kind, part.rId, start)
-    : queries.hfRangeRects(part.kind, part.rId, start, end);
+  switch (part.kind) {
+    case 'footnote':
+    case 'endnote':
+      return start === end
+        ? queries.noteCaretRects(part.kind, part.noteId, start)
+        : queries.noteRangeRects(part.kind, part.noteId, start, end);
+    case 'header':
+    case 'footer':
+      if (!part.rId) return [];
+      return start === end
+        ? queries.hfCaretRects(part.kind, part.rId, start)
+        : queries.hfRangeRects(part.kind, part.rId, start, end);
+  }
 }
 
 export function CanvasPartSelectionOverlay({
@@ -72,8 +81,8 @@ export function CanvasPartSelectionOverlay({
     const isCaret = from === to;
 
     const recompute = () => {
-      // Candidates come back one-per-page (the part paints on every page it
-      // covers); each rect carries its own pageIndex.
+      // Candidates come back one-per-page (an HF part paints on every page it
+      // covers, a note on exactly one); each rect carries its own pageIndex.
       const candidates = partSelectionRects(displayListQueries, part, from, to);
       if (candidates.length === 0) {
         setState({ caret: null, rects: [] });

--- a/packages/docx-react/src/components/DocxEditor/overlays/CanvasPartSelectionOverlay.tsx
+++ b/packages/docx-react/src/components/DocxEditor/overlays/CanvasPartSelectionOverlay.tsx
@@ -1,28 +1,23 @@
-/** Draws header/footer selection geometry over canvas pages. */
+/** Draws the open part's selection geometry over canvas pages. */
 
 import { useLayoutEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { DisplayListQueries } from '@betteroffice/docx/layout/render';
-import {
-  computeHfCaretRectsFromDisplayList,
-  computeHfSelectionRectsFromDisplayList,
-} from '@betteroffice/docx/layout';
+import type { DisplayListQueries, DisplayListRect } from '@betteroffice/docx/layout/render';
 import { projectPageLocalRect } from '../internals/canvasProjection';
+import type { PartEdit } from '../partEdit';
 
-export interface CanvasHfSelectionOverlayProps {
-  /** Which HF band is being edited. */
-  region: 'header' | 'footer';
-  /** Relationship id of the active HF part (the display-list variant's `rId`). */
-  rId: string;
-  /** Current HF selection (positions in the HF doc), or null. */
+export interface CanvasPartSelectionOverlayProps {
+  /** Which band is open. */
+  part: PartEdit;
+  /** Current selection, in the open part's own display positions, or null. */
   selection: { from: number; to: number } | null;
   /** Portal target — `editorContentRef.current` (shares the canvas host's top-left). */
   overlayTarget: HTMLElement;
   /** `.canvas-pages` host — live per-page `<canvas>` rects are read from here. */
   canvasHostRef: React.RefObject<HTMLDivElement | null>;
-  /** Display-list queries — HF geometry source + page-local → canvas scale. */
+  /** Display-list queries — part geometry source + page-local → canvas scale. */
   displayListQueries: DisplayListQueries;
-  /** Exact display page whose HF band was activated. */
+  /** Exact display page whose band was activated. */
   activePageIndex?: number;
   /** Sidebar open — recompute after its `translateX` transition settles. */
   sidebarOpen: boolean;
@@ -37,9 +32,23 @@ interface ProjectedRect {
   height: number;
 }
 
-export function CanvasHfSelectionOverlay({
-  region,
-  rId,
+/** The open part's own story answers, never the body's. */
+function partSelectionRects(
+  queries: DisplayListQueries,
+  part: PartEdit,
+  from: number,
+  to: number
+): DisplayListRect[] {
+  if (!part.rId) return [];
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  return start === end
+    ? queries.hfCaretRects(part.kind, part.rId, start)
+    : queries.hfRangeRects(part.kind, part.rId, start, end);
+}
+
+export function CanvasPartSelectionOverlay({
+  part,
   selection,
   overlayTarget,
   canvasHostRef,
@@ -47,7 +56,7 @@ export function CanvasHfSelectionOverlay({
   activePageIndex,
   sidebarOpen,
   zoom,
-}: CanvasHfSelectionOverlayProps) {
+}: CanvasPartSelectionOverlayProps) {
   const [state, setState] = useState<{ caret: ProjectedRect | null; rects: ProjectedRect[] }>({
     caret: null,
     rects: [],
@@ -55,7 +64,7 @@ export function CanvasHfSelectionOverlay({
 
   useLayoutEffect(() => {
     const host = canvasHostRef.current;
-    if (!host || !rId || !selection) {
+    if (!host || !selection) {
       setState({ caret: null, rects: [] });
       return;
     }
@@ -63,17 +72,15 @@ export function CanvasHfSelectionOverlay({
     const isCaret = from === to;
 
     const recompute = () => {
-      // Candidates come back one-per-page (the HF part paints on every page it
+      // Candidates come back one-per-page (the part paints on every page it
       // covers); each rect carries its own pageIndex.
-      const candidates = isCaret
-        ? computeHfCaretRectsFromDisplayList(displayListQueries, region, rId, from)
-        : computeHfSelectionRectsFromDisplayList(displayListQueries, region, rId, from, to);
+      const candidates = partSelectionRects(displayListQueries, part, from, to);
       if (candidates.length === 0) {
         setState({ caret: null, rects: [] });
         return;
       }
 
-      // Render on the page the user is editing = the one whose HF band sits
+      // Render on the page the user is editing = the one whose band sits
       // nearest the viewport center (the display-list analogue of the DOM
       // path's nearest visible HF-page behavior.
       const pageIndices = [...new Set(candidates.map((c) => c.pageIndex))];
@@ -134,8 +141,7 @@ export function CanvasHfSelectionOverlay({
       host.removeEventListener('transitionend', recompute);
     };
   }, [
-    region,
-    rId,
+    part,
     selection,
     overlayTarget,
     canvasHostRef,
@@ -152,7 +158,7 @@ export function CanvasHfSelectionOverlay({
       {state.caret && (
         <div
           aria-hidden="true"
-          data-testid="hf-caret"
+          data-testid="part-caret"
           style={{
             position: 'absolute',
             top: state.caret.top,
@@ -162,15 +168,15 @@ export function CanvasHfSelectionOverlay({
             background: '#4285f4',
             pointerEvents: 'none',
             zIndex: 11,
-            animation: 'hf-caret-blink 1.06s steps(1) infinite',
+            animation: 'part-caret-blink 1.06s steps(1) infinite',
           }}
         />
       )}
       {state.rects.map((r, i) => (
         <div
-          key={`hf-sel-${i}-${r.top}-${r.left}`}
+          key={`part-sel-${i}-${r.top}-${r.left}`}
           aria-hidden="true"
-          data-testid="hf-selection-rect"
+          data-testid="part-selection-rect"
           style={{
             position: 'absolute',
             top: r.top,
@@ -188,4 +194,4 @@ export function CanvasHfSelectionOverlay({
   );
 }
 
-export default CanvasHfSelectionOverlay;
+export default CanvasPartSelectionOverlay;

--- a/packages/docx-react/src/components/DocxEditor/overlays/CanvasTableResizeOverlay.tsx
+++ b/packages/docx-react/src/components/DocxEditor/overlays/CanvasTableResizeOverlay.tsx
@@ -23,7 +23,7 @@
  * separate doc, so `deriveDisplayListTableFragments` + the commit path would
  * need to bind to the active header/footer story and its region geometry; see the note
  * in `displayListTables.ts`). The HF *caret + selection* on canvas are covered
- * by `CanvasHfSelectionOverlay`.
+ * by `CanvasPartSelectionOverlay`.
  *
  */
 

--- a/packages/docx-react/src/components/DocxEditor/partEdit.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/partEdit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
+import { hitBelongsToPart, partEditStory, partImageRegion, type PartEdit } from './partEdit';
+
+const hit = (over: Partial<DisplayListRegionHit>): DisplayListRegionHit => ({
+  region: 'body',
+  pos: 12,
+  ...over,
+});
+
+describe('partEditStory', () => {
+  test('the body owns typing while no part is open', () => {
+    expect(partEditStory(null)).toBe('body');
+  });
+
+  test('a header or footer addresses its relationship story', () => {
+    expect(partEditStory({ kind: 'header', rId: 'rId7' })).toBe('hf:rId7');
+    expect(partEditStory({ kind: 'footer', rId: 'rId8' })).toBe('hf:rId8');
+  });
+
+  // The band is opened before its part exists, and an unresolved one has no
+  // story to type into — the body keeps the caret until the rId lands.
+  test('a header opened without a resolved part still addresses the body', () => {
+    expect(partEditStory({ kind: 'header', rId: null })).toBe('body');
+  });
+});
+
+describe('hitBelongsToPart', () => {
+  test('nothing belongs to the body', () => {
+    expect(hitBelongsToPart(null, hit({ region: 'header' }))).toBe(false);
+  });
+
+  test('an open band takes its own region and no other', () => {
+    const header: PartEdit = { kind: 'header', rId: 'rId7' };
+    expect(hitBelongsToPart(header, hit({ region: 'header' }))).toBe(true);
+    expect(hitBelongsToPart(header, hit({ region: 'footer' }))).toBe(false);
+    expect(hitBelongsToPart(header, hit({ region: 'body' }))).toBe(false);
+    expect(hitBelongsToPart(header, null)).toBe(false);
+  });
+});
+
+describe('partImageRegion', () => {
+  test('the body and the bands index their own images', () => {
+    expect(partImageRegion(null)).toBe('body');
+    expect(partImageRegion({ kind: 'header', rId: 'rId7' })).toBe('header');
+    expect(partImageRegion({ kind: 'footer', rId: 'rId8' })).toBe('footer');
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/partEdit.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/partEdit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
 import {
   hitBelongsToPart,
+  isNoteAreaHit,
   noteEditFromHit,
   partEditStory,
   partImageRegion,
@@ -12,6 +13,15 @@ const hit = (over: Partial<DisplayListRegionHit>): DisplayListRegionHit => ({
   region: 'body',
   pos: 12,
   ...over,
+});
+
+describe('isNoteAreaHit', () => {
+  test('recognises both note regions without requiring an attributed note', () => {
+    expect(isNoteAreaHit(hit({ region: 'footnote', noteId: undefined, pos: null }))).toBe(true);
+    expect(isNoteAreaHit(hit({ region: 'endnote', noteId: undefined, pos: null }))).toBe(true);
+    expect(isNoteAreaHit(hit({ region: 'body' }))).toBe(false);
+    expect(isNoteAreaHit(null)).toBe(false);
+  });
 });
 
 describe('partEditStory', () => {

--- a/packages/docx-react/src/components/DocxEditor/partEdit.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/partEdit.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import type { DisplayListRegionHit } from '@betteroffice/docx/layout/render';
-import { hitBelongsToPart, partEditStory, partImageRegion, type PartEdit } from './partEdit';
+import {
+  hitBelongsToPart,
+  noteEditFromHit,
+  partEditStory,
+  partImageRegion,
+  type PartEdit,
+} from './partEdit';
 
 const hit = (over: Partial<DisplayListRegionHit>): DisplayListRegionHit => ({
   region: 'body',
@@ -23,11 +29,16 @@ describe('partEditStory', () => {
   test('a header opened without a resolved part still addresses the body', () => {
     expect(partEditStory({ kind: 'header', rId: null })).toBe('body');
   });
+
+  test('a note addresses its own numbered story', () => {
+    expect(partEditStory({ kind: 'footnote', noteId: 2 })).toBe('fn:2');
+    expect(partEditStory({ kind: 'endnote', noteId: 2 })).toBe('en:2');
+  });
 });
 
 describe('hitBelongsToPart', () => {
   test('nothing belongs to the body', () => {
-    expect(hitBelongsToPart(null, hit({ region: 'header' }))).toBe(false);
+    expect(hitBelongsToPart(null, hit({ region: 'footnote', noteId: 1 }))).toBe(false);
   });
 
   test('an open band takes its own region and no other', () => {
@@ -37,6 +48,15 @@ describe('hitBelongsToPart', () => {
     expect(hitBelongsToPart(header, hit({ region: 'body' }))).toBe(false);
     expect(hitBelongsToPart(header, null)).toBe(false);
   });
+
+  // Notes of one kind share a region, so the id is what separates them.
+  test('an open note takes only its own id', () => {
+    const note: PartEdit = { kind: 'footnote', noteId: 2 };
+    expect(hitBelongsToPart(note, hit({ region: 'footnote', noteId: 2 }))).toBe(true);
+    expect(hitBelongsToPart(note, hit({ region: 'footnote', noteId: 3 }))).toBe(false);
+    expect(hitBelongsToPart(note, hit({ region: 'endnote', noteId: 2 }))).toBe(false);
+    expect(hitBelongsToPart(note, hit({ region: 'footnote' }))).toBe(false);
+  });
 });
 
 describe('partImageRegion', () => {
@@ -44,5 +64,33 @@ describe('partImageRegion', () => {
     expect(partImageRegion(null)).toBe('body');
     expect(partImageRegion({ kind: 'header', rId: 'rId7' })).toBe('header');
     expect(partImageRegion({ kind: 'footer', rId: 'rId8' })).toBe('footer');
+  });
+
+  // The display list indexes images by band, never by note, so a note has no
+  // scope to look one up in — and answering `body` would hand back an image
+  // from behind the note area.
+  test('an open note has no image scope', () => {
+    expect(partImageRegion({ kind: 'footnote', noteId: 2 })).toBeNull();
+    expect(partImageRegion({ kind: 'endnote', noteId: 2 })).toBeNull();
+  });
+});
+
+describe('noteEditFromHit', () => {
+  test('a note hit names the note it opens', () => {
+    expect(noteEditFromHit(hit({ region: 'footnote', noteId: 4 }))).toEqual({
+      kind: 'footnote',
+      noteId: 4,
+    });
+    expect(noteEditFromHit(hit({ region: 'endnote', noteId: 4 }))).toEqual({
+      kind: 'endnote',
+      noteId: 4,
+    });
+  });
+
+  test('a hit that names no note opens none', () => {
+    expect(noteEditFromHit(hit({ region: 'body' }))).toBeNull();
+    expect(noteEditFromHit(hit({ region: 'header' }))).toBeNull();
+    expect(noteEditFromHit(hit({ region: 'footnote' }))).toBeNull();
+    expect(noteEditFromHit(null)).toBeNull();
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/partEdit.ts
+++ b/packages/docx-react/src/components/DocxEditor/partEdit.ts
@@ -59,8 +59,14 @@ export function partImageRegion(part: PartEdit | null): DisplayListImageRegion |
   return isNote(part) ? null : part.kind;
 }
 
+export function isNoteAreaHit(
+  hit: DisplayListRegionHit | null
+): hit is DisplayListRegionHit & { region: 'footnote' | 'endnote' } {
+  return hit?.region === 'footnote' || hit?.region === 'endnote';
+}
+
 /** The note a hit opens for editing, or null when it names none. */
 export function noteEditFromHit(hit: DisplayListRegionHit | null): NoteEdit | null {
-  if (hit?.region !== 'footnote' && hit?.region !== 'endnote') return null;
+  if (!isNoteAreaHit(hit)) return null;
   return hit.noteId == null ? null : { kind: hit.region, noteId: hit.noteId };
 }

--- a/packages/docx-react/src/components/DocxEditor/partEdit.ts
+++ b/packages/docx-react/src/components/DocxEditor/partEdit.ts
@@ -1,6 +1,7 @@
 /**
- * The one non-body part the editor can have open. A single value rather than a
- * flag per kind, so nothing can claim the caret alongside it.
+ * The one non-body part the editor can have open. Header/footer bands and
+ * notes are alternatives, never neighbours: opening one closes the other, so
+ * they share a single value rather than a flag each.
  */
 
 import type {
@@ -9,21 +10,33 @@ import type {
 } from '@betteroffice/docx/layout/render';
 
 /**
- * What the user opened, before the package resolves it: the band names the
+ * What the user opened, before the package resolves it. A band names the
  * variant to look up (the first-page one wins on a `titlePg` page 1) and the
- * page it was opened from.
+ * page it was opened from; a note is already addressed by its id.
  */
-export type PartEditTarget = { kind: 'header' | 'footer'; isFirstPage: boolean; pageIndex: number };
+export type PartEditTarget =
+  | { kind: 'header' | 'footer'; isFirstPage: boolean; pageIndex: number }
+  | { kind: 'footnote' | 'endnote'; noteId: number };
 
 /**
- * The resolved part: a band with the relationship id of its part, null until a
- * newly materialised one registers.
+ * The resolved part: a band with the relationship id of its part (null until
+ * a newly materialised one registers), or a note with its id.
  */
-export type PartEdit = { kind: 'header' | 'footer'; rId: string | null };
+export type PartEdit =
+  | { kind: 'header' | 'footer'; rId: string | null }
+  | { kind: 'footnote' | 'endnote'; noteId: number };
+
+/** The note half of {@link PartEdit} — one note, on one page, by id. */
+export type NoteEdit = Extract<PartEdit, { noteId: number }>;
+
+function isNote(part: PartEdit): part is NoteEdit {
+  return part.kind === 'footnote' || part.kind === 'endnote';
+}
 
 /** yrs root story the open part types into; the body when none is typeable. */
 export function partEditStory(part: PartEdit | null): string {
   if (!part) return 'body';
+  if (isNote(part)) return `${part.kind === 'footnote' ? 'fn' : 'en'}:${part.noteId}`;
   return part.rId ? `hf:${part.rId}` : 'body';
 }
 
@@ -32,10 +45,22 @@ export function hitBelongsToPart(
   part: PartEdit | null,
   hit: DisplayListRegionHit | null
 ): boolean {
-  return Boolean(part && hit && hit.region === part.kind);
+  if (!part || !hit || hit.region !== part.kind) return false;
+  return isNote(part) ? hit.noteId === part.noteId : true;
 }
 
-/** Display-list image scope of the open part. */
-export function partImageRegion(part: PartEdit | null): DisplayListImageRegion {
-  return part ? part.kind : 'body';
+/**
+ * Display-list image scope of the open part. Null for a note: the list indexes
+ * images by band, so the only answer available there would be a body image
+ * from behind the note area.
+ */
+export function partImageRegion(part: PartEdit | null): DisplayListImageRegion | null {
+  if (!part) return 'body';
+  return isNote(part) ? null : part.kind;
+}
+
+/** The note a hit opens for editing, or null when it names none. */
+export function noteEditFromHit(hit: DisplayListRegionHit | null): NoteEdit | null {
+  if (hit?.region !== 'footnote' && hit?.region !== 'endnote') return null;
+  return hit.noteId == null ? null : { kind: hit.region, noteId: hit.noteId };
 }

--- a/packages/docx-react/src/components/DocxEditor/partEdit.ts
+++ b/packages/docx-react/src/components/DocxEditor/partEdit.ts
@@ -1,0 +1,41 @@
+/**
+ * The one non-body part the editor can have open. A single value rather than a
+ * flag per kind, so nothing can claim the caret alongside it.
+ */
+
+import type {
+  DisplayListImageRegion,
+  DisplayListRegionHit,
+} from '@betteroffice/docx/layout/render';
+
+/**
+ * What the user opened, before the package resolves it: the band names the
+ * variant to look up (the first-page one wins on a `titlePg` page 1) and the
+ * page it was opened from.
+ */
+export type PartEditTarget = { kind: 'header' | 'footer'; isFirstPage: boolean; pageIndex: number };
+
+/**
+ * The resolved part: a band with the relationship id of its part, null until a
+ * newly materialised one registers.
+ */
+export type PartEdit = { kind: 'header' | 'footer'; rId: string | null };
+
+/** yrs root story the open part types into; the body when none is typeable. */
+export function partEditStory(part: PartEdit | null): string {
+  if (!part) return 'body';
+  return part.rId ? `hf:${part.rId}` : 'body';
+}
+
+/** Whether a hit lands in the open part — what separates typing from leaving. */
+export function hitBelongsToPart(
+  part: PartEdit | null,
+  hit: DisplayListRegionHit | null
+): boolean {
+  return Boolean(part && hit && hit.region === part.kind);
+}
+
+/** Display-list image scope of the open part. */
+export function partImageRegion(part: PartEdit | null): DisplayListImageRegion {
+  return part ? part.kind : 'body';
+}

--- a/packages/docx-react/src/components/DocxEditor/verticalCaretGoal.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/verticalCaretGoal.test.ts
@@ -20,11 +20,12 @@ describe('VerticalCaretGoal', () => {
 });
 
 describe('paragraphVerticalMove', () => {
+  const paragraphs = [
+    { paraId: 'first', length: 8 },
+    { paraId: 'second', length: 3 },
+  ];
+
   test('keeps header and footer navigation available without a display-list facade', () => {
-    const paragraphs = [
-      { paraId: 'first', length: 8 },
-      { paraId: 'second', length: 3 },
-    ];
     expect(
       paragraphVerticalMove(
         paragraphs,
@@ -39,5 +40,23 @@ describe('paragraphVerticalMove', () => {
         'up'
       )
     ).toEqual({ story: 'hf:rIdFooter', paraId: 'first', offset: 2 });
+  });
+
+  // The facade answers body positions only, so a note navigates the same way a
+  // band does — and the caret never leaves the note it is in.
+  test('keeps footnote and endnote navigation inside their own story', () => {
+    expect(
+      paragraphVerticalMove(paragraphs, { story: 'fn:2', paraId: 'first', offset: 6 }, 'down')
+    ).toEqual({ story: 'fn:2', paraId: 'second', offset: 3 });
+    expect(
+      paragraphVerticalMove(paragraphs, { story: 'en:2', paraId: 'second', offset: 2 }, 'up')
+    ).toEqual({ story: 'en:2', paraId: 'first', offset: 2 });
+  });
+
+  test('the ends of a note story hold the caret', () => {
+    const top = { story: 'fn:2', paraId: 'first', offset: 4 };
+    const bottom = { story: 'fn:2', paraId: 'second', offset: 1 };
+    expect(paragraphVerticalMove(paragraphs, top, 'up')).toEqual(top);
+    expect(paragraphVerticalMove(paragraphs, bottom, 'down')).toEqual(bottom);
   });
 });

--- a/packages/docx-react/src/components/DocxEditor/yrsCommands.history.test.ts
+++ b/packages/docx-react/src/components/DocxEditor/yrsCommands.history.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import type { YrsSession } from '@betteroffice/docx/yrs';
+import { performYrsHistoryAction } from './yrsCommands';
+
+describe('performYrsHistoryAction', () => {
+  test('reports the mutated history story instead of the active selection story', () => {
+    const session = {
+      historyStory: () => 'body',
+      selection: () => ({
+        anchor: { story: 'fn:2', paraId: 'note', offset: 0 },
+        head: { story: 'fn:2', paraId: 'note', offset: 0 },
+      }),
+      undo: () => true,
+    } as unknown as YrsSession;
+
+    expect(performYrsHistoryAction(session, false)).toEqual({ changed: true, story: 'body' });
+  });
+
+  test('does not report a dirty story when history is unchanged', () => {
+    const session = {
+      historyStory: () => 'body',
+      selection: () => null,
+      redo: () => false,
+    } as unknown as YrsSession;
+
+    expect(performYrsHistoryAction(session, true)).toEqual({ changed: false, story: null });
+  });
+});

--- a/packages/docx-react/src/components/DocxEditor/yrsCommands.ts
+++ b/packages/docx-react/src/components/DocxEditor/yrsCommands.ts
@@ -572,19 +572,28 @@ export function yrsSelectionNearTable(session: YrsSession, table: YrsTableLoc) {
  * the structural transaction may delete. A surviving cell selection is
  * restored after the transaction; otherwise the caret stays beside the table.
  */
-export function performYrsHistoryAction(session: YrsSession, redo: boolean): boolean {
+export interface YrsHistoryActionResult {
+  changed: boolean;
+  story: string | null;
+}
+
+export function performYrsHistoryAction(
+  session: YrsSession,
+  redo: boolean
+): YrsHistoryActionResult {
+  const story = session.historyStory();
   const before = session.selection();
   const cell = before ? yrsCellLocFromStory(before.head.story) : null;
   const nearby = cell ? yrsSelectionNearTable(session, cell) : null;
   if (nearby) session.setSelection(nearby);
 
   const changed = redo ? session.redo() : session.undo();
-  if (!changed || !before || !nearby) return changed;
+  if (!changed || !before || !nearby) return { changed, story: changed ? story : null };
 
   const restoredCell = yrsCellLocFromStory(before.head.story);
   const cellIsLive =
     !restoredCell || yrsCellStory(session, restoredCell) === before.head.story;
-  if (!cellIsLive) return changed;
+  if (!cellIsLive) return { changed, story };
   try {
     const paragraphs = session.paragraphs(before.head.story);
     const paraIds = new Set(paragraphs.map((paragraph) => paragraph.paraId));
@@ -594,7 +603,7 @@ export function performYrsHistoryAction(session: YrsSession, redo: boolean): boo
   } catch {
     // The structural history operation removed the selected story.
   }
-  return changed;
+  return { changed, story };
 }
 
 function authoredId(value: unknown): string | null {

--- a/packages/docx-react/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/docx-react/src/components/InlineHeaderFooterEditor.tsx
@@ -75,17 +75,6 @@ export function InlineHeaderFooterEditor({
   const label = position === 'header' ? t('headerFooter.header') : t('headerFooter.footer');
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      event.stopPropagation();
-      onClose();
-    };
-    document.addEventListener('keydown', handleKeyDown, true);
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
-  }, [onClose]);
-
-  useEffect(() => {
     if (!showOptions) return;
     const handleClick = (event: MouseEvent) => {
       if (optionsRef.current && !optionsRef.current.contains(event.target as Node)) {

--- a/packages/docx-react/src/components/dialogs/FootnotePropertiesDialog.tsx
+++ b/packages/docx-react/src/components/dialogs/FootnotePropertiesDialog.tsx
@@ -174,7 +174,7 @@ export function FootnotePropertiesDialog({
 
   return (
     <div style={overlayStyle} onClick={onClose}>
-      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()} role="dialog">
         <h3 style={{ margin: '0 0 16px', fontSize: 16 }}>
           {t('dialogs.footnoteProperties.title')}
         </h3>

--- a/packages/docx-react/src/components/dialogs/FootnotePropertiesDialog.tsx
+++ b/packages/docx-react/src/components/dialogs/FootnotePropertiesDialog.tsx
@@ -173,7 +173,13 @@ export function FootnotePropertiesDialog({
   if (!isOpen) return null;
 
   return (
-    <div style={overlayStyle} onClick={onClose}>
+    <div
+      style={overlayStyle}
+      onClick={onClose}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+      }}
+    >
       <div style={dialogStyle} onClick={(e) => e.stopPropagation()} role="dialog">
         <h3 style={{ margin: '0 0 16px', fontSize: 16 }}>
           {t('dialogs.footnoteProperties.title')}

--- a/packages/docx-react/src/components/sidebar/CommentCard.tsx
+++ b/packages/docx-react/src/components/sidebar/CommentCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Comment } from '@betteroffice/docx/types/content';
 import { MaterialSymbol } from '../ui/Icons';
 import type { SidebarItemRenderProps } from '../../plugin-api/types';
@@ -36,6 +36,15 @@ export function CommentCard({
 }: CommentCardProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [menuOpen]);
 
   return (
     <div
@@ -98,6 +107,8 @@ export function CommentCard({
                 e.stopPropagation();
                 setMenuOpen(!menuOpen);
               }}
+              aria-expanded={menuOpen}
+              aria-haspopup="menu"
               title={t('comments.moreOptions')}
               style={ICON_BUTTON_STYLE}
             >
@@ -105,6 +116,7 @@ export function CommentCard({
             </button>
             {menuOpen && (
               <div
+                role="menu"
                 onClick={(e) => e.stopPropagation()}
                 onMouseDown={(e) => e.stopPropagation()}
                 style={{
@@ -120,6 +132,7 @@ export function CommentCard({
                 }}
               >
                 <button
+                  role="menuitem"
                   onClick={() => {
                     setMenuOpen(false);
                     onDelete?.(comment.id);

--- a/packages/docx-react/src/components/ui/AlignmentButtons.tsx
+++ b/packages/docx-react/src/components/ui/AlignmentButtons.tsx
@@ -198,6 +198,7 @@ export function AlignmentButtons({
       {isOpen && !disabled && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           style={{
             ...dropdownStyle,
             backgroundColor: 'var(--doc-surface)',

--- a/packages/docx-react/src/components/ui/FontSizePicker.tsx
+++ b/packages/docx-react/src/components/ui/FontSizePicker.tsx
@@ -283,6 +283,7 @@ export function FontSizePicker({
       {isDropdownOpen && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           style={{
             ...fixedDropdownStyle,
             backgroundColor: 'var(--doc-surface)',

--- a/packages/docx-react/src/components/ui/IconGridDropdown.tsx
+++ b/packages/docx-react/src/components/ui/IconGridDropdown.tsx
@@ -100,6 +100,7 @@ export function IconGridDropdown<T extends string = string>({
       {isOpen && !disabled && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           style={{
             ...dropdownStyle,
             backgroundColor: 'var(--doc-surface)',

--- a/packages/docx-react/src/components/ui/MenuDropdown.tsx
+++ b/packages/docx-react/src/components/ui/MenuDropdown.tsx
@@ -188,6 +188,7 @@ export function MenuDropdown({ label, items, disabled, showChevron = false }: Me
       {isOpen && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           style={{
             position: 'fixed',
             top: dropdownPos.top,

--- a/packages/docx-react/src/components/ui/Select.tsx
+++ b/packages/docx-react/src/components/ui/Select.tsx
@@ -58,6 +58,7 @@ function SelectContent({
       {/* Wrap in .oox-root so Tailwind scoped utilities apply inside the portal */}
       <div className={cn('oox-root', isDark && 'dark')}>
         <SelectPrimitive.Content
+          data-docx-escape-layer="true"
           className={cn(
             'relative z-50 max-h-72 min-w-[8rem] overflow-hidden',
             'rounded-lg border border-border bg-popover text-popover-foreground shadow-lg',

--- a/packages/docx-react/src/components/ui/TableBorderPicker.tsx
+++ b/packages/docx-react/src/components/ui/TableBorderPicker.tsx
@@ -77,6 +77,7 @@ export function TableBorderPicker({ onAction, disabled = false }: TableBorderPic
       {isOpen && !disabled && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           style={{
             ...dropdownStyle,
             backgroundColor: 'var(--doc-surface)',

--- a/packages/docx-react/src/components/ui/TableBorderWidthPicker.tsx
+++ b/packages/docx-react/src/components/ui/TableBorderWidthPicker.tsx
@@ -75,6 +75,7 @@ export function TableBorderWidthPicker({
       {isOpen && !disabled && (
         <div
           ref={dropdownRef}
+          data-docx-escape-layer="true"
           style={{
             ...dropdownStyle,
             backgroundColor: 'var(--doc-surface)',

--- a/packages/docx-react/src/components/ui/TableStyleGallery.tsx
+++ b/packages/docx-react/src/components/ui/TableStyleGallery.tsx
@@ -462,6 +462,7 @@ export function TableStyleGallery({
 
       {isOpen && (
         <div
+          data-docx-escape-layer="true"
           style={{
             position: 'absolute',
             top: '100%',

--- a/packages/docx-react/src/components/ui/TableStyleGallery.tsx
+++ b/packages/docx-react/src/components/ui/TableStyleGallery.tsx
@@ -401,7 +401,6 @@ export function TableStyleGallery({
   const [hoveredBtn, setHoveredBtn] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Close on outside click
   useEffect(() => {
     if (!isOpen) return;
     function handleClickOutside(e: MouseEvent) {
@@ -409,8 +408,15 @@ export function TableStyleGallery({
         setIsOpen(false);
       }
     }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') setIsOpen(false);
+    }
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
   }, [isOpen]);
 
   const handleApply = useCallback(

--- a/packages/docx-react/src/hooks/useEscapeKey.ts
+++ b/packages/docx-react/src/hooks/useEscapeKey.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Runs `onEscape` while `active`. Capture phase, so it wins over the hidden
+ * input and anything else holding focus inside the editor.
+ */
+export function useEscapeKey(active: boolean, onEscape: () => void): void {
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!active) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      onEscapeRef.current();
+    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [active]);
+}

--- a/packages/docx-react/src/hooks/useEscapeKey.ts
+++ b/packages/docx-react/src/hooks/useEscapeKey.ts
@@ -1,22 +1,51 @@
 import { useEffect, useRef } from 'react';
 
-/**
- * Runs `onEscape` while `active`. Capture phase, so it wins over the hidden
- * input and anything else holding focus inside the editor.
- */
+const INNER_ESCAPE_LAYER =
+  '[role="dialog"], [role="menu"], .oox-hyperlink-popup, [data-docx-escape-layer]';
+
+function hasEditableTarget(event: KeyboardEvent): boolean {
+  const target = event.target instanceof Element ? event.target : null;
+  const editable = target?.closest('input, textarea, select, [contenteditable]');
+  if (!editable || editable.matches('.paged-editor__yrs-input')) return false;
+  return editable.getAttribute('contenteditable') !== 'false';
+}
+
+function hasInnerEscapeLayer(): boolean {
+  return document.querySelector(INNER_ESCAPE_LAYER) != null;
+}
+
+/** Runs `onEscape` for an unhandled Escape while `active`. */
 export function useEscapeKey(active: boolean, onEscape: () => void): void {
   const onEscapeRef = useRef(onEscape);
   onEscapeRef.current = onEscape;
 
   useEffect(() => {
     if (!active) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const yieldedEvents = new WeakSet<KeyboardEvent>();
+    const markYieldedEvent = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
+      if (hasEditableTarget(event) || hasInnerEscapeLayer()) yieldedEvents.add(event);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== 'Escape' ||
+        event.isComposing ||
+        event.keyCode === 229 ||
+        event.defaultPrevented ||
+        yieldedEvents.has(event) ||
+        hasEditableTarget(event) ||
+        hasInnerEscapeLayer()
+      ) {
+        return;
+      }
       event.preventDefault();
-      event.stopPropagation();
       onEscapeRef.current();
     };
-    document.addEventListener('keydown', handleKeyDown, true);
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
+    document.addEventListener('keydown', markYieldedEvent, true);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', markYieldedEvent, true);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
   }, [active]);
 }

--- a/packages/docx/src/layout/contracts.ts
+++ b/packages/docx/src/layout/contracts.ts
@@ -1,5 +1,4 @@
 import type { Document, HeaderFooter, SectionProperties } from '../types/document';
-import type { DisplayListQueries, DisplayListRect } from './render';
 
 export const DEFAULT_PAGE_HEIGHT_PX = 1056;
 
@@ -27,27 +26,4 @@ export function resolveHeaderFooter(
     footer ??= firstFooter;
   }
   return { header, footer, firstHeader, firstFooter };
-}
-
-export function computeHfCaretRectsFromDisplayList(
-  queries: DisplayListQueries,
-  section: 'header' | 'footer',
-  rId: string,
-  position: number,
-  pageIndex?: number
-): DisplayListRect[] {
-  const rects = queries.hfCaretRects(section, rId, position);
-  return pageIndex === undefined ? rects : rects.filter((rect) => rect.pageIndex === pageIndex);
-}
-
-export function computeHfSelectionRectsFromDisplayList(
-  queries: DisplayListQueries,
-  section: 'header' | 'footer',
-  rId: string,
-  from: number,
-  to: number,
-  pageIndex?: number
-): DisplayListRect[] {
-  const rects = queries.hfRangeRects(section, rId, Math.min(from, to), Math.max(from, to));
-  return pageIndex === undefined ? rects : rects.filter((rect) => rect.pageIndex === pageIndex);
 }

--- a/packages/docx/src/layout/index.ts
+++ b/packages/docx/src/layout/index.ts
@@ -28,10 +28,5 @@ export type {
   ShapeTextBodyProperties,
 } from './drawing';
 
-export {
-  computeHfCaretRectsFromDisplayList,
-  computeHfSelectionRectsFromDisplayList,
-  DEFAULT_PAGE_HEIGHT_PX,
-  resolveHeaderFooter,
-} from './contracts';
+export { DEFAULT_PAGE_HEIGHT_PX, resolveHeaderFooter } from './contracts';
 export { LayoutSelectionGate } from './selectionGate';

--- a/packages/docx/src/layout/render/displayListNoteRects.test.ts
+++ b/packages/docx/src/layout/render/displayListNoteRects.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A caret inside a note, resolved against a display list the real layout wasm
+ * built. The note's own story answers, so the geometry has to land in the note
+ * area and nowhere else.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { buildDisplayListJson, preloadLayoutWasm } from '../../wasm/layout';
+import { createDisplayListQueries, type DisplayListQueries } from './displayListQueries';
+import type { DisplayList } from './displayList';
+
+// two footnotes in one area at y 900..960, each story starting at position 1
+const FIXTURE = resolve(
+  import.meta.dir,
+  '../../../../../crates/docx-layout/tests/fixtures/notes/two-footnotes.input.json'
+);
+
+let list: DisplayList;
+let queries: DisplayListQueries;
+
+beforeAll(async () => {
+  await preloadLayoutWasm();
+  list = JSON.parse(buildDisplayListJson(readFileSync(FIXTURE, 'utf8'))) as DisplayList;
+  queries = createDisplayListQueries(list);
+  await queries.whenReady();
+});
+
+afterAll(() => queries.dispose());
+
+/** First position of the note story that covers nothing — its end. */
+function endOfNote(noteId: number): number {
+  for (let position = 1; position < 200; position += 1) {
+    if (queries.noteRangeRects('footnote', noteId, position, position + 1).length === 0) {
+      return position;
+    }
+  }
+  throw new Error(`footnote ${noteId} never ends`);
+}
+
+describe('noteCaretRects', () => {
+  test('a caret inside a note sits on the leading edge of its position', () => {
+    const covered = queries.noteRangeRects('footnote', 1, 1, 2);
+    expect(covered).toHaveLength(1);
+
+    const caret = queries.noteCaretRects('footnote', 1, 1);
+    expect(caret).toHaveLength(1);
+    expect(caret[0]!.width).toBe(0);
+    expect(caret[0]!.x).toBe(covered[0]!.x);
+    expect(caret[0]!.pageIndex).toBe(covered[0]!.pageIndex);
+  });
+
+  // A note paints on exactly one page, so there is never a second candidate to
+  // choose between — unlike a header, which repeats.
+  test('a note answers on the one page it paints on', () => {
+    const area = list.pages[0].noteAreas?.[0];
+    if (!area) throw new Error('the fixture page has no note area');
+    const caret = queries.noteCaretRects('footnote', 1, 1);
+
+    expect(caret).toHaveLength(1);
+    expect(caret[0]!.pageIndex).toBe(0);
+    expect(caret[0]!.y).toBeGreaterThanOrEqual(area.y ?? 0);
+    expect(caret[0]!.y).toBeLessThanOrEqual((area.y ?? 0) + (area.height ?? 0));
+  });
+
+  test('a caret at the end of a note falls back to the trailing edge', () => {
+    const end = endOfNote(1);
+    const last = queries.noteRangeRects('footnote', 1, end - 1, end);
+    expect(last).toHaveLength(1);
+
+    const caret = queries.noteCaretRects('footnote', 1, end);
+    expect(caret).toHaveLength(1);
+    expect(caret[0]!.width).toBe(0);
+    expect(caret[0]!.x).toBe(last[0]!.x + last[0]!.width);
+  });
+
+  test('a note the page does not carry has no caret', () => {
+    expect(queries.noteCaretRects('endnote', 1, 1)).toEqual([]);
+  });
+});

--- a/packages/docx/src/layout/render/displayListQueries.ts
+++ b/packages/docx/src/layout/render/displayListQueries.ts
@@ -228,6 +228,11 @@ export interface DisplayListQueries {
    * caret rect per page carrying the part; the caller picks the edited page.
    */
   hfCaretRects(region: 'header' | 'footer', rId: string, pos: number): DisplayListRect[];
+  /**
+   * Caret geometry for a collapsed selection in a note story — the note twin of
+   * `hfCaretRects`. A note paints on one page, so this returns at most one rect.
+   */
+  noteCaretRects(region: 'footnote' | 'endnote', noteId: number, pos: number): DisplayListRect[];
   /** Header/footer sidebar anchors, one per page carrying the part. */
   hfAnchorRects(region: 'header' | 'footer', rId: string, pos: number): DisplayListRect[];
   /**
@@ -716,49 +721,53 @@ export function createDisplayListQueries(
     to: number
   ): DisplayListRect[] => regionRangeRects(region, String(noteId), from, to);
 
+  /**
+   * One caret per page from a scoped range query. An HF part paints on every
+   * page carrying it, so the caller picks the edited page; a note paints on
+   * exactly one, so the single answer is already the right one.
+   */
+  const scopedCaretRects = (
+    scopedRangeRects: (from: number, to: number) => DisplayListRect[],
+    pos: number
+  ): DisplayListRect[] => {
+    // The leading edge is the first slice on a page, the trailing edge the last.
+    const caretsByPage = (rects: DisplayListRect[], leading: boolean) => {
+      const byPage = new Map<number, DisplayListRect>();
+      for (const rect of rects) {
+        if (leading && byPage.has(rect.pageIndex)) continue;
+        byPage.set(rect.pageIndex, {
+          pageIndex: rect.pageIndex,
+          x: leading ? rect.x : rect.x + rect.width,
+          y: rect.y,
+          width: 0,
+          height: rect.height,
+        });
+      }
+      return [...byPage.values()];
+    };
+    const forward = scopedRangeRects(pos, pos + 1);
+    if (forward.length > 0) return caretsByPage(forward, true);
+    if (pos > 0) {
+      // end of line / end of doc: trailing edge of the previous position
+      const backward = scopedRangeRects(pos - 1, pos);
+      if (backward.length > 0) return caretsByPage(backward, false);
+    }
+    return [];
+  };
+
   const hfCaretRects = (
     region: 'header' | 'footer',
     rId: string,
     pos: number
-  ): DisplayListRect[] => {
-    // The same HF doc paints on every page carrying the part, so a caret query
-    // returns one candidate per page; the caller renders the edited one.
-    const forward = hfRangeRects(region, rId, pos, pos + 1);
-    if (forward.length > 0) {
-      // left edge of the first slice on each page is the caret there
-      const byPage = new Map<number, DisplayListRect>();
-      for (const r of forward) {
-        if (!byPage.has(r.pageIndex)) {
-          byPage.set(r.pageIndex, {
-            pageIndex: r.pageIndex,
-            x: r.x,
-            y: r.y,
-            width: 0,
-            height: r.height,
-          });
-        }
-      }
-      return [...byPage.values()];
-    }
-    if (pos > 0) {
-      // end of line / end of doc: trailing edge of the previous position
-      const backward = hfRangeRects(region, rId, pos - 1, pos);
-      if (backward.length > 0) {
-        const byPage = new Map<number, DisplayListRect>();
-        for (const r of backward) {
-          byPage.set(r.pageIndex, {
-            pageIndex: r.pageIndex,
-            x: r.x + r.width,
-            y: r.y,
-            width: 0,
-            height: r.height,
-          });
-        }
-        return [...byPage.values()];
-      }
-    }
-    return [];
-  };
+  ): DisplayListRect[] =>
+    scopedCaretRects((from, to) => hfRangeRects(region, rId, from, to), pos);
+
+  const noteCaretRects = (
+    region: 'footnote' | 'endnote',
+    noteId: number,
+    pos: number
+  ): DisplayListRect[] =>
+    scopedCaretRects((from, to) => noteRangeRects(region, noteId, from, to), pos);
 
   const caretRect = (pos: number): DisplayListRect | null => {
     const forward = rangeRects(pos, pos + 1);
@@ -1051,6 +1060,7 @@ export function createDisplayListQueries(
     hfRangeRects,
     noteRangeRects,
     hfCaretRects,
+    noteCaretRects,
     hfAnchorRects,
     caretRect,
     anchorRect,

--- a/packages/docx/src/layout/render/displayListTables.ts
+++ b/packages/docx/src/layout/render/displayListTables.ts
@@ -36,7 +36,7 @@
  *
  * Body region only. The HF caret + selection on canvas are now sourced from the
  * region-aware `hfRangeRects` / `hfCaretRects` queries (see
- * `CanvasHfSelectionOverlay`), but HF *table* resize handles remain a documented
+ * `CanvasPartSelectionOverlay`), but HF *table* resize handles remain a documented
  * gap: this walker takes `page.primitives` (body), and the overlay's
  * `tableKeyOf` / commit path resolves against the body doc. Closing it needs
  * (1) an optional region parameter here to walk `page.header|footer.primitives`,

--- a/packages/docx/src/styles/editor.css
+++ b/packages/docx/src/styles/editor.css
@@ -893,10 +893,10 @@
   background-color: transparent;
 }
 
-/* HF caret overlay blink. Used by the painted HF caret in both adapters
-   (DocxEditorPagedArea.tsx / DocxEditor.vue set `animation: hf-caret-blink ...`
-   inline). Defined once here so the keyframes aren't duplicated per adapter. */
-@keyframes hf-caret-blink {
+/* Part caret overlay blink. Used by the caret painted inside the open
+   header/footer band or note (CanvasPartSelectionOverlay sets
+   `animation: part-caret-blink ...` inline). */
+@keyframes part-caret-blink {
   0%,
   49% {
     opacity: 1;

--- a/packages/docx/src/yrs/index.ts
+++ b/packages/docx/src/yrs/index.ts
@@ -732,6 +732,8 @@ export interface YrsSession extends CollaborationReplica {
   cellSelection(): YrsTableRange | null;
   /** Lazily begin local-origin undo capture after import/seeding has completed. */
   beginUndoCapture(story: string, includeTableStories?: boolean): void;
+  /** Story owned by the current undo/redo scope, or null before the first local edit. */
+  historyStory(): string | null;
   /** Coalesce the stack entries added since `startDepth` into one host undo intent. */
   markUndoGroup(startDepth: number): void;
   /** Undo/redo only local-origin direct operations (never remote/system transactions). */
@@ -1326,6 +1328,8 @@ function wrapSession(session: EditSession, clientId: number): YrsSession {
     cellSelection: () => JSON.parse(session.cell_selection()) as YrsTableRange | null,
     beginUndoCapture: (story, includeTableStories = false) =>
       includeTableStories ? ensureTableUndo(story) : ensureUndo(story),
+    historyStory: () =>
+      undoStory?.startsWith('table:') ? undoStory.slice('table:'.length) : undoStory,
     markUndoGroup: (startDepth) => {
       const endDepth = session.undo_depth();
       const size = Math.max(0, endDepth - startDepth);

--- a/packages/docx/src/yrs/noteEditSave.test.ts
+++ b/packages/docx/src/yrs/noteEditSave.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The editor's own path into a note: a click resolves to a display position in
+ * the note's story, the caret goes there, and typing at the caret has to reach
+ * the saved file. `noteSave.test.ts` covers the projection with a caret the
+ * test built by hand; this one builds it the way a pointer does.
+ */
+
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parseDocx } from '../docx';
+import { repackDocx } from '../docx/rezip';
+import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
+import type { BlockContent, Document, Endnote, Footnote } from '../types/document';
+import { preloadEditWasm } from '../wasm/edit';
+import { createYrsSession, type YrsSession } from './index';
+import { createYrsInputPositionMap, displayPositionToYrsLoc } from './inputPositionMap';
+import { yrsToDocument } from './yrsToDocument';
+
+const WASM = resolve(import.meta.dir, '../wasm/generated/edit/docx_edit_bg.wasm');
+const OFFICE_DOC = 'application/vnd.openxmlformats-officedocument';
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="${OFFICE_DOC}.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="${OFFICE_DOC}.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="${OFFICE_DOC}.wordprocessingml.footnotes+xml"/>
+  <Override PartName="/word/endnotes.xml" ContentType="${OFFICE_DOC}.wordprocessingml.endnotes+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPkg1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const DOCUMENT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/>
+</Relationships>`;
+
+const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r><w:t xml:space="preserve">Body text</w:t></w:r>
+      <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="2"/></w:r>
+      <w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteReference w:id="2"/></w:r>
+    </w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="FootnoteText"><w:name w:val="footnote text"/><w:basedOn w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="EndnoteText"><w:name w:val="endnote text"/><w:basedOn w:val="Normal"/></w:style>
+  <w:style w:type="character" w:styleId="FootnoteReference"><w:name w:val="footnote reference"/><w:rPr><w:vertAlign w:val="superscript"/></w:rPr></w:style>
+  <w:style w:type="character" w:styleId="EndnoteReference"><w:name w:val="endnote reference"/><w:rPr><w:vertAlign w:val="superscript"/></w:rPr></w:style>
+</w:styles>`;
+
+const FOOTNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:footnote w:id="-1" w:type="separator"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
+  <w:footnote w:id="0" w:type="continuationSeparator"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+  <w:footnote w:id="2">
+    <w:p>
+      <w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>
+      <w:r><w:t xml:space="preserve">Ibsen 1879</w:t></w:r>
+    </w:p>
+  </w:footnote>
+</w:footnotes>`;
+
+const ENDNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:endnote w:id="-1" w:type="separator"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>
+  <w:endnote w:id="0" w:type="continuationSeparator"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>
+  <w:endnote w:id="2">
+    <w:p>
+      <w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr>
+      <w:r><w:t xml:space="preserve">Ibsen 1879</w:t></w:r>
+    </w:p>
+  </w:endnote>
+</w:endnotes>`;
+
+function fixture(): Uint8Array {
+  const parts: PartsMap = new Map();
+  parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
+  parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
+  parts.set('word/_rels/document.xml.rels', toBytes(DOCUMENT_RELS));
+  parts.set('word/document.xml', toBytes(DOCUMENT));
+  parts.set('word/styles.xml', toBytes(STYLES));
+  parts.set('word/footnotes.xml', toBytes(FOOTNOTES));
+  parts.set('word/endnotes.xml', toBytes(ENDNOTES));
+  return new Uint8Array(rezipPartsToArrayBuffer(parts));
+}
+
+/**
+ * Place the caret from a display position in `story` — the hit test's own
+ * output — and type there, the way the pointer path and YrsInput do.
+ */
+function typeAtDisplayPosition(
+  session: YrsSession,
+  story: string,
+  position: number,
+  text: string
+): void {
+  const map = createYrsInputPositionMap(story, session.paragraphSpans(story));
+  const caret = displayPositionToYrsLoc(map, position);
+  if (!caret) throw new Error(`no location at display position ${position} of ${story}`);
+  session.setSelection(caret);
+  const head = session.selection()?.head;
+  if (!head) throw new Error(`the selection did not land in ${story}`);
+  session.insertText(head, text);
+}
+
+function blocksText(blocks: readonly BlockContent[]): string {
+  return blocks
+    .map((block) =>
+      block.type === 'paragraph'
+        ? block.content
+            .map((item) =>
+              item.type === 'run'
+                ? item.content.map((run) => (run.type === 'text' ? run.text : '')).join('')
+                : ''
+            )
+            .join('')
+        : ''
+    )
+    .join('');
+}
+
+function noteText(notes: readonly (Footnote | Endnote)[] | undefined, id: number): string {
+  const note = notes?.find((candidate) => candidate.id === id);
+  return note ? blocksText(note.content) : '';
+}
+
+describe('typing into a note through the editor path', () => {
+  beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
+
+  it('saves what was typed where the caret was clicked', async () => {
+    const bytes = fixture();
+    const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+    const session = await createYrsSession({ clientId: 53003 });
+
+    let saved: Document;
+    try {
+      session.seedFromDocx(bytes);
+      // display position 6 = five characters into "Ibsen 1879", i.e. between
+      // the name and the year — a caret a click could put there
+      typeAtDisplayPosition(session, 'fn:2', 6, ',');
+      typeAtDisplayPosition(session, 'en:2', 6, ',');
+      saved = yrsToDocument(session, parsed);
+    } finally {
+      session.destroy();
+    }
+
+    const reopened = await parseDocx(await repackDocx(saved), { preloadFonts: false });
+    expect(noteText(reopened.package.footnotes, 2)).toBe('Ibsen, 1879');
+    expect(noteText(reopened.package.endnotes, 2)).toBe('Ibsen, 1879');
+  });
+});

--- a/packages/docx/src/yrs/noteEditSave.test.ts
+++ b/packages/docx/src/yrs/noteEditSave.test.ts
@@ -12,7 +12,9 @@ import { resolve } from 'node:path';
 import { parseDocx } from '../docx';
 import { repackDocx } from '../docx/rezip';
 import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
-import type { BlockContent, Document, Endnote, Footnote } from '../types/document';
+import { readDocxContainer } from '../docx/zipContainer';
+import type { DisplayList, DisplayListRegionHit, TextRunPrimitive } from '../layout/render';
+import type { Document } from '../types/document';
 import { preloadEditWasm } from '../wasm/edit';
 import { createYrsSession, type YrsSession } from './index';
 import { createYrsInputPositionMap, displayPositionToYrsLoc } from './inputPositionMap';
@@ -71,9 +73,11 @@ const FOOTNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <w:footnote w:id="2">
     <w:p>
       <w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>
+      <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>
       <w:r><w:t xml:space="preserve">Ibsen 1879</w:t></w:r>
     </w:p>
   </w:footnote>
+  <w:footnote w:id="3"><w:p><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r><w:r><w:t>Clean footnote sibling.</w:t></w:r></w:p></w:footnote>
 </w:footnotes>`;
 
 const ENDNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -83,9 +87,11 @@ const ENDNOTES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <w:endnote w:id="2">
     <w:p>
       <w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr>
+      <w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteRef/></w:r>
       <w:r><w:t xml:space="preserve">Ibsen 1879</w:t></w:r>
     </w:p>
   </w:endnote>
+  <w:endnote w:id="3"><w:p><w:pPr><w:pStyle w:val="EndnoteText"/></w:pPr><w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteRef/></w:r><w:r><w:t>Clean endnote sibling.</w:t></w:r></w:p></w:endnote>
 </w:endnotes>`;
 
 function fixture(): Uint8Array {
@@ -119,31 +125,75 @@ function typeAtDisplayPosition(
   session.insertText(head, text);
 }
 
-function blocksText(blocks: readonly BlockContent[]): string {
-  return blocks
-    .map((block) =>
-      block.type === 'paragraph'
-        ? block.content
-            .map((item) =>
-              item.type === 'run'
-                ? item.content.map((run) => (run.type === 'text' ? run.text : '')).join('')
-                : ''
-            )
-            .join('')
-        : ''
-    )
-    .join('');
+interface NoteClick {
+  story: string;
+  position: number;
 }
 
-function noteText(notes: readonly (Footnote | Endnote)[] | undefined, id: number): string {
-  const note = notes?.find((candidate) => candidate.id === id);
-  return note ? blocksText(note.content) : '';
+function clickedNotePositions(session: YrsSession): NoteClick[] {
+  const layout = session.layoutDocumentWithRegionsJson(
+    JSON.stringify({
+      bodyStory: 'body',
+      regions: { sections: [{ sectionId: 'main', properties: {} }] },
+      notes: {
+        contents: [
+          { id: 2, noteKind: 'footnote', height: 0 },
+          { id: 2, noteKind: 'endnote', height: 0 },
+        ],
+      },
+      measurement: {
+        fontChains: {},
+        defaults: { fontSize: 11, fontFamily: 'Calibri' },
+        authoritativeShaping: false,
+      },
+      renderEnv: {},
+    })
+  );
+  const list = JSON.parse(session.buildDisplayListJson(layout)) as DisplayList;
+  return (['footnote', 'endnote'] as const).map((kind) => {
+    const located = list.pages
+      .flatMap((page) => (page.noteAreas ?? []).map((area) => ({ page, area })))
+      .find(({ area }) => (area.kind ?? 'footnote') === kind && (area.noteIds ?? []).includes(2));
+    if (!located) throw new Error(`no ${kind} area`);
+    const run = located.area.primitives?.find(
+      (primitive): primitive is TextRunPrimitive & { docStart: number } =>
+        primitive.kind === 'text' && primitive.docStart != null && primitive.text.includes('Ibsen')
+    );
+    if (!run) throw new Error(`no positioned ${kind} text`);
+    const split = run.text.indexOf(' ');
+    if (split < 0) throw new Error(`no word boundary in ${kind} text`);
+    const target = run.docStart + split;
+    for (let step = 0; step <= 512; step += 1) {
+      const x = run.x + (run.width * step) / 512;
+      const hit = JSON.parse(
+        session.displayHitTestRegionsJson(located.page.pageIndex, x, run.baselineY - 2)
+      ) as DisplayListRegionHit | null;
+      if (hit?.region !== kind || hit.noteId !== 2 || hit.pos !== target) continue;
+      return {
+        story: `${kind === 'footnote' ? 'fn' : 'en'}:${hit.noteId}`,
+        position: hit.pos,
+      };
+    }
+    throw new Error(`no ${kind} hit resolved display position ${target}`);
+  });
+}
+
+function noteXml(xml: string, tag: 'footnote' | 'endnote', id: number): string {
+  const match = new RegExp(
+    `<w:${tag}\\b[^>]*\\bw:id=["']${id}["'][^>]*>[\\s\\S]*?</w:${tag}>`
+  ).exec(xml);
+  if (!match) throw new Error(`no ${tag} ${id}`);
+  return match[0];
+}
+
+function rawNoteText(xml: string): string {
+  return [...xml.matchAll(/<w:t(?:\s[^>]*)?>([\s\S]*?)<\/w:t>/g)].map((match) => match[1]).join('');
 }
 
 describe('typing into a note through the editor path', () => {
   beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
 
-  it('saves what was typed where the caret was clicked', async () => {
+  it('selectively saves note clicks without rewriting clean stories', async () => {
     const bytes = fixture();
     const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
     const session = await createYrsSession({ clientId: 53003 });
@@ -151,17 +201,29 @@ describe('typing into a note through the editor path', () => {
     let saved: Document;
     try {
       session.seedFromDocx(bytes);
-      // display position 6 = five characters into "Ibsen 1879", i.e. between
-      // the name and the year — a caret a click could put there
-      typeAtDisplayPosition(session, 'fn:2', 6, ',');
-      typeAtDisplayPosition(session, 'en:2', 6, ',');
-      saved = yrsToDocument(session, parsed);
+      const clicks = clickedNotePositions(session);
+      expect(clicks.map((click) => click.story)).toEqual(['fn:2', 'en:2']);
+      for (const click of clicks) typeAtDisplayPosition(session, click.story, click.position, ',');
+      saved = yrsToDocument(session, parsed, {
+        storyIds: new Set(clicks.map((click) => click.story)),
+      });
     } finally {
       session.destroy();
     }
 
-    const reopened = await parseDocx(await repackDocx(saved), { preloadFonts: false });
-    expect(noteText(reopened.package.footnotes, 2)).toBe('Ibsen, 1879');
-    expect(noteText(reopened.package.endnotes, 2)).toBe('Ibsen, 1879');
+    expect(saved.package.document.content).toBe(parsed.package.document.content);
+
+    const parts = readDocxContainer(await repackDocx(saved));
+    const footnotesXml = parts.text('word/footnotes.xml') ?? '';
+    const endnotesXml = parts.text('word/endnotes.xml') ?? '';
+    const footnote = noteXml(footnotesXml, 'footnote', 2);
+    const endnote = noteXml(endnotesXml, 'endnote', 2);
+
+    expect(footnote).toContain('<w:footnoteRef/>');
+    expect(rawNoteText(footnote)).toBe('Ibsen, 1879');
+    expect(endnote).toContain('<w:endnoteRef/>');
+    expect(rawNoteText(endnote)).toBe('Ibsen, 1879');
+    expect(noteXml(footnotesXml, 'footnote', 3)).toBe(noteXml(FOOTNOTES, 'footnote', 3));
+    expect(noteXml(endnotesXml, 'endnote', 3)).toBe(noteXml(ENDNOTES, 'endnote', 3));
   });
 });

--- a/packages/docx/src/yrs/noteEditSave.test.ts
+++ b/packages/docx/src/yrs/noteEditSave.test.ts
@@ -226,4 +226,43 @@ describe('typing into a note through the editor path', () => {
     expect(noteXml(footnotesXml, 'footnote', 3)).toBe(noteXml(FOOTNOTES, 'footnote', 3));
     expect(noteXml(endnotesXml, 'endnote', 3)).toBe(noteXml(ENDNOTES, 'endnote', 3));
   });
+
+  it('selectively saves a body undo while the note caret is active', async () => {
+    const bytes = fixture();
+    const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+    const session = await createYrsSession({ clientId: 53004 });
+
+    try {
+      session.seedFromDocx(bytes);
+      const body = session.paragraphs('body')[0];
+      session.setSelection({ story: 'body', paraId: body.paraId, offset: 9 });
+      session.insertText(session.selection()!.head, '!');
+      expect(session.historyStory()).toBe('body');
+      const afterBodyEdit = yrsToDocument(session, parsed, {
+        storyIds: new Set(['body']),
+      });
+      const note = session.paragraphs('fn:2')[0];
+      session.setSelection({ story: 'fn:2', paraId: note.paraId, offset: 0 });
+
+      expect(session.historyStory()).toBe('body');
+      expect(session.undo()).toBe(true);
+      expect(session.paragraphs('body')[0].text).toBe('Body text');
+
+      const misattributed = yrsToDocument(session, afterBodyEdit, {
+        storyIds: new Set(['fn:2']),
+      });
+      const misattributedParts = readDocxContainer(await repackDocx(misattributed));
+      expect(rawNoteText(misattributedParts.text('word/document.xml') ?? '')).toBe('Body text!');
+
+      const historyStory = session.historyStory();
+      expect(historyStory).toBe('body');
+      const saved = yrsToDocument(session, afterBodyEdit, {
+        storyIds: new Set([historyStory!]),
+      });
+      const savedParts = readDocxContainer(await repackDocx(saved));
+      expect(rawNoteText(savedParts.text('word/document.xml') ?? '')).toBe('Body text');
+    } finally {
+      session.destroy();
+    }
+  });
 });


### PR DESCRIPTION
TL;DR:


Repro file:
`crates/docx-layout/tests/fixtures/notes/two-footnotes.input.json` — the two-footnote page the new caret-geometry test resolves against. The editor-path round trip builds its own footnote/endnote package inline in `packages/docx/src/yrs/noteEditSave.test.ts`.

Summary:
Two commits, meant to be read in order. The first is a pure state refactor with no behaviour change; the second adds the feature on top. Reviewing them separately is much cheaper than reviewing the union — most of the churn is in the first, and all of the new behaviour is in the second.

**1 — `refactor(docx): unify the open header/footer into one part-edit value`** (381+/280-)

- Header/footer mode becomes one value. `partEdit` names the single open non-body part, and the band's first-page variant and originating page fold into it — three `useState`s in `DocxEditor` become one.
- `PagedEditor` takes `partEdit` in place of `hfEditMode` / `hfEditRId`, and reports the open part's selection through `onYrsPartSelectionChange` in place of `onYrsHfSelectionChange`.
- `CanvasHfSelectionOverlay` becomes `CanvasPartSelectionOverlay` and queries the display list directly, which leaves `computeHfCaretRectsFromDisplayList` and `computeHfSelectionRectsFromDisplayList` unreachable — both are removed from `@betteroffice/docx/layout`.
- Escape moves from the header/footer chrome component into a reusable `useEscapeKey` hook on the paged area, so it now also closes a band whose chrome never mounted. That is the one behaviour difference in this commit.
- Everything else is rename plus rewiring: the gates in `PagedEditor` were re-decided one by one rather than copied, and the existing header/footer tests are unchanged in intent.

**2 — `feat(docx): edit footnote and endnote text in place`** (723+/81-)

- A single click in a footnote or endnote area opens that note for editing, puts the caret under the pointer, and routes typing into the note's `fn:{id}` / `en:{id}` story. Escape or a click in the body leaves.
- The click that opens a note also places its caret: the resolved position belongs to a story the editor is not on yet, so it is held until that story becomes active, and dropped if the host never opens the note.
- `PartEdit` gains its note variants, so every gate the first commit unified now covers notes for free — the body caret, body selection rects, focus flag, painted-caret interrupt, body cell-selection overlay, image selection and table-resize overlay all treat an open note exactly as an open band.
- Three gates deliberately differ for a note, because the display list indexes images, tables and hyperlinks by band and has no note scope: selecting a picture, the row/column insert affordance and opening a hyperlink are inert inside a note. Answering `body` there would hand back geometry from behind the note area, so those paths bail out instead. Caret movement, word/paragraph multi-click, drag-selection and Home/End are unaffected.
- Arrow navigation inside a note falls back to paragraph-by-paragraph movement, the same path a band uses, because the display-list vertical-move query answers body positions only. The caret never leaves the note it is in.
- `noteCaretRects` is the note twin of `hfCaretRects`; both now derive their caret edge from one shared helper. A note paints on exactly one page, so there is never a second candidate page to pick between.

Where to look hardest: `usePagesPointer.ts` in commit 2 (the deferred-caret effect is the subtlest part) and the `partSelection` reset in `DocxEditorPagedArea.tsx`, which is cleared during render rather than in an effect — an effect there runs after the child publishes the opening click's caret and would wipe it.

Test plan:
- [x] `bun run typecheck:packages`
- [x] `bun test packages apps/web/app apps/demo/lib scripts`
- [x] `git diff --exit-code -- 'packages/*/src/wasm/generated/*'`
- [x] Both commits typecheck and pass the package suite independently
- [x] Open a document with a footnote, click into the note, type — the text appears in the note and the body caret is gone
- [x] Press Escape, then click in the body — the caret returns to the body and typing goes there
- [x] Click straight from one footnote into another — the caret follows into the second note
- [x] Double-click a header, then click a footnote — the band closes and the note opens
- [x] Save and reopen — the typed note text is still there
