### PR TITLE
fix(xlsx): keep a far-anchored chart from failing the default render

### DIFF
--- a/.changeset/xlsx-far-chart-render.md
+++ b/.changeset/xlsx-far-chart-render.md
@@ -3,4 +3,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Rendering a sheet without an explicit range no longer fails on a workbook whose chart is parked far below the data. The frame still grows to take in a chart near the used range, but one that would push the image past the renderer's pixel caps is now left out of frame — the way a chart past the edge of an explicit viewport already is — instead of taking the whole render down with it.
+Rendering a sheet without an explicit range no longer fails on a workbook whose chart is parked far below the data. The frame still grows to take in a chart near the used range, but one that would push the image past the renderer's pixel caps is now left out of frame — the way a chart past the edge of an explicit viewport already is — instead of taking the whole render down with it. A render capped by `max_width` / `max_height` that used to pad out to the cap around such a chart now returns the tighter used-range frame, so its reported dimensions can be smaller than before.

--- a/.changeset/xlsx-far-chart-render.md
+++ b/.changeset/xlsx-far-chart-render.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/xlsx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Rendering a sheet without an explicit range no longer fails on a workbook whose chart is parked far below the data. The frame still grows to take in a chart near the used range, but one that would push the image past the renderer's pixel caps is now left out of frame — the way a chart past the edge of an explicit viewport already is — instead of taking the whole render down with it.

--- a/crates/betteroffice-xlsx/src/lib.rs
+++ b/crates/betteroffice-xlsx/src/lib.rs
@@ -31,7 +31,7 @@ pub use xlsx_ops::{
 pub use xlsx_render::{
     Align, ChartA11yAttrs, ChartRegion, DisplayList, DrawCmd, GridGeometry, GridMeta,
     HyperlinkRegion, PathStroke, Rect, RenderError, Viewport, viewport_for_range,
-    viewport_for_used_range,
+    viewport_for_used_range, viewport_for_used_range_within,
 };
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -23,7 +23,7 @@ use xlsx_render::{
 };
 #[cfg(feature = "raster")]
 use xlsx_render::{
-    build_display_list_with_charts, scaled, viewport_for_range, viewport_for_used_range,
+    build_display_list_with_charts, scaled, viewport_for_range, viewport_for_used_range_within,
 };
 
 use crate::authority::{
@@ -1591,7 +1591,9 @@ impl Workbook {
         }
         let mut viewport = match options.range {
             Some(range) => viewport_for_range(sheet_ref, range),
-            None => viewport_for_used_range(sheet_ref),
+            None => viewport_for_used_range_within(sheet_ref, |grown| {
+                renderable(sheet_ref, grown, options.scale)
+            }),
         };
         if let Some(width) = options.max_width {
             viewport.width = viewport.width.min(width as f32 / options.scale);
@@ -3209,6 +3211,16 @@ fn validate_display_region(sheet: &Sheet, viewport: &Viewport) -> Result<()> {
         });
     }
     Ok(())
+}
+
+/// Whether a default-range render of `viewport` would clear every guard
+/// [`Workbook::render_sheet`] applies. The used range itself is the caller's
+/// to answer for; this decides only whether a chart may widen the frame.
+#[cfg(feature = "raster")]
+fn renderable(sheet: &Sheet, viewport: &Viewport, scale: f32) -> bool {
+    let width = ((viewport.width * scale).ceil() as u32).max(1);
+    let height = ((viewport.height * scale).ceil() as u32).max(1);
+    validate_render_size(width, height).is_ok() && validate_display_region(sheet, viewport).is_ok()
 }
 
 #[cfg(feature = "raster")]

--- a/crates/betteroffice-xlsx/tests/chart_render.rs
+++ b/crates/betteroffice-xlsx/tests/chart_render.rs
@@ -1,4 +1,7 @@
-use betteroffice_xlsx::{ChartAnchor, DrawCmd, RenderOptions, SheetId, Viewport, Workbook};
+use betteroffice_xlsx::{
+    ChartAnchor, DrawCmd, MAX_PIXMAP_DIM, MAX_PIXMAP_PIXELS, RenderOptions, SheetId, Viewport,
+    Workbook,
+};
 
 const FIXTURE: &[u8] = include_bytes!("../../../packages/xlsx/test-fixtures/charts.xlsx");
 const UNSUPPORTED: &[u8] =
@@ -154,4 +157,91 @@ fn decode_rgba(bytes: &[u8]) -> Vec<[u8; 3]> {
         .chunks_exact(4)
         .map(|pixel| [pixel[0], pixel[1], pixel[2]])
         .collect()
+}
+
+const SHOWCASE: &[u8] = include_bytes!("../../../apps/demo/public/showcase.xlsx");
+
+/// showcase.xlsx with its one `twoCellAnchor` repinned `from_row` rows down,
+/// keeping the chart's 15-row height. Data stays in A1:F11.
+fn showcase_with_chart_at_row(from_row: u32) -> Vec<u8> {
+    let mut parts = ooxml_opc::unzip_parts(SHOWCASE).unwrap();
+    let drawing = parts
+        .iter_mut()
+        .find(|(name, _)| name == "xl/drawings/drawing1.xml")
+        .expect("drawing part");
+    drawing.1 = String::from_utf8(drawing.1.clone())
+        .unwrap()
+        .replace(
+            "<xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>",
+            &format!("<xdr:row>{from_row}</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>"),
+        )
+        .replace(
+            "<xdr:row>16</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>",
+            &format!(
+                "<xdr:row>{}</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>",
+                from_row + 15
+            ),
+        )
+        .into_bytes();
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// A chart anchored below the data still grows the default render to take it in.
+#[test]
+fn a_reachable_chart_grows_the_default_render() {
+    let workbook = Workbook::open_for_read(SHOWCASE).unwrap();
+    let png = workbook
+        .render_sheet(SheetId(0), &RenderOptions::default())
+        .unwrap();
+    assert_eq!((png.width, png.height), (1075, 340));
+
+    let display_list = workbook
+        .display_list_for(
+            SheetId(0),
+            &Viewport {
+                x: 0.0,
+                y: 0.0,
+                width: png.width as f32,
+                height: png.height as f32,
+            },
+        )
+        .unwrap();
+    assert_eq!(display_list.charts.len(), 1);
+}
+
+/// Where a chart sits may not decide whether a legal sheet renders at all: one
+/// parked far below the data is out of frame, and the data still comes out.
+#[test]
+fn a_chart_parked_far_below_the_data_leaves_the_sheet_renderable() {
+    for row in [800, 1_000, 60_000] {
+        let bytes = showcase_with_chart_at_row(row);
+        let workbook = Workbook::open_for_read(&bytes).unwrap();
+        let png = workbook
+            .render_sheet(SheetId(0), &RenderOptions::default())
+            .unwrap();
+        assert!(png.bytes.starts_with(&[0x89, b'P', b'N', b'G']));
+        assert_eq!((png.width, png.height), (563, 240), "chart at row {row}");
+        assert!(u64::from(png.width) * u64::from(png.height) <= MAX_PIXMAP_PIXELS);
+        assert!(png.width.max(png.height) <= MAX_PIXMAP_DIM);
+    }
+}
+
+/// The frame the default render declines is still the caller's to ask for.
+#[test]
+fn an_explicit_viewport_still_reaches_a_far_chart() {
+    let bytes = showcase_with_chart_at_row(1_000);
+    let workbook = Workbook::open_for_read(&bytes).unwrap();
+    let display_list = workbook
+        .display_list_for(
+            SheetId(0),
+            &Viewport {
+                x: 0.0,
+                y: 20_000.0,
+                width: 1075.0,
+                height: 400.0,
+            },
+        )
+        .unwrap();
+    assert_eq!(display_list.charts.len(), 1);
+    assert!(!display_list.charts[0].placeholder);
 }

--- a/crates/xlsx-render/src/lib.rs
+++ b/crates/xlsx-render/src/lib.rs
@@ -31,7 +31,7 @@ pub use display_list::{
 };
 pub use geometry::GridGeometry;
 pub use hit::chart_at_point;
-pub use region::{viewport_for_range, viewport_for_used_range};
+pub use region::{viewport_for_range, viewport_for_used_range, viewport_for_used_range_within};
 
 /// a scrolled window in pixels; `x`/`y` offset the non-frozen body.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/crates/xlsx-render/src/region.rs
+++ b/crates/xlsx-render/src/region.rs
@@ -1,6 +1,7 @@
 //! range -> viewport helpers: turn a cell range (or a sheet's used range) into
 //! the content-pixel rectangle the display list is built for.
 
+use ooxml_drawingml::chart::PlotRect;
 use xlsx_model::workbook::Sheet;
 use xlsx_model::{CellRange, CellRef};
 
@@ -27,6 +28,21 @@ pub fn viewport_for_range(sheet: &Sheet, range: CellRange) -> Viewport {
 /// content-pixel rectangle spanning the sheet's whole used range; an empty
 /// sheet falls back to a1:z50, matching `xlsx-wasm`'s `sheet_info` default extent.
 pub fn viewport_for_used_range(sheet: &Sheet) -> Viewport {
+    viewport_for_used_range_within(sheet, |_| true)
+}
+
+/// [`viewport_for_used_range`], but a chart only widens the frame while `fits`
+/// accepts the widened rectangle. A chart parked far below the data would
+/// otherwise inflate the frame past a renderer's limits and take the whole
+/// render down with it; declining it leaves the chart out of frame instead,
+/// exactly as a chart past the edge of an explicit viewport already is.
+///
+/// Charts are offered in sheet order, so of two that fit alone but not together
+/// the earlier one wins. A used range `fits` already rejects grows no further.
+pub fn viewport_for_used_range_within(
+    sheet: &Sheet,
+    mut fits: impl FnMut(&Viewport) -> bool,
+) -> Viewport {
     let range = sheet
         .used_range()
         .unwrap_or_else(|| CellRange::new(CellRef::new(0, 0), CellRef::new(49, 25)));
@@ -40,22 +56,26 @@ pub fn viewport_for_used_range(sheet: &Sheet) -> Viewport {
         else {
             continue;
         };
-        let x = anchor.rect.x as f32;
-        let y = anchor.rect.y as f32;
-        let right = (anchor.rect.x + anchor.rect.w) as f32;
-        let bottom = (anchor.rect.y + anchor.rect.h) as f32;
-        let viewport_right = viewport.x + viewport.width;
-        let viewport_bottom = viewport.y + viewport.height;
-        let left = viewport.x.min(x);
-        let top = viewport.y.min(y);
-        viewport = Viewport {
-            x: left,
-            y: top,
-            width: viewport_right.max(right) - left,
-            height: viewport_bottom.max(bottom) - top,
-        };
+        let grown = grown_to(viewport, anchor.rect);
+        if fits(&grown) {
+            viewport = grown;
+        }
     }
     viewport
+}
+
+/// `viewport` widened to take in a chart's content-pixel rectangle.
+fn grown_to(viewport: Viewport, rect: PlotRect) -> Viewport {
+    let viewport_right = viewport.x + viewport.width;
+    let viewport_bottom = viewport.y + viewport.height;
+    let left = viewport.x.min(rect.x as f32);
+    let top = viewport.y.min(rect.y as f32);
+    Viewport {
+        x: left,
+        y: top,
+        width: viewport_right.max((rect.x + rect.w) as f32) - left,
+        height: viewport_bottom.max((rect.y + rect.h) as f32) - top,
+    }
 }
 
 #[cfg(test)]
@@ -65,6 +85,7 @@ mod tests {
         DEFAULT_COL_WIDTH_CHARS, DEFAULT_ROW_HEIGHT_PT, col_chars_to_px, row_pt_to_px,
     };
     use xlsx_model::CellValue;
+    use xlsx_model::chart::{AnchorCell, AnchorEditAs, ChartAnchor, SheetChart};
     use xlsx_model::workbook::Cell;
 
     fn text_cell(s: &str) -> Cell {
@@ -72,6 +93,38 @@ mod tests {
             value: CellValue::Text { value: s.into() },
             ..Cell::default()
         }
+    }
+
+    /// a 15-row chart hanging off column h, `row` rows down the sheet.
+    fn chart_at_row(row: u32) -> SheetChart {
+        SheetChart {
+            part: "xl/charts/chart1.xml".into(),
+            drawing: "xl/drawings/drawing1.xml".into(),
+            anchor_index: 0,
+            anchor: ChartAnchor::TwoCell {
+                from: AnchorCell {
+                    col: 7,
+                    row,
+                    ..AnchorCell::default()
+                },
+                to: AnchorCell {
+                    col: 14,
+                    row: row + 15,
+                    ..AnchorCell::default()
+                },
+                edit_as: AnchorEditAs::OneCell,
+            },
+            refs: Vec::new(),
+        }
+    }
+
+    /// a sheet used out to f11, with one chart.
+    fn sheet_with_chart(row: u32) -> Sheet {
+        let mut sheet = Sheet::new("S");
+        sheet.set_cell(CellRef::parse_a1("A1").unwrap(), text_cell("a"));
+        sheet.set_cell(CellRef::parse_a1("F11").unwrap(), text_cell("b"));
+        sheet.charts.push(chart_at_row(row));
+        sheet
     }
 
     #[test]
@@ -122,5 +175,52 @@ mod tests {
         assert_eq!((vp.x, vp.y), (0.0, 0.0));
         assert!((vp.width - dc * 26.0).abs() < 0.01);
         assert!((vp.height - dr * 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_chart_grows_the_used_range() {
+        let sheet = sheet_with_chart(1);
+        let dc = col_chars_to_px(DEFAULT_COL_WIDTH_CHARS);
+        let dr = row_pt_to_px(DEFAULT_ROW_HEIGHT_PT);
+        let vp = viewport_for_used_range(&sheet);
+        assert_eq!((vp.x, vp.y), (0.0, 0.0));
+        assert!((vp.width - dc * 14.0).abs() < 0.01);
+        assert!((vp.height - dr * 16.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_chart_the_budget_allows_still_grows_the_used_range() {
+        let sheet = sheet_with_chart(1);
+        let dc = col_chars_to_px(DEFAULT_COL_WIDTH_CHARS);
+        let dr = row_pt_to_px(DEFAULT_ROW_HEIGHT_PT);
+        let vp = viewport_for_used_range_within(&sheet, |grown| grown.height <= 16_384.0);
+        assert!((vp.width - dc * 14.0).abs() < 0.01);
+        assert!((vp.height - dr * 16.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_chart_past_the_budget_is_left_out_of_frame() {
+        let sheet = sheet_with_chart(2_000);
+        let used = viewport_for_range(&sheet, CellRange::parse_a1("A1:F11").unwrap());
+        let vp = viewport_for_used_range_within(&sheet, |grown| grown.height <= 16_384.0);
+        assert_eq!(vp, used);
+    }
+
+    #[test]
+    fn a_used_range_the_budget_already_refuses_grows_no_further() {
+        let sheet = sheet_with_chart(1);
+        let used = viewport_for_range(&sheet, CellRange::parse_a1("A1:F11").unwrap());
+        assert_eq!(viewport_for_used_range_within(&sheet, |_| false), used);
+    }
+
+    #[test]
+    fn a_reachable_chart_survives_an_unreachable_one() {
+        let mut sheet = sheet_with_chart(2_000);
+        sheet.charts.push(chart_at_row(1));
+        let dc = col_chars_to_px(DEFAULT_COL_WIDTH_CHARS);
+        let dr = row_pt_to_px(DEFAULT_ROW_HEIGHT_PT);
+        let vp = viewport_for_used_range_within(&sheet, |grown| grown.height <= 16_384.0);
+        assert!((vp.width - dc * 14.0).abs() < 0.01);
+        assert!((vp.height - dr * 16.0).abs() < 0.01);
     }
 }


### PR DESCRIPTION
TL;DR:


Repro file:
Any workbook whose chart is anchored ~780+ rows below a small used range. Build one from `apps/demo/public/showcase.xlsx` by editing the `twoCellAnchor` from/to rows in `xl/drawings/drawing1.xml`; the tests in `crates/betteroffice-xlsx/tests/chart_render.rs` do exactly this.

Summary:
- `render_sheet` with no explicit range no longer fails on a workbook whose chart is parked far below the data. Since #121 the default frame unioned every chart anchor into the used range, so a far chart inflated the frame past the pixel caps and the render errored with no output; at the last release the same file rendered.
- A chart now widens the default frame only while the widened frame still clears the render guards (`validate_render_size` at the requested scale, and `validate_display_region`). One that would not is left out of frame — the way a chart past the edge of an explicit viewport already is. The bound is the guard itself, so it cannot drift from it, and no caller of the default path can bypass it.
- A chart near the used range still grows the frame and is drawn: `showcase.xlsx` renders 1075x340 with its bar chart, as #121 intended.
- Explicit ranges and explicit viewports (`display_list_for`, `render_png_for`) are untouched. Pixel caps are unchanged.
- Adds `viewport_for_used_range_within`; `viewport_for_used_range` keeps its old semantics.

Test plan:
- [x] `cargo test -p betteroffice-xlsx-render -p betteroffice-xlsx-raster -p betteroffice-xlsx`
- [x] `cargo clippy -p betteroffice-xlsx-render -p betteroffice-xlsx --all-targets -- -D warnings && cargo fmt --check`
- [x] `bun run build:xlsx-wasm && bun test packages/xlsx/src/`
- [x] `xlsx render` on a chart-at-row-1000 fixture writes a 563x240 PNG, exit 0 (was exit 1, no file); on `showcase.xlsx` writes 1075x340 with the chart drawn
