### PR TITLE
fix(docx): open a document whose chart part cannot be read

### DIFF
--- a/.changeset/docx-damaged-chart-part.md
+++ b/.changeset/docx-damaged-chart-part.md
@@ -3,4 +3,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-A document whose chart part cannot be read now opens with that chart missing, instead of the whole file being refused; paragraphs, tables and text come through intact. Chart parts also get their own parse budget, so a valid document whose charts carry large cached series opens with every chart, and the part the parser declined is still written back untouched on save.
+A document whose chart part cannot be read, or is absent from the package, now opens with that chart missing instead of the whole file being refused, and the drawing that referenced it is carried as opaque content — a full save drops it, as it already drops every chart, rather than writing it back as a picture pointing at whatever `rId1` happens to be. Chart parts read against one shared event allowance, so a document cannot spend more on charts than one part was allowed before, and the part the parser declined is still written back untouched on save.

--- a/.changeset/docx-damaged-chart-part.md
+++ b/.changeset/docx-damaged-chart-part.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+A document whose chart part cannot be read now opens with that chart missing, instead of the whole file being refused; paragraphs, tables and text come through intact. Chart parts also get their own parse budget, so a valid document whose charts carry large cached series opens with every chart, and the part the parser declined is still written back untouched on save.

--- a/crates/betteroffice-docx/tests/document.rs
+++ b/crates/betteroffice-docx/tests/document.rs
@@ -101,3 +101,59 @@ fn lays_out_typed_input_and_builds_a_display_list() {
     assert_eq!(result.display_list.pages.len(), 1);
     assert!(!result.display_list.pages[0].primitives.is_empty());
 }
+
+const DAMAGED_CHART: &[u8] = b"<c:chartSpace><c:chart></c:chartSpace>";
+
+/// A document whose only chart part cannot be read.
+fn damaged_chart_docx() -> Vec<u8> {
+    let parts = vec![
+        (
+            "[Content_Types].xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#.to_vec(),
+        ),
+        (
+            "_rels/.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#.to_vec(),
+        ),
+        (
+            "word/_rels/document.xml.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="charts/chart1.xml"/></Relationships>"#.to_vec(),
+        ),
+        (
+            "word/document.xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><w:body><w:p w14:paraId="11111111"><w:r><w:t>Hello DOCX</w:t></w:r></w:p><w:p w14:paraId="22222222"><w:r><w:drawing><wp:inline><wp:extent cx="5486400" cy="3200400"/><wp:docPr id="1" name="Chart 1"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rIdChart1"/></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p><w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr></w:body></w:document>"#.to_vec(),
+        ),
+        ("word/charts/chart1.xml".to_owned(), DAMAGED_CHART.to_vec()),
+    ];
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// Declining to read a chart part must not stop the package from carrying it:
+/// an untouched save still writes the source bytes back.
+#[test]
+fn an_unreadable_chart_part_survives_a_save_byte_for_byte() {
+    let bytes = damaged_chart_docx();
+    let document = Document::open(&bytes).unwrap();
+    assert_eq!(document.structure().body_paragraphs, 2);
+    assert_eq!(
+        get_paragraph_text(document.paragraph("11111111").unwrap()),
+        "Hello DOCX"
+    );
+    assert!(document.model().charts.is_empty());
+
+    let before = ooxml_opc::unzip_parts(&bytes).unwrap();
+    let after = ooxml_opc::unzip_parts(&document.save().unwrap()).unwrap();
+    let part_bytes = |parts: &[(String, Vec<u8>)]| {
+        parts
+            .iter()
+            .find(|(path, _)| path == "word/charts/chart1.xml")
+            .map(|(_, bytes)| bytes.clone())
+            .unwrap()
+    };
+    assert_eq!(part_bytes(&after), DAMAGED_CHART);
+    assert_eq!(part_bytes(&after), part_bytes(&before));
+    assert_eq!(
+        after.iter().map(|(path, _)| path).collect::<Vec<_>>(),
+        before.iter().map(|(path, _)| path).collect::<Vec<_>>()
+    );
+}

--- a/crates/betteroffice-docx/tests/document.rs
+++ b/crates/betteroffice-docx/tests/document.rs
@@ -1,4 +1,7 @@
-use betteroffice_docx::{Document, LayoutInput, ParseLimits, get_paragraph_text};
+use betteroffice_docx::{
+    BlockContent, Document, InlineNode, LayoutInput, ParagraphContent, ParseLimits, RunContent,
+    get_paragraph_text,
+};
 
 fn sample_docx() -> Vec<u8> {
     let parts = vec![
@@ -156,4 +159,146 @@ fn an_unreadable_chart_part_survives_a_save_byte_for_byte() {
         after.iter().map(|(path, _)| path).collect::<Vec<_>>(),
         before.iter().map(|(path, _)| path).collect::<Vec<_>>()
     );
+}
+
+const CHART_DRAWING: &str = r#"<w:drawing><wp:inline><wp:extent cx="5486400" cy="3200400"/><wp:docPr id="1" name="Chart 1"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rId5"/></a:graphicData></a:graphic></wp:inline></w:drawing>"#;
+
+const STORY_NAMESPACES: &str = r#"xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart""#;
+
+/// A Word-shaped package whose body, header and footnote each hold the same
+/// chart drawing, and whose `rId1` is the styles part Word always puts there.
+fn charted_story_docx(chart_part: Option<&[u8]>) -> Vec<u8> {
+    let mut parts = vec![
+        (
+            "[Content_Types].xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/><Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/><Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/><Override PartName="/word/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#.to_vec(),
+        ),
+        (
+            "_rels/.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#.to_vec(),
+        ),
+        (
+            "word/_rels/document.xml.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/><Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="charts/chart1.xml"/></Relationships>"#.to_vec(),
+        ),
+        (
+            "word/styles.xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:docDefaults><w:rPrDefault><w:rPr><w:sz w:val="24"/></w:rPr></w:rPrDefault></w:docDefaults></w:styles>"#.to_vec(),
+        ),
+        (
+            "word/document.xml".to_owned(),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document {STORY_NAMESPACES}><w:body><w:p w14:paraId="11111111"><w:r><w:t>Hello DOCX</w:t></w:r></w:p><w:p w14:paraId="33333333"><w:r><w:footnoteReference w:id="1"/></w:r></w:p><w:p w14:paraId="22222222"><w:r>{CHART_DRAWING}</w:r></w:p><w:sectPr><w:headerReference w:type="default" r:id="rId2"/><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr></w:body></w:document>"#
+            )
+            .into_bytes(),
+        ),
+        (
+            "word/header1.xml".to_owned(),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr {STORY_NAMESPACES}><w:p w14:paraId="44444444"><w:r><w:t>Native header</w:t></w:r></w:p><w:p w14:paraId="55555555"><w:r>{CHART_DRAWING}</w:r></w:p></w:hdr>"#
+            )
+            .into_bytes(),
+        ),
+        (
+            "word/footnotes.xml".to_owned(),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:footnotes {STORY_NAMESPACES}><w:footnote w:id="-1" w:type="separator"><w:p w14:paraId="77777777"><w:r><w:separator/></w:r></w:p></w:footnote><w:footnote w:id="1"><w:p w14:paraId="66666666"><w:r><w:t>Note text</w:t></w:r><w:r>{CHART_DRAWING}</w:r></w:p></w:footnote></w:footnotes>"#
+            )
+            .into_bytes(),
+        ),
+    ];
+    if let Some(bytes) = chart_part {
+        parts.push(("word/charts/chart1.xml".to_owned(), bytes.to_vec()));
+    }
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// The drawings in `content` no chart was read for.
+fn opaque_drawings(content: &[BlockContent]) -> usize {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            BlockContent::Paragraph(paragraph) => Some(paragraph),
+            _ => None,
+        })
+        .flat_map(|paragraph| &paragraph.content)
+        .filter_map(|item| match item {
+            ParagraphContent::Inline(InlineNode::Run(run)) => Some(run),
+            _ => None,
+        })
+        .flat_map(|run| &run.content)
+        .filter(|item| matches!(item, RunContent::OpaqueDrawing { .. }))
+        .count()
+}
+
+fn saved_part(parts: &[(String, Vec<u8>)], path: &str) -> String {
+    parts
+        .iter()
+        .find(|(name, _)| name == path)
+        .map(|(_, bytes)| String::from_utf8_lossy(bytes).into_owned())
+        .unwrap_or_else(|| panic!("{path} is not in the package"))
+}
+
+/// A drawing whose chart part the parser has no chart for must stay opaque:
+/// reading it as a picture would invent a `<a:blip r:embed="rId1"/>`, and in a
+/// Word-shaped package `rId1` is the styles part. A full save drops the
+/// drawing, exactly as it drops a chart it did read.
+fn assert_no_stray_picture(chart_part: Option<&[u8]>) {
+    let bytes = charted_story_docx(chart_part);
+    let mut document = Document::open(&bytes).unwrap();
+    assert_eq!(document.structure().body_paragraphs, 3);
+    assert!(document.model().charts.is_empty());
+    for story in [
+        document.model().body.content.clone(),
+        document.headers()[0].1.content.clone(),
+        document.model().footnotes[0].content.clone(),
+    ] {
+        assert_eq!(opaque_drawings(&story), 1);
+    }
+
+    document
+        .replace_paragraph_text("11111111", "Edited natively")
+        .unwrap();
+    let saved = document.save().unwrap();
+
+    let parts = ooxml_opc::unzip_parts(&saved).unwrap();
+    for path in [
+        "word/document.xml",
+        "word/header1.xml",
+        "word/footnotes.xml",
+    ] {
+        let xml = saved_part(&parts, path);
+        assert!(!xml.contains("pic:pic"), "{path} gained a picture");
+        assert!(!xml.contains("a:blip"), "{path} gained a picture");
+        assert!(
+            !xml.contains(r#"r:embed="rId1""#),
+            "{path} embeds the styles part"
+        );
+    }
+    assert!(saved_part(&parts, "word/document.xml").contains("Edited natively"));
+    assert_eq!(
+        chart_part,
+        parts
+            .iter()
+            .find(|(path, _)| path == "word/charts/chart1.xml")
+            .map(|(_, bytes)| bytes.as_slice())
+    );
+
+    let reopened = Document::open(&saved).unwrap();
+    assert_eq!(reopened.structure(), document.structure());
+    assert_eq!(opaque_drawings(&reopened.model().body.content), 0);
+    assert_eq!(
+        get_paragraph_text(reopened.paragraph("11111111").unwrap()),
+        "Edited natively"
+    );
+}
+
+#[test]
+fn an_unreadable_chart_part_writes_no_picture_in_any_story() {
+    assert_no_stray_picture(Some(DAMAGED_CHART));
+}
+
+#[test]
+fn an_absent_chart_part_writes_no_picture_in_any_story() {
+    assert_no_stray_picture(None);
 }

--- a/crates/docx-parse/src/chart.rs
+++ b/crates/docx-parse/src/chart.rs
@@ -117,25 +117,38 @@ pub fn parse_chart_xml(
 ///
 /// A chart part is a decorative leaf: nothing structural is read from it and
 /// nothing structural is read after it. So each gets its own [`ParseBudget`] —
-/// one cached series can neither starve the body nor starve the next chart —
-/// and a part `parse_xml` refuses is skipped, leaving the document to open with
-/// that chart missing exactly as it opens when the part is absent. `parse_xml`
-/// reports only `MalformedXml`, `UnsafeXml` and `ResourceLimit`, each naming
-/// this part; a hostile package is refused earlier, by `ooxml_opc::unzip_parts`.
-/// A path [`normalize_chart_path`] rejects cannot name a chart part either, so
-/// it is skipped the same way.
+/// one cached series can neither starve the body nor starve the next chart on
+/// depth, attributes or text — and a part `parse_xml` refuses is skipped,
+/// leaving the document to open with that chart missing exactly as it opens
+/// when the part is absent. `parse_xml` reports only `MalformedXml`,
+/// `UnsafeXml` and `ResourceLimit`, each naming this part; a hostile package is
+/// refused earlier, by `ooxml_opc::unzip_parts`. A path
+/// [`normalize_chart_path`] rejects cannot name a chart part either, so it is
+/// skipped the same way.
+///
+/// What bounds the whole is one shared allowance of `max_xml_events`: every
+/// part draws its event budget from the same remainder, so all the charts
+/// together cost no more reads than one part was allowed before. A part the
+/// remainder cannot cover is declined like a malformed one. Nothing else is
+/// shared, so per-part isolation still holds.
 pub fn parse_chart_parts(
     all_xml: &IndexMap<String, Vec<u8>>,
     limits: &ParseLimits,
 ) -> ChartPartsMap {
     let mut charts = ChartPartsMap::new();
+    let mut events = limits.max_xml_events;
     for (path, xml) in all_xml {
         let Some(normalized) = chart_part_path(path) else {
             continue;
         };
-        let Ok(Some(chart)) =
-            parse_chart_xml(xml, Some(&normalized), path, &mut ParseBudget::new(limits))
-        else {
+        let part_limits = ParseLimits {
+            max_xml_events: events,
+            ..limits.clone()
+        };
+        let mut budget = ParseBudget::new(&part_limits);
+        let parsed = parse_chart_xml(xml, Some(&normalized), path, &mut budget);
+        events -= budget.xml_events();
+        let Ok(Some(chart)) = parsed else {
             continue;
         };
         charts.insert(normalized.clone(), chart.clone());
@@ -177,42 +190,52 @@ pub fn normalize_chart_path(target: &str) -> Result<String, ParseError> {
     Ok(normalized)
 }
 
+/// What chart reading made of one `<w:drawing>`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DrawingChart {
+    /// The drawing names no internal chart part.
+    None,
+    /// The drawing names a chart part this package has no chart for: the
+    /// parser declined it, or it is missing. Anything else the drawing holds
+    /// belongs to that chart, so it must not be read as a picture.
+    Unread,
+    /// The chart the drawing names.
+    Chart(Box<Chart>),
+}
+
 pub fn parse_chart_from_drawing(
     drawing: &XmlElement,
     relationships: Option<&RelationshipMap>,
     charts: Option<&ChartPartsMap>,
-) -> Result<Option<Chart>, ParseError> {
+) -> Result<DrawingChart, ParseError> {
     let (Some(relationships), Some(charts)) = (relationships, charts) else {
-        return Ok(None);
+        return Ok(DrawingChart::None);
     };
-    if charts.is_empty() {
-        return Ok(None);
-    }
     let Some(chart_ref) = first_deep(drawing, "chart", 0) else {
-        return Ok(None);
+        return Ok(DrawingChart::None);
     };
     let Some(relationship_id) = chart_ref.attribute(Some("r"), "id") else {
-        return Ok(None);
+        return Ok(DrawingChart::None);
     };
     let Some(relationship) = relationships.get(relationship_id) else {
-        return Ok(None);
+        return Ok(DrawingChart::None);
     };
     if relationship.relationship_type != relationship_types::CHART
         || relationship.target_mode == Some(TargetMode::External)
     {
-        return Ok(None);
+        return Ok(DrawingChart::None);
     }
     let path = normalize_chart_path(&relationship.target)?;
     let alias = path.strip_prefix("word/").unwrap_or(&path);
     let Some(source) = charts.get(&path).or_else(|| charts.get(alias)) else {
-        return Ok(None);
+        return Ok(DrawingChart::Unread);
     };
     let mut chart = source.clone();
     apply_drawing_metadata(&mut chart, drawing);
     chart.relationship_id = Some(relationship_id.to_owned());
     chart.path = Some(path);
     chart.size = parse_drawing_extent(drawing).or(chart.size);
-    Ok(Some(chart))
+    Ok(DrawingChart::Chart(Box::new(chart)))
 }
 
 fn first_deep<'a>(root: &'a XmlElement, local: &str, depth: usize) -> Option<&'a XmlElement> {
@@ -414,14 +437,14 @@ mod tests {
             &mut budget,
         )
         .unwrap();
-        assert!(
+        assert_eq!(
             parse_chart_from_drawing(
                 document.root().unwrap(),
                 Some(&relationships),
                 Some(&charts)
             )
-            .unwrap()
-            .is_none()
+            .unwrap(),
+            DrawingChart::None
         );
     }
 
@@ -490,6 +513,87 @@ mod tests {
         ooxml_opc::rezip_parts(&parts).unwrap()
     }
 
+    /// [`DOCUMENT_XML`] with `count` more one-run paragraphs before the section.
+    fn padded_document_xml(count: usize) -> Vec<u8> {
+        let padding = (0..count)
+            .map(|index| {
+                format!(
+                    r#"<w:p w14:paraId="{:08X}"><w:r><w:t>pad</w:t></w:r></w:p>"#,
+                    0x0100_0000 + index
+                )
+            })
+            .collect::<String>();
+        String::from_utf8(DOCUMENT_XML.to_vec())
+            .unwrap()
+            .replace("<w:sectPr>", &format!("{padding}<w:sectPr>"))
+            .into_bytes()
+    }
+
+    /// A document of `count` charted paragraphs, each chart caching `points`.
+    fn many_chart_docx(count: usize, points: usize) -> Vec<u8> {
+        let mut overrides = String::new();
+        let mut relationships = String::new();
+        let mut body = String::new();
+        let mut chart_parts = Vec::new();
+        for index in 1..=count {
+            overrides.push_str(&format!(
+                r#"<Override PartName="/word/charts/chart{index}.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>"#
+            ));
+            relationships.push_str(&format!(
+                r#"<Relationship Id="rIdChart{index}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="charts/chart{index}.xml"/>"#
+            ));
+            body.push_str(&format!(
+                r#"<w:p w14:paraId="{:08X}"><w:r><w:drawing><wp:inline><wp:extent cx="5486400" cy="3200400"/><wp:docPr id="{index}" name="Chart {index}"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rIdChart{index}"/></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#,
+                0x0200_0000 + index
+            ));
+            chart_parts.push((format!("word/charts/chart{index}.xml"), chart_space(points)));
+        }
+        let mut parts = vec![
+            (
+                "[Content_Types].xml".to_owned(),
+                format!(
+                    r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>{overrides}</Types>"#
+                )
+                .into_bytes(),
+            ),
+            ("_rels/.rels".to_owned(), ROOT_RELS.to_vec()),
+            (
+                "word/_rels/document.xml.rels".to_owned(),
+                format!(
+                    r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{relationships}</Relationships>"#
+                )
+                .into_bytes(),
+            ),
+            (
+                "word/document.xml".to_owned(),
+                format!(
+                    r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><w:body>{body}<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr></w:body></w:document>"#
+                )
+                .into_bytes(),
+            ),
+        ];
+        parts.extend(chart_parts);
+        ooxml_opc::rezip_parts(&parts).unwrap()
+    }
+
+    /// The drawings in `content` no chart was read for.
+    fn opaque_drawings(content: &[BlockContent]) -> usize {
+        content
+            .iter()
+            .filter_map(|block| match block {
+                BlockContent::Paragraph(paragraph) => Some(paragraph),
+                _ => None,
+            })
+            .flat_map(|paragraph| &paragraph.content)
+            .filter_map(|item| match item {
+                ParagraphContent::Inline(InlineNode::Run(run)) => Some(run),
+                _ => None,
+            })
+            .flat_map(|run| &run.content)
+            .filter(|item| matches!(item, RunContent::OpaqueDrawing { .. }))
+            .count()
+    }
+
     /// The chart part every charted run in `content` resolved to.
     fn body_charts(content: &[BlockContent]) -> Vec<String> {
         content
@@ -537,6 +641,7 @@ mod tests {
             ["word/charts/chart2.xml", "charts/chart2.xml"]
         );
         assert_eq!(body_charts(content), ["word/charts/chart2.xml"]);
+        assert_eq!(opaque_drawings(content), 1);
     }
 
     #[test]
@@ -547,6 +652,12 @@ mod tests {
     #[test]
     fn an_empty_chart_part_drops_only_that_chart() {
         assert_damaged_chart_is_dropped(b"");
+    }
+
+    /// A chart part that reads but models nothing is declined the same way.
+    #[test]
+    fn a_chart_part_without_a_chart_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(br#"<c:chartSpace xmlns:c="c"/>"#);
     }
 
     #[test]
@@ -596,20 +707,22 @@ mod tests {
     }
 
     /// The undamaged document that used to be refused: spec-valid charts whose
-    /// caches together outgrow one budget. Each chart holds a cache that most
-    /// of a budget covers, so a budget shared with the body — or with the other
-    /// chart — leaves the document unopenable.
+    /// caches fill the chart allowance on their own, in a body the same budget
+    /// could not have covered too.
     #[test]
-    fn a_document_whose_charts_each_fill_a_budget_opens_with_every_chart() {
+    fn a_document_whose_charts_fill_the_chart_budget_opens_with_every_chart() {
         let mut parts = chart_docx();
         for (path, bytes) in &mut parts {
             if path.starts_with("word/charts/") {
                 *bytes = chart_space(4_000);
             }
+            if path == "word/document.xml" {
+                *bytes = padded_document_xml(400);
+            }
         }
         let document = ooxml_opc::rezip_parts(&parts).unwrap();
         let limits = ParseLimits {
-            max_xml_events: 30_000,
+            max_xml_events: 41_000,
             ..ParseLimits::default()
         };
 
@@ -628,6 +741,32 @@ mod tests {
                 .iter()
                 .all(|(_, chart)| chart.series[0].values.len() == 4_000)
         );
+    }
+
+    /// Chart parts draw on one shared event allowance. The parts it covers are
+    /// read; the rest are declined and their drawings stay opaque.
+    #[test]
+    fn charts_past_the_shared_event_budget_are_declined() {
+        let limits = ParseLimits {
+            max_xml_events: 12_000,
+            ..ParseLimits::default()
+        };
+
+        let package = parse_docx_s9_wire_with_limits(
+            &many_chart_docx(4, 1_000),
+            S9ParseOptions::default(),
+            &limits,
+        )
+        .unwrap()
+        .document
+        .package;
+
+        assert_eq!(package.document.content.len(), 4);
+        assert_eq!(
+            body_charts(&package.document.content),
+            ["word/charts/chart1.xml", "word/charts/chart2.xml"]
+        );
+        assert_eq!(opaque_drawings(&package.document.content), 2);
     }
 
     #[test]

--- a/crates/docx-parse/src/chart.rs
+++ b/crates/docx-parse/src/chart.rs
@@ -13,7 +13,7 @@ use crate::image::{
 use crate::relationships::{
     RelationshipMap, TargetMode, relationship_types, resolve_relative_path,
 };
-use crate::xml::{ParseBudget, ParseError, XmlElement, parse_xml};
+use crate::xml::{ParseBudget, ParseError, ParseLimits, XmlElement, parse_xml};
 
 pub use ooxml_drawingml::chart::{
     ChartAxes, ChartAxis, ChartLegend, ChartMarker, ChartPlotGroup, ChartPoint, ChartSeries,
@@ -112,29 +112,53 @@ pub fn parse_chart_xml(
     }))
 }
 
+/// Every chart the package carries, keyed by its normalized path and by the
+/// `word/`-relative alias a drawing may reference it under.
+///
+/// A chart part is a decorative leaf: nothing structural is read from it and
+/// nothing structural is read after it. So each gets its own [`ParseBudget`] —
+/// one cached series can neither starve the body nor starve the next chart —
+/// and a part `parse_xml` refuses is skipped, leaving the document to open with
+/// that chart missing exactly as it opens when the part is absent. `parse_xml`
+/// reports only `MalformedXml`, `UnsafeXml` and `ResourceLimit`, each naming
+/// this part; a hostile package is refused earlier, by `ooxml_opc::unzip_parts`.
+/// A path [`normalize_chart_path`] rejects cannot name a chart part either, so
+/// it is skipped the same way.
 pub fn parse_chart_parts(
     all_xml: &IndexMap<String, Vec<u8>>,
-    budget: &mut ParseBudget<'_>,
-) -> Result<ChartPartsMap, ParseError> {
+    limits: &ParseLimits,
+) -> ChartPartsMap {
     let mut charts = ChartPartsMap::new();
     for (path, xml) in all_xml {
-        let normalized = normalize_chart_path(path)?;
-        let lower = normalized.to_ascii_lowercase();
-        if !lower.starts_with("word/charts/") || !lower.ends_with(".xml") {
+        let Some(normalized) = chart_part_path(path) else {
             continue;
-        }
-        if let Some(chart) = parse_chart_xml(xml, Some(&normalized), path, budget)? {
-            charts.insert(normalized.clone(), chart.clone());
-            charts.insert(
-                normalized
-                    .strip_prefix("word/")
-                    .unwrap_or(&normalized)
-                    .to_owned(),
-                chart,
-            );
-        }
+        };
+        let Ok(Some(chart)) =
+            parse_chart_xml(xml, Some(&normalized), path, &mut ParseBudget::new(limits))
+        else {
+            continue;
+        };
+        charts.insert(normalized.clone(), chart.clone());
+        charts.insert(
+            normalized
+                .strip_prefix("word/")
+                .unwrap_or(&normalized)
+                .to_owned(),
+            chart,
+        );
     }
-    Ok(charts)
+    charts
+}
+
+/// Whether [`parse_chart_parts`] reads `path` as a chart part.
+pub fn is_chart_part(path: &str) -> bool {
+    chart_part_path(path).is_some()
+}
+
+fn chart_part_path(path: &str) -> Option<String> {
+    let normalized = normalize_chart_path(path).ok()?;
+    let lower = normalized.to_ascii_lowercase();
+    (lower.starts_with("word/charts/") && lower.ends_with(".xml")).then_some(normalized)
 }
 
 pub fn normalize_chart_path(target: &str) -> Result<String, ParseError> {
@@ -312,7 +336,15 @@ fn apply_drawing_metadata(chart: &mut Chart, drawing: &XmlElement) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block::BlockContent;
+    use crate::document::get_paragraph_text;
+    use crate::inline::{InlineNode, RunContent};
+    use crate::paragraph::ParagraphContent;
     use crate::relationships::{Relationship, TargetMode};
+    use crate::s4::parse_docx_s4_projection;
+    use crate::s6::parse_docx_s6_projection;
+    use crate::s8::parse_docx_s8_projection;
+    use crate::s9::{S9ParseOptions, parse_docx_s9_wire, parse_docx_s9_wire_with_limits};
     use crate::xml::ParseLimits;
 
     fn parse(xml: &str) -> Chart {
@@ -407,5 +439,217 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    const CHART_PART: &str = "word/charts/chart1.xml";
+    const MALFORMED: &[u8] = b"<c:chartSpace><c:chart></c:chartSpace>";
+
+    const CONTENT_TYPES: &[u8] = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/><Override PartName="/word/charts/chart2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/></Types>"#;
+    const ROOT_RELS: &[u8] = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+    const DOCUMENT_RELS: &[u8] = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdChart1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="charts/chart1.xml"/><Relationship Id="rIdChart2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="charts/chart2.xml"/></Relationships>"#;
+    const DOCUMENT_XML: &[u8] = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><w:body><w:p w14:paraId="11111111"><w:r><w:t>Body text</w:t></w:r></w:p><w:p w14:paraId="22222222"><w:r><w:drawing><wp:inline><wp:extent cx="5486400" cy="3200400"/><wp:docPr id="1" name="Chart 1"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rIdChart1"/></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p><w:p w14:paraId="33333333"><w:r><w:drawing><wp:inline><wp:extent cx="5486400" cy="3200400"/><wp:docPr id="2" name="Chart 2"/><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rIdChart2"/></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p><w:tbl><w:tblGrid><w:gridCol w:w="2400"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr><w:p w14:paraId="44444444"><w:r><w:t>Cell text</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr></w:body></w:document>"#;
+
+    /// A chart part whose only weight is its cache. Every point costs the
+    /// reader five events.
+    fn chart_space(points: usize) -> Vec<u8> {
+        let mut xml = String::from(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><c:chart><c:plotArea><c:barChart><c:barDir val="col"/><c:ser><c:val><c:numRef><c:numCache>"#,
+        );
+        for point in 0..points {
+            xml.push_str(&format!("<c:pt><c:v>{point}</c:v></c:pt>"));
+        }
+        xml.push_str(
+            "</c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>",
+        );
+        xml.into_bytes()
+    }
+
+    /// A document of one paragraph, two charted paragraphs and a table.
+    fn chart_docx() -> Vec<(String, Vec<u8>)> {
+        vec![
+            ("[Content_Types].xml".to_owned(), CONTENT_TYPES.to_vec()),
+            ("_rels/.rels".to_owned(), ROOT_RELS.to_vec()),
+            (
+                "word/_rels/document.xml.rels".to_owned(),
+                DOCUMENT_RELS.to_vec(),
+            ),
+            ("word/document.xml".to_owned(), DOCUMENT_XML.to_vec()),
+            ("word/charts/chart1.xml".to_owned(), chart_space(1)),
+            ("word/charts/chart2.xml".to_owned(), chart_space(1)),
+        ]
+    }
+
+    /// [`chart_docx`] with `part`'s bytes replaced.
+    fn chart_docx_with(part: &str, bytes: &[u8]) -> Vec<u8> {
+        let mut parts = chart_docx();
+        let slot = parts
+            .iter_mut()
+            .find(|(path, _)| path == part)
+            .unwrap_or_else(|| panic!("{part} is not in the fixture"));
+        slot.1 = bytes.to_vec();
+        ooxml_opc::rezip_parts(&parts).unwrap()
+    }
+
+    /// The chart part every charted run in `content` resolved to.
+    fn body_charts(content: &[BlockContent]) -> Vec<String> {
+        content
+            .iter()
+            .filter_map(|block| match block {
+                BlockContent::Paragraph(paragraph) => Some(paragraph),
+                _ => None,
+            })
+            .flat_map(|paragraph| &paragraph.content)
+            .filter_map(|item| match item {
+                ParagraphContent::Inline(InlineNode::Run(run)) => Some(run),
+                _ => None,
+            })
+            .flat_map(|run| &run.content)
+            .filter_map(|item| match item {
+                RunContent::Chart { chart } => chart.path.clone(),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Opens a document whose first chart part carries `bytes` and asserts the
+    /// document is whole apart from that one chart.
+    fn assert_damaged_chart_is_dropped(bytes: &[u8]) {
+        let package = parse_docx_s9_wire(
+            &chart_docx_with(CHART_PART, bytes),
+            S9ParseOptions::default(),
+        )
+        .unwrap()
+        .document
+        .package;
+        let content = &package.document.content;
+        assert_eq!(content.len(), 4);
+        let BlockContent::Paragraph(first) = &content[0] else {
+            panic!("the first block is a paragraph");
+        };
+        assert_eq!(get_paragraph_text(first), "Body text");
+        assert!(matches!(&content[3], BlockContent::Table(_)));
+        assert_eq!(
+            package
+                .chart_entries
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            ["word/charts/chart2.xml", "charts/chart2.xml"]
+        );
+        assert_eq!(body_charts(content), ["word/charts/chart2.xml"]);
+    }
+
+    #[test]
+    fn a_malformed_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(MALFORMED);
+    }
+
+    #[test]
+    fn an_empty_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(b"");
+    }
+
+    #[test]
+    fn a_doctype_bearing_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(
+            br#"<?xml version="1.0"?><!DOCTYPE c:chartSpace [<!ENTITY x "y">]><c:chartSpace xmlns:c="c"/>"#,
+        );
+    }
+
+    #[test]
+    fn a_truncated_chart_part_drops_only_that_chart() {
+        let source = chart_space(8);
+        assert_damaged_chart_is_dropped(&source[..source.len() / 2]);
+    }
+
+    #[test]
+    fn a_binary_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(&[0x00, 0xff, 0xfe, 0x01, 0x80, 0x7f]);
+    }
+
+    #[test]
+    fn an_undeclared_entity_in_a_chart_part_drops_only_that_chart() {
+        assert_damaged_chart_is_dropped(
+            br#"<c:chartSpace xmlns:c="c"><c:chart><c:title>&nbsp;</c:title></c:chart></c:chartSpace>"#,
+        );
+    }
+
+    /// Every stage that reads chart parts declines the same part.
+    #[test]
+    fn a_damaged_chart_part_stops_no_projection_stage() {
+        let document = chart_docx_with(CHART_PART, MALFORMED);
+        assert_eq!(
+            parse_docx_s4_projection(&document)
+                .unwrap()
+                .chart_entries
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            ["word/charts/chart2.xml", "charts/chart2.xml"]
+        );
+        for body in [
+            parse_docx_s6_projection(&document).unwrap().body,
+            parse_docx_s8_projection(&document).unwrap().body,
+        ] {
+            assert_eq!(body_charts(&body.content), ["word/charts/chart2.xml"]);
+        }
+    }
+
+    /// The undamaged document that used to be refused: spec-valid charts whose
+    /// caches together outgrow one budget. Each chart holds a cache that most
+    /// of a budget covers, so a budget shared with the body — or with the other
+    /// chart — leaves the document unopenable.
+    #[test]
+    fn a_document_whose_charts_each_fill_a_budget_opens_with_every_chart() {
+        let mut parts = chart_docx();
+        for (path, bytes) in &mut parts {
+            if path.starts_with("word/charts/") {
+                *bytes = chart_space(4_000);
+            }
+        }
+        let document = ooxml_opc::rezip_parts(&parts).unwrap();
+        let limits = ParseLimits {
+            max_xml_events: 30_000,
+            ..ParseLimits::default()
+        };
+
+        let package = parse_docx_s9_wire_with_limits(&document, S9ParseOptions::default(), &limits)
+            .unwrap()
+            .document
+            .package;
+
+        assert_eq!(
+            body_charts(&package.document.content),
+            ["word/charts/chart1.xml", "word/charts/chart2.xml"]
+        );
+        assert!(
+            package
+                .chart_entries
+                .iter()
+                .all(|(_, chart)| chart.series[0].values.len() == 4_000)
+        );
+    }
+
+    #[test]
+    fn a_damaged_chart_part_reads_as_an_absent_one() {
+        let package = parse_docx_s9_wire(
+            &chart_docx_with(CHART_PART, MALFORMED),
+            S9ParseOptions::default(),
+        )
+        .unwrap()
+        .document
+        .package;
+        let mut absent = chart_docx();
+        absent.retain(|(path, _)| path != CHART_PART);
+        let without = parse_docx_s9_wire(
+            &ooxml_opc::rezip_parts(&absent).unwrap(),
+            S9ParseOptions::default(),
+        )
+        .unwrap()
+        .document
+        .package;
+        assert_eq!(package.document.content, without.document.content);
+        assert_eq!(package.chart_entries, without.chart_entries);
+        println!("DAMAGED == ABSENT");
     }
 }

--- a/crates/docx-parse/src/paragraph.rs
+++ b/crates/docx-parse/src/paragraph.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::chart::{ChartPartsMap, parse_chart_from_drawing};
+use crate::chart::{ChartPartsMap, DrawingChart, parse_chart_from_drawing};
 use crate::formatting::{
     ParagraphFormatting, ParagraphFrame, SpacingExplicit, TextFormatting,
     parse_paragraph_properties,
@@ -1059,10 +1059,14 @@ fn parse_drawing_owned(
         return Ok(Vec::new());
     }
     let charts = drawing.as_ref().map(|context| context.charts);
-    if let Some(chart) = parse_chart_from_drawing(element, relationships, charts)? {
-        return Ok(vec![RunContent::Chart {
-            chart: Box::new(chart),
-        }]);
+    match parse_chart_from_drawing(element, relationships, charts)? {
+        DrawingChart::Chart(chart) => return Ok(vec![RunContent::Chart { chart }]),
+        DrawingChart::Unread => {
+            return Ok(vec![RunContent::OpaqueDrawing {
+                kind: "drawing".to_owned(),
+            }]);
+        }
+        DrawingChart::None => {}
     }
     if is_smart_art_drawing(element) {
         let shape = match drawing {

--- a/crates/docx-parse/src/s4.rs
+++ b/crates/docx-parse/src/s4.rs
@@ -5,7 +5,9 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::canonical::{canonical_sha256, from_serializable, to_canonical_bytes};
-use crate::chart::{Chart, is_chart_part, parse_chart_from_drawing, parse_chart_parts};
+use crate::chart::{
+    Chart, DrawingChart, is_chart_part, parse_chart_from_drawing, parse_chart_parts,
+};
 use crate::image::parse_drawing;
 use crate::media::{MediaFile, build_media_map};
 use crate::relationships::{RelationshipMap, parse_relationships};
@@ -206,10 +208,13 @@ fn project_drawing(
     smart_art: &mut SmartArtContext,
     budget: &mut ParseBudget<'_>,
 ) -> Result<Option<DrawingLeaf>, ParseError> {
+    let chart = parse_chart_from_drawing(drawing, relationships, Some(charts))?;
     let (kind, value) = if let Some(text_box) = parse_text_box(drawing) {
         ("textBox", serde_json::to_value(text_box))
-    } else if let Some(chart) = parse_chart_from_drawing(drawing, relationships, Some(charts))? {
+    } else if let DrawingChart::Chart(chart) = &chart {
         ("chart", serde_json::to_value(chart))
+    } else if matches!(chart, DrawingChart::Unread) {
+        return Ok(None);
     } else if is_smart_art_drawing(drawing) {
         let Some(shape) =
             parse_smart_art_from_drawing(drawing, relationships, Some(smart_art), budget)?

--- a/crates/docx-parse/src/s4.rs
+++ b/crates/docx-parse/src/s4.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::canonical::{canonical_sha256, from_serializable, to_canonical_bytes};
-use crate::chart::{Chart, parse_chart_from_drawing, parse_chart_parts};
+use crate::chart::{Chart, is_chart_part, parse_chart_from_drawing, parse_chart_parts};
 use crate::image::parse_drawing;
 use crate::media::{MediaFile, build_media_map};
 use crate::relationships::{RelationshipMap, parse_relationships};
@@ -68,7 +68,7 @@ pub fn parse_docx_s4_projection(data: &[u8]) -> Result<S4Projection, ParseError>
         })
         .cloned()
         .collect::<IndexMap<_, _>>();
-    let charts = parse_chart_parts(&all_xml, &mut budget)?;
+    let charts = parse_chart_parts(&all_xml, &limits);
     let mut smart_art = create_smart_art_context(&all_xml);
     let mut relationship_parts = IndexMap::new();
     for (path, xml) in &all_xml {
@@ -79,7 +79,9 @@ pub fn parse_docx_s4_projection(data: &[u8]) -> Result<S4Projection, ParseError>
     let document_relationships = relationship_parts.get("word/_rels/document.xml.rels");
     let mut xml_parts = Vec::new();
     for (path, xml) in &all_xml {
-        if !path.to_ascii_lowercase().ends_with(".xml") || xml.contains(&0) {
+        // Chart parts carry no drawing, VML or watermark leaf, and
+        // `parse_chart_parts` has already read them on their own budget.
+        if !path.to_ascii_lowercase().ends_with(".xml") || is_chart_part(path) || xml.contains(&0) {
             continue;
         }
         let document = parse_xml(xml, path, &mut budget)?;

--- a/crates/docx-parse/src/s6.rs
+++ b/crates/docx-parse/src/s6.rs
@@ -94,7 +94,7 @@ pub(crate) fn parse_docx_story_projection(data: &[u8]) -> Result<S6Projection, P
         })
         .cloned()
         .collect();
-    let charts = parse_chart_parts(&all_xml, &mut budget)?;
+    let charts = parse_chart_parts(&all_xml, &limits);
     let mut smart_art = create_smart_art_context(&all_xml);
     let digest = format!("{:x}", Sha256::digest(data));
     let mut ids = HexIdAllocator::from_sha256(&digest)?;

--- a/crates/docx-parse/src/s8.rs
+++ b/crates/docx-parse/src/s8.rs
@@ -95,7 +95,7 @@ pub fn parse_docx_s8_projection(data: &[u8]) -> Result<S8Projection, ParseError>
         })
         .cloned()
         .collect();
-    let charts = parse_chart_parts(&all_xml, &mut budget)?;
+    let charts = parse_chart_parts(&all_xml, &limits);
     let mut smart_art = create_smart_art_context(&all_xml);
     let digest = format!("{:x}", Sha256::digest(data));
     let mut ids = HexIdAllocator::from_sha256(&digest)?;

--- a/crates/docx-parse/src/s9.rs
+++ b/crates/docx-parse/src/s9.rs
@@ -238,7 +238,7 @@ pub fn parse_docx_s9_wire_with_limits(
         })
         .cloned()
         .collect();
-    let charts = parse_chart_parts(&all_xml, &mut budget)?;
+    let charts = parse_chart_parts(&all_xml, limits);
     let mut smart_art = create_smart_art_context(&all_xml);
     let digest = options
         .determinism_seed

--- a/crates/docx-parse/src/xml.rs
+++ b/crates/docx-parse/src/xml.rs
@@ -120,6 +120,11 @@ impl<'a> ParseBudget<'a> {
         )
     }
 
+    /// XML events charged so far.
+    pub(crate) fn xml_events(&self) -> usize {
+        self.xml_events
+    }
+
     pub(crate) fn charge_event(&mut self, part: &str) -> Result<(), ParseError> {
         charge(
             &mut self.xml_events,


### PR DESCRIPTION
TL;DR:


Repro file:
Any `.docx` whose `word/charts/chart1.xml` is malformed XML, an empty part, a `<!DOCTYPE>` declaration, a truncated part, binary bytes, or an undeclared entity — or is absent from the package, or is valid but large enough that its cached series exceed `max_xml_events`. The tests in `crates/docx-parse/src/chart.rs` and `crates/betteroffice-docx/tests/document.rs` build each of these in-test.

Summary:
- A document whose chart part the parser cannot read now opens without that chart. Chart parts are parsed on open through all four entry points (`s4`, `s6`, `s8`, `s9`), and a failure on one of them failed the whole document — paragraphs, tables and text intact, no document.
- The drawing that referenced a declined chart is carried as opaque content. `parse_chart_from_drawing` now tells "this drawing is a chart whose part we could not read" apart from "this drawing is not a chart", so it no longer falls through to the picture parser — which invented an image with an empty relationship id that a full save wrote back as `r:embed="rId1"`, in a Word-shaped document the stylesheet. That fallthrough already corrupted a document whose chart part was simply absent from the package; the same change closes it.
- A full save drops the opaque drawing, as it already drops every chart today; the changeset says so.
- Chart parts draw XML events from one pool the size of the package's budget, per-part limits kept for everything else, so a document's charts together cost no more than one budget allowed before.

Test plan:
- [x] `cargo test -p betteroffice-docx-parse -p betteroffice-docx -p betteroffice-docx-layout`
- [x] `cargo clippy -p betteroffice-docx-parse -p betteroffice-docx --all-targets -- -D warnings && cargo fmt --check`
- [x] `bun run build:docx-wasm && bun test packages/docx/src/`
- [x] Counterfactuals: turning the skip back into a hard failure fails the trigger tests; reverting the opaque arm fails the save tests with the picture back; reverting the pool fails the budget test
