### PR TITLE
fix(docx): honour a hard break on the no-face measure path

### DIFF
--- a/.changeset/docx-fallback-hard-break.md
+++ b/.changeset/docx-fallback-hard-break.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+A hard line break now starts a new line even when no measurement font resolves, so a title split by `<w:br/>` no longer collapses onto one baseline. Those fallback lines also carry the paragraph's `w:spacing` line rule instead of a fixed single-spaced box.

--- a/crates/docx-layout/src/measure_blocks.rs
+++ b/crates/docx-layout/src/measure_blocks.rs
@@ -6,9 +6,10 @@ use serde_json::{Value, json};
 use crate::table_grid::{resolve_cell_grid, resolve_table_column_widths, resolve_table_width_px};
 use crate::types::{
     BlockExtent, ChartExtent, ImageExtent, ImageRunPosition, LayoutBlock, ParagraphBlock,
-    ParagraphExtent, Run, ShapeBlock, ShapeExtent, TableBlock, TableCellExtent, TableExtent,
-    TableRowExtent, TextBoxBlock, TextBoxExtent,
+    ParagraphExtent, ParagraphSpacing, Run, ShapeBlock, ShapeExtent, TableBlock, TableCellExtent,
+    TableExtent, TableRowExtent, TextBoxBlock, TextBoxExtent, TypesetRow,
 };
+use ooxml_text::{LineBox, LineSpacingRule, apply_spacing_rule};
 
 const DEFAULT_CELL_PADDING_X: f64 = 7.0;
 const DEFAULT_CELL_PADDING_Y: f64 = 0.0;
@@ -550,6 +551,72 @@ fn synthetic_inline_image_width(image: &crate::types::ImageRun) -> f64 {
         .max(0.0)
 }
 
+/// `w:spacing` mapped onto a line rule, in the same precedence order the
+/// measured path uses. `None` is single spacing, which leaves the box alone.
+fn synthetic_line_rule(spacing: Option<&ParagraphSpacing>) -> Option<LineSpacingRule> {
+    let spacing = spacing?;
+    match (
+        spacing.line_rule.as_deref(),
+        spacing.line,
+        spacing.line_unit.as_deref(),
+    ) {
+        (Some("exact"), Some(line), _) => Some(LineSpacingRule::Exact {
+            px: line.max(0.0) as f32,
+        }),
+        (Some("atLeast"), Some(line), _) => Some(LineSpacingRule::AtLeast {
+            px: line.max(0.0) as f32,
+        }),
+        (_, Some(line), Some("multiplier")) => Some(LineSpacingRule::Auto {
+            line_240ths: (line * 240.0).round().clamp(0.0, 24_000_000.0) as u32,
+        }),
+        (_, Some(line), Some("px")) => Some(LineSpacingRule::Exact {
+            px: line.max(0.0) as f32,
+        }),
+        _ => None,
+    }
+}
+
+fn synthetic_row(
+    head_run: usize,
+    tail_run: usize,
+    tail_char: usize,
+    width: f64,
+    font_px: f64,
+    rule: Option<&LineSpacingRule>,
+) -> TypesetRow {
+    let (ascent, descent, line_height) = match rule {
+        // single spacing is the identity, so skip the f32 box round-trip
+        None => (font_px * 0.8, font_px * 0.2, font_px * 1.15),
+        Some(rule) => {
+            let ruled = apply_spacing_rule(
+                LineBox {
+                    ascent: (font_px * 0.8) as f32,
+                    descent: (font_px * 0.2) as f32,
+                    leading: (font_px * 0.15) as f32,
+                },
+                rule,
+            );
+            (
+                f64::from(ruled.ascent),
+                f64::from(ruled.descent),
+                f64::from(ruled.height()),
+            )
+        }
+    };
+    TypesetRow {
+        head_run,
+        head_char: 0,
+        tail_run,
+        tail_char,
+        width,
+        ascent,
+        descent,
+        line_height,
+        synthetic_fallback: Some(true),
+        ..TypesetRow::default()
+    }
+}
+
 fn synthetic_paragraph_extent(paragraph: &ParagraphBlock, content_width: f64) -> ParagraphExtent {
     let default_font_size = valid_font_size(
         paragraph
@@ -559,9 +626,19 @@ fn synthetic_paragraph_extent(paragraph: &ParagraphBlock, content_width: f64) ->
         11.0,
     );
     let default_font_px = default_font_size * 96.0 / 72.0;
+    let spacing = paragraph
+        .attrs
+        .as_ref()
+        .and_then(|attrs| attrs.spacing.as_ref());
+    let rule = synthetic_line_rule(spacing);
+    let measurable = content_width.is_finite() && content_width > 0.0;
+    let slot = |width: f64| if measurable { width } else { 0.0 };
+
+    let mut lines = Vec::new();
+    let mut head_run = 0usize;
     let mut font_px = default_font_px;
     let mut line_width = 0.0f64;
-    for run in &paragraph.runs {
+    for (index, run) in paragraph.runs.iter().enumerate() {
         match run {
             Run::Text(text) => {
                 font_px = font_px.max(synthetic_font_px(&text.fmt, default_font_size));
@@ -581,39 +658,43 @@ fn synthetic_paragraph_extent(paragraph: &ParagraphBlock, content_width: f64) ->
                     .unwrap_or("1");
                 line_width += synthetic_text_width(fallback, &field.fmt, default_font_size);
             }
-            Run::LineBreak(_) | Run::Unsupported => {}
+            // an authored break is exact, so it splits the fallback rows even
+            // though their widths are guesses
+            Run::LineBreak(_) => {
+                lines.push(synthetic_row(
+                    head_run,
+                    index,
+                    0,
+                    slot(line_width),
+                    font_px,
+                    rule.as_ref(),
+                ));
+                head_run = index + 1;
+                font_px = default_font_px;
+                line_width = 0.0;
+            }
+            Run::Unsupported => {}
         }
     }
-    let tail_run = paragraph.runs.len().saturating_sub(1);
+    let tail_run = paragraph.runs.len().saturating_sub(1).max(head_run);
     let tail_char = paragraph.runs.get(tail_run).map_or(0, |run| match run {
         Run::Text(text) => text.text.encode_utf16().count(),
         _ => 0,
     });
-    let spacing = paragraph
-        .attrs
-        .as_ref()
-        .and_then(|attrs| attrs.spacing.as_ref());
-    let line_height = font_px * 1.15;
+    lines.push(synthetic_row(
+        head_run,
+        tail_run,
+        tail_char,
+        slot(line_width),
+        font_px,
+        rule.as_ref(),
+    ));
+
     ParagraphExtent {
         total_height: spacing.and_then(|value| value.before).unwrap_or(0.0)
-            + line_height
+            + lines.iter().map(|line| line.line_height).sum::<f64>()
             + spacing.and_then(|value| value.after).unwrap_or(0.0),
-        lines: vec![crate::types::TypesetRow {
-            head_run: 0,
-            head_char: 0,
-            tail_run,
-            tail_char,
-            width: if content_width.is_finite() && content_width > 0.0 {
-                line_width
-            } else {
-                0.0
-            },
-            ascent: font_px * 0.8,
-            descent: font_px * 0.2,
-            line_height,
-            synthetic_fallback: Some(true),
-            ..crate::types::TypesetRow::default()
-        }],
+        lines,
     }
 }
 

--- a/crates/docx-layout/src/measure_blocks.rs
+++ b/crates/docx-layout/src/measure_blocks.rs
@@ -586,7 +586,9 @@ fn synthetic_row(
 ) -> TypesetRow {
     let (ascent, descent, line_height) = match rule {
         // single spacing is the identity, so skip the f32 box round-trip
-        None => (font_px * 0.8, font_px * 0.2, font_px * 1.15),
+        None | Some(LineSpacingRule::Auto { line_240ths: 240 }) => {
+            (font_px * 0.8, font_px * 0.2, font_px * 1.15)
+        }
         Some(rule) => {
             let ruled = apply_spacing_rule(
                 LineBox {

--- a/crates/docx-layout/tests/synthetic_metrics.rs
+++ b/crates/docx-layout/tests/synthetic_metrics.rs
@@ -511,6 +511,10 @@ fn hard_break_splits_the_fallback_line_under_every_rule() {
             EXACT_LINE_PX,
         ),
         (serde_json::json!({}), TITLE_PX * 1.15),
+        (
+            serde_json::json!({ "line": 1.0, "lineUnit": "multiplier", "lineRule": "auto" }),
+            TITLE_PX * 1.15,
+        ),
     ] {
         let what = spacing.to_string();
         docx_layout::clear_measure_fonts();
@@ -555,6 +559,27 @@ fn hard_break_splits_the_fallback_line_under_every_rule() {
         );
         assert!((runs[0].1 - runs[1].1).abs() < 0.01, "{what}");
     }
+}
+
+/// Single spacing written out is the same identity as single spacing left
+/// implicit; a paragraph must not gain a page from an f32 detour.
+#[test]
+fn explicit_single_spacing_measures_bit_for_bit_like_the_default() {
+    docx_layout::clear_measure_fonts();
+    let mut implicit = cjk_paragraph("第一段的文字");
+    let mut explicit = implicit.clone();
+    implicit["attrs"]["spacing"] = serde_json::json!({});
+    explicit["attrs"]["spacing"] =
+        serde_json::json!({ "line": 1.0, "lineUnit": "multiplier", "lineRule": "auto" });
+    let a = measure_paragraph(implicit, CONTENT_WIDTH, &fallback_config()).unwrap();
+    let b = measure_paragraph(explicit, CONTENT_WIDTH, &fallback_config()).unwrap();
+    assert_eq!(a.lines.len(), b.lines.len());
+    for (x, y) in a.lines.iter().zip(&b.lines) {
+        assert_eq!(x.line_height.to_bits(), y.line_height.to_bits());
+        assert_eq!(x.ascent.to_bits(), y.ascent.to_bits());
+        assert_eq!(x.descent.to_bits(), y.descent.to_bits());
+    }
+    assert_eq!(a.total_height.to_bits(), b.total_height.to_bits());
 }
 
 #[test]

--- a/crates/docx-layout/tests/synthetic_metrics.rs
+++ b/crates/docx-layout/tests/synthetic_metrics.rs
@@ -479,3 +479,107 @@ fn indented_fallback_accepts_overflow_instead_of_guessing_wraps() {
     assert!(fallback.lines[0].width > 100.0);
     assert!(fallback.lines[0].width > 60.0);
 }
+
+/// `w:line="560"` at `w:lineRule="exact"` — 28pt, the pitch of a Chinese
+/// official-document title (issue #204).
+const EXACT_LINE_PX: f64 = 560.0 / 20.0 * 96.0 / 72.0;
+const TITLE_PT: f64 = 22.0;
+const TITLE_PX: f64 = TITLE_PT * 96.0 / 72.0;
+
+fn hard_break_paragraph(spacing: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "paragraph",
+        "id": 0,
+        "runs": [
+            { "kind": "text", "text": "第一行", "fontSize": TITLE_PT },
+            { "kind": "lineBreak" },
+            { "kind": "text", "text": "第二行", "fontSize": TITLE_PT }
+        ],
+        "attrs": { "defaultFontSize": TITLE_PT, "spacing": spacing }
+    })
+}
+
+#[test]
+fn hard_break_splits_the_fallback_line_under_every_rule() {
+    for (spacing, pitch) in [
+        (
+            serde_json::json!({ "line": EXACT_LINE_PX, "lineRule": "exact" }),
+            EXACT_LINE_PX,
+        ),
+        (
+            serde_json::json!({ "line": EXACT_LINE_PX, "lineRule": "atLeast" }),
+            EXACT_LINE_PX,
+        ),
+        (serde_json::json!({}), TITLE_PX * 1.15),
+    ] {
+        let what = spacing.to_string();
+        docx_layout::clear_measure_fonts();
+        let extent = measure_paragraph(
+            hard_break_paragraph(spacing.clone()),
+            CONTENT_WIDTH,
+            &fallback_config(),
+        )
+        .expect("fallback measures");
+
+        assert_eq!(extent.lines.len(), 2, "{what}");
+        assert_eq!(
+            (extent.lines[0].head_run, extent.lines[0].tail_run),
+            (0, 1),
+            "{what}"
+        );
+        assert_eq!(
+            (extent.lines[1].head_run, extent.lines[1].tail_run),
+            (2, 2),
+            "{what}"
+        );
+        for line in &extent.lines {
+            assert!(
+                (line.line_height - pitch).abs() < 0.01,
+                "{what}: line height {} is not the ruled {pitch}",
+                line.line_height
+            );
+            assert!((line.width - 3.0 * TITLE_PX).abs() < 0.01, "{what}");
+        }
+        assert!((extent.total_height - 2.0 * pitch).abs() < 0.01, "{what}");
+
+        let runs = text_runs(&display_list_without_faces(
+            hard_break_paragraph(spacing),
+            CONTENT_WIDTH,
+        ));
+        assert_eq!(runs.len(), 2, "{what}");
+        assert!(
+            (runs[1].0 - runs[0].0 - pitch).abs() < 0.01,
+            "{what}: baselines {} and {} are not {pitch} apart",
+            runs[0].0,
+            runs[1].0
+        );
+        assert!((runs[0].1 - runs[1].1).abs() < 0.01, "{what}");
+    }
+}
+
+#[test]
+fn trailing_hard_break_adds_an_empty_fallback_line() {
+    let paragraph = serde_json::json!({
+        "kind": "paragraph",
+        "id": 0,
+        "runs": [
+            { "kind": "text", "text": "第一行", "fontSize": TITLE_PT },
+            { "kind": "lineBreak" }
+        ],
+        "attrs": { "defaultFontSize": TITLE_PT }
+    });
+    docx_layout::clear_measure_fonts();
+    let extent =
+        measure_paragraph(paragraph, CONTENT_WIDTH, &fallback_config()).expect("fallback measures");
+
+    assert_eq!(extent.lines.len(), 2);
+    assert_eq!(
+        (
+            extent.lines[1].head_run,
+            extent.lines[1].tail_run,
+            extent.lines[1].tail_char
+        ),
+        (2, 2, 0)
+    );
+    assert_eq!(extent.lines[1].width, 0.0);
+}


### PR DESCRIPTION
TL;DR:


Repro file:
Built in-test: `crates/docx-layout/tests/synthetic_metrics.rs` `hard_break_splits_the_fallback_line_under_every_rule` — a 22pt title `第一行<w:br/>第二行` under `w:spacing w:line="560" w:lineRule="exact"`, laid out with no measurement face registered, asserting two rows with baselines exactly 37.333px (28pt) apart.

Summary:
- Fixes #204. When no measurement font resolves, layout falls back to `synthetic_paragraph_extent`, which ignored every `w:br` and the paragraph's line rule: the whole paragraph became one row, and both halves of a hard-broken title painted on one baseline. That is the reported collapse, and it reproduces on 0.0.4 and on `main` before this change.
- The fallback now starts a new row at each hard break, mirroring the measured path's head/tail bookkeeping including a trailing break's empty row, and runs each row through `ooxml_text::apply_spacing_rule` with the paragraph's `w:spacing` mapped in the same precedence the measured path uses (`exact` → `atLeast` → multiplier → px). Single spacing short-circuits, so existing exact-value fallback assertions are unchanged.
- With a real face registered, `exact` + `w:br` already produced two rows at the right pitch on both commits; `apply_spacing_rule` from #180 is not involved. The fixed fallback output is now byte-identical to the same paragraph measured with a real Noto Sans SC face.
- The reporter's sibling #203 (mixed-font overprint on the same no-face path) is already fixed on `main` by #189 and needs no change here.

Test plan:
- [x] `cargo test -p betteroffice-docx-layout -p betteroffice-ooxml-text -p betteroffice-docx`
- [x] `cargo clippy -p betteroffice-docx-layout --all-targets -- -D warnings && cargo fmt --check`
- [x] `bun run build:docx-wasm && bun test packages/docx/src/`
- [x] Counterfactual: reverting `measure_blocks.rs` alone fails both new tests with one row instead of two
