### PR TITLE
fix(pptx): open a deck whose chart part cannot be read

### DIFF
--- a/.changeset/pptx-damaged-chart-part.md
+++ b/.changeset/pptx-damaged-chart-part.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/pptx": patch
+"@betteroffice/rust-crates": patch
+---
+
+A deck whose chart part cannot be read now opens with that chart missing, instead of the whole file being refused; slides, masters and text come through intact. Chart parts also get their own parse budget, so a valid deck whose charts carry large cached series opens with every chart, and the part the parser declined is still written back untouched on save.

--- a/.changeset/pptx-damaged-chart-part.md
+++ b/.changeset/pptx-damaged-chart-part.md
@@ -3,4 +3,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-A deck whose chart part cannot be read now opens with that chart missing, instead of the whole file being refused; slides, masters and text come through intact. Chart parts also get their own parse budget, so a valid deck whose charts carry large cached series opens with every chart, and the part the parser declined is still written back untouched on save.
+A deck whose chart part cannot be read now opens with that chart missing, instead of the whole file being refused; slides, masters and text come through intact. Chart parts are read against a budget of their own, so a valid deck whose charts carry large cached series opens with every chart, and the part the parser declined is still written back untouched on save. That budget is one pool for the whole deck, so a chart beyond what it covers is declined the same way.

--- a/crates/pptx-parse/src/package.rs
+++ b/crates/pptx-parse/src/package.rs
@@ -360,12 +360,18 @@ impl ChartSources<'_> {
 /// resolves to.
 ///
 /// A chart part is a decorative leaf: nothing structural is read from it and
-/// nothing structural is read after it. So each gets its own [`ParseBudget`] —
-/// one cached series can neither starve a slide nor starve the next chart — and
-/// a part `parse_xml` refuses is skipped, leaving the deck to open with that
-/// chart missing exactly as it opens when the part is absent. `parse_xml`
-/// reports only `MalformedXml`, `UnsafeXml` and `ResourceLimit`, each naming
-/// this part; a hostile package is refused earlier, by `ooxml_opc::unzip_parts`.
+/// nothing structural is read after it. So a part `parse_xml` refuses is
+/// skipped, leaving the deck to open with that chart missing exactly as it opens
+/// when the part is absent. `parse_xml` reports only `MalformedXml`, `UnsafeXml`
+/// and `ResourceLimit`, each naming this part; a hostile package is refused
+/// earlier, by `ooxml_opc::unzip_parts`.
+///
+/// What bounds the reading: each part gets its own [`ParseBudget`], so no cached
+/// series can starve a slide or spend another part's depth, byte and text
+/// limits; all of them draw their XML events from one pool the size of
+/// `max_xml_events` ([`read_chart_root`]); and each part is read once however
+/// many themes reference it, the tree being the same for all of them and only
+/// the colours it resolves against differing.
 fn parse_chart_parts(
     parts: &HashMap<&str, &[u8]>,
     sources: &ChartSources<'_>,
@@ -382,8 +388,9 @@ fn parse_chart_parts(
         collect_chart_references(&master.shapes, &master.part_path, &mut references);
     }
     let default_theme = Theme::default();
-    let mut charts = Vec::new();
+    let mut reads = Vec::new();
     let mut loaded = HashSet::new();
+    let mut pending_reads: HashMap<String, usize> = HashMap::new();
     for (source_part, relationship_id) in references {
         let Some(part_path) = sources.chart_target(&source_part, &relationship_id) else {
             continue;
@@ -393,22 +400,61 @@ fn parse_chart_parts(
         if !loaded.insert((part_path.clone(), theme_part_path.clone())) {
             continue;
         }
-        let Some(bytes) = parts.get(part_path.as_str()) else {
-            continue;
-        };
-        let Ok(root) = parse_xml(bytes, &part_path, &mut ParseBudget::new(limits)) else {
-            continue;
-        };
+        *pending_reads.entry(part_path.clone()).or_default() += 1;
         let theme = theme_part.map(|part| &part.theme).unwrap_or(&default_theme);
-        if let Some(chart) = parse_chart_part(&root, theme) {
+        reads.push((part_path, theme_part_path, theme));
+    }
+
+    let mut charts = Vec::new();
+    let mut roots: HashMap<String, Option<XmlElement>> = HashMap::new();
+    let mut remaining_events = limits.max_xml_events;
+    for (part_path, theme_part_path, theme) in reads {
+        if !roots.contains_key(&part_path) {
+            let root = parts.get(part_path.as_str()).and_then(|bytes| {
+                read_chart_root(bytes, &part_path, limits, &mut remaining_events)
+            });
+            roots.insert(part_path.clone(), root);
+        }
+        let chart = roots
+            .get(&part_path)
+            .and_then(Option::as_ref)
+            .and_then(|root| parse_chart_part(root, theme));
+        if let Some(chart) = chart {
             charts.push(ChartPart {
-                part_path,
+                part_path: part_path.clone(),
                 theme_part_path,
                 chart,
             });
         }
+        if let Some(pending) = pending_reads.get_mut(&part_path) {
+            *pending -= 1;
+            if *pending == 0 {
+                roots.remove(&part_path);
+            }
+        }
     }
     charts
+}
+
+/// Reads one chart part against its own budget, drawing its XML events from
+/// `remaining_events` — a pool the size of the package's `max_xml_events` that
+/// every chart part shares. A part that empties the pool is declined like a
+/// malformed one, so the deck's charts together cost no more than the one budget
+/// they used to be read against.
+fn read_chart_root(
+    bytes: &[u8],
+    part_path: &str,
+    limits: &ParseLimits,
+    remaining_events: &mut usize,
+) -> Option<XmlElement> {
+    let part_limits = ParseLimits {
+        max_xml_events: *remaining_events,
+        ..limits.clone()
+    };
+    let mut budget = ParseBudget::new(&part_limits);
+    let root = parse_xml(bytes, part_path, &mut budget).ok();
+    *remaining_events = remaining_events.saturating_sub(budget.xml_events_spent());
+    root
 }
 
 /// `(referencing part, relationship id)` for every chart in `shapes`, groups
@@ -635,8 +681,28 @@ mod tests {
         assert_eq!(points[1].explosion, Some(10.0));
     }
 
-    #[test]
-    fn a_shared_chart_is_resolved_once_per_referencing_theme() {
+    /// Three slides sharing `ppt/charts/chart1.xml`, resolving to two themes.
+    struct SharedChartDeck {
+        slides: Vec<Slide>,
+        layouts: Vec<SlideLayout>,
+        masters: Vec<SlideMaster>,
+        themes: Vec<ThemePart>,
+        relationships: BTreeMap<String, Vec<Relationship>>,
+    }
+
+    impl SharedChartDeck {
+        fn sources(&self) -> ChartSources<'_> {
+            ChartSources {
+                slides: &self.slides,
+                layouts: &self.layouts,
+                masters: &self.masters,
+                themes: &self.themes,
+                relationships: &self.relationships,
+            }
+        }
+    }
+
+    fn shared_chart_deck() -> SharedChartDeck {
         fn chart_shape(id: u32) -> ShapeNode {
             ShapeNode::GraphicFrame(GraphicFrame {
                 base: ShapeBase {
@@ -739,17 +805,23 @@ mod tests {
             ("ppt/slides/slide2.xml".to_owned(), chart_relationships()),
             ("ppt/slides/slide3.xml".to_owned(), chart_relationships()),
         ]);
-        let sources = ChartSources {
-            slides: &slides,
-            layouts: &layouts,
-            masters: &masters,
-            themes: &themes,
-            relationships: &relationships,
-        };
+        SharedChartDeck {
+            slides,
+            layouts,
+            masters,
+            themes,
+            relationships,
+        }
+    }
+
+    #[test]
+    fn a_shared_chart_is_resolved_once_per_referencing_theme() {
+        let deck = shared_chart_deck();
         let chart_xml = br#"<c:chartSpace xmlns:c="c" xmlns:a="a"><c:chart><c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></c:spPr></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
         let parts: HashMap<&str, &[u8]> =
             HashMap::from([("ppt/charts/chart1.xml", chart_xml.as_slice())]);
-        let charts = parse_chart_parts(&parts, &sources, &ParseLimits::default());
+
+        let charts = parse_chart_parts(&parts, &deck.sources(), &ParseLimits::default());
 
         assert_eq!(charts.len(), 2);
         assert_eq!(
@@ -761,6 +833,30 @@ mod tests {
         );
         assert_eq!(charts[0].chart.series[0].color, "#112233");
         assert_eq!(charts[1].chart.series[0].color, "#AABBCC");
+    }
+
+    /// A chart part parses to the same tree whatever theme it is coloured
+    /// against, so it is read once: an event pool only one read fits still
+    /// resolves the chart against both themes.
+    #[test]
+    fn a_shared_chart_part_is_read_once_however_many_themes_reference_it() {
+        let deck = shared_chart_deck();
+        let chart_xml = cached_chart(1_000);
+        let parts: HashMap<&str, &[u8]> =
+            HashMap::from([("ppt/charts/chart1.xml", chart_xml.as_slice())]);
+        let limits = ParseLimits {
+            max_xml_events: 6_000,
+            ..ParseLimits::default()
+        };
+
+        let charts = parse_chart_parts(&parts, &deck.sources(), &limits);
+
+        assert_eq!(charts.len(), 2);
+        assert!(
+            charts
+                .iter()
+                .all(|part| part.chart.series[0].values.len() == 1_000)
+        );
     }
 
     #[test]
@@ -887,19 +983,39 @@ mod tests {
         xml.into_bytes()
     }
 
-    /// The undamaged deck that used to be refused: spec-valid charts whose
-    /// caches together outgrow one budget. Each chart holds a cache that most
-    /// of a budget covers, so a budget shared with the slides — or with the
-    /// other chart — leaves the deck unopenable.
-    #[test]
-    fn a_deck_whose_charts_each_fill_a_budget_opens_with_every_chart() {
+    /// `chart-deck.pptx` with charts of `points` cached values and `shapes`
+    /// more shapes on the second slide, so charts and slides both cost real
+    /// events.
+    fn cached_chart_deck(points: usize, shapes: usize) -> Vec<u8> {
+        let crowd = (0..shapes)
+            .map(|shape| {
+                format!(
+                    r#"<p:sp><p:nvSpPr><p:cNvPr id="{}" name=""/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr/></p:sp>"#,
+                    shape + 100
+                )
+            })
+            .collect::<String>();
         let mut parts = ooxml_opc::unzip_parts(CHART_FIXTURE).unwrap();
         for (path, bytes) in &mut parts {
             if path.starts_with("ppt/charts/") {
-                *bytes = cached_chart(4_000);
+                *bytes = cached_chart(points);
+            }
+            if path == "ppt/slides/slide2.xml" {
+                *bytes = String::from_utf8(bytes.clone())
+                    .unwrap()
+                    .replace("</p:spTree>", &format!("{crowd}</p:spTree>"))
+                    .into_bytes();
             }
         }
-        let deck = ooxml_opc::rezip_parts(&parts).unwrap();
+        ooxml_opc::rezip_parts(&parts).unwrap()
+    }
+
+    /// The undamaged deck that used to be refused: spec-valid charts whose
+    /// caches, added to what the slides cost, outgrow one budget. The charts
+    /// draw from a pool of their own, so slides and charts both come through.
+    #[test]
+    fn a_deck_whose_charts_outgrow_the_slides_budget_opens_with_every_chart() {
+        let deck = cached_chart_deck(2_000, 1_500);
         let limits = ParseLimits {
             max_xml_events: 30_000,
             ..ParseLimits::default()
@@ -916,13 +1032,48 @@ mod tests {
                 .collect::<Vec<_>>(),
             [Some("Charts"), Some("Grouped")]
         );
+        assert_eq!(package.slides[1].shapes.len(), 1_501);
         assert_eq!(package.charts.len(), 2);
         assert!(
             package
                 .charts
                 .iter()
-                .all(|part| part.chart.series[0].values.len() == 4_000)
+                .all(|part| part.chart.series[0].values.len() == 2_000)
         );
+    }
+
+    /// The pool the charts share is one budget for the whole deck, so a chart
+    /// that empties it leaves the next one declined like a damaged part — and
+    /// the deck still opens.
+    #[test]
+    fn a_deck_whose_charts_outgrow_the_chart_budget_opens_with_the_charts_that_fit() {
+        let deck = cached_chart_deck(4_000, 1_500);
+        let limits = ParseLimits {
+            max_xml_events: 30_000,
+            ..ParseLimits::default()
+        };
+
+        let package = parse_pptx_with_limits(&deck, &limits).unwrap();
+
+        assert_eq!(package.slides.len(), 2);
+        assert_eq!(package.slides[1].shapes.len(), 1_501);
+        assert_eq!(
+            package.slides[0]
+                .shapes
+                .iter()
+                .filter(|shape| matches!(shape, ShapeNode::GraphicFrame(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            package
+                .charts
+                .iter()
+                .map(|part| part.part_path.as_str())
+                .collect::<Vec<_>>(),
+            ["ppt/charts/chart1.xml"]
+        );
+        assert_eq!(package.charts[0].chart.series[0].values.len(), 4_000);
     }
 
     #[test]

--- a/crates/pptx-parse/src/package.rs
+++ b/crates/pptx-parse/src/package.rs
@@ -155,8 +155,8 @@ pub fn parse_pptx_with_limits(data: &[u8], limits: &ParseLimits) -> Result<PptxP
             themes: &themes,
             relationships: &relationships,
         },
-        &mut budget,
-    )?;
+        limits,
+    );
 
     let content_types = parse_content_types(&parts, &mut budget)?;
     let media = source_parts
@@ -356,11 +356,21 @@ impl ChartSources<'_> {
     }
 }
 
+/// Every chart the deck references, read against the theme its source part
+/// resolves to.
+///
+/// A chart part is a decorative leaf: nothing structural is read from it and
+/// nothing structural is read after it. So each gets its own [`ParseBudget`] —
+/// one cached series can neither starve a slide nor starve the next chart — and
+/// a part `parse_xml` refuses is skipped, leaving the deck to open with that
+/// chart missing exactly as it opens when the part is absent. `parse_xml`
+/// reports only `MalformedXml`, `UnsafeXml` and `ResourceLimit`, each naming
+/// this part; a hostile package is refused earlier, by `ooxml_opc::unzip_parts`.
 fn parse_chart_parts(
     parts: &HashMap<&str, &[u8]>,
     sources: &ChartSources<'_>,
-    budget: &mut ParseBudget<'_>,
-) -> Result<Vec<ChartPart>, PptxError> {
+    limits: &ParseLimits,
+) -> Vec<ChartPart> {
     let mut references = Vec::new();
     for slide in sources.slides {
         collect_chart_references(&slide.shapes, &slide.part_path, &mut references);
@@ -386,7 +396,9 @@ fn parse_chart_parts(
         let Some(bytes) = parts.get(part_path.as_str()) else {
             continue;
         };
-        let root = parse_xml(bytes, &part_path, budget)?;
+        let Ok(root) = parse_xml(bytes, &part_path, &mut ParseBudget::new(limits)) else {
+            continue;
+        };
         let theme = theme_part.map(|part| &part.theme).unwrap_or(&default_theme);
         if let Some(chart) = parse_chart_part(&root, theme) {
             charts.push(ChartPart {
@@ -396,7 +408,7 @@ fn parse_chart_parts(
             });
         }
     }
-    Ok(charts)
+    charts
 }
 
 /// `(referencing part, relationship id)` for every chart in `shapes`, groups
@@ -528,6 +540,7 @@ mod tests {
 
     const FIXTURE: &[u8] = include_bytes!("../../../apps/demo/public/betteroffice-demo.pptx");
     const CHART_FIXTURE: &[u8] = include_bytes!("../tests/fixtures/chart-deck.pptx");
+    const CHART_PART: &str = "ppt/charts/chart1.xml";
 
     #[test]
     fn parses_betteroffice_demo_deck_surface() {
@@ -736,10 +749,7 @@ mod tests {
         let chart_xml = br#"<c:chartSpace xmlns:c="c" xmlns:a="a"><c:chart><c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></c:spPr></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
         let parts: HashMap<&str, &[u8]> =
             HashMap::from([("ppt/charts/chart1.xml", chart_xml.as_slice())]);
-        let limits = ParseLimits::default();
-        let mut budget = ParseBudget::new(&limits);
-
-        let charts = parse_chart_parts(&parts, &sources, &mut budget).unwrap();
+        let charts = parse_chart_parts(&parts, &sources, &ParseLimits::default());
 
         assert_eq!(charts.len(), 2);
         assert_eq!(
@@ -756,6 +766,163 @@ mod tests {
     #[test]
     fn a_deck_without_charts_loads_no_chart_parts() {
         assert!(parse_pptx(FIXTURE).unwrap().charts.is_empty());
+    }
+
+    /// `chart-deck.pptx` with `part`'s bytes replaced.
+    fn chart_deck_with(part: &str, bytes: &[u8]) -> Vec<u8> {
+        let mut parts = ooxml_opc::unzip_parts(CHART_FIXTURE).unwrap();
+        let slot = parts
+            .iter_mut()
+            .find(|(path, _)| path == part)
+            .unwrap_or_else(|| panic!("{part} is not in the fixture"));
+        slot.1 = bytes.to_vec();
+        ooxml_opc::rezip_parts(&parts).unwrap()
+    }
+
+    /// Opens a deck whose first chart part carries `bytes` and asserts the deck
+    /// is whole apart from that one chart.
+    fn assert_damaged_chart_is_dropped(bytes: &[u8]) {
+        let package = parse_pptx(&chart_deck_with(CHART_PART, bytes)).unwrap();
+        assert_eq!(package.slides.len(), 2);
+        assert_eq!(package.layouts.len(), 1);
+        assert_eq!(package.masters.len(), 1);
+        assert_eq!(package.themes.len(), 1);
+        assert_eq!(
+            package
+                .slides
+                .iter()
+                .map(|slide| slide.name.as_deref())
+                .collect::<Vec<_>>(),
+            [Some("Charts"), Some("Grouped")]
+        );
+        assert_eq!(
+            package.slides[0]
+                .shapes
+                .iter()
+                .filter(|shape| matches!(shape, ShapeNode::GraphicFrame(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            package
+                .charts
+                .iter()
+                .map(|part| part.part_path.as_str())
+                .collect::<Vec<_>>(),
+            ["ppt/charts/chart2.xml"]
+        );
+    }
+
+    #[test]
+    fn a_malformed_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(b"<c:chartSpace><c:chart></c:chartSpace>");
+    }
+
+    #[test]
+    fn an_empty_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(b"");
+    }
+
+    #[test]
+    fn a_doctype_bearing_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(
+            br#"<?xml version="1.0"?><!DOCTYPE c:chartSpace [<!ENTITY x "y">]><c:chartSpace xmlns:c="c"/>"#,
+        );
+    }
+
+    #[test]
+    fn a_truncated_chart_part_drops_only_that_chart() {
+        let source = ooxml_opc::unzip_parts(CHART_FIXTURE)
+            .unwrap()
+            .into_iter()
+            .find(|(path, _)| path == CHART_PART)
+            .map(|(_, bytes)| bytes)
+            .unwrap();
+        assert_damaged_chart_is_dropped(&source[..source.len() / 2]);
+    }
+
+    #[test]
+    fn a_binary_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(&[0x00, 0xff, 0xfe, 0x01, 0x80, 0x7f]);
+    }
+
+    #[test]
+    fn an_undeclared_entity_in_a_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(
+            br#"<c:chartSpace xmlns:c="c"><c:chart><c:title>&nbsp;</c:title></c:chart></c:chartSpace>"#,
+        );
+    }
+
+    /// Declining to read a chart part must not stop the package from carrying
+    /// it: an untouched save still writes the source bytes back.
+    #[test]
+    fn an_unreadable_chart_part_survives_a_save_byte_for_byte() {
+        const DAMAGED: &[u8] = b"<c:chartSpace><c:chart></c:chartSpace>";
+        let deck = chart_deck_with(CHART_PART, DAMAGED);
+        let written = write_pptx(&parse_pptx(&deck).unwrap()).unwrap();
+        assert_eq!(
+            ooxml_opc::unzip_parts(&written).unwrap(),
+            ooxml_opc::unzip_parts(&deck).unwrap()
+        );
+        assert_eq!(
+            ooxml_opc::unzip_parts(&written)
+                .unwrap()
+                .into_iter()
+                .find(|(path, _)| path == CHART_PART)
+                .map(|(_, bytes)| bytes),
+            Some(DAMAGED.to_vec())
+        );
+    }
+
+    /// A chart part whose only fault is a large cache. Every point costs the
+    /// reader five events.
+    fn cached_chart(points: usize) -> Vec<u8> {
+        let mut xml = String::from(
+            r#"<c:chartSpace xmlns:c="c" xmlns:a="a"><c:chart><c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:val><c:numRef><c:numCache>"#,
+        );
+        for point in 0..points {
+            xml.push_str(&format!("<c:pt><c:v>{point}</c:v></c:pt>"));
+        }
+        xml.push_str("</c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>");
+        xml.into_bytes()
+    }
+
+    /// The undamaged deck that used to be refused: spec-valid charts whose
+    /// caches together outgrow one budget. Each chart holds a cache that most
+    /// of a budget covers, so a budget shared with the slides — or with the
+    /// other chart — leaves the deck unopenable.
+    #[test]
+    fn a_deck_whose_charts_each_fill_a_budget_opens_with_every_chart() {
+        let mut parts = ooxml_opc::unzip_parts(CHART_FIXTURE).unwrap();
+        for (path, bytes) in &mut parts {
+            if path.starts_with("ppt/charts/") {
+                *bytes = cached_chart(4_000);
+            }
+        }
+        let deck = ooxml_opc::rezip_parts(&parts).unwrap();
+        let limits = ParseLimits {
+            max_xml_events: 30_000,
+            ..ParseLimits::default()
+        };
+
+        let package = parse_pptx_with_limits(&deck, &limits).unwrap();
+
+        assert_eq!(package.slides.len(), 2);
+        assert_eq!(
+            package
+                .slides
+                .iter()
+                .map(|slide| slide.name.as_deref())
+                .collect::<Vec<_>>(),
+            [Some("Charts"), Some("Grouped")]
+        );
+        assert_eq!(package.charts.len(), 2);
+        assert!(
+            package
+                .charts
+                .iter()
+                .all(|part| part.chart.series[0].values.len() == 4_000)
+        );
     }
 
     #[test]

--- a/crates/pptx-parse/src/xml.rs
+++ b/crates/pptx-parse/src/xml.rs
@@ -62,6 +62,11 @@ impl<'a> ParseBudget<'a> {
         }
     }
 
+    /// XML events this budget has been charged, including the one that broke it.
+    pub fn xml_events_spent(&self) -> usize {
+        self.xml_events
+    }
+
     pub fn charge_relationship(&mut self, part: &str) -> Result<(), PptxError> {
         charge(
             &mut self.relationships,


### PR DESCRIPTION
TL;DR:


Repro file:
`crates/pptx-parse/tests/fixtures/chart-deck.pptx` with `ppt/charts/chart1.xml` replaced by malformed XML, an empty part, a `<!DOCTYPE>` declaration, a truncated part, binary bytes, or `&nbsp;` — or left valid but large enough that its cached series exceed `max_xml_events`. The tests in `crates/pptx-parse/src/package.rs` build each of these in-test.

Summary:
- A deck whose chart part the parser cannot read now opens without that chart. Since #115 chart parts are parsed on open, and a failure on one of them failed the whole deck — slides, masters and text intact, no document. At the last release chart parts were never read.
- A valid deck with large cached series no longer fails on the shared XML budget. Chart parts still parse after everything structural, so `[Content_Types].xml` keeps its budget; each part parses against its own `ParseBudget` for depth, attributes and bytes, but draws its XML events from one pool the size of the package's budget, so a deck's charts together cost no more than one budget allowed before. A part that empties the pool is declined like a malformed one.
- A chart part shared by many masters is read once and its tree handed to each theme, instead of once per theme against a fresh budget.
- `parse_xml` reports only `MalformedXml`, `UnsafeXml` and `ResourceLimit` for a chart part; a hostile package is refused earlier by `ooxml_opc::unzip_parts` and still propagates.
- A skipped part is carried through a save byte for byte; the frame that referenced it stays on the slide, draws a placeholder, and can be moved, saved and reopened with its relationship intact.

Test plan:
- [x] `cargo test -p betteroffice-pptx-parse -p betteroffice-pptx -p betteroffice-pptx-render`
- [x] `cargo clippy -p betteroffice-pptx-parse --all-targets -- -D warnings && cargo fmt --check`
- [x] `bun run build:pptx-wasm && bun test packages/pptx/src/`
- [x] Counterfactuals: reverting the skip fails the trigger tests with the parse error; reverting parse-once fails the theme test; reverting the pool fails the budget test
