### PR TITLE
fix(docx): stop importing the fonts package implicitly

### DIFF
--- a/.changeset/docx-opt-in-fonts.md
+++ b/.changeset/docx-opt-in-fonts.md
@@ -1,7 +1,0 @@
----
-"@betteroffice/docx": minor
-"@betteroffice/docx-react": minor
-"@betteroffice/fonts": patch
----
-
-`@betteroffice/docx` no longer imports `@betteroffice/fonts` on its own, so installing the package does nothing by itself and its specifier is gone from the published bundle — an esbuild consumer without the optional peer builds again. Opt in with `configureDefaultFonts({ fonts })` after importing the module, or lazily with `configureDefaultFonts({ load: () => import('@betteroffice/fonts') })`; add `baseUrl` to either to serve the face binaries from a CDN.

--- a/.changeset/docx-opt-in-fonts.md
+++ b/.changeset/docx-opt-in-fonts.md
@@ -1,0 +1,7 @@
+---
+"@betteroffice/docx": minor
+"@betteroffice/docx-react": minor
+"@betteroffice/fonts": patch
+---
+
+`@betteroffice/docx` no longer imports `@betteroffice/fonts` on its own, so installing the package does nothing by itself and its specifier is gone from the published bundle — an esbuild consumer without the optional peer builds again. Opt in with `configureDefaultFonts({ fonts })` after importing the module, or lazily with `configureDefaultFonts({ load: () => import('@betteroffice/fonts') })`; add `baseUrl` to either to serve the face binaries from a CDN.

--- a/.changeset/shared-fonts-package.md
+++ b/.changeset/shared-fonts-package.md
@@ -5,4 +5,4 @@
 "@betteroffice/docx-react": minor
 ---
 
-DOCX now loads installed bundled fonts by default from `@betteroffice/fonts`, with optional CJK fonts available separately from `@betteroffice/fonts-cjk`.
+Bundled metric-compatible fonts ship as `@betteroffice/fonts`, plus `@betteroffice/fonts-cjk` for Chinese, Japanese or Korean, and DOCX uses them only when you hand the module over: `configureDefaultFonts({ fonts })`, or `configureDefaultFonts({ load: () => import('@betteroffice/fonts') })` to keep it in its own chunk. Installing the packages alone does nothing — without that call the engine reaches for no font package, measurement falls back to the browser, and pagination will not match Word. Because `@betteroffice/docx` no longer names `@betteroffice/fonts` anywhere in its published bundle, an esbuild consumer without the optional peer builds again.

--- a/apps/demo/app/docx/DocxDemoClient.tsx
+++ b/apps/demo/app/docx/DocxDemoClient.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { CollaborationProvider } from "@betteroffice/docx/collaboration";
+import { configureDefaultFonts } from "@betteroffice/docx/layout";
+import * as fonts from "@betteroffice/fonts";
 import { Logo } from "../components/Logo";
 import {
   CollaborationControls,
@@ -16,6 +18,9 @@ import {
   type CollaborationTransport,
 } from "../collab";
 import { planDemoSession } from "../../lib/demoSession";
+
+// The engine loads no fonts on its own; hand it the bundled set before any editor mounts.
+configureDefaultFonts({ fonts });
 
 // The editor is browser-only (canvas + wasm + worker); keep it out of SSR.
 const DocxEditor = dynamic(

--- a/apps/docs/content/docs/javascript.mdx
+++ b/apps/docs/content/docs/javascript.mdx
@@ -25,7 +25,9 @@ import "@betteroffice/docx-react/styles.css";
 ```
 
 `documentBuffer` accepts an `ArrayBuffer`, `Uint8Array`, `Blob`, or `File`.
-Without `onSave`, File > Save downloads the edited bytes. The other two editors
+Without `onSave`, File > Save downloads the edited bytes. For pagination that
+matches Word, add [`@betteroffice/fonts`](./packages#fonts) and configure it once
+before the editor mounts; without it the editor measures with browser fonts. The other two editors
 take their file as a `Uint8Array`:
 
 ```tsx

--- a/apps/docs/content/docs/packages.mdx
+++ b/apps/docs/content/docs/packages.mdx
@@ -34,14 +34,25 @@ same advance widths, so line breaks and pagination match Word.
 | `@betteroffice/fonts` | 7.9 MB | Carlito, Caladea, Liberation Sans/Serif/Mono, Noto Hebrew/Arabic |
 | `@betteroffice/fonts-cjk` | 33 MB | Noto Sans SC/TC/JP/KR, Noto Serif SC |
 
-`npm install @betteroffice/fonts` is the whole setup: `@betteroffice/docx` picks
-it up through an optional dynamic import, so measurement uses real font metrics
-with no wiring. Add `@betteroffice/fonts-cjk` only for Chinese, Japanese, or
-Korean text — it is separate so nobody installs 33 MB they do not need.
+The engine loads no fonts on its own and never reaches for a font package.
+Install `@betteroffice/fonts` and hand it over once, before any editor mounts:
 
-Without either, families a document does not embed measure with synthetic
-metrics and pagination will not match Word. Neither package is installed
-automatically; both are declared optional peers.
+```ts
+import { configureDefaultFonts } from "@betteroffice/docx/layout";
+import * as fonts from "@betteroffice/fonts";
+
+configureDefaultFonts({ fonts });
+```
+
+Add a `baseUrl` alongside it to fetch the binaries from your own CDN instead of
+the package assets; the module stays required either way, because it carries the
+manifest that maps a Word font name to a face. Add `@betteroffice/fonts-cjk`
+only for Chinese, Japanese, or Korean text — it is separate so nobody installs
+33 MB they do not need.
+
+Unconfigured, families a document does not embed measure with synthetic metrics
+and pagination will not match Word. Neither package is installed automatically;
+both are declared optional peers.
 
 ## Picking one
 

--- a/packages/docx-react/README.md
+++ b/packages/docx-react/README.md
@@ -79,8 +79,10 @@ revisions).
 - Real-time collaboration with people or agents; the document is a CRDT
 - Live collaborator cursors and selections, shown in each peer's color
 
-Bundled metric-compatible fonts ship in-repo, and the `measurementFontProvider`
-prop accepts a custom provider for Word-accurate metrics.
+For Word-accurate metrics install `@betteroffice/fonts` and hand it to the
+engine once at module scope — `configureDefaultFonts({ fonts })`, re-exported
+here — or pass your own provider through the `measurementFontProvider` prop.
+Without either, measurement falls back to the browser.
 
 ## Collaboration
 

--- a/packages/docx-react/src/components/DocxEditor.tsx
+++ b/packages/docx-react/src/components/DocxEditor.tsx
@@ -297,10 +297,10 @@ export interface DocxEditorProps {
   /** Translation overrides. Import a locale JSON file and pass it directly. */
   i18n?: Translations;
   /**
-   * Overrides the optional `@betteroffice/fonts` provider for this editor.
-   * Without either source, browser measurement may not paginate like Word.
-   * Configure a global CDN base before editors load; existing registries retain
-   * their provider, so that setting is not per editor or tenant.
+   * Font provider for this editor, overriding whatever `configureDefaultFonts`
+   * set globally. With neither, measurement falls back to the browser and may
+   * not paginate like Word. Call `configureDefaultFonts` before editors load;
+   * existing registries retain their provider, so it is not per editor or tenant.
    */
   measurementFontProvider?: BundledFontProvider;
 }

--- a/packages/docx-react/src/index.ts
+++ b/packages/docx-react/src/index.ts
@@ -19,7 +19,11 @@ export {
 } from './components/DocxEditor';
 
 export type { BundledFontProvider } from '@betteroffice/docx/layout';
-export { configureDefaultFonts, type DefaultFontOptions } from '@betteroffice/docx/layout';
+export {
+  configureDefaultFonts,
+  type BundledFontModule,
+  type DefaultFontOptions,
+} from '@betteroffice/docx/layout';
 
 // i18n contract — runtime only. Locale string types (LocaleStrings,
 // Translations, PartialLocaleStrings, TranslationKey) live in

--- a/packages/docx/src/layout/measure/defaultFontProvider.test.ts
+++ b/packages/docx/src/layout/measure/defaultFontProvider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 
+import * as fonts from '@betteroffice/fonts';
 import { configureDefaultFonts, resolveDefaultFontProvider } from './defaultFontProvider';
 import { TextMeasureFontRegistry, type BundledFontProvider } from './fontRegistry';
 
@@ -31,7 +32,37 @@ describe('default font provider', () => {
     configureDefaultFonts({});
   });
 
-  test('resolves real font bytes with no explicit injection', async () => {
+  test('reaches for no font package until one is configured', async () => {
+    let loaderCalls = 0;
+    configureDefaultFonts({
+      load: () => {
+        loaderCalls++;
+        return Promise.resolve(fonts);
+      },
+    });
+    configureDefaultFonts({});
+
+    expect(await resolveDefaultFontProvider()).toBeUndefined();
+    expect(loaderCalls).toBe(0);
+  });
+
+  test('leaves the chain empty when nothing is configured', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const { registered, sink } = recordingSink();
+      const registry = new TextMeasureFontRegistry(sink, { bundled: resolveDefaultFontProvider });
+
+      expect(await registry.getFontIdChain('Calibri', false, false)).toEqual([]);
+      expect(registered).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('resolves real font bytes from the passed module', async () => {
+    configureDefaultFonts({ fonts });
+
     const provider = await resolveDefaultFontProvider();
     expect(provider).toBeDefined();
 
@@ -44,7 +75,8 @@ describe('default font provider', () => {
     expect(new Uint8Array(bytes)).toEqual(new Uint8Array(await Bun.file(CARLITO_REGULAR).bytes()));
   });
 
-  test('feeds those bytes into a chain with nothing injected', async () => {
+  test('feeds those bytes into a chain', async () => {
+    configureDefaultFonts({ fonts });
     const { registered, sink } = recordingSink();
     const registry = new TextMeasureFontRegistry(sink, { bundled: resolveDefaultFontProvider });
 
@@ -54,8 +86,8 @@ describe('default font provider', () => {
     expect(registered[0]).toEqual(await Bun.file(CARLITO_REGULAR).bytes());
   });
 
-  test('serves the faces from a configured base URL', async () => {
-    configureDefaultFonts({ baseUrl: new URL('../../../../fonts/assets/', import.meta.url) });
+  test('takes the same module from a lazy loader', async () => {
+    configureDefaultFonts({ load: () => import('@betteroffice/fonts') });
 
     const provider = await resolveDefaultFontProvider();
     const bytes = await provider!.resolve('Calibri', false, false)!();
@@ -63,7 +95,36 @@ describe('default font provider', () => {
     expect(new Uint8Array(bytes)).toEqual(new Uint8Array(await Bun.file(CARLITO_REGULAR).bytes()));
   });
 
+  test('serves the faces from a configured base URL', async () => {
+    configureDefaultFonts({
+      fonts,
+      baseUrl: new URL('../../../../fonts/assets/', import.meta.url),
+    });
+
+    const provider = await resolveDefaultFontProvider();
+    const bytes = await provider!.resolve('Calibri', false, false)!();
+
+    expect(new Uint8Array(bytes)).toEqual(new Uint8Array(await Bun.file(CARLITO_REGULAR).bytes()));
+  });
+
+  test('warns that a base URL on its own loads nothing', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      configureDefaultFonts({ baseUrl: 'https://cdn.example.test/betteroffice-fonts/' });
+
+      expect(warn.mock.calls.map((call) => String(call[0])).join('\n')).toContain(
+        'a baseUrl on its own loads nothing'
+      );
+      expect(await resolveDefaultFontProvider()).toBeUndefined();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test('resolves CJK coverage faces through the optional add-on package', async () => {
+    configureDefaultFonts({ fonts });
+
     const provider = await resolveDefaultFontProvider();
     const loader = provider!.resolveScriptFallback!('cjk-sc', false, false);
     expect(loader).toBeDefined();
@@ -225,6 +286,7 @@ describe('default font provider', () => {
       const fallbacks = warn.mock.calls.filter((call) => String(call[0]).includes('no font bytes'));
       expect(fallbacks).toHaveLength(1);
       expect(String(fallbacks[0]![0])).toContain('Install @betteroffice/fonts');
+      expect(String(fallbacks[0]![0])).toContain('configureDefaultFonts({ fonts })');
       expect(String(fallbacks[0]![0])).toContain('measureText');
       expect(String(fallbacks[0]![0])).toContain('OS fonts');
     } finally {
@@ -285,7 +347,8 @@ describe('default font provider', () => {
     }
   });
 
-  test('does not warn when the default provider covers the family', async () => {
+  test('does not warn when the configured provider covers the family', async () => {
+    configureDefaultFonts({ fonts });
     const warn = spyOn(console, 'warn').mockImplementation(() => {});
 
     try {

--- a/packages/docx/src/layout/measure/defaultFontProvider.test.ts
+++ b/packages/docx/src/layout/measure/defaultFontProvider.test.ts
@@ -122,6 +122,21 @@ describe('default font provider', () => {
     }
   });
 
+  test('names a configured source that fails to load', async () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      configureDefaultFonts({ load: () => Promise.reject(new Error('chunk 404')) });
+
+      expect(await resolveDefaultFontProvider()).toBeUndefined();
+      expect(warn.mock.calls.map((call) => String(call[0])).join('\n')).toContain(
+        'the configured font source failed to load'
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test('resolves CJK coverage faces through the optional add-on package', async () => {
     configureDefaultFonts({ fonts });
 

--- a/packages/docx/src/layout/measure/defaultFontProvider.ts
+++ b/packages/docx/src/layout/measure/defaultFontProvider.ts
@@ -1,15 +1,31 @@
-/** Optional bundled-font provider resolution. @packageDocumentation */
+/** Opt-in bundled-font provider resolution. @packageDocumentation */
 
 import type { BundledFontProvider } from './fontRegistry';
 
-type BundledFontsModule = typeof import('@betteroffice/fonts');
+/**
+ * The slice of `@betteroffice/fonts` this module consumes. Structural on
+ * purpose: the engine never names that package, so no bundler ever has to
+ * resolve it.
+ *
+ * @public
+ */
+export interface BundledFontModule {
+  createFontProvider(options?: { baseUrl?: string | URL }): BundledFontProvider;
+}
 
-/** @public */
+/**
+ * How to obtain bundled fonts. Nothing is loaded until one of `fonts` or
+ * `load` is given — the engine never reaches for a font package on its own.
+ *
+ * @public
+ */
 export interface DefaultFontOptions {
-  /** Serve faces from a base URL pinned when this configuration is applied. */
-  baseUrl?: string | URL;
-  /** Override loading of the optional `@betteroffice/fonts` peer. */
+  /** The imported `@betteroffice/fonts` module. */
+  fonts?: BundledFontModule;
+  /** Lazy alternative to {@link DefaultFontOptions.fonts}, resolving to the same module. */
   load?: () => Promise<unknown>;
+  /** Fetch the faces from this base URL instead of the module's own assets. */
+  baseUrl?: string | URL;
 }
 
 let options: DefaultFontOptions = {};
@@ -28,27 +44,35 @@ function configuredBaseUrl(baseUrl: string | URL | undefined): URL | undefined {
   }
 }
 
+function hasFontSource(): boolean {
+  return options.fonts !== undefined || options.load !== undefined;
+}
+
 /** Configure the default provider and reset its memoized resolution. @public */
 export function configureDefaultFonts(next: DefaultFontOptions): void {
   options = { ...next, baseUrl: configuredBaseUrl(next.baseUrl) };
   resolved = undefined;
+  if (options.baseUrl !== undefined && !hasFontSource()) {
+    console.warn(
+      '[configureDefaultFonts] a baseUrl on its own loads nothing — the face manifest lives in ' +
+        '@betteroffice/fonts. Pass the module too: configureDefaultFonts({ fonts, baseUrl }).'
+    );
+  }
 }
 
 async function load(): Promise<BundledFontProvider | undefined> {
-  const { baseUrl, load: loader } = options;
-  // Keep this syntactic try/catch: webpack tolerates a missing optional peer
-  // here but fails the build when the import uses `.catch()`.
+  const { baseUrl, fonts, load: loader } = options;
   try {
-    const imported = await (loader ? loader() : import('@betteroffice/fonts'));
-    const module = imported as BundledFontsModule;
+    const module = fonts ?? ((await loader!()) as BundledFontModule);
     return module.createFontProvider(baseUrl === undefined ? undefined : { baseUrl });
   } catch {
     return undefined;
   }
 }
 
-/** Resolve the bundled provider, or `undefined` when its optional peer is absent. @public */
+/** Resolve the configured provider, or `undefined` when no font source is set. @public */
 export function resolveDefaultFontProvider(): Promise<BundledFontProvider | undefined> {
+  if (!hasFontSource()) return Promise.resolve(undefined);
   if (resolved === undefined) {
     const promise = load();
     promise.then((provider) => {

--- a/packages/docx/src/layout/measure/defaultFontProvider.ts
+++ b/packages/docx/src/layout/measure/defaultFontProvider.ts
@@ -65,7 +65,8 @@ async function load(): Promise<BundledFontProvider | undefined> {
   try {
     const module = fonts ?? ((await loader!()) as BundledFontModule);
     return module.createFontProvider(baseUrl === undefined ? undefined : { baseUrl });
-  } catch {
+  } catch (error) {
+    console.warn('[configureDefaultFonts] the configured font source failed to load', error);
     return undefined;
   }
 }

--- a/packages/docx/src/layout/measure/fontRegistry.ts
+++ b/packages/docx/src/layout/measure/fontRegistry.ts
@@ -405,8 +405,9 @@ export class TextMeasureFontRegistry {
         : providerResolved
           ? `[fontRegistry] no font bytes for "${family}" — the configured font provider has ` +
             `no matching face. Add coverage for this family. ${consequence}`
-          : `[fontRegistry] no font bytes for "${family}" — no font provider resolved. Install ` +
-            `@betteroffice/fonts. ${consequence}`
+          : `[fontRegistry] no font bytes for "${family}" — no font provider is configured. ` +
+            'Install @betteroffice/fonts and pass it with configureDefaultFonts({ fonts }). ' +
+            consequence
     );
   }
 

--- a/packages/docx/src/layout/measure/index.ts
+++ b/packages/docx/src/layout/measure/index.ts
@@ -21,5 +21,6 @@ export type {
 export {
   configureDefaultFonts,
   resolveDefaultFontProvider,
+  type BundledFontModule,
   type DefaultFontOptions,
 } from './defaultFontProvider';

--- a/packages/fonts-cjk/README.md
+++ b/packages/fonts-cjk/README.md
@@ -6,7 +6,7 @@ Optional CJK font binaries for [`@betteroffice/fonts`](https://www.npmjs.com/pac
 npm install @betteroffice/fonts @betteroffice/fonts-cjk
 ```
 
-Nothing else is required. `@betteroffice/fonts` picks these faces up through an optional dynamic import, so the CJK script-fallback chain starts resolving as soon as the package is present.
+Then hand the base module to the engine once, before any editor mounts — `configureDefaultFonts({ fonts })` from `@betteroffice/docx/layout`, as the [`@betteroffice/fonts` README](https://www.npmjs.com/package/@betteroffice/fonts) shows. `@betteroffice/fonts` picks these faces up through an optional dynamic import, so once the base package is configured the CJK script-fallback chain resolves as soon as this one is present.
 
 Without it nothing breaks: a CJK face resolves to a loader that rejects, the engine logs it once and measures the run with the Latin last-resort face instead. That keeps pagination on the native path, but the ideographs are measured with a font that has no glyphs for them, so CJK line breaking will be wrong.
 

--- a/packages/fonts/README.md
+++ b/packages/fonts/README.md
@@ -10,7 +10,7 @@ Measured across 813 real-world documents, scored against Word's own page count i
 
 |                            | exact page-count match | within ±1 | mean abs error |
 | -------------------------- | ---------------------- | --------- | -------------- |
-| This package installed     | **61.9%**              | 84.6%     | 0.80           |
+| This package configured    | **61.9%**              | 84.6%     | 0.80           |
 | No font provider at all    | 46.5%                  | 70.8%     | 2.47           |
 
 ## Install
@@ -19,7 +19,18 @@ Measured across 813 real-world documents, scored against Word's own page count i
 npm install @betteroffice/fonts
 ```
 
-That is the whole setup. `@betteroffice/docx` picks the package up through an optional dynamic import, so measurement starts using real font metrics with no wiring. Add [`@betteroffice/fonts-cjk`](https://www.npmjs.com/package/@betteroffice/fonts-cjk) when your documents contain Chinese, Japanese or Korean text — those five faces are 33 MB and ship separately so nobody installs them unnecessarily.
+`@betteroffice/docx` never reaches for this package on its own: nothing is co-installed, no bundler has to resolve it, and measurement stays on the browser fallback until you say otherwise. Hand the module over once, before any editor mounts:
+
+```ts
+import { configureDefaultFonts } from '@betteroffice/docx/layout';
+import * as fonts from '@betteroffice/fonts';
+
+configureDefaultFonts({ fonts });
+```
+
+`configureDefaultFonts({ load: () => import('@betteroffice/fonts') })` does the same lazily, keeping the package in its own chunk. To leave the binaries off your origin, add a `baseUrl` — see [Serving the faces from a CDN](#serving-the-faces-from-a-cdn).
+
+Add [`@betteroffice/fonts-cjk`](https://www.npmjs.com/package/@betteroffice/fonts-cjk) when your documents contain Chinese, Japanese or Korean text — those five faces are 33 MB and ship separately so nobody installs them unnecessarily.
 
 | Package                   | Faces | Size on disk | Contents                                     |
 | ------------------------- | ----- | ------------ | -------------------------------------------- |
@@ -82,11 +93,14 @@ Same-origin is the default deliberately: a CDN default would leak document-font 
 
 ```ts
 import { configureDefaultFonts } from '@betteroffice/docx/layout';
+import * as fonts from '@betteroffice/fonts';
 
-configureDefaultFonts({ baseUrl: 'https://cdn.example.com/betteroffice-fonts/' });
+configureDefaultFonts({ fonts, baseUrl: 'https://cdn.example.com/betteroffice-fonts/' });
 ```
 
 or by building the provider yourself with `createFontProvider({ baseUrl })`. The base URL is joined with each face's asset filename, so serve the contents of `assets/` at that path.
+
+**A base URL moves the binaries, not the package.** The manifest that maps a Word font name to a face lives in this package's 14 KB of JavaScript, so a CDN deployment still installs `@betteroffice/fonts`; what it stops shipping is the 7.9 MB of faces. A `baseUrl` with no module loads nothing and warns.
 
 `configureDefaultFonts` is process-global: call it at module initialization before any editor resolves fonts, not from `useEffect`; existing registries retain their provider, and a multi-tenant server cannot use it to choose different base URLs per tenant.
 
@@ -100,18 +114,9 @@ Serve the files with `Content-Encoding: br` or `gzip`. The faces are TTF/OTF rat
 
 ## Bundler note
 
-Both optional edges — `@betteroffice/docx` → `@betteroffice/fonts`, and `@betteroffice/fonts` → `@betteroffice/fonts-cjk` — are dynamic `import()`s of packages declared as optional peer dependencies. At runtime an absent package is caught and degraded.
+One optional edge is left: `@betteroffice/fonts` → `@betteroffice/fonts-cjk`, a dynamic `import()` of an optional peer dependency, caught and degraded at runtime when the add-on is absent. `@betteroffice/docx` no longer names this package at all, so nothing has to resolve it to build.
 
-Measured with the peer **not** installed:
-
-| Bundler | Result |
-| --- | --- |
-| **esbuild** | **build fails**, exit 1, no output |
-| Vite | clean, silent |
-| Next (Turbopack) | clean, silent |
-| Next (webpack), webpack, rollup | succeeds with a non-fatal warning |
-
-**esbuild is the one that breaks.** It resolves the specifier at build time and refuses to emit anything, so a consumer who has not installed `@betteroffice/fonts` cannot build at all.
+Measured with the add-on **not** installed, esbuild 0.28 builds cleanly and leaves the unresolved specifier in the output for the runtime catch. That holds only while the `await import()` is the direct body of the try — put it behind a conditional and esbuild resolves it eagerly and fails with exit 1, which is exactly how this package's own edge used to break consumer builds. Vite and Turbopack are clean; webpack and rollup warn.
 
 ### rollup and esbuild must not bundle this package
 
@@ -134,9 +139,9 @@ export default {
 };
 ```
 
-Externalizing resolves both problems at once: the absent-peer build failure and the asset-URL breakage. Verified against the packed tarballs — externalized, both bundlers load 628,032 bytes of Carlito and 8,331,336 bytes of Noto Sans SC; inlined, both fail every load.
+Verified against the packed tarballs — externalized, both bundlers load 628,032 bytes of Carlito and 8,331,336 bytes of Noto Sans SC; inlined, both fail every load.
 
-For the engine edge specifically, `configureDefaultFonts({ load })` replaces the import entirely, so you can point it at your own module and keep the specifier out of your graph. `configureDefaultFonts({ baseUrl })` sidesteps asset URLs altogether by fetching every face over HTTP.
+`configureDefaultFonts({ fonts, baseUrl })` sidesteps the asset URLs altogether by fetching every face over HTTP, which removes the reason to externalize this package at all.
 
 ## Deterministic resolution
 
@@ -144,7 +149,7 @@ With the bundled provider available, measurement never consults OS-installed fon
 
 ## API
 
-Most hosts need none of this — installing the package is enough. It is here for custom byte sources, non-docx consumers, and browser-side `FontFace` registration.
+Most hosts need none of this — `configureDefaultFonts({ fonts })` is enough. It is here for custom byte sources, non-docx consumers, and browser-side `FontFace` registration.
 
 ```ts
 import {

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -411,11 +411,10 @@ export interface FontAssetOptions {
 let cjkAssetUrls: Promise<Record<string, () => URL> | undefined> | undefined;
 
 async function importCjkAssetUrls(): Promise<Record<string, () => URL> | undefined> {
-  // Keep the SYNTACTIC try/catch around the await. Rewriting this as
-  // `import(…).catch()` or a two-argument `.then()` makes webpack (and so
-  // `next build`) fail hard instead of emitting a warning for the absent
-  // optional peer; only this shape is tolerated. esbuild recognises the
-  // opposite idiom and errors either way — see the bundler note in README.md.
+  // Keep the SYNTACTIC try/catch with the await as its direct body. Rewriting
+  // this as `import(…).catch()` or a two-argument `.then()` makes webpack (and
+  // so `next build`) fail hard on the absent optional peer, and esbuild starts
+  // resolving the specifier eagerly the moment it stops being that direct body.
   try {
     return (await import('@betteroffice/fonts-cjk')).CJK_FONT_ASSET_URLS;
   } catch {


### PR DESCRIPTION
TL;DR:


Summary:
- `@betteroffice/docx` no longer imports `@betteroffice/fonts` on its own. The default font provider fell back to a literal `import('@betteroffice/fonts')` inside a conditional — a shape esbuild refuses to bundle when the optional peer is absent (`try { await import(x) }` alone is tolerated; `try { await (cond ? f() : import(x)) }` is not, measured on esbuild 0.28.1). Any esbuild consumer without the package failed to build; `docx-react` consumers hit it transitively through value imports from `@betteroffice/docx/layout`.
- The engine now never reaches for a font package on its own. Unconfigured, `resolveDefaultFontProvider()` resolves `undefined` immediately and measurement stays on the browser fallback, exactly as when the package is absent. The specifier no longer appears anywhere in the published bundle.
- Two explicit opt-ins, both routed through the existing `configureDefaultFonts`: pass the imported module with `{ fonts }` (new option, typed by a structural `BundledFontModule` so the engine names no package), or lazily with `{ load: () => import('@betteroffice/fonts') }` to keep it in its own chunk. Add `baseUrl` to either to serve the 7.9 MB of binaries from a CDN; the module itself is still needed there because the manifest mapping a Word family to a face lives in it, and a `baseUrl` on its own now warns instead of silently loading nothing.
- Docs that promised "install it and it is picked up with no wiring" are rewritten (`packages/fonts/README.md`, `apps/docs/content/docs/packages.mdx`); the fonts README's bundler note is corrected to what was re-measured. The demo relied on the implicit pickup and now configures fonts explicitly.
- Five existing tests asserted the implicit fallback and now pass the module; six new tests cover unconfigured, `fonts`, `load`, `fonts` + `baseUrl`, and the `baseUrl`-alone warning.

Test plan:
- [x] `bun run build:docx-wasm && bun test packages/docx/src/` and `packages/docx-react/src/` and `packages/fonts/src/`
- [x] `bun run typecheck:packages`
- [x] `bun test apps/web/app/llms-txt.test.js`
- [x] esbuild `--bundle --format=esm --platform=browser` of an entry importing `@betteroffice/docx/layout`, and one importing `@betteroffice/docx-react`, with `@betteroffice/fonts` absent and no `--external`: both succeed. Counterfactual against `main`'s dist: `Could not resolve "@betteroffice/fonts"`.
- [x] `grep` of `packages/docx/dist/` for the specifier in import position: none.
- [x] Vite build of both entries still succeeds.
