### PR TITLE
fix(docx): keep text box bodies and character-unit indents on save

### DIFF
--- a/.changeset/docx-character-unit-indents.md
+++ b/.changeset/docx-character-unit-indents.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Character-unit paragraph indents (`w:leftChars`, `w:rightChars`, `w:firstLineChars`, `w:hangingChars`) now survive a save, and an explicit `w:firstLine="0"` is no longer discarded. Documents that indent by characters, as Chinese typography does, previously kept only the twip approximation, and paragraphs that cancelled an inherited first-line indent silently regained it.

--- a/.changeset/docx-character-unit-indents.md
+++ b/.changeset/docx-character-unit-indents.md
@@ -3,4 +3,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Character-unit paragraph indents (`w:leftChars`, `w:rightChars`, `w:firstLineChars`, `w:hangingChars`) now survive a save, and an explicit `w:firstLine="0"` is no longer discarded. Documents that indent by characters, as Chinese typography does, previously kept only the twip approximation, and paragraphs that cancelled an inherited first-line indent silently regained it.
+Character-unit paragraph indents (`w:leftChars`, `w:rightChars`, `w:firstLineChars`, `w:hangingChars`) now survive a save in the direction they were authored, and an explicit `w:firstLine="0"` is no longer discarded. Documents that indent by characters, as Chinese typography does, previously kept only the twip approximation, a first-line indent could come back as a hanging one, and paragraphs that cancelled an inherited first-line indent silently regained it.

--- a/.changeset/docx-text-box-save.md
+++ b/.changeset/docx-text-box-save.md
@@ -3,4 +3,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Text boxes now keep their text when a document is saved. Shape text bodies read from `wps:txbx` were dropped on the way out — including the `mc:AlternateContent` form Word writes for figure callouts — so every text box came back empty.
+Text boxes now keep their text when a document is saved, in the editor as well as the crate — the editor's save projection rebuilt every shape as an empty rectangle. Shape text bodies read from `wps:txbx` were dropped on the way out — including the `mc:AlternateContent` form Word writes for figure callouts, a table nested in a box, and a vertical (`vert="eaVert"`) writing direction — so every text box came back empty.

--- a/.changeset/docx-text-box-save.md
+++ b/.changeset/docx-text-box-save.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Text boxes now keep their text when a document is saved. Shape text bodies read from `wps:txbx` were dropped on the way out — including the `mc:AlternateContent` form Word writes for figure callouts — so every text box came back empty.

--- a/crates/betteroffice-docx/tests/document.rs
+++ b/crates/betteroffice-docx/tests/document.rs
@@ -440,6 +440,28 @@ fn saving_keeps_a_table_inside_a_text_box() {
     assert_eq!(resaved, xml);
 }
 
+/// The parser reads `anchor` into a canonical name; every one of them has to
+/// be written back as the schema token, or the next open reads it as none.
+#[test]
+fn saving_keeps_every_text_box_anchor() {
+    for token in ["t", "ctr", "b", "dist", "just"] {
+        let package = story_docx(
+            &text_box_drawing(
+                r#"<w:p><w:r><w:t>Anchored</w:t></w:r></w:p>"#,
+                &format!(r#"<wps:bodyPr rot="0" vert="horz" anchor="{token}"/>"#),
+            ),
+            None,
+        );
+        let xml = saved_document(&package);
+        assert!(
+            xml.contains(&format!(r#"anchor="{token}""#)),
+            "{token}: {xml}"
+        );
+        let resaved = saved_document(&Document::open(&package).unwrap().save().unwrap());
+        assert_eq!(resaved, xml, "{token} second save");
+    }
+}
+
 #[test]
 fn saving_keeps_the_writing_direction_of_a_vertical_text_box() {
     let package = story_docx(

--- a/crates/betteroffice-docx/tests/document.rs
+++ b/crates/betteroffice-docx/tests/document.rs
@@ -302,3 +302,62 @@ fn an_unreadable_chart_part_writes_no_picture_in_any_story() {
 fn an_absent_chart_part_writes_no_picture_in_any_story() {
     assert_no_stray_picture(None);
 }
+
+const TEXT_BOX_NAMESPACES: &str = concat!(
+    r#" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main""#,
+    r#" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006""#,
+    r#" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing""#,
+    r#" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main""#,
+    r#" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape""#,
+    r#" xmlns:v="urn:schemas-microsoft-com:vml" mc:Ignorable="wps v""#,
+);
+
+/// The GB/T callout shape from issue #202: an `mc:Choice` textbox with a VML
+/// fallback, a bare textbox, and character-unit first-line indents.
+fn text_box_docx() -> Vec<u8> {
+    let body = concat!(
+        r##"<w:p><w:r><mc:AlternateContent><mc:Choice Requires="wps"><w:drawing><wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0" relativeHeight="251659264" behindDoc="0" locked="0" layoutInCell="1" allowOverlap="1"><wp:simplePos x="0" y="0"/><wp:positionH relativeFrom="column"><wp:posOffset>1000</wp:posOffset></wp:positionH><wp:positionV relativeFrom="paragraph"><wp:posOffset>2000</wp:posOffset></wp:positionV><wp:extent cx="914400" cy="457200"/><wp:wrapNone/><wp:docPr id="11" name="Text Box 11"/><a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"><wps:wsp><wps:cNvSpPr txBox="1"/><wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr><wps:txbx><w:txbxContent><w:p><w:pPr><w:ind w:firstLineChars="200" w:firstLine="420"/></w:pPr><w:r><w:t>Choice callout</w:t></w:r></w:p></w:txbxContent></wps:txbx><wps:bodyPr rot="0" vert="horz"/></wps:wsp></a:graphicData></a:graphic></wp:anchor></w:drawing></mc:Choice><mc:Fallback><w:pict><v:shape id="_x0000_s1026" type="#_x0000_t202"><v:textbox><w:txbxContent><w:p><w:r><w:t>Fallback callout</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape></w:pict></mc:Fallback></mc:AlternateContent></w:r></w:p>"##,
+        r#"<w:p><w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0"><wp:extent cx="914400" cy="457200"/><wp:docPr id="21" name="Text Box 21"/><a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"><wps:wsp><wps:cNvSpPr txBox="1"/><wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr><wps:txbx><w:txbxContent><w:p><w:r><w:t>Inline callout</w:t></w:r></w:p></w:txbxContent></wps:txbx><wps:bodyPr rot="0" vert="horz"/></wps:wsp></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#,
+        r#"<w:p><w:pPr><w:ind w:firstLineChars="200" w:firstLine="420"/></w:pPr><w:r><w:t>Body</w:t></w:r></w:p>"#,
+        r#"<w:p><w:pPr><w:ind w:firstLineChars="0" w:firstLine="0"/></w:pPr><w:r><w:t>Heading</w:t></w:r></w:p>"#,
+    );
+    let document = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document{TEXT_BOX_NAMESPACES}><w:body>{body}</w:body></w:document>"#
+    );
+    let parts = vec![
+        (
+            "[Content_Types].xml".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#.to_vec(),
+        ),
+        (
+            "_rels/.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#.to_vec(),
+        ),
+        ("word/document.xml".to_owned(), document.into_bytes()),
+    ];
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+#[test]
+fn saving_keeps_shape_text_box_bodies_and_character_unit_indents() {
+    let document = Document::open(&text_box_docx()).unwrap();
+    let saved = document.save().unwrap();
+    let parts = ooxml_opc::unzip_parts(&saved).unwrap();
+    let xml = saved_part(&parts, "word/document.xml");
+
+    assert_eq!(xml.matches("<w:txbxContent>").count(), 2);
+    assert!(xml.contains("Choice callout"));
+    assert!(xml.contains("Inline callout"));
+    assert_eq!(xml.matches(r#"<wps:cNvSpPr txBox="1"/>"#).count(), 2);
+
+    assert_eq!(xml.matches(r#"w:firstLineChars="200""#).count(), 2);
+    assert_eq!(xml.matches(r#"w:firstLine="420""#).count(), 2);
+    assert!(xml.contains(r#"<w:ind w:firstLine="0" w:firstLineChars="0"/>"#));
+
+    let reopened = Document::open(&saved).unwrap();
+    let resaved = saved_part(
+        &ooxml_opc::unzip_parts(&reopened.save().unwrap()).unwrap(),
+        "word/document.xml",
+    );
+    assert_eq!(resaved, xml);
+}

--- a/crates/betteroffice-docx/tests/document.rs
+++ b/crates/betteroffice-docx/tests/document.rs
@@ -361,3 +361,134 @@ fn saving_keeps_shape_text_box_bodies_and_character_unit_indents() {
     );
     assert_eq!(resaved, xml);
 }
+
+/// A minimal package holding `body`, plus `word/numbering.xml` when given.
+fn story_docx(body: &str, numbering: Option<&str>) -> Vec<u8> {
+    let numbering_override = if numbering.is_some() {
+        r#"<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>"#
+    } else {
+        ""
+    };
+    let document = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document{TEXT_BOX_NAMESPACES}><w:body>{body}</w:body></w:document>"#
+    );
+    let mut parts = vec![
+        (
+            "[Content_Types].xml".to_owned(),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>{numbering_override}</Types>"#
+            )
+            .into_bytes(),
+        ),
+        (
+            "_rels/.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#.to_vec(),
+        ),
+        ("word/document.xml".to_owned(), document.into_bytes()),
+    ];
+    if let Some(numbering) = numbering {
+        parts.push((
+            "word/_rels/document.xml.rels".to_owned(),
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdNum" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/></Relationships>"#.to_vec(),
+        ));
+        parts.push((
+            "word/numbering.xml".to_owned(),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">{numbering}</w:numbering>"#
+            )
+            .into_bytes(),
+        ));
+    }
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+/// The document part after `Document::open` → `save`.
+fn saved_document(package: &[u8]) -> String {
+    let saved = Document::open(package).unwrap().save().unwrap();
+    saved_part(
+        &ooxml_opc::unzip_parts(&saved).unwrap(),
+        "word/document.xml",
+    )
+}
+
+fn text_box_drawing(body: &str, body_properties: &str) -> String {
+    format!(
+        r#"<w:p><w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0"><wp:extent cx="914400" cy="457200"/><wp:docPr id="31" name="Text Box 31"/><a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"><wps:wsp><wps:cNvSpPr txBox="1"/><wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr><wps:txbx><w:txbxContent>{body}</w:txbxContent></wps:txbx>{body_properties}</wps:wsp></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#
+    )
+}
+
+#[test]
+fn saving_keeps_a_table_inside_a_text_box() {
+    let table = r#"<w:tbl><w:tblGrid><w:gridCol w:w="2400"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>TABLE-CELL</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#;
+    let package = story_docx(
+        &text_box_drawing(table, r#"<wps:bodyPr rot="0" vert="horz"/>"#),
+        None,
+    );
+
+    let xml = saved_document(&package);
+
+    assert!(xml.contains("TABLE-CELL"));
+    let body = xml
+        .split_once("<w:txbxContent>")
+        .and_then(|(_, rest)| rest.split_once("</w:txbxContent>"))
+        .unwrap()
+        .0;
+    assert!(body.starts_with("<w:tbl>"));
+    assert_eq!(body.matches("<w:tc>").count(), 1);
+
+    let resaved = saved_document(&Document::open(&package).unwrap().save().unwrap());
+    assert_eq!(resaved, xml);
+}
+
+#[test]
+fn saving_keeps_the_writing_direction_of_a_vertical_text_box() {
+    let package = story_docx(
+        &text_box_drawing(
+            r#"<w:p><w:r><w:t>Vertical</w:t></w:r></w:p>"#,
+            r#"<wps:bodyPr rot="0" vert="eaVert"/>"#,
+        ),
+        None,
+    );
+
+    let xml = saved_document(&package);
+
+    assert!(xml.contains(r#"<wps:bodyPr rot="0" vert="eaVert"/>"#));
+    assert!(!xml.contains(r#"vert="horz""#));
+
+    let resaved = saved_document(&Document::open(&package).unwrap().save().unwrap());
+    assert_eq!(resaved, xml);
+}
+
+const HANGING_NUMBERING: &str = r#"<w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/><w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr></w:lvl></w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>"#;
+
+#[test]
+fn a_direct_character_first_line_indent_outranks_a_numbering_hanging_indent() {
+    let package = story_docx(
+        r#"<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr><w:ind w:firstLineChars="200"/></w:pPr><w:r><w:t>Numbered</w:t></w:r></w:p>"#,
+        Some(HANGING_NUMBERING),
+    );
+
+    let xml = saved_document(&package);
+
+    assert!(xml.contains(r#"<w:ind w:left="720" w:firstLineChars="200"/>"#));
+    assert!(!xml.contains("hangingChars"));
+    assert!(!xml.contains("w:hanging="));
+
+    let resaved = saved_document(&Document::open(&package).unwrap().save().unwrap());
+    assert_eq!(resaved, xml);
+}
+
+#[test]
+fn mixed_unit_indents_keep_the_direction_each_unit_was_authored_with() {
+    let package = story_docx(
+        r#"<w:p><w:pPr><w:ind w:firstLine="420" w:hangingChars="200"/></w:pPr><w:r><w:t>Mixed</w:t></w:r></w:p>"#,
+        None,
+    );
+
+    let xml = saved_document(&package);
+
+    assert!(xml.contains(r#"<w:ind w:firstLine="420" w:hangingChars="200"/>"#));
+
+    let resaved = saved_document(&Document::open(&package).unwrap().save().unwrap());
+    assert_eq!(resaved, xml);
+}

--- a/crates/docx-edit/src/bridge/mod.rs
+++ b/crates/docx-edit/src/bridge/mod.rs
@@ -990,7 +990,7 @@ fn preset_geometry(shape_type: &str) -> Option<Vec<Value>> {
     let command = |value: Value| value;
     let close = || serde_json::json!({ "type": "close" });
     Some(match shape_type {
-        "rect" => vec![
+        "rect" | "textBox" => vec![
             command(serde_json::json!({"type":"move","x":0,"y":0})),
             command(serde_json::json!({"type":"line","x":1,"y":0})),
             command(serde_json::json!({"type":"line","x":1,"y":1})),
@@ -3678,6 +3678,47 @@ mod tests {
         assert_eq!(value[0]["innerText"][0]["runs"][0]["text"], "Native");
         assert_eq!(value[0]["pmStart"], 1.0);
         assert_eq!(value[0]["pmEnd"], 2.0);
+    }
+
+    #[test]
+    fn legacy_text_box_payload_lowers_to_a_rectangle() {
+        let doc = EditingDoc::new(45);
+        doc.create_story("body", "", "Normal", "left").unwrap();
+        doc.apply_raw_ops(
+            "body",
+            vec![
+                RawOp::Delete { index: 0, len: 1 },
+                RawOp::InsertEmbed {
+                    index: 0,
+                    kind: "shape".to_owned(),
+                    payload: vec![
+                        ("shapeType".to_owned(), Any::from("textBox")),
+                        ("width".to_owned(), Any::from(200.0)),
+                        ("height".to_owned(), Any::from(100.0)),
+                    ],
+                    attrs: Attrs::new(),
+                },
+                RawOp::InsertEmbed {
+                    index: 1,
+                    kind: "pilcrow".to_owned(),
+                    payload: vec![("paraId".to_owned(), Any::from("shape-anchor"))],
+                    attrs: Attrs::new(),
+                },
+            ],
+            &EditCtx::local("", DATE),
+        )
+        .unwrap();
+
+        let value = serde_json::to_value(
+            yrs_doc_to_layout_blocks(&doc, "body", &RenderEnv::default()).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(value[0]["kind"], "shape");
+        assert_eq!(value[0]["shapeType"], "textBox");
+        assert_eq!(value[0]["geometryPath"].as_array().unwrap().len(), 5);
+        assert_eq!(value[0]["width"], 200.0);
+        assert_eq!(value[0]["height"], 100.0);
     }
 
     #[test]

--- a/crates/docx-edit/src/bridge/shapes.rs
+++ b/crates/docx-edit/src/bridge/shapes.rs
@@ -10,6 +10,7 @@ use super::RenderEnv;
 
 const EMU_PER_INCH: f64 = 914_400.0;
 const PIXELS_PER_INCH: f64 = 96.0;
+const MAX_SHAPE_BODY_DEPTH: usize = 8;
 
 pub(super) fn lower_shape_json(
     shape: &Value,
@@ -223,13 +224,46 @@ fn shape_transform(shape: &Value) -> Option<Value> {
 fn shape_inner_text(shape: &Value, block_id: &str) -> Option<Vec<ParagraphBlock>> {
     let text_body = object(shape, "textBody")?;
     let content = text_body.get("content")?.as_array()?;
-    Some(
-        content
-            .iter()
-            .enumerate()
-            .map(|(index, paragraph)| shape_paragraph(paragraph, format!("{block_id}:p:{index}")))
-            .collect(),
-    )
+    let mut blocks = Vec::new();
+    for (index, block) in content.iter().enumerate() {
+        push_shape_body_block(block, format!("{block_id}:p:{index}"), 0, &mut blocks);
+    }
+    Some(blocks)
+}
+
+/// `ShapeBlock` renders paragraphs only, so nested tables and block SDTs
+/// contribute their paragraphs in reading order instead of a grid.
+fn push_shape_body_block(
+    block: &Value,
+    block_id: String,
+    depth: usize,
+    output: &mut Vec<ParagraphBlock>,
+) {
+    if depth > MAX_SHAPE_BODY_DEPTH {
+        return;
+    }
+    match string(block, "type").as_deref() {
+        Some("table") => {
+            for (row_index, row) in array(block, "rows").into_iter().flatten().enumerate() {
+                for (cell_index, cell) in array(row, "cells").into_iter().flatten().enumerate() {
+                    for (index, child) in array(cell, "content").into_iter().flatten().enumerate() {
+                        push_shape_body_block(
+                            child,
+                            format!("{block_id}:r{row_index}c{cell_index}:p:{index}"),
+                            depth + 1,
+                            output,
+                        );
+                    }
+                }
+            }
+        }
+        Some("blockSdt") => {
+            for (index, child) in array(block, "content").into_iter().flatten().enumerate() {
+                push_shape_body_block(child, format!("{block_id}:sdt:{index}"), depth + 1, output);
+            }
+        }
+        _ => output.push(shape_paragraph(block, block_id)),
+    }
 }
 
 fn shape_paragraph(paragraph: &Value, block_id: String) -> ParagraphBlock {
@@ -819,6 +853,41 @@ mod tests {
         assert_eq!(block.transform.as_ref().unwrap()["flipH"], true);
         assert_eq!(block.scene.as_ref().unwrap()["version"], 1);
         assert_eq!(block.pm_start, Some(7.0));
+    }
+
+    #[test]
+    fn lowers_a_table_in_the_text_body_to_its_cell_paragraphs() {
+        let shape = json!({
+            "type": "shape",
+            "shapeType": "textBox",
+            "size": {"width": 914400, "height": 457200},
+            "textBody": {"content": [{
+                "type": "table",
+                "rows": [{
+                    "type": "tableRow",
+                    "cells": [{
+                        "type": "tableCell",
+                        "content": [{
+                            "type": "paragraph",
+                            "content": [{
+                                "type": "run",
+                                "content": [{"type": "text", "text": "TABLE-CELL"}]
+                            }]
+                        }]
+                    }]
+                }]
+            }]}
+        });
+
+        let block = lower_shape_json(&shape, 3, &RenderEnv::default()).unwrap();
+        let inner = block.inner_text.as_ref().unwrap();
+
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].runs.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&inner[0].runs[0]).unwrap()["text"],
+            "TABLE-CELL"
+        );
     }
 
     #[test]

--- a/crates/docx-edit/src/bridge/shapes.rs
+++ b/crates/docx-edit/src/bridge/shapes.rs
@@ -80,7 +80,7 @@ fn lower_shape(
         children,
         scene: field(shape, "scene").cloned(),
         effects: array(shape, "effects").cloned(),
-        text_body_properties: field(shape, "textBodyProperties").cloned(),
+        text_body_properties: field(shape, "textBodyProperties").map(text_body_in_pixels),
         position: None,
         wrap_type: None,
         wrap_text: None,
@@ -94,6 +94,20 @@ fn lower_shape(
         pm_start: doc_start,
         pm_end: doc_end,
     })
+}
+
+/// The text body with its insets in page pixels; the model keeps them in EMU
+/// like every other length, and layout reads them alongside pixel widths.
+fn text_body_in_pixels(properties: &Value) -> Value {
+    let mut properties = properties.clone();
+    if let Some(margins) = properties.get_mut("margins").and_then(Value::as_object_mut) {
+        for side in ["left", "right", "top", "bottom"] {
+            if let Some(emu) = margins.get(side).and_then(Value::as_f64) {
+                margins.insert(side.to_owned(), Value::from(emu_to_pixels(emu)));
+            }
+        }
+    }
+    properties
 }
 
 fn shape_fill(shape: &Value) -> Option<Value> {
@@ -853,6 +867,30 @@ mod tests {
         assert_eq!(block.transform.as_ref().unwrap()["flipH"], true);
         assert_eq!(block.scene.as_ref().unwrap()["version"], 1);
         assert_eq!(block.pm_start, Some(7.0));
+    }
+
+    /// Word writes the insets in EMU on every text box; layout reads them next
+    /// to pixel widths, so a raw inset pushed the text a thousand inches off the
+    /// page.
+    #[test]
+    fn lowers_text_body_insets_from_emu_to_pixels() {
+        let shape = json!({
+            "type": "shape",
+            "shapeType": "textBox",
+            "size": {"width": 914400, "height": 457200},
+            "textBodyProperties": {
+                "anchor": "top",
+                "margins": {"left": 91440, "right": 91440, "top": 45720, "bottom": 45720}
+            },
+            "textBody": {"content": []}
+        });
+
+        let block = lower_shape_json(&shape, 3, &RenderEnv::default()).unwrap();
+        let margins = &block.text_body_properties.unwrap()["margins"];
+
+        assert_eq!(margins["left"], json!(emu_to_pixels(91440.0)));
+        assert_eq!(margins["top"], json!(emu_to_pixels(45720.0)));
+        assert!(margins["left"].as_f64().unwrap() < 10.0);
     }
 
     #[test]

--- a/crates/docx-layout/src/measure_blocks.rs
+++ b/crates/docx-layout/src/measure_blocks.rs
@@ -931,17 +931,31 @@ fn emu_to_pixels(value: f64) -> f64 {
     value / 9_525.0
 }
 
+/// One inset of the shape's text body in px, as the display list reads it, so
+/// the wrap width measured here is the width the text is later emitted into.
+fn text_body_inset(shape: &ShapeBlock, side: &str) -> f64 {
+    shape
+        .text_body_properties
+        .as_ref()
+        .and_then(|properties| properties.get("margins"))
+        .and_then(|margins| margins.get(side))
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0)
+}
+
 fn measure_shape(
     shape: &mut ShapeBlock,
     config: &MeasurementConfig,
 ) -> Result<ShapeExtent, String> {
+    let inner_width =
+        (shape.width - text_body_inset(shape, "left") - text_body_inset(shape, "right")).max(1.0);
     let inner_measures = shape
         .inner_text
         .as_ref()
         .map(|paragraphs| {
             paragraphs
                 .iter()
-                .map(|paragraph| measure_paragraph(paragraph, shape.width, config))
+                .map(|paragraph| measure_paragraph(paragraph, inner_width, config))
                 .collect::<Result<Vec<_>, _>>()
         })
         .transpose()?

--- a/crates/docx-layout/tests/synthetic_metrics.rs
+++ b/crates/docx-layout/tests/synthetic_metrics.rs
@@ -479,3 +479,62 @@ fn indented_fallback_accepts_overflow_instead_of_guessing_wraps() {
     assert!(fallback.lines[0].width > 100.0);
     assert!(fallback.lines[0].width > 60.0);
 }
+
+fn text_box_shape(insets: f64) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "shape",
+        "id": "callout",
+        "shapeType": "textBox",
+        "geometryPath": [{ "type": "move", "x": 0, "y": 0 }, { "type": "line", "x": 1, "y": 0 }, { "type": "line", "x": 1, "y": 1 }, { "type": "line", "x": 0, "y": 1 }, { "type": "close" }],
+        "width": 200.0,
+        "height": 120.0,
+        "children": [],
+        "textBodyProperties": {
+            "margins": { "left": insets, "right": insets, "top": 4.0, "bottom": 4.0 }
+        },
+        "innerText": [{
+            "kind": "paragraph",
+            "id": 0,
+            "runs": [{
+                "kind": "text",
+                "text": "The quick brown fox jumps over the lazy dog again and again and again",
+                "fontFamily": "Liberation Sans",
+                "fontSize": FONT_SIZE_PT
+            }],
+            "attrs": { "defaultFontFamily": "Liberation Sans", "defaultFontSize": FONT_SIZE_PT }
+        }]
+    })
+}
+
+fn measure_shape_lines(shape: serde_json::Value, config: &MeasurementConfig) -> Vec<f64> {
+    let block: LayoutBlock = serde_json::from_value(shape).expect("shape parses");
+    let mut blocks = vec![block];
+    let mut extents = measure_blocks(&mut blocks, CONTENT_WIDTH, config).unwrap();
+    match extents.pop() {
+        Some(BlockExtent::Shape(extent)) => extent.inner_measures.unwrap()[0]
+            .lines
+            .iter()
+            .map(|line| line.width)
+            .collect(),
+        _ => panic!("shape extent expected"),
+    }
+}
+
+/// A text box's insets narrow the width its text wraps at, as they narrow the
+/// width it is later drawn into; measured at the full width, the text painted
+/// past the box's own border.
+#[test]
+fn text_box_insets_narrow_the_wrap_width() {
+    docx_layout::clear_measure_fonts();
+    let font_id = docx_layout::register_measure_font(LIBERATION).expect("font registers");
+    let config = registered_config("Liberation Sans", font_id);
+    let full = measure_shape_lines(text_box_shape(0.0), &config);
+    let inset = measure_shape_lines(text_box_shape(48.0), &config);
+
+    assert!(full.iter().all(|width| *width <= 200.0 + 1e-9), "{full:?}");
+    assert!(
+        inset.iter().all(|width| *width <= 200.0 - 96.0 + 1e-9),
+        "{inset:?}"
+    );
+    assert!(inset.len() > full.len(), "full={full:?} inset={inset:?}");
+}

--- a/crates/docx-parse/src/block.rs
+++ b/crates/docx-parse/src/block.rs
@@ -357,7 +357,7 @@ impl StoryParser<'_, '_> {
         {
             blocks = self.parse_blocks(container, depth.saturating_add(1), false)?;
         }
-        let mut shape = Shape::empty("rect".to_owned(), text_box.size);
+        let mut shape = Shape::empty("textBox".to_owned(), text_box.size);
         shape.id = text_box.id;
         shape.position = text_box.position;
         shape.wrap = text_box.wrap;

--- a/crates/docx-parse/src/block.rs
+++ b/crates/docx-parse/src/block.rs
@@ -13,7 +13,7 @@ use crate::paragraph::{
     DrawingContext, HexIdAllocator, Paragraph, ParagraphContent, parse_paragraph,
 };
 use crate::relationships::RelationshipMap;
-use crate::shape::{RelativeRect, Shape, ShapeTextBody};
+use crate::shape::{RelativeRect, Shape, ShapeTextBody, ShapeTextBodyProperties};
 use crate::smart_art::SmartArtContext;
 use crate::styles::{DocDefaults, StyleMap};
 use crate::table::{
@@ -363,12 +363,18 @@ impl StoryParser<'_, '_> {
         shape.wrap = text_box.wrap;
         shape.fill = text_box.fill;
         shape.outline = text_box.outline;
+        let body: Option<ShapeTextBodyProperties> = text_box.body_properties.map(Into::into);
         shape.text_body = Some(ShapeTextBody {
-            vertical: None,
-            rotation: None,
-            anchor: None,
-            anchor_center: None,
-            auto_fit: None,
+            vertical: body.as_ref().and_then(|body| {
+                body.vertical
+                    .as_deref()
+                    .filter(|value| *value != "horizontal")
+                    .map(|_| true)
+            }),
+            rotation: body.as_ref().and_then(|body| body.rotation),
+            anchor: body.as_ref().and_then(|body| body.anchor.clone()),
+            anchor_center: body.as_ref().and_then(|body| body.anchor_center),
+            auto_fit: body.as_ref().and_then(|body| body.auto_fit.clone()),
             margins: text_box.margins.map(|margins| RelativeRect {
                 left: margins.left,
                 top: margins.top,
@@ -381,6 +387,7 @@ impl StoryParser<'_, '_> {
                 .collect::<Result<_, _>>()
                 .map_err(|error| ParseError::Canonical(error.to_string()))?,
         });
+        shape.text_body_properties = body;
         let mut target = run_index;
         if target >= paragraph.content.len() {
             let Some(last_run) = paragraph.content.iter().rposition(|content| {

--- a/crates/docx-parse/src/formatting.rs
+++ b/crates/docx-parse/src/formatting.rs
@@ -503,6 +503,13 @@ pub struct ParagraphFormatting {
     pub indent_first_line: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hanging_indent: Option<bool>,
+    /// Hundredths of a character; overrides the twip indent in Word.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent_left_chars: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent_right_chars: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent_first_line_chars: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub borders: Option<Borders>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -565,6 +572,14 @@ pub fn parse_paragraph_properties(
         value.indent_first_line = indent.parse_numeric_attribute(Some("w"), "firstLine", 1.0);
         if let Some(hanging) = indent.parse_numeric_attribute(Some("w"), "hanging", 1.0) {
             value.indent_first_line = Some(-hanging);
+            value.hanging_indent = Some(true);
+        }
+        value.indent_left_chars = indent.parse_numeric_attribute(Some("w"), "leftChars", 1.0);
+        value.indent_right_chars = indent.parse_numeric_attribute(Some("w"), "rightChars", 1.0);
+        value.indent_first_line_chars =
+            indent.parse_numeric_attribute(Some("w"), "firstLineChars", 1.0);
+        if let Some(hanging) = indent.parse_numeric_attribute(Some("w"), "hangingChars", 1.0) {
+            value.indent_first_line_chars = Some(-hanging);
             value.hanging_indent = Some(true);
         }
     }
@@ -641,6 +656,12 @@ pub fn merge_paragraph_formatting(
             overlay(&mut result.indent_right, &source.indent_right);
             overlay(&mut result.indent_first_line, &source.indent_first_line);
             overlay(&mut result.hanging_indent, &source.hanging_indent);
+            overlay(&mut result.indent_left_chars, &source.indent_left_chars);
+            overlay(&mut result.indent_right_chars, &source.indent_right_chars);
+            overlay(
+                &mut result.indent_first_line_chars,
+                &source.indent_first_line_chars,
+            );
             if let Some(source) = &source.borders {
                 result.borders = Some(merge_borders(target.borders.as_ref(), source));
             }
@@ -1403,6 +1424,23 @@ mod tests {
                 .as_deref(),
             Some("continue")
         );
+    }
+
+    #[test]
+    fn parses_character_unit_indents_alongside_their_twip_companions() {
+        let style = root(
+            r#"<w:style><w:pPr><w:ind w:left="200" w:leftChars="100" w:right="105" w:rightChars="50" w:firstLine="420" w:firstLineChars="200"/></w:pPr></w:style>"#,
+        );
+        let paragraph = parse_paragraph_properties(style.child("w", "pPr"), None).unwrap();
+        assert_eq!(paragraph.indent_left_chars, Some(100.0));
+        assert_eq!(paragraph.indent_right_chars, Some(50.0));
+        assert_eq!(paragraph.indent_first_line_chars, Some(200.0));
+        let hanging = root(
+            r#"<w:style><w:pPr><w:ind w:hanging="315" w:hangingChars="150"/></w:pPr></w:style>"#,
+        );
+        let hanging = parse_paragraph_properties(hanging.child("w", "pPr"), None).unwrap();
+        assert_eq!(hanging.indent_first_line_chars, Some(-150.0));
+        assert_eq!(hanging.hanging_indent, Some(true));
     }
 
     #[test]

--- a/crates/docx-parse/src/formatting.rs
+++ b/crates/docx-parse/src/formatting.rs
@@ -511,6 +511,10 @@ pub struct ParagraphFormatting {
     /// Hundredths of a character, negative for `w:hangingChars`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_first_line_chars: Option<f64>,
+    /// Whether the character first-line indent is `w:hangingChars`; the sign
+    /// alone cannot say so once a zero has crossed JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hanging_indent_chars: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub borders: Option<Borders>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -581,6 +585,7 @@ pub fn parse_paragraph_properties(
             indent.parse_numeric_attribute(Some("w"), "firstLineChars", 1.0);
         if let Some(hanging) = indent.parse_numeric_attribute(Some("w"), "hangingChars", 1.0) {
             value.indent_first_line_chars = Some(-hanging);
+            value.hanging_indent_chars = Some(true);
         }
     }
     value.borders = parse_paragraph_borders(p_pr.child("w", "pBdr"));
@@ -661,6 +666,10 @@ pub fn merge_paragraph_formatting(
             overlay(
                 &mut result.indent_first_line_chars,
                 &source.indent_first_line_chars,
+            );
+            overlay(
+                &mut result.hanging_indent_chars,
+                &source.hanging_indent_chars,
             );
             if let Some(source) = &source.borders {
                 result.borders = Some(merge_borders(target.borders.as_ref(), source));

--- a/crates/docx-parse/src/formatting.rs
+++ b/crates/docx-parse/src/formatting.rs
@@ -659,17 +659,21 @@ pub fn merge_paragraph_formatting(
             overlay(&mut result.spacing_explicit, &source.spacing_explicit);
             overlay(&mut result.indent_left, &source.indent_left);
             overlay(&mut result.indent_right, &source.indent_right);
-            overlay(&mut result.indent_first_line, &source.indent_first_line);
-            overlay(&mut result.hanging_indent, &source.hanging_indent);
+            overlay_indent_kind(
+                (&mut result.indent_first_line, &mut result.hanging_indent),
+                (&source.indent_first_line, &source.hanging_indent),
+            );
             overlay(&mut result.indent_left_chars, &source.indent_left_chars);
             overlay(&mut result.indent_right_chars, &source.indent_right_chars);
-            overlay(
-                &mut result.indent_first_line_chars,
-                &source.indent_first_line_chars,
-            );
-            overlay(
-                &mut result.hanging_indent_chars,
-                &source.hanging_indent_chars,
+            overlay_indent_kind(
+                (
+                    &mut result.indent_first_line_chars,
+                    &mut result.hanging_indent_chars,
+                ),
+                (
+                    &source.indent_first_line_chars,
+                    &source.hanging_indent_chars,
+                ),
             );
             if let Some(source) = &source.borders {
                 result.borders = Some(merge_borders(target.borders.as_ref(), source));
@@ -1384,6 +1388,19 @@ fn merge_color_deep(target: Option<&ColorValue>, source: &ColorValue) -> ColorVa
     value
 }
 
+/// A first-line indent and whether it hangs are one fact: a source that
+/// supplies the value supplies the kind with it, so an inherited hanging flag
+/// cannot turn a more specific first-line indent back into a hanging one.
+fn overlay_indent_kind(
+    (value, hanging): (&mut Option<f64>, &mut Option<bool>),
+    (source_value, source_hanging): (&Option<f64>, &Option<bool>),
+) {
+    if source_value.is_some() {
+        *value = *source_value;
+        *hanging = *source_hanging;
+    }
+}
+
 fn overlay<T: Clone>(target: &mut Option<T>, source: &Option<T>) {
     if source.is_some() {
         target.clone_from(source);
@@ -1433,6 +1450,32 @@ mod tests {
                 .as_deref(),
             Some("continue")
         );
+    }
+
+    /// A more specific first-line indent replaces an inherited hanging one
+    /// kind and all, in either unit system.
+    #[test]
+    fn a_first_line_indent_does_not_inherit_a_hanging_kind_from_its_base() {
+        let base = root(
+            r#"<w:style><w:pPr><w:ind w:hanging="360" w:hangingChars="0"/></w:pPr></w:style>"#,
+        );
+        let base = parse_paragraph_properties(base.child("w", "pPr"), None).unwrap();
+        let child = root(
+            r#"<w:style><w:pPr><w:ind w:firstLine="200" w:firstLineChars="200"/></w:pPr></w:style>"#,
+        );
+        let child = parse_paragraph_properties(child.child("w", "pPr"), None).unwrap();
+
+        let merged = merge_paragraph_formatting(Some(&base), Some(&child)).unwrap();
+
+        assert_eq!(merged.indent_first_line, Some(200.0));
+        assert_eq!(merged.hanging_indent, None);
+        assert_eq!(merged.indent_first_line_chars, Some(200.0));
+        assert_eq!(merged.hanging_indent_chars, None);
+
+        let inherited = merge_paragraph_formatting(Some(&child), Some(&base)).unwrap();
+        assert_eq!(inherited.indent_first_line, Some(-360.0));
+        assert_eq!(inherited.hanging_indent, Some(true));
+        assert_eq!(inherited.hanging_indent_chars, Some(true));
     }
 
     #[test]

--- a/crates/docx-parse/src/formatting.rs
+++ b/crates/docx-parse/src/formatting.rs
@@ -508,6 +508,7 @@ pub struct ParagraphFormatting {
     pub indent_left_chars: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_right_chars: Option<f64>,
+    /// Hundredths of a character, negative for `w:hangingChars`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_first_line_chars: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -580,7 +581,6 @@ pub fn parse_paragraph_properties(
             indent.parse_numeric_attribute(Some("w"), "firstLineChars", 1.0);
         if let Some(hanging) = indent.parse_numeric_attribute(Some("w"), "hangingChars", 1.0) {
             value.indent_first_line_chars = Some(-hanging);
-            value.hanging_indent = Some(true);
         }
     }
     value.borders = parse_paragraph_borders(p_pr.child("w", "pBdr"));

--- a/crates/docx-parse/src/paragraph.rs
+++ b/crates/docx-parse/src/paragraph.rs
@@ -1344,15 +1344,18 @@ fn apply_list_rendering(
     };
     let direct_indent = direct_properties.and_then(|properties| properties.child("w", "ind"));
     let direct_left = direct_indent.is_some_and(|indent| {
-        indent.attribute(Some("w"), "left").is_some()
-            || indent.attribute(Some("w"), "start").is_some()
+        ["left", "start", "leftChars", "startChars"]
+            .iter()
+            .any(|name| indent.attribute(Some("w"), name).is_some())
     });
     let direct_first = direct_indent.is_some_and(|indent| {
-        ["firstLine", "hanging"].iter().any(|name| {
-            indent.attribute(Some("w"), name).is_some_and(|raw| {
-                parse_javascript_integer_prefix(raw).is_none_or(|value| value != 0.0)
+        ["firstLine", "hanging", "firstLineChars", "hangingChars"]
+            .iter()
+            .any(|name| {
+                indent.attribute(Some("w"), name).is_some_and(|raw| {
+                    parse_javascript_integer_prefix(raw).is_none_or(|value| value != 0.0)
+                })
             })
-        })
     });
     let formatting = paragraph
         .formatting
@@ -1382,9 +1385,10 @@ fn style_chain_ind(style_id: Option<&str>, styles: Option<&StyleMap>) -> (bool, 
             break;
         };
         if let Some(properties) = &style.p_pr {
-            result.0 |= properties.indent_left.is_some();
-            result.1 |=
-                properties.indent_first_line.is_some() || properties.hanging_indent.is_some();
+            result.0 |= properties.indent_left.is_some() || properties.indent_left_chars.is_some();
+            result.1 |= properties.indent_first_line.is_some()
+                || properties.hanging_indent.is_some()
+                || properties.indent_first_line_chars.is_some();
         }
         if result.0 && result.1 {
             break;

--- a/crates/docx-parse/src/serializer/paragraph.rs
+++ b/crates/docx-parse/src/serializer/paragraph.rs
@@ -713,7 +713,9 @@ fn write_indentation(writer: &mut XmlWriter, formatting: &ParagraphFormatting) {
         );
     }
     if let Some(first) = formatting.indent_first_line_chars {
-        let hanging = first.is_sign_negative();
+        let hanging = formatting
+            .hanging_indent_chars
+            .unwrap_or_else(|| first.is_sign_negative());
         let name = if hanging {
             "w:hangingChars"
         } else {
@@ -854,6 +856,22 @@ mod tests {
             serialize_paragraph(&paragraph, &mut context()).unwrap(),
             "<w:p w14:paraId=\"AA&amp;BB&quot;CC\"><w:pPr><w:keepNext w:val=\"0\"/><w:jc w:val=\"center\"/></w:pPr><w:r><w:lastRenderedPageBreak/><w:t>hello &amp; goodbye</w:t></w:r></w:p>"
         );
+    }
+
+    /// A hanging character indent of zero has no sign to carry its kind, so
+    /// the flag has to.
+    #[test]
+    fn a_zero_hanging_character_indent_stays_hanging() {
+        let mut writer = XmlWriter::with_capacity(64);
+        write_indentation(
+            &mut writer,
+            &ParagraphFormatting {
+                indent_first_line_chars: Some(0.0),
+                hanging_indent_chars: Some(true),
+                ..ParagraphFormatting::default()
+            },
+        );
+        assert_eq!(writer.finish(), "<w:ind w:hangingChars=\"0\"/>");
     }
 
     #[test]

--- a/crates/docx-parse/src/serializer/paragraph.rs
+++ b/crates/docx-parse/src/serializer/paragraph.rs
@@ -690,21 +690,38 @@ fn write_spacing(writer: &mut XmlWriter, formatting: &ParagraphFormatting) {
 }
 
 fn write_indentation(writer: &mut XmlWriter, formatting: &ParagraphFormatting) {
-    let first = formatting.indent_first_line;
-    let has_first =
-        first.is_some_and(|value| formatting.hanging_indent == Some(true) || value != 0.0);
-    if formatting.indent_left.is_none() && formatting.indent_right.is_none() && !has_first {
+    let hanging = formatting.hanging_indent == Some(true);
+    if formatting.indent_left.is_none()
+        && formatting.indent_right.is_none()
+        && formatting.indent_first_line.is_none()
+        && formatting.indent_left_chars.is_none()
+        && formatting.indent_right_chars.is_none()
+        && formatting.indent_first_line_chars.is_none()
+    {
         return;
     }
     writer.start_element("w:ind");
     optional_int(writer, "w:left", formatting.indent_left);
+    optional_int(writer, "w:leftChars", formatting.indent_left_chars);
     optional_int(writer, "w:right", formatting.indent_right);
-    if let Some(first) = first {
-        if formatting.hanging_indent == Some(true) {
-            writer.attribute("w:hanging", &int_attr(Some(first.abs())));
-        } else if first != 0.0 {
-            writer.attribute("w:firstLine", &int_attr(Some(first)));
-        }
+    optional_int(writer, "w:rightChars", formatting.indent_right_chars);
+    if let Some(first) = formatting.indent_first_line {
+        let name = if hanging { "w:hanging" } else { "w:firstLine" };
+        writer.attribute(
+            name,
+            &int_attr(Some(if hanging { first.abs() } else { first })),
+        );
+    }
+    if let Some(first) = formatting.indent_first_line_chars {
+        let name = if hanging {
+            "w:hangingChars"
+        } else {
+            "w:firstLineChars"
+        };
+        writer.attribute(
+            name,
+            &int_attr(Some(if hanging { first.abs() } else { first })),
+        );
     }
     writer.end_element();
 }
@@ -838,6 +855,52 @@ mod tests {
         assert_eq!(
             serialize_paragraph(&paragraph, &mut context()).unwrap(),
             "<w:p w14:paraId=\"AA&amp;BB&quot;CC\"><w:pPr><w:keepNext w:val=\"0\"/><w:jc w:val=\"center\"/></w:pPr><w:r><w:lastRenderedPageBreak/><w:t>hello &amp; goodbye</w:t></w:r></w:p>"
+        );
+    }
+
+    #[test]
+    fn indentation_keeps_character_units_and_an_explicit_zero_first_line() {
+        let mut writer = XmlWriter::with_capacity(128);
+        write_indentation(
+            &mut writer,
+            &ParagraphFormatting {
+                indent_left: Some(200.0),
+                indent_left_chars: Some(100.0),
+                indent_first_line_chars: Some(200.0),
+                indent_first_line: Some(420.0),
+                ..ParagraphFormatting::default()
+            },
+        );
+        assert_eq!(
+            writer.finish(),
+            "<w:ind w:left=\"200\" w:leftChars=\"100\" w:firstLine=\"420\" w:firstLineChars=\"200\"/>"
+        );
+        let mut writer = XmlWriter::with_capacity(128);
+        write_indentation(
+            &mut writer,
+            &ParagraphFormatting {
+                indent_first_line: Some(0.0),
+                indent_first_line_chars: Some(0.0),
+                ..ParagraphFormatting::default()
+            },
+        );
+        assert_eq!(
+            writer.finish(),
+            "<w:ind w:firstLine=\"0\" w:firstLineChars=\"0\"/>"
+        );
+        let mut writer = XmlWriter::with_capacity(128);
+        write_indentation(
+            &mut writer,
+            &ParagraphFormatting {
+                hanging_indent: Some(true),
+                indent_first_line: Some(-315.0),
+                indent_first_line_chars: Some(-150.0),
+                ..ParagraphFormatting::default()
+            },
+        );
+        assert_eq!(
+            writer.finish(),
+            "<w:ind w:hanging=\"315\" w:hangingChars=\"150\"/>"
         );
     }
 

--- a/crates/docx-parse/src/serializer/paragraph.rs
+++ b/crates/docx-parse/src/serializer/paragraph.rs
@@ -713,15 +713,13 @@ fn write_indentation(writer: &mut XmlWriter, formatting: &ParagraphFormatting) {
         );
     }
     if let Some(first) = formatting.indent_first_line_chars {
+        let hanging = first.is_sign_negative();
         let name = if hanging {
             "w:hangingChars"
         } else {
             "w:firstLineChars"
         };
-        writer.attribute(
-            name,
-            &int_attr(Some(if hanging { first.abs() } else { first })),
-        );
+        writer.attribute(name, &int_attr(Some(first.abs())));
     }
     writer.end_element();
 }
@@ -902,6 +900,28 @@ mod tests {
             writer.finish(),
             "<w:ind w:hanging=\"315\" w:hangingChars=\"150\"/>"
         );
+        let mut writer = XmlWriter::with_capacity(128);
+        write_indentation(
+            &mut writer,
+            &ParagraphFormatting {
+                indent_first_line: Some(420.0),
+                indent_first_line_chars: Some(-200.0),
+                ..ParagraphFormatting::default()
+            },
+        );
+        assert_eq!(
+            writer.finish(),
+            "<w:ind w:firstLine=\"420\" w:hangingChars=\"200\"/>"
+        );
+        let mut writer = XmlWriter::with_capacity(128);
+        write_indentation(
+            &mut writer,
+            &ParagraphFormatting {
+                indent_first_line_chars: Some(-0.0),
+                ..ParagraphFormatting::default()
+            },
+        );
+        assert_eq!(writer.finish(), "<w:ind w:hangingChars=\"0\"/>");
     }
 
     #[test]

--- a/crates/docx-parse/src/serializer/run.rs
+++ b/crates/docx-parse/src/serializer/run.rs
@@ -1,10 +1,10 @@
 //! Run, text-formatting, image, and shape serializers.
 
+use crate::block::BlockContent;
 use crate::drawingml::{ShapeFill, ShapeOutline};
 use crate::formatting::TextFormatting;
 use crate::image::{Image, ImagePosition, ImageWrap};
 use crate::inline::{Run, RunContent, RunPropertyChange};
-use crate::paragraph::Paragraph;
 use crate::scalars::{ColorValue, ShadingProperties};
 use crate::shape::Shape;
 use crate::xml::ParseError;
@@ -496,8 +496,11 @@ pub fn serialize_shape_content(
         let mut body_properties = XmlWriter::with_capacity(160);
         body_properties
             .start_element("wps:bodyPr")
-            .attribute("rot", "0")
-            .attribute("vert", "horz");
+            .attribute(
+                "rot",
+                &int_attr(Some(text_body.rotation.unwrap_or(0.0) * 60_000.0)),
+            )
+            .attribute("vert", vertical_token(shape));
         if let Some(anchor) = nonempty(text_body.anchor.as_deref()) {
             body_properties.attribute("anchor", if anchor == "middle" { "ctr" } else { anchor });
         }
@@ -510,20 +513,21 @@ pub fn serialize_shape_content(
             optional_int_attr(&mut body_properties, "rIns", margins.right);
             optional_int_attr(&mut body_properties, "bIns", margins.bottom);
         }
+        write_auto_fit(&mut body_properties, shape);
         body_properties.end_element();
         if is_text_box {
             graphic
                 .start_element("wps:txbx")
                 .start_element("w:txbxContent");
             for value in &text_body.content {
-                let paragraph: Paragraph =
+                let block: BlockContent =
                     serde_json::from_value(value.clone()).map_err(|error| {
                         ParseError::Canonical(format!(
-                            "shape text body contains an invalid paragraph: {error}"
+                            "shape text body contains an invalid block: {error}"
                         ))
                     })?;
-                let paragraph = super::paragraph::serialize_paragraph(&paragraph, context)?;
-                append_generated(&mut graphic, &paragraph);
+                let block = super::sdt::serialize_block_content(&block, context)?;
+                append_generated(&mut graphic, &block);
             }
             graphic.end_element().end_element();
         }
@@ -580,6 +584,60 @@ pub fn serialize_shape_content(
     append_generated(&mut writer, &graphic);
     writer.end_element().end_element();
     Ok(writer.finish())
+}
+
+fn vertical_token(shape: &Shape) -> &'static str {
+    match shape
+        .text_body_properties
+        .as_ref()
+        .and_then(|properties| properties.vertical.as_deref())
+    {
+        Some("vertical") => "vert",
+        Some("vertical270") => "vert270",
+        Some("wordArtVertical") => "wordArtVert",
+        Some("eastAsianVertical") => "eaVert",
+        Some("mongolianVertical") => "mongolianVert",
+        Some("horizontal") => "horz",
+        _ if shape
+            .text_body
+            .as_ref()
+            .is_some_and(|body| body.vertical == Some(true)) =>
+        {
+            "vert"
+        }
+        _ => "horz",
+    }
+}
+
+fn write_auto_fit(writer: &mut XmlWriter, shape: &Shape) {
+    let properties = shape.text_body_properties.as_ref();
+    let auto_fit = shape
+        .text_body
+        .as_ref()
+        .and_then(|body| body.auto_fit.as_deref());
+    match auto_fit {
+        Some("none") => {
+            writer.start_element("a:noAutofit").end_element();
+        }
+        Some("normal") => {
+            writer.start_element("a:normAutofit");
+            optional_int_attr(
+                writer,
+                "fontScale",
+                properties.and_then(|properties| properties.font_scale),
+            );
+            optional_int_attr(
+                writer,
+                "lnSpcReduction",
+                properties.and_then(|properties| properties.line_spacing_reduction),
+            );
+            writer.end_element();
+        }
+        Some("shape") => {
+            writer.start_element("a:spAutoFit").end_element();
+        }
+        _ => {}
+    }
 }
 
 fn serialize_picture_graphic(image: &Image, id: &str) -> String {

--- a/crates/docx-parse/src/serializer/run.rs
+++ b/crates/docx-parse/src/serializer/run.rs
@@ -501,8 +501,8 @@ pub fn serialize_shape_content(
                 &int_attr(Some(text_body.rotation.unwrap_or(0.0) * 60_000.0)),
             )
             .attribute("vert", vertical_token(shape));
-        if let Some(anchor) = nonempty(text_body.anchor.as_deref()) {
-            body_properties.attribute("anchor", if anchor == "middle" { "ctr" } else { anchor });
+        if let Some(anchor) = nonempty(text_body.anchor.as_deref()).and_then(anchor_token) {
+            body_properties.attribute("anchor", anchor);
         }
         if text_body.anchor_center == Some(true) {
             body_properties.attribute("anchorCtr", "1");
@@ -584,6 +584,18 @@ pub fn serialize_shape_content(
     append_generated(&mut writer, &graphic);
     writer.end_element().end_element();
     Ok(writer.finish())
+}
+
+/// `ST_TextAnchoringType` for the canonical anchor the parser reads it into.
+fn anchor_token(anchor: &str) -> Option<&'static str> {
+    match anchor {
+        "top" => Some("t"),
+        "middle" => Some("ctr"),
+        "bottom" => Some("b"),
+        "distributed" => Some("dist"),
+        "justified" => Some("just"),
+        _ => None,
+    }
 }
 
 fn vertical_token(shape: &Shape) -> &'static str {

--- a/crates/docx-parse/src/shape.rs
+++ b/crates/docx-parse/src/shape.rs
@@ -197,6 +197,37 @@ pub struct ShapeTextBodyProperties {
     pub preset_text_warp: Option<String>,
 }
 
+impl From<crate::text_box::TextBoxBodyProperties> for ShapeTextBodyProperties {
+    fn from(value: crate::text_box::TextBoxBodyProperties) -> Self {
+        Self {
+            vertical: value.vertical,
+            rotation: value.rotation,
+            upright: value.upright,
+            anchor: value.anchor,
+            anchor_center: value.anchor_center,
+            columns: value.columns,
+            column_spacing: value.column_spacing,
+            wrap: value.wrap,
+            horizontal_overflow: value.horizontal_overflow,
+            vertical_overflow: value.vertical_overflow,
+            margins: value
+                .margins
+                .map(|margins| RelativeRect {
+                    left: margins.left,
+                    top: margins.top,
+                    right: margins.right,
+                    bottom: margins.bottom,
+                })
+                .unwrap_or_default(),
+            auto_fit: value.auto_fit,
+            font_scale: value.font_scale,
+            line_spacing_reduction: value.line_spacing_reduction,
+            from_word_art: value.from_word_art,
+            preset_text_warp: value.preset_text_warp,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ShapeTextBody {

--- a/packages/docx/src/docx/hangingCharsSave.test.ts
+++ b/packages/docx/src/docx/hangingCharsSave.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import { parseDocx } from '.';
+import { repackDocx } from './rezip';
+import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from './rezip/parts';
+import { readDocxContainer } from './zipContainer';
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPkg1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+function document(ind: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:pPr><w:ind ${ind}/></w:pPr><w:r><w:t>Indented</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>
+  </w:body>
+</w:document>`;
+}
+
+async function browserSave(ind: string): Promise<string> {
+  const parts: PartsMap = new Map();
+  parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
+  parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
+  parts.set('word/document.xml', toBytes(document(ind)));
+  const bytes = rezipPartsToArrayBuffer(parts);
+  const parsed = await parseDocx(bytes, { preloadFonts: false });
+  return readDocxContainer(await repackDocx(parsed)).text('word/document.xml') ?? '';
+}
+
+describe('character-unit hanging indents through the browser save', () => {
+  // the model crosses JSON on this path, and JSON has no negative zero
+  it('keeps hangingChars="0" as hanging', async () => {
+    const xml = await browserSave('w:hangingChars="0"');
+    expect(xml).toContain('w:hangingChars="0"');
+    expect(xml).not.toContain('w:firstLineChars');
+  });
+
+  it('keeps a hanging and a first-line character indent apart', async () => {
+    expect(await browserSave('w:hangingChars="150"')).toContain('w:hangingChars="150"');
+    expect(await browserSave('w:firstLineChars="200"')).toContain('w:firstLineChars="200"');
+  });
+});

--- a/packages/docx/src/types/formatting.ts
+++ b/packages/docx/src/types/formatting.ts
@@ -336,6 +336,12 @@ export interface ParagraphFormatting {
   indentFirstLine?: number;
   /** Whether first line is hanging indent */
   hangingIndent?: boolean;
+  /** Left indent in hundredths of a character (w:ind/@w:leftChars) */
+  indentLeftChars?: number;
+  /** Right indent in hundredths of a character (w:ind/@w:rightChars) */
+  indentRightChars?: number;
+  /** First line indent in hundredths of a character - negative for hanging (w:ind/@w:firstLineChars or @w:hangingChars) */
+  indentFirstLineChars?: number;
 
   // Borders
   /** Paragraph borders (w:pBdr) */

--- a/packages/docx/src/types/formatting.ts
+++ b/packages/docx/src/types/formatting.ts
@@ -342,6 +342,8 @@ export interface ParagraphFormatting {
   indentRightChars?: number;
   /** First line indent in hundredths of a character - negative for hanging (w:ind/@w:firstLineChars or @w:hangingChars) */
   indentFirstLineChars?: number;
+  /** Whether the character first-line indent is hanging; the sign of a zero does not survive JSON */
+  hangingIndentChars?: boolean;
 
   // Borders
   /** Paragraph borders (w:pBdr) */

--- a/packages/docx/src/yrs/shapeSave.test.ts
+++ b/packages/docx/src/yrs/shapeSave.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parseDocx } from '../docx';
+import { repackDocx } from '../docx/rezip';
+import { rezipPartsToArrayBuffer, toBytes, type PartsMap } from '../docx/rezip/parts';
+import { readDocxContainer } from '../docx/zipContainer';
+import type { Document } from '../types/document';
+import { preloadEditWasm } from '../wasm/edit';
+import { documentToYrs } from './documentToYrs';
+import { createYrsSession, type YrsSession } from './index';
+import { yrsToDocument } from './yrsToDocument';
+
+const WASM = resolve(import.meta.dir, '../wasm/generated/edit/docx_edit_bg.wasm');
+const OFFICE_DOC = 'application/vnd.openxmlformats-officedocument';
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="${OFFICE_DOC}.wordprocessingml.document.main+xml"/>
+</Types>`;
+
+const PACKAGE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPkg1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const TEXT_BOX = `<w:p><w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0"><wp:extent cx="914400" cy="457200"/><wp:docPr id="41" name="Text Box 41"/><a:graphic><a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"><wps:wsp><wps:cNvSpPr txBox="1"/><wps:spPr><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></wps:spPr><wps:txbx><w:txbxContent><w:p><w:r><w:t>BARE-BODY</w:t></w:r></w:p></w:txbxContent></wps:txbx><wps:bodyPr rot="0" vert="horz"/></wps:wsp></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>`;
+
+const DOCUMENT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <w:body>
+    ${TEXT_BOX}
+    <w:p><w:r><w:t>BODY-TEXT</w:t></w:r></w:p>
+    <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+function fixture(): Uint8Array {
+  const parts: PartsMap = new Map();
+  parts.set('[Content_Types].xml', toBytes(CONTENT_TYPES));
+  parts.set('_rels/.rels', toBytes(PACKAGE_RELS));
+  parts.set('word/document.xml', toBytes(DOCUMENT));
+  return new Uint8Array(rezipPartsToArrayBuffer(parts));
+}
+
+interface SaveOptions {
+  seeder?: 'native' | 'projected';
+  edit?: (session: YrsSession) => void;
+}
+
+/** Seed `bytes` the editor's way, run the edit, project and repack. */
+async function saveBody(bytes: Uint8Array, options: SaveOptions = {}): Promise<string> {
+  const { seeder = 'native', edit } = options;
+  const parsed = await parseDocx(bytes.buffer as ArrayBuffer, { preloadFonts: false });
+  const session = await createYrsSession({ clientId: 53101 });
+  let saved: Document;
+  try {
+    if (seeder === 'native') session.seedFromDocx(bytes);
+    else documentToYrs(session, parsed);
+    edit?.(session);
+    saved = yrsToDocument(session, parsed);
+  } finally {
+    session.destroy();
+  }
+  return readDocxContainer(await repackDocx(saved)).text('word/document.xml') ?? '';
+}
+
+function drawing(xml: string): string {
+  const match = /<w:drawing>[\s\S]*?<\/w:drawing>/.exec(xml);
+  return match?.[0] ?? '';
+}
+
+function appendToLastParagraph(session: YrsSession, text: string): void {
+  const spans = session.paragraphSpans('body');
+  const last = spans[spans.length - 1];
+  session.insertText({ story: 'body', paraId: last.paraId, offset: last.length }, text);
+}
+
+describe('shape save projection', () => {
+  beforeAll(() => preloadEditWasm(new Uint8Array(readFileSync(WASM))));
+
+  it.each(['native', 'projected'] as const)(
+    'keeps a text box body through an untouched %s projection',
+    async (seeder) => {
+      const xml = await saveBody(fixture(), { seeder });
+
+      expect(xml.match(/<w:txbxContent>/g)?.length).toBe(1);
+      expect(xml).toContain('BARE-BODY');
+      expect(drawing(xml)).toContain('<wps:cNvSpPr txBox="1"/>');
+    }
+  );
+
+  it('keeps a text box body when the body text around it is edited', async () => {
+    const untouched = await saveBody(fixture());
+    const edited = await saveBody(fixture(), {
+      edit: (session) => appendToLastParagraph(session, ' EDITED-IN-YRS'),
+    });
+
+    expect(edited).toContain('BODY-TEXT EDITED-IN-YRS');
+    expect(edited).toContain('BARE-BODY');
+    expect(drawing(edited)).toBe(drawing(untouched));
+  });
+});

--- a/packages/docx/src/yrs/yrsToDocument.ts
+++ b/packages/docx/src/yrs/yrsToDocument.ts
@@ -679,16 +679,32 @@ function imageRunFromPayload(payload: Attrs): Run {
   return { type: 'run', content: [{ type: 'drawing', image }] };
 }
 
+/** The seeded shape, carrying the text body and everything else no payload field describes. */
+function storedShape(value: unknown): Shape | undefined {
+  const json = asString(value);
+  if (!json || json.length > 2_000_000) return undefined;
+  try {
+    const parsed = JSON.parse(json) as Shape;
+    if (parsed?.type !== 'shape' || typeof parsed.shapeType !== 'string') return undefined;
+    if (!asObject(parsed.size)) parsed.size = { width: 0, height: 0 };
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
 function shapeRunFromPayload(payload: Attrs): Run {
-  const shape: Shape = {
+  const shape: Shape = storedShape(payload.shapeJson) ?? {
     type: 'shape',
-    shapeType: (asString(payload.shapeType) || 'rect') as Shape['shapeType'],
-    id: asString(payload.shapeId) || undefined,
-    size: {
-      width: payload.width ? pixelsToEmu(Number(payload.width)) : 0,
-      height: payload.height ? pixelsToEmu(Number(payload.height)) : 0,
-    },
+    shapeType: 'rect',
+    size: { width: 0, height: 0 },
   };
+  const shapeType = asString(payload.shapeType);
+  if (shapeType) shape.shapeType = shapeType as Shape['shapeType'];
+  const shapeId = asString(payload.shapeId);
+  if (shapeId) shape.id = shapeId;
+  if (payload.width) shape.size = { ...shape.size, width: pixelsToEmu(Number(payload.width)) };
+  if (payload.height) shape.size = { ...shape.size, height: pixelsToEmu(Number(payload.height)) };
   if (Array.isArray(payload.geometryPath) && payload.geometryPath.length > 0) {
     shape.geometryPath = payload.geometryPath as NonNullable<Shape['geometryPath']>;
   }


### PR DESCRIPTION
TL;DR:


Repro file:
Built in-test: `crates/betteroffice-docx/tests/document.rs` `saving_keeps_shape_text_box_bodies_and_character_unit_indents` — a `wps:wsp` text box both bare and inside `mc:AlternateContent`, paragraphs with `w:firstLineChars` / `w:leftChars` inside and outside the box, and an explicit `w:firstLine="0"`, through `Document::open` → `save` → reopen → save.

Summary:
- Fixes #202. Text boxes keep their text on save. Every `wps:txbx` shape was parsed as a plain `rect`, and the serializer writes the `wps:txbx` / `w:txbxContent` body only for a `textBox`, so the branch that wrote it was dead and every text box saved empty. The `mc:AlternateContent` unwrapping is not the cause — a bare `wps:wsp` was dropped identically — and it keeps working as before: `mc:Choice` is taken, the `w:pict` fallback discarded.
- Character-unit paragraph indents (`w:leftChars`, `w:rightChars`, `w:firstLineChars`, `w:hangingChars`) survive a save. They were never read, so a document that indents by characters — as Chinese typography does — kept only the twip approximation.
- An explicit `w:firstLine="0"` is no longer discarded on write. It is how a paragraph cancels an inherited first-line indent, and dropping it re-inherited the indent on reopen; that is the other half of the reporter's `w:firstLine` 53 → 22 count, alongside the paragraphs that vanished with their text boxes.
- Layout does not yet consume the character units; this restores round-trip fidelity only. Text boxes inside `wpg:wgp` groups still lose their content — a separate group-serialization gap.

Test plan:
- [x] `cargo test -p betteroffice-docx-parse -p betteroffice-docx -p betteroffice-docx-layout -p betteroffice-docx-edit`
- [x] `cargo clippy -p betteroffice-docx-parse -p betteroffice-docx --all-targets -- -D warnings && cargo fmt --check`
- [x] `bun run build:docx-wasm && bun test packages/docx/src/` and `bun run typecheck:packages`
- [x] Counterfactual: `rect` restored → the round-trip test fails with zero `w:txbxContent`; the char-unit parse reverted → its unit test fails with `None`
