### PR TITLE
ci(release): fail before publishing a set that cannot complete

### DIFF
--- a/.github/workflows/publish-python-binding.yml
+++ b/.github/workflows/publish-python-binding.yml
@@ -3,11 +3,19 @@ name: Publish a Python binding
 # Publishes one bindings/python-* distribution at its committed version, outside
 # the release train. Use it to create a PyPI project from a pending Trusted
 # Publisher, or to fill in a wheel a release run dropped.
+#
+# The dispatch API returns no run id, so release.yml finds the run it started by
+# matching this title.
+run-name: Publish betteroffice-${{ inputs.binding }} @ ${{ inputs.sha }}
 on:
   workflow_dispatch:
     inputs:
       binding:
         description: The bindings/python-<binding> distribution to publish.
+        required: true
+        type: string
+      sha:
+        description: The commit to build and publish. `main` moves; pass the commit you mean.
         required: true
         type: string
       dry_run:
@@ -24,6 +32,7 @@ jobs:
     uses: ./.github/workflows/python-dist.yml
     with:
       binding: ${{ inputs.binding }}
+      sha: ${{ inputs.sha }}
     permissions:
       contents: read
 

--- a/.github/workflows/python-dist.yml
+++ b/.github/workflows/python-dist.yml
@@ -11,6 +11,10 @@ on:
         description: The bindings/python-<binding> distribution to build.
         required: true
         type: string
+      sha:
+        description: The commit to build. A branch would move under the build.
+        required: true
+        type: string
 
 jobs:
   wheels:
@@ -38,6 +42,8 @@ jobs:
             manylinux: auto
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.sha }}
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -60,6 +66,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.sha }}
 
       - uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,12 @@ jobs:
         if: steps.pending.outputs.publishing == 'true' && steps.crates-bootstrap.outputs.enabled != 'true'
         uses: rust-lang/crates-io-auth-action@v1
 
+      - name: Check crates.io publish targets
+        if: steps.pending.outputs.publishing == 'true'
+        env:
+          CRATES_IO_BOOTSTRAP_TOKEN: ${{ secrets.CRATES_IO_BOOTSTRAP_TOKEN }}
+        run: node scripts/check-publish-targets.mjs --crates
+
       - name: Publish Rust crates
         if: steps.pending.outputs.publishing == 'true'
         env:
@@ -107,6 +113,12 @@ jobs:
       - name: Pin workspace deps for npm publish
         if: steps.pending.outputs.publishing == 'true'
         run: bun scripts/rewrite-workspace-deps.ts
+
+      # Publishing here means there are no pending changesets, so changesets/action
+      # runs no `version` command: these manifests carry the versions it publishes.
+      - name: Check npm publish targets
+        if: steps.pending.outputs.publishing == 'true'
+        run: node scripts/check-publish-targets.mjs --npm
 
       - name: Release PR or publish
         id: changesets
@@ -137,7 +149,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      bindings: ${{ steps.registry.outputs.bindings }}
       publish: ${{ steps.registry.outputs.publish }}
     permissions:
       contents: read
@@ -150,7 +161,7 @@ jobs:
           if [ -n "$TOKEN" ]; then
             echo "::error::PYPI_API_TOKEN is readable by a job that declares no environment, so it is a repository or organization secret and every binding's publish leg can upload with it."
             echo "::error::Delete it under Settings > Secrets and variables > Actions, then revoke it on PyPI."
-            echo "::error::Preferred: add a PyPI Trusted Publisher (owner openooxml, repository betteroffice, workflow release.yml, environment pypi-<binding>) and keep no token at all."
+            echo "::error::Preferred: add a PyPI Trusted Publisher (owner openooxml, repository betteroffice, workflow publish-python-binding.yml, environment pypi-<binding>) and keep no token at all."
             echo "::error::Otherwise: mint a project-scoped token and re-add it as an environment secret on the pypi-<binding> environment only. This step cannot tell a project-scoped token from an account-scoped one, so an account-scoped token would pass."
             echo "::error::See RELEASING.md."
             exit 1
@@ -159,77 +170,30 @@ jobs:
       - uses: actions/checkout@v7
 
       - id: registry
-        run: |
-          {
-            echo "bindings=$(node scripts/python-bindings.mjs)"
-            echo "publish=$(node scripts/python-bindings.mjs --publish)"
-          } >> "$GITHUB_OUTPUT"
+        run: echo "publish=$(node scripts/python-bindings.mjs --publish)" >> "$GITHUB_OUTPUT"
 
-  python-dist:
-    name: Python ${{ matrix.binding }}
-    needs: python-bindings
-    strategy:
-      fail-fast: false
-      matrix:
-        binding: ${{ fromJSON(needs.python-bindings.outputs.bindings) }}
-    uses: ./.github/workflows/python-dist.yml
-    with:
-      binding: ${{ matrix.binding }}
-    permissions:
-      contents: read
-
-  # Never a reusable workflow: the OIDC claim must name release.yml.
+  # A PyPI Trusted Publisher is scoped to the file that runs the upload, and every
+  # publisher here names publish-python-binding.yml, so the release dispatches that
+  # workflow instead of uploading. It builds main, which already carries the
+  # release commit this run was triggered by.
   python-pypi:
-    name: Publish betteroffice-${{ matrix.binding }}
-    needs: [python-bindings, python-dist]
-    # `needs` collapses the python-dist matrix: `success()` would skip every binding on one failure.
-    if: ${{ !cancelled() && needs.python-bindings.result == 'success' && needs.python-bindings.outputs.publish != '[]' }}
+    name: Dispatch Python publishes
+    needs: python-bindings
+    if: needs.python-bindings.outputs.publish != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        binding: ${{ fromJSON(needs.python-bindings.outputs.publish) }}
-    # Scopes each Trusted Publisher to one project; the workflow alone cannot.
-    environment: pypi-${{ matrix.binding }}
+    timeout-minutes: 5
     permissions:
-      id-token: write # OIDC Trusted Publishing
+      actions: write # dispatch publish-python-binding.yml
     steps:
-      - name: Require a complete build
-        uses: actions/download-artifact@v4
-        with:
-          name: built-${{ matrix.binding }}
-          path: receipt
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: python-${{ matrix.binding }}.*
-          path: dist
-          merge-multiple: true
-
-      # Never at repository scope: one secret would reach every binding's leg.
-      - name: Detect PyPI token
-        id: pypi-token
+      - name: Dispatch a publish per binding
         env:
-          TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PUBLISH: ${{ needs.python-bindings.outputs.publish }}
         run: |
-          if [ -n "$TOKEN" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish with API token
-        if: steps.pypi-token.outputs.enabled == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: dist
-          skip-existing: true
-
-      - name: Publish via Trusted Publishing
-        if: steps.pypi-token.outputs.enabled != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist
-          skip-existing: true
+          status=0
+          for binding in $(echo "$PUBLISH" | jq -r '.[]'); do
+            gh workflow run publish-python-binding.yml --ref main \
+              -f binding="$binding" -f dry_run=false || status=1
+          done
+          exit $status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,33 +197,24 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           status=0
-          dispatched=""
+          runs=""
           for binding in $(echo "$PUBLISH" | jq -r '.[]'); do
-            if gh workflow run publish-python-binding.yml --ref main \
-              -f binding="$binding" -f sha="$SHA" -f dry_run=false; then
-              dispatched="$dispatched $binding"
+            # From API version 2026-03-10 the dispatch returns the created run's id,
+            # so the wait below watches exactly the runs this job started.
+            if run=$(gh api --method POST -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/$GH_REPO/actions/workflows/publish-python-binding.yml/dispatches" \
+              -f ref=main -f "inputs[binding]=$binding" -f "inputs[sha]=$SHA" \
+              -F "inputs[dry_run]=false" --jq '.workflow_run_id') && [ -n "$run" ]; then
+              runs="$runs $binding:$run"
             else
+              echo "::error::Dispatching the publish of betteroffice-$binding failed."
               status=1
             fi
           done
 
-          # Every binding is dispatched before anything is waited on, so they build
-          # in parallel. The dispatch returns no run id; run-name carries the match.
-          for binding in $dispatched; do
-            run=""
-            for _ in $(seq 30); do
-              run=$(gh run list --workflow publish-python-binding.yml --event workflow_dispatch \
-                --limit 50 --json databaseId,displayTitle |
-                jq -r --arg title "Publish betteroffice-$binding @ $SHA" \
-                  'map(select(.displayTitle == $title)) | first | .databaseId // empty')
-              if [ -n "$run" ]; then break; fi
-              sleep 5
-            done
-            if [ -z "$run" ]; then
-              echo "::error::No publish-python-binding run for $binding appeared at $SHA."
-              status=1
-              continue
-            fi
+          for entry in $runs; do
+            binding=${entry%%:*}
+            run=${entry#*:}
             if ! gh run watch "$run" --exit-status; then
               echo "::error::betteroffice-$binding did not publish: $GITHUB_SERVER_URL/$GH_REPO/actions/runs/$run"
               status=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,20 @@ jobs:
         if: steps.pending.outputs.publishing == 'true' && steps.crates-bootstrap.outputs.enabled != 'true'
         uses: rust-lang/crates-io-auth-action@v1
 
+      # Both registries are checked before the first upload: a guard that fails
+      # after the crates publish leaves the release half-published.
       - name: Check crates.io publish targets
         if: steps.pending.outputs.publishing == 'true'
         env:
           CRATES_IO_BOOTSTRAP_TOKEN: ${{ secrets.CRATES_IO_BOOTSTRAP_TOKEN }}
         run: node scripts/check-publish-targets.mjs --crates
+
+      # Publishing here means there are no pending changesets, so changesets/action
+      # runs no `version` command: these manifests carry the versions it publishes.
+      # It reads name and version, which the pin below leaves alone.
+      - name: Check npm publish targets
+        if: steps.pending.outputs.publishing == 'true'
+        run: node scripts/check-publish-targets.mjs --npm
 
       - name: Publish Rust crates
         if: steps.pending.outputs.publishing == 'true'
@@ -113,12 +122,6 @@ jobs:
       - name: Pin workspace deps for npm publish
         if: steps.pending.outputs.publishing == 'true'
         run: bun scripts/rewrite-workspace-deps.ts
-
-      # Publishing here means there are no pending changesets, so changesets/action
-      # runs no `version` command: these manifests carry the versions it publishes.
-      - name: Check npm publish targets
-        if: steps.pending.outputs.publishing == 'true'
-        run: node scripts/check-publish-targets.mjs --npm
 
       - name: Release PR or publish
         id: changesets
@@ -161,8 +164,8 @@ jobs:
           if [ -n "$TOKEN" ]; then
             echo "::error::PYPI_API_TOKEN is readable by a job that declares no environment, so it is a repository or organization secret and every binding's publish leg can upload with it."
             echo "::error::Delete it under Settings > Secrets and variables > Actions, then revoke it on PyPI."
-            echo "::error::Preferred: add a PyPI Trusted Publisher (owner openooxml, repository betteroffice, workflow publish-python-binding.yml, environment pypi-<binding>) and keep no token at all."
-            echo "::error::Otherwise: mint a project-scoped token and re-add it as an environment secret on the pypi-<binding> environment only. This step cannot tell a project-scoped token from an account-scoped one, so an account-scoped token would pass."
+            echo "::error::Add a PyPI Trusted Publisher instead (owner openooxml, repository betteroffice, workflow publish-python-binding.yml, environment pypi-<binding>) and keep no token at all."
+            echo "::error::There is no token path: publish-python-binding.yml refuses every PYPI_API_TOKEN it can read, including an environment secret on pypi-<binding>."
             echo "::error::See RELEASING.md."
             exit 1
           fi
@@ -174,26 +177,56 @@ jobs:
 
   # A PyPI Trusted Publisher is scoped to the file that runs the upload, and every
   # publisher here names publish-python-binding.yml, so the release dispatches that
-  # workflow instead of uploading. It builds main, which already carries the
-  # release commit this run was triggered by.
+  # workflow instead of uploading. The dispatch carries this run's commit, because
+  # main moves; the wait is what makes a failed upload fail the release.
   python-pypi:
-    name: Dispatch Python publishes
+    name: Publish Python bindings
     needs: python-bindings
     if: needs.python-bindings.outputs.publish != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Covers the dispatched workflow's own worst case: 45 (wheels) + 5 + 15 (publish).
+    timeout-minutes: 75
     permissions:
       actions: write # dispatch publish-python-binding.yml
     steps:
-      - name: Dispatch a publish per binding
+      - name: Dispatch a publish per binding, then wait for each
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PUBLISH: ${{ needs.python-bindings.outputs.publish }}
+          SHA: ${{ github.sha }}
         run: |
           status=0
+          dispatched=""
           for binding in $(echo "$PUBLISH" | jq -r '.[]'); do
-            gh workflow run publish-python-binding.yml --ref main \
-              -f binding="$binding" -f dry_run=false || status=1
+            if gh workflow run publish-python-binding.yml --ref main \
+              -f binding="$binding" -f sha="$SHA" -f dry_run=false; then
+              dispatched="$dispatched $binding"
+            else
+              status=1
+            fi
+          done
+
+          # Every binding is dispatched before anything is waited on, so they build
+          # in parallel. The dispatch returns no run id; run-name carries the match.
+          for binding in $dispatched; do
+            run=""
+            for _ in $(seq 30); do
+              run=$(gh run list --workflow publish-python-binding.yml --event workflow_dispatch \
+                --limit 50 --json databaseId,displayTitle |
+                jq -r --arg title "Publish betteroffice-$binding @ $SHA" \
+                  'map(select(.displayTitle == $title)) | first | .databaseId // empty')
+              if [ -n "$run" ]; then break; fi
+              sleep 5
+            done
+            if [ -z "$run" ]; then
+              echo "::error::No publish-python-binding run for $binding appeared at $SHA."
+              status=1
+              continue
+            fi
+            if ! gh run watch "$run" --exit-status; then
+              echo "::error::betteroffice-$binding did not publish: $GITHUB_SERVER_URL/$GH_REPO/actions/runs/$run"
+              status=1
+            fi
           done
           exit $status

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,8 +6,8 @@ Changesets drive npm and crates.io releases through the same release PR.
 
 Run `bun changeset` and select every affected npm package. Select
 `@betteroffice/rust-crates` when a change affects the published Rust API or
-implementation. The eight Rust crates version and publish in lockstep,
-independently from npm versions.
+implementation. Every Rust crate in `scripts/rust-crates.mjs` versions and
+publishes in lockstep, independently from npm versions.
 
 Merging a changeset opens or updates `chore: release`. Merging that release PR
 publishes every unpublished npm and Cargo version. The Cargo publisher checks
@@ -21,7 +21,7 @@ Publishing can only be configured after a crate exists.
 1. Create a short-lived crates.io token authorized to publish new crates.
 2. Add it to the repository as `CRATES_IO_BOOTSTRAP_TOKEN` before merging the
    initial release PR.
-3. Merge the release PR and confirm all eight crates were published.
+3. Merge the release PR and confirm every crate was published.
 4. Add a GitHub Trusted Publisher to each crate with owner `openooxml`,
    repository `betteroffice`, and workflow `release.yml`.
 5. Remove the GitHub secret and revoke the bootstrap token.
@@ -65,12 +65,14 @@ npm depending on a name that 404s.
 
 An optional peer that 404s does not make installation fail: npm silently omits
 it. Consumers then fall back to synthetic metrics while being told to install a
-package that does not exist. `scripts/check-publish-targets.mjs --npm` runs
-before `changeset publish` and fails the release, naming every package that is
-not on npm yet, so a skipped bootstrap stops the run instead of half-publishing
-it. The versions it reads are the ones about to be published: the publish path
-runs only when no changesets are pending, and `changesets/action` runs no
-`version` command then.
+package that does not exist. `scripts/check-publish-targets.mjs --npm` fails the
+release, naming every package that is not on npm yet, so a skipped bootstrap
+stops the run instead of half-publishing it. Both guards run before the first
+upload of either registry — a guard that failed after the crates went out would
+leave the release half-published, and a crate cannot be unpublished. The
+versions it reads are the ones about to be published: the publish path runs only
+when no changesets are pending, and `changesets/action` runs no `version`
+command then.
 
 ## Python bindings
 
@@ -99,12 +101,16 @@ Trusted Publisher is scoped to the workflow file that runs the upload, because
 that is what the OIDC claim names, and every publisher here names that file — so
 `release.yml` cannot upload from a job of its own. Its `python-pypi` job
 dispatches `publish-python-binding.yml` once per publishable binding with
-`dry_run=false` at `--ref main`. The release commit that triggered the run is
-already on `main`, so the dispatched build carries the versions just released.
+`dry_run=false` and `sha=<the release commit>`. The dispatch API takes only a
+branch or tag as its `ref`, and `main` moves during a release, so that `sha` is
+what every checkout in the build uses — the wheels carry the versions just
+released, not whatever landed on `main` meanwhile.
 
-Each upload is therefore its own **Publish a Python binding** run rather than a
-leg of the release run, and the same dispatch by hand is how a wheel that a
-release dropped gets filled in.
+The release then waits for each dispatched run and fails if one of them does, so
+a green **Release** means the wheels are on PyPI. Each upload is still its own
+**Publish a Python binding** run rather than a leg of the release run, and the
+same dispatch by hand — with the `sha` you mean, which is required — is how a
+wheel that a release dropped gets filled in.
 
 ### Launching a binding
 
@@ -172,14 +178,9 @@ distribution fails only that distribution's upload.
 
 ## Publish order
 
-The workflow publishes dependencies before consumers:
-
-```text
-betteroffice-opc, betteroffice-xlsx-model
-betteroffice-xlsx-parse, betteroffice-xlsx-calc, betteroffice-xlsx-render
-betteroffice-xlsx-ops, betteroffice-xlsx-raster
-betteroffice-xlsx
-```
+The workflow publishes dependencies before consumers, in the order
+`RUST_CRATES` lists them in `scripts/rust-crates.mjs`: the shared crates, then
+each format's own layers, then the crate that ties them together.
 
 Cargo versions and internal registry requirements live in the root
 `Cargo.toml`. `scripts/version-packages.mjs` synchronizes them with the private

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,11 @@ Publishing can only be configured after a crate exists.
 Subsequent releases use `rust-lang/crates-io-auth-action` and GitHub OIDC to
 obtain a short-lived crates.io token.
 
+`scripts/check-publish-targets.mjs --crates` runs before the crates publish and
+fails the release, naming every crate that is not on crates.io yet — unless
+`CRATES_IO_BOOTSTRAP_TOKEN` is set, which is the one credential that can create
+a crate.
+
 ## Initial npm release of a new package
 
 `release.yml` authenticates to npm with OIDC Trusted Publishing and carries no
@@ -60,16 +65,19 @@ npm depending on a name that 404s.
 
 An optional peer that 404s does not make installation fail: npm silently omits
 it. Consumers then fall back to synthetic metrics while being told to install a
-package that does not exist. Nothing in CI enforces this bootstrap ordering. If
-the manual publish is skipped and a release runs anyway, publish the missing
-package and republish the dependent as soon as possible.
+package that does not exist. `scripts/check-publish-targets.mjs --npm` runs
+before `changeset publish` and fails the release, naming every package that is
+not on npm yet, so a skipped bootstrap stops the run instead of half-publishing
+it. The versions it reads are the ones about to be published: the publish path
+runs only when no changesets are pending, and `changesets/action` runs no
+`version` command then.
 
 ## Python bindings
 
 `scripts/python-bindings.mjs` is the single registry of Python distributions.
 `scripts/version-packages.mjs` imports it, and both the CI gate and the release
-workflow read it at runtime — `release.yml` turns it into the build and publish
-matrices — so the list is never duplicated in a workflow.
+workflow read it at runtime — `release.yml` turns it into one publish dispatch
+per binding — so the list is never duplicated in a workflow.
 
 `bindings/Cargo.lock` pins the workspace crates by version, so every bump
 invalidates it and CI's `cargo clippy --locked` would fail.
@@ -77,12 +85,26 @@ invalidates it and CI's `cargo clippy --locked` would fail.
 the release commit carries it alongside the manifests.
 
 Each entry carries a `publish` flag. Every registered binding is versioned by
-Changesets, installed and tested by the CI gate, and built into wheels and an
-sdist by the release; only a flagged one enters the publish matrix. A binding
-lands with `publish: false`, so merging it cannot create a PyPI project.
-Flipping that flag is what arms the upload, and it is the last step of a launch.
+Changesets and installed and tested by the CI gate; only a flagged one is built
+into wheels and an sdist and uploaded. A binding lands with `publish: false`, so
+merging it cannot create a PyPI project. Flipping that flag is what arms the
+upload, and it is the last step of a launch.
 
 Every registered binding is at `publish: true` today; none is held back.
+
+### One publish path
+
+`publish-python-binding.yml` is the only workflow that uploads to PyPI. A
+Trusted Publisher is scoped to the workflow file that runs the upload, because
+that is what the OIDC claim names, and every publisher here names that file — so
+`release.yml` cannot upload from a job of its own. Its `python-pypi` job
+dispatches `publish-python-binding.yml` once per publishable binding with
+`dry_run=false` at `--ref main`. The release commit that triggered the run is
+already on `main`, so the dispatched build carries the versions just released.
+
+Each upload is therefore its own **Publish a Python binding** run rather than a
+leg of the release run, and the same dispatch by hand is how a wheel that a
+release dropped gets filled in.
 
 ### Launching a binding
 
@@ -109,39 +131,34 @@ To launch `betteroffice-<format>`:
    `pypi-<binding>`, which is what scopes a Trusted Publisher to one project.
 3. Add a pending publisher at <https://pypi.org/manage/account/publishing/> with
    project name `betteroffice-<format>`, owner `openooxml`, repository
-   `betteroffice`, workflow `release.yml`, and environment `pypi-<format>`.
-   Publishing must stay a direct job in `release.yml`: PyPI [cannot name a
-   reusable workflow][reusable] as a Trusted Publisher.
+   `betteroffice`, workflow `publish-python-binding.yml`, and environment
+   `pypi-<format>`. Publishing stays a direct job in that file: PyPI [cannot name
+   a reusable workflow][reusable] as a Trusted Publisher, which is why the
+   release dispatches it instead of calling it.
 4. Flip the registry entry to `publish: true`. The next push to `main` with no
    pending changesets uploads the distribution and converts the publisher. The
    site's PyPI downloads badge reads the same flag, so no other list needs it.
 
 No step needs a `PYPI_API_TOKEN`.
 
-### The API token path
+### No API token path
 
-`release.yml` keeps a token path that runs only when the `pypi-<binding>`
-environment holds a `PYPI_API_TOKEN`. It exists for `betteroffice-xlsx`, which
-shipped on a token before pending publishers were used here. Delete both steps
-once that project has a Trusted Publisher; a new binding must never take it.
+Neither workflow can upload with a token. The release train fails at `Refuse a
+repository-scoped PyPI token` before it dispatches anything: that job declares no
+environment, so anything it can read is repository- or organization-scoped, and a
+repository secret would reach every binding. `publish-python-binding.yml` repeats
+the guard inside `pypi-<binding>`, where an environment secret is visible too.
 
 A PyPI API token is scoped either to a single project or to the entire account,
 and a project that does not exist yet cannot be named — so a bootstrap token is
 necessarily account-wide. That blast radius is what pending publishers remove.
 
-A token that is kept anyway must be **project-scoped** and held as an environment
-secret on `pypi-<binding>`, never at repository or organization scope. The guard
-below proves only that a token is not repository- or organization-scoped; nothing
-in CI can prove a token is project-scoped, so that part is on whoever adds it.
-
-**Outstanding:** `PYPI_API_TOKEN` is a **repository** secret today, and it
-created `betteroffice-xlsx`, so it is almost certainly account-scoped. Delete it
-under Settings → Secrets and variables → Actions, revoke it on PyPI, and add a
-Trusted Publisher to `betteroffice-xlsx` (owner `openooxml`, repository
-`betteroffice`, workflow `release.yml`, environment `pypi-xlsx`). Until it is
-gone the release fails at `Refuse a repository-scoped PyPI token`: that job
-declares no environment, so anything it can read is repository- or
-organization-scoped, and a repository secret reaches every binding's publish leg.
+**Outstanding:** `betteroffice-xlsx` was created by such a token before pending
+publishers were used here, and it has no Trusted Publisher — its wheels carry no
+provenance, unlike `betteroffice-docx` and `betteroffice-pptx`, whose
+attestations name `publish-python-binding.yml`. Add one (owner `openooxml`,
+repository `betteroffice`, workflow `publish-python-binding.yml`, environment
+`pypi-xlsx`) or its upload fails the OIDC exchange.
 
 Naming an environment that does not exist does not fail a job — GitHub creates it
 empty — so `environment: pypi-<binding>` cannot block a publish by itself. The

--- a/scripts/check-publish-targets.mjs
+++ b/scripts/check-publish-targets.mjs
@@ -1,0 +1,119 @@
+// Fail a release before it publishes half a set.
+//
+// Trusted Publishing attaches only to a name that already exists, so a
+// brand-new package or crate cannot be created by the workflow. `changeset
+// publish` attempts every unpublished package in parallel, tags the ones that
+// worked, and only then throws — leaving live dependents pointing at a name
+// that 404s. This runs first and names what has to be bootstrapped by hand.
+import { fileURLToPath } from 'node:url';
+import { publishedPackageVersions } from './published-packages.mjs';
+import { RUST_CRATES } from './rust-crates.mjs';
+
+const NPM_REGISTRY = process.env.NPM_REGISTRY_URL ?? 'https://registry.npmjs.org';
+const CRATES_REGISTRY = process.env.CRATES_REGISTRY_URL ?? 'https://crates.io/api/v1/crates';
+// crates.io rejects a request without one.
+const USER_AGENT = 'betteroffice-release (https://github.com/openooxml/betteroffice)';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchRegistry(url, headers = {}) {
+  let lastError;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: { 'User-Agent': USER_AGENT, ...headers },
+        cache: 'no-store'
+      });
+    } catch (error) {
+      lastError = error;
+      await sleep(2 ** attempt * 500);
+      continue;
+    }
+    if (response.ok || response.status === 404) return response;
+    if (response.status !== 429 && response.status < 500) {
+      throw new Error(`${url} returned ${response.status}`);
+    }
+    lastError = new Error(`${url} returned ${response.status}`);
+    await sleep(2 ** attempt * 500);
+  }
+  throw lastError;
+}
+
+/** `missing` (the name is unclaimed), `new` (this version is), or `published`. */
+export async function auditNpmPackages(packages, registry = NPM_REGISTRY) {
+  const audit = [];
+  for (const { name, version } of packages) {
+    const response = await fetchRegistry(`${registry}/${encodeURIComponent(name)}`, {
+      Accept: 'application/vnd.npm.install-v1+json'
+    });
+    if (response.status === 404) {
+      audit.push({ name, version, state: 'missing' });
+      continue;
+    }
+    const versions = (await response.json()).versions ?? {};
+    audit.push({ name, version, state: version in versions ? 'published' : 'new' });
+  }
+  return audit;
+}
+
+/** `missing` (the crate is unclaimed) or `present`. Versions are the publisher's job. */
+export async function auditCrates(names, registry = CRATES_REGISTRY) {
+  const audit = [];
+  for (const name of names) {
+    const response = await fetchRegistry(`${registry}/${encodeURIComponent(name)}`);
+    audit.push({ name, state: response.status === 404 ? 'missing' : 'present' });
+  }
+  return audit;
+}
+
+async function checkNpm() {
+  const audit = await auditNpmPackages(publishedPackageVersions());
+  for (const { name, version, state } of audit) {
+    if (state === 'published') console.log(`${name}@${version} is on npm.`);
+    if (state === 'new') console.log(`${name}@${version} is a new version of a package on npm.`);
+  }
+
+  const missing = audit.filter((entry) => entry.state === 'missing');
+  if (missing.length === 0) return 0;
+  for (const { name } of missing) console.error(`${name} is not on npm.`);
+  console.error(
+    'release.yml publishes with OIDC Trusted Publishing, which cannot create a package. `changeset publish` would publish the rest of the set before it fails on these.'
+  );
+  console.error('Publish each by hand first: RELEASING.md, "Initial npm release of a new package".');
+  return 1;
+}
+
+async function checkCrates() {
+  const audit = await auditCrates(RUST_CRATES.map((crate) => crate.name));
+  // Mirrors release.yml's `Detect crates.io bootstrap token`: a token can create a crate.
+  const bootstrap = Boolean(process.env.CRATES_IO_BOOTSTRAP_TOKEN);
+  for (const { name, state } of audit) {
+    if (state === 'present') console.log(`${name} is on crates.io.`);
+    if (state === 'missing' && bootstrap) {
+      console.log(`${name} is not on crates.io; CRATES_IO_BOOTSTRAP_TOKEN can create it.`);
+    }
+  }
+
+  const missing = bootstrap ? [] : audit.filter((entry) => entry.state === 'missing');
+  if (missing.length === 0) return 0;
+  for (const { name } of missing) console.error(`${name} is not on crates.io.`);
+  console.error(
+    'The OIDC token from crates-io-auth-action cannot create a crate, and the crates publish stops at the first failure.'
+  );
+  console.error(
+    'Set CRATES_IO_BOOTSTRAP_TOKEN, or publish each by hand first: RELEASING.md, "Initial crates.io release".'
+  );
+  return 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [mode, ...rest] = process.argv.slice(2);
+  if (rest.length > 0 || (mode !== '--npm' && mode !== '--crates')) {
+    console.error('check-publish-targets.mjs: expected exactly one of --npm or --crates');
+    process.exit(2);
+  }
+  process.exit(await (mode === '--npm' ? checkNpm() : checkCrates()));
+}

--- a/scripts/check-publish-targets.mjs
+++ b/scripts/check-publish-targets.mjs
@@ -13,31 +13,59 @@ const NPM_REGISTRY = process.env.NPM_REGISTRY_URL ?? 'https://registry.npmjs.org
 const CRATES_REGISTRY = process.env.CRATES_REGISTRY_URL ?? 'https://crates.io/api/v1/crates';
 // crates.io rejects a request without one.
 const USER_AGENT = 'betteroffice-release (https://github.com/openooxml/betteroffice)';
+const ATTEMPTS = 5;
+const REQUEST_TIMEOUT_MS = Number(process.env.REGISTRY_TIMEOUT_MS ?? 15_000);
+// A registry may ask for an hour; a release gate waits a minute.
+const RETRY_AFTER_CAP_MS = 60_000;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Half the backoff plus a random half, so parallel releases don't retry in lockstep. */
+function backoffMs(attempt) {
+  const base = 2 ** attempt * 500;
+  return base / 2 + Math.random() * (base / 2);
+}
+
+/** `Retry-After` in ms — seconds or an HTTP-date — or undefined if there is none. */
+function retryAfterMs(response) {
+  const header = response.headers.get('Retry-After');
+  if (!header) return undefined;
+  const seconds = Number(header);
+  const ms = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(header) - Date.now();
+  if (!Number.isFinite(ms)) return undefined;
+  return Math.min(Math.max(ms, 0), RETRY_AFTER_CAP_MS);
+}
+
+/** The parsed body, `null` when the name is unclaimed, or a failure to weigh. */
+async function attemptRegistry(url, headers) {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': USER_AGENT, ...headers },
+    cache: 'no-store',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  });
+  if (response.status === 404) return { body: null };
+  if (response.ok) return { body: await response.json() };
+  const error = new Error(`${url} returned ${response.status}`);
+  const retry = response.status === 429 || response.status >= 500;
+  return { error, retry, wait: retry ? retryAfterMs(response) : undefined };
+}
+
 async function fetchRegistry(url, headers = {}) {
   let lastError;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    let response;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    let result;
     try {
-      response = await fetch(url, {
-        headers: { 'User-Agent': USER_AGENT, ...headers },
-        cache: 'no-store'
-      });
+      result = await attemptRegistry(url, headers);
     } catch (error) {
-      lastError = error;
-      await sleep(2 ** attempt * 500);
-      continue;
+      // A refused connection, a request past REQUEST_TIMEOUT_MS, or a body that stops mid-JSON.
+      result = { error, retry: true };
     }
-    if (response.ok || response.status === 404) return response;
-    if (response.status !== 429 && response.status < 500) {
-      throw new Error(`${url} returned ${response.status}`);
-    }
-    lastError = new Error(`${url} returned ${response.status}`);
-    await sleep(2 ** attempt * 500);
+    if (!result.error) return result.body;
+    if (!result.retry) throw result.error;
+    lastError = result.error;
+    if (attempt < ATTEMPTS - 1) await sleep(result.wait ?? backoffMs(attempt));
   }
   throw lastError;
 }
@@ -46,14 +74,14 @@ async function fetchRegistry(url, headers = {}) {
 export async function auditNpmPackages(packages, registry = NPM_REGISTRY) {
   const audit = [];
   for (const { name, version } of packages) {
-    const response = await fetchRegistry(`${registry}/${encodeURIComponent(name)}`, {
+    const body = await fetchRegistry(`${registry}/${encodeURIComponent(name)}`, {
       Accept: 'application/vnd.npm.install-v1+json'
     });
-    if (response.status === 404) {
+    if (body === null) {
       audit.push({ name, version, state: 'missing' });
       continue;
     }
-    const versions = (await response.json()).versions ?? {};
+    const versions = body.versions ?? {};
     audit.push({ name, version, state: version in versions ? 'published' : 'new' });
   }
   return audit;
@@ -63,8 +91,8 @@ export async function auditNpmPackages(packages, registry = NPM_REGISTRY) {
 export async function auditCrates(names, registry = CRATES_REGISTRY) {
   const audit = [];
   for (const name of names) {
-    const response = await fetchRegistry(`${registry}/${encodeURIComponent(name)}`);
-    audit.push({ name, state: response.status === 404 ? 'missing' : 'present' });
+    const body = await fetchRegistry(`${registry}/${encodeURIComponent(name)}`);
+    audit.push({ name, state: body === null ? 'missing' : 'present' });
   }
   return audit;
 }

--- a/scripts/check-publish-targets.test.ts
+++ b/scripts/check-publish-targets.test.ts
@@ -18,7 +18,11 @@ function versions(...published: string[]) {
 }
 
 // Bun.spawnSync would block the loop this fake registry answers on.
-async function guard(mode: string, respond: (name: string) => Response, env: object = {}) {
+async function guard(
+  mode: string,
+  respond: (name: string) => Response | Promise<Response>,
+  env: object = {}
+) {
   const server = Bun.serve({
     port: 0,
     hostname: '127.0.0.1',
@@ -26,6 +30,7 @@ async function guard(mode: string, respond: (name: string) => Response, env: obj
   });
   const origin = `http://127.0.0.1:${server.port}`;
   try {
+    const started = performance.now();
     const child = Bun.spawn(['node', script, mode], {
       stdout: 'pipe',
       stderr: 'pipe',
@@ -42,10 +47,27 @@ async function guard(mode: string, respond: (name: string) => Response, env: obj
       new Response(child.stderr).text(),
       child.exited
     ]);
-    return { stdout, stderr, status };
+    return { stdout, stderr, status, elapsed: performance.now() - started };
   } finally {
     server.stop(true);
   }
+}
+
+/** A registry that answers differently on each call for a name. */
+function flaky(respond: (name: string, call: number) => Response | Promise<Response>) {
+  const calls = new Map<string, number>();
+  return {
+    calls,
+    respond: (name: string) => {
+      const call = (calls.get(name) ?? 0) + 1;
+      calls.set(name, call);
+      return respond(name, call);
+    }
+  };
+}
+
+function published(name: string) {
+  return versions(packages.find((entry) => entry.name === name)!.version);
 }
 
 describe('npm publish targets', () => {
@@ -122,20 +144,94 @@ describe('release wiring', () => {
     }
   });
 
-  test('crates.io is checked before anything is uploaded to it', () => {
-    expect(steps.indexOf('Check crates.io publish targets')).toBeLessThan(
-      steps.indexOf('Publish Rust crates')
+  test('both registries are checked before the first upload of either', () => {
+    const publishes = ['Publish Rust crates', 'Release PR or publish'].map((step) =>
+      steps.indexOf(step)
     );
+    for (const guard of ['Check crates.io publish targets', 'Check npm publish targets']) {
+      for (const publish of publishes) expect(steps.indexOf(guard)).toBeLessThan(publish);
+    }
     expect(guards[0].env.CRATES_IO_BOOTSTRAP_TOKEN).toBe('${{ secrets.CRATES_IO_BOOTSTRAP_TOKEN }}');
   });
 
-  test('npm is checked after the pin and before changesets publishes', () => {
-    expect(steps.indexOf('Pin workspace deps for npm publish')).toBeLessThan(
-      steps.indexOf('Check npm publish targets')
-    );
+  test('the npm guard reads what the pin that follows it cannot change', () => {
     expect(steps.indexOf('Check npm publish targets')).toBeLessThan(
-      steps.indexOf('Release PR or publish')
+      steps.indexOf('Pin workspace deps for npm publish')
     );
+    for (const entry of packages) expect(Object.keys(entry).sort()).toEqual(['name', 'version']);
+  });
+});
+
+describe('the npm publish set', () => {
+  test('is every non-private workspace, so no new package escapes the guard', () => {
+    const names = packages.map((entry) => entry.name);
+    expect(names).toContain('@betteroffice/fonts');
+    expect(names).not.toContain('@betteroffice/rust-crates');
+    expect(names).not.toContain('@betteroffice/collaboration-relay');
+  });
+});
+
+describe('a registry that misbehaves', () => {
+  const first = packages[0]!.name;
+
+  test('waits out a 429 for as long as its Retry-After asks', async () => {
+    const registry = flaky((name, call) =>
+      name === first && call === 1
+        ? new Response('{"error":"too many requests"}', {
+            status: 429,
+            headers: { 'Retry-After': '1' }
+          })
+        : published(name)
+    );
+    const result = await guard('--npm', registry.respond);
+
+    expect(result.status).toBe(0);
+    expect(registry.calls.get(first)).toBe(2);
+    expect(result.elapsed).toBeGreaterThan(900);
+  });
+
+  test('gives up on a request that hangs, and retries it', async () => {
+    const registry = flaky((name, call) =>
+      name === first && call === 1 ? new Promise<Response>(() => {}) : published(name)
+    );
+    const result = await guard('--npm', registry.respond, { REGISTRY_TIMEOUT_MS: '400' });
+
+    expect(result.status).toBe(0);
+    expect(registry.calls.get(first)).toBe(2);
+    expect(result.elapsed).toBeGreaterThan(400);
+  });
+
+  test('retries a body that stops mid-JSON', async () => {
+    const registry = flaky((name, call) =>
+      name === first && call === 1
+        ? new Response('{"versions":{"0.0.1"', { headers: { 'Content-Type': 'application/json' } })
+        : published(name)
+    );
+    const result = await guard('--npm', registry.respond);
+
+    expect(result.status).toBe(0);
+    expect(registry.calls.get(first)).toBe(2);
+  });
+
+  test('stops after five attempts instead of publishing on a guess', async () => {
+    const registry = flaky(
+      () =>
+        new Response('{"error":"unavailable"}', { status: 503, headers: { 'Retry-After': '0' } })
+    );
+    const result = await guard('--npm', registry.respond);
+
+    expect(result.status).not.toBe(0);
+    expect(registry.calls.get(first)).toBe(5);
+    expect(result.stderr).toContain('503');
+  });
+
+  test('a 4xx that is not a rate limit is not retried', async () => {
+    const registry = flaky(() => new Response('{"error":"gone"}', { status: 410 }));
+    const result = await guard('--npm', registry.respond);
+
+    expect(result.status).not.toBe(0);
+    expect(registry.calls.get(first)).toBe(1);
+    expect(result.stderr).toContain('410');
   });
 });
 

--- a/scripts/check-publish-targets.test.ts
+++ b/scripts/check-publish-targets.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { publishedPackageVersions } from './published-packages.mjs';
+import { RUST_CRATES } from './rust-crates.mjs';
+
+const script = fileURLToPath(new URL('./check-publish-targets.mjs', import.meta.url));
+const releaseWorkflow = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url));
+
+const release = Bun.YAML.parse(readFileSync(releaseWorkflow, 'utf8')) as any;
+const packages = publishedPackageVersions();
+const crates = RUST_CRATES.map((crate) => crate.name);
+
+const NOT_FOUND = new Response('{"error":"Not found"}', { status: 404 });
+
+function versions(...published: string[]) {
+  return Response.json({ versions: Object.fromEntries(published.map((v) => [v, {}])) });
+}
+
+// Bun.spawnSync would block the loop this fake registry answers on.
+async function guard(mode: string, respond: (name: string) => Response, env: object = {}) {
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    fetch: (request) => respond(decodeURIComponent(new URL(request.url).pathname.slice(1)))
+  });
+  const origin = `http://127.0.0.1:${server.port}`;
+  try {
+    const child = Bun.spawn(['node', script, mode], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        CRATES_IO_BOOTSTRAP_TOKEN: '',
+        NPM_REGISTRY_URL: origin,
+        CRATES_REGISTRY_URL: origin,
+        ...env
+      }
+    });
+    const [stdout, stderr, status] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited
+    ]);
+    return { stdout, stderr, status };
+  } finally {
+    server.stop(true);
+  }
+}
+
+describe('npm publish targets', () => {
+  test('a package that exists at its release version passes', async () => {
+    const result = await guard('--npm', (name) => {
+      const found = packages.find((entry) => entry.name === name);
+      return found ? versions(found.version) : NOT_FOUND;
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`${packages[0]!.name}@${packages[0]!.version} is on npm.`);
+  });
+
+  test('a package that exists at an older version passes: that is a normal publish', async () => {
+    const result = await guard('--npm', () => versions('0.0.0'));
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('is a new version of a package on npm.');
+    expect(result.stderr).toBe('');
+  });
+
+  test('a package that does not exist fails, by name', async () => {
+    const missing = packages[0]!.name;
+    const result = await guard('--npm', (name) => {
+      if (name === missing) return NOT_FOUND;
+      const found = packages.find((entry) => entry.name === name);
+      return versions(found!.version);
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`${missing} is not on npm.`);
+    expect(result.stderr).toContain('Initial npm release of a new package');
+  });
+});
+
+describe('crates.io publish targets', () => {
+  test('a crate that exists passes', async () => {
+    const result = await guard('--crates', () => Response.json({}));
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`${crates[0]} is on crates.io.`);
+  });
+
+  test('a crate that does not exist fails, by name', async () => {
+    const result = await guard('--crates', (name) =>
+      name === crates[0] ? NOT_FOUND : Response.json({})
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`${crates[0]} is not on crates.io.`);
+    expect(result.stderr).toContain('Initial crates.io release');
+  });
+
+  test('a bootstrap token creates crates, so a missing one only prints', async () => {
+    const result = await guard(
+      '--crates',
+      (name) => (name === crates[0] ? NOT_FOUND : Response.json({})),
+      { CRATES_IO_BOOTSTRAP_TOKEN: 'cio_bootstrap' }
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`${crates[0]} is not on crates.io; CRATES_IO_BOOTSTRAP_TOKEN`);
+    expect(result.stderr).toBe('');
+  });
+});
+
+describe('release wiring', () => {
+  const steps = release.jobs.release.steps.map((step: any) => step.name ?? step.uses);
+  const guards = release.jobs.release.steps.filter((step: any) =>
+    step.run?.includes('check-publish-targets.mjs')
+  );
+
+  test('both guards run only on the publish path', () => {
+    expect(guards.map((step: any) => step.run.trim())).toEqual([
+      'node scripts/check-publish-targets.mjs --crates',
+      'node scripts/check-publish-targets.mjs --npm'
+    ]);
+    for (const step of guards) {
+      expect(step.if).toBe("steps.pending.outputs.publishing == 'true'");
+    }
+  });
+
+  test('crates.io is checked before anything is uploaded to it', () => {
+    expect(steps.indexOf('Check crates.io publish targets')).toBeLessThan(
+      steps.indexOf('Publish Rust crates')
+    );
+    expect(guards[0].env.CRATES_IO_BOOTSTRAP_TOKEN).toBe('${{ secrets.CRATES_IO_BOOTSTRAP_TOKEN }}');
+  });
+
+  test('npm is checked after the pin and before changesets publishes', () => {
+    expect(steps.indexOf('Pin workspace deps for npm publish')).toBeLessThan(
+      steps.indexOf('Check npm publish targets')
+    );
+    expect(steps.indexOf('Check npm publish targets')).toBeLessThan(
+      steps.indexOf('Release PR or publish')
+    );
+  });
+});
+
+describe('the mode argument', () => {
+  test('an unknown mode fails instead of checking nothing', async () => {
+    const result = await guard('--npmm', () => Response.json({}));
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--npm or --crates');
+  });
+});

--- a/scripts/published-packages.mjs
+++ b/scripts/published-packages.mjs
@@ -5,17 +5,29 @@ import { fileURLToPath } from 'node:url';
 export { PYPI_DISTRIBUTIONS } from './python-bindings.mjs';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
-const WORKSPACES = ['apps', 'bindings', 'packages'];
 
+function readManifest(directory) {
+  try {
+    return JSON.parse(readFileSync(join(ROOT, directory, 'package.json'), 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Every workspace manifest, from the same globs Bun and Changesets expand. */
 function workspaceManifests() {
   const manifests = [];
-  for (const workspace of WORKSPACES) {
-    for (const entry of readdirSync(join(ROOT, workspace))) {
-      try {
-        manifests.push(JSON.parse(readFileSync(join(ROOT, workspace, entry, 'package.json'), 'utf8')));
-      } catch {
-        continue;
-      }
+  for (const pattern of readManifest('.').workspaces) {
+    if (pattern.includes('*') && !pattern.endsWith('/*')) {
+      throw new Error(`published-packages.mjs cannot expand the workspace glob ${pattern}`);
+    }
+    const parent = pattern.endsWith('/*') ? pattern.slice(0, -2) : undefined;
+    const directories = parent
+      ? readdirSync(join(ROOT, parent)).map((entry) => join(parent, entry))
+      : [pattern];
+    for (const directory of directories) {
+      const manifest = readManifest(directory);
+      if (manifest) manifests.push(manifest);
     }
   }
   return manifests;
@@ -29,10 +41,13 @@ export function workspacePackages() {
     .sort();
 }
 
-/** The npm packages a release uploads, with the version it would upload. */
+/**
+ * The npm packages a release uploads, with the version it would upload: every
+ * non-private workspace, which is exactly the set `changeset publish` takes.
+ */
 export function publishedPackageVersions() {
   return workspaceManifests()
-    .filter((manifest) => !manifest.private && manifest.name?.startsWith('@betteroffice/'))
+    .filter((manifest) => !manifest.private && manifest.name && manifest.version)
     .map((manifest) => ({ name: manifest.name, version: manifest.version }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/scripts/published-packages.mjs
+++ b/scripts/published-packages.mjs
@@ -29,12 +29,17 @@ export function workspacePackages() {
     .sort();
 }
 
-/** The npm packages a release uploads. */
-export function publishedPackages() {
+/** The npm packages a release uploads, with the version it would upload. */
+export function publishedPackageVersions() {
   return workspaceManifests()
     .filter((manifest) => !manifest.private && manifest.name?.startsWith('@betteroffice/'))
-    .map((manifest) => manifest.name)
-    .sort();
+    .map((manifest) => ({ name: manifest.name, version: manifest.version }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** The npm packages a release uploads. */
+export function publishedPackages() {
+  return publishedPackageVersions().map((entry) => entry.name);
 }
 
 /** The crates a release uploads to crates.io. */

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -14,6 +14,9 @@ import {
 const script = fileURLToPath(new URL('./python-bindings.mjs', import.meta.url));
 const repository = fileURLToPath(new URL('..', import.meta.url));
 const releaseWorkflow = fileURLToPath(new URL('../.github/workflows/release.yml', import.meta.url));
+const publishWorkflow = fileURLToPath(
+  new URL('../.github/workflows/publish-python-binding.yml', import.meta.url)
+);
 const ciWorkflow = fileURLToPath(new URL('../.github/workflows/ci.yml', import.meta.url));
 
 function cli(...args: string[]) {
@@ -23,6 +26,7 @@ function cli(...args: string[]) {
 }
 
 const release = Bun.YAML.parse(readFileSync(releaseWorkflow, 'utf8')) as any;
+const publish = Bun.YAML.parse(readFileSync(publishWorkflow, 'utf8')) as any;
 
 describe('registry', () => {
   test('every publishable binding is a registered binding', () => {
@@ -74,7 +78,7 @@ describe('registry', () => {
 });
 
 describe('release wiring', () => {
-  test('the registry step computes each list from the registry', () => {
+  test('the registry step computes the publish list from the registry', () => {
     const step = release.jobs['python-bindings'].steps.find((s: any) => s.id === 'registry');
     expect(step.run).toContain('scripts/python-bindings.mjs --publish');
 
@@ -90,31 +94,81 @@ describe('release wiring', () => {
 
     expect(result.status).toBe(0);
     expect(readFileSync(outputs, 'utf8').trim().split('\n')).toEqual([
-      `bindings=${JSON.stringify(PYTHON_BINDING_NAMES)}`,
       `publish=${JSON.stringify(PYTHON_PUBLISH_NAMES)}`
     ]);
   });
 
-  test('the release train exposes both lists', () => {
+  test('the release train exposes the publish list', () => {
     expect(release.jobs['python-bindings'].outputs).toEqual({
-      bindings: '${{ steps.registry.outputs.bindings }}',
       publish: '${{ steps.registry.outputs.publish }}'
     });
   });
 
-  test('builds fan out over every binding', () => {
-    expect(release.jobs['python-dist'].strategy.matrix.binding).toBe(
-      '${{ fromJSON(needs.python-bindings.outputs.bindings) }}'
-    );
+  test('the release publishes nothing to PyPI itself', () => {
+    expect(release.jobs['python-dist']).toBeUndefined();
+    const runs = JSON.stringify(release.jobs['python-pypi']);
+    expect(runs).not.toContain('pypa/gh-action-pypi-publish');
+    expect(runs).not.toContain('PYPI_API_TOKEN');
+    expect(release.jobs['python-pypi'].permissions).toEqual({ actions: 'write' });
   });
 
-  test('publishes fan out only over the opted-in bindings', () => {
-    expect(release.jobs['python-pypi'].strategy.matrix.binding).toBe(
-      '${{ fromJSON(needs.python-bindings.outputs.publish) }}'
-    );
+  test('a dispatch fans out only over the opted-in bindings', () => {
+    expect(release.jobs['python-pypi'].needs).toBe('python-bindings');
     expect(release.jobs['python-pypi'].if).toContain(
       "needs.python-bindings.outputs.publish != '[]'"
     );
+    const step = release.jobs['python-pypi'].steps[0];
+    expect(step.env.PUBLISH).toBe('${{ needs.python-bindings.outputs.publish }}');
+
+    const directory = mkdtempSync(join(tmpdir(), 'dispatch-'));
+    const log = join(directory, 'gh.log');
+    writeFileSync(join(directory, 'gh'), `#!/bin/sh\necho "$@" >> "${log}"\n`, { mode: 0o755 });
+    const path = join(directory, 'dispatch.sh');
+    writeFileSync(path, step.run);
+    const result = spawnSync('bash', ['-e', path], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH}`,
+        PUBLISH: JSON.stringify(PYTHON_PUBLISH_NAMES)
+      }
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(log, 'utf8').trim().split('\n')).toEqual(
+      PYTHON_PUBLISH_NAMES.map(
+        (name) =>
+          `workflow run publish-python-binding.yml --ref main -f binding=${name} -f dry_run=false`
+      )
+    );
+  });
+
+  test('one failed dispatch fails the job without skipping the rest', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dispatch-fail-'));
+    const log = join(directory, 'gh.log');
+    writeFileSync(join(directory, 'gh'), `#!/bin/sh\necho "$@" >> "${log}"\nexit 1\n`, {
+      mode: 0o755
+    });
+    const path = join(directory, 'dispatch.sh');
+    writeFileSync(path, release.jobs['python-pypi'].steps[0].run);
+    const result = spawnSync('bash', ['-e', path], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH}`,
+        PUBLISH: JSON.stringify(PYTHON_PUBLISH_NAMES)
+      }
+    });
+
+    expect(result.status).toBe(1);
+    expect(readFileSync(log, 'utf8').trim().split('\n')).toHaveLength(PYTHON_PUBLISH_NAMES.length);
+  });
+
+  test('the dispatched workflow is the one PyPI trusts', () => {
+    expect(Object.keys(publish.on)).toEqual(['workflow_dispatch']);
+    expect(Object.keys(publish.on.workflow_dispatch.inputs)).toEqual(['binding', 'dry_run']);
+    expect(publish.jobs.publish.environment).toBe('pypi-${{ inputs.binding }}');
+    expect(publish.jobs.publish.permissions['id-token']).toBe('write');
   });
 
   test('CI installs and tests every binding, publishable or not', () => {
@@ -141,7 +195,7 @@ describe('repository-scoped token guard', () => {
   test('runs where an environment secret is invisible', () => {
     expect(job.environment).toBeUndefined();
     expect(guard.env.TOKEN).toBe('${{ secrets.PYPI_API_TOKEN }}');
-    expect(release.jobs['python-pypi'].environment).toBe('pypi-${{ matrix.binding }}');
+    expect(publish.jobs.publish.environment).toBe('pypi-${{ inputs.binding }}');
   });
 
   test('passes when no token is visible', () => {

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -17,6 +17,7 @@ const releaseWorkflow = fileURLToPath(new URL('../.github/workflows/release.yml'
 const publishWorkflow = fileURLToPath(
   new URL('../.github/workflows/publish-python-binding.yml', import.meta.url)
 );
+const distWorkflow = fileURLToPath(new URL('../.github/workflows/python-dist.yml', import.meta.url));
 const ciWorkflow = fileURLToPath(new URL('../.github/workflows/ci.yml', import.meta.url));
 
 function cli(...args: string[]) {
@@ -27,6 +28,49 @@ function cli(...args: string[]) {
 
 const release = Bun.YAML.parse(readFileSync(releaseWorkflow, 'utf8')) as any;
 const publish = Bun.YAML.parse(readFileSync(publishWorkflow, 'utf8')) as any;
+const dist = Bun.YAML.parse(readFileSync(distWorkflow, 'utf8')) as any;
+
+const SHA = '9b3f0c1d2e4a5b6c7d8e9f0a1b2c3d4e5f607182';
+const dispatchStep = release.jobs['python-pypi'].steps[0];
+const RUN_IDS = PYTHON_PUBLISH_NAMES.map((_, index) => 4200 + index);
+
+/** The dispatch step against a `gh` that dispatches, lists, and watches. */
+function dispatch({ dispatchStatus = 0, failing = 0 } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), 'dispatch-'));
+  const log = join(directory, 'gh.log');
+  const runs = PYTHON_PUBLISH_NAMES.map((name, index) => ({
+    databaseId: RUN_IDS[index],
+    displayTitle: (publish['run-name'] as string)
+      .replace('${{ inputs.binding }}', name)
+      .replace('${{ inputs.sha }}', SHA)
+  }));
+  writeFileSync(
+    join(directory, 'gh'),
+    [
+      '#!/bin/sh',
+      `echo "$@" >> "${log}"`,
+      'case "$1 $2" in',
+      `  "workflow run") exit ${dispatchStatus} ;;`,
+      `  "run list") echo '${JSON.stringify(runs)}' ;;`,
+      `  "run watch") [ "$3" = "${failing}" ] && exit 1 ;;`,
+      'esac',
+      'exit 0'
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+  const path = join(directory, 'dispatch.sh');
+  writeFileSync(path, dispatchStep.run);
+  const result = spawnSync('bash', ['-e', path], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH}`,
+      PUBLISH: JSON.stringify(PYTHON_PUBLISH_NAMES),
+      SHA
+    }
+  });
+  return { ...result, log: readFileSync(log, 'utf8').trim().split('\n') };
+}
 
 describe('registry', () => {
   test('every publishable binding is a registered binding', () => {
@@ -112,63 +156,78 @@ describe('release wiring', () => {
     expect(release.jobs['python-pypi'].permissions).toEqual({ actions: 'write' });
   });
 
-  test('a dispatch fans out only over the opted-in bindings', () => {
+  test('a dispatch fans out only over the opted-in bindings, at the commit that triggered it', () => {
     expect(release.jobs['python-pypi'].needs).toBe('python-bindings');
     expect(release.jobs['python-pypi'].if).toContain(
       "needs.python-bindings.outputs.publish != '[]'"
     );
-    const step = release.jobs['python-pypi'].steps[0];
-    expect(step.env.PUBLISH).toBe('${{ needs.python-bindings.outputs.publish }}');
+    expect(dispatchStep.env.PUBLISH).toBe('${{ needs.python-bindings.outputs.publish }}');
+    expect(dispatchStep.env.SHA).toBe('${{ github.sha }}');
 
-    const directory = mkdtempSync(join(tmpdir(), 'dispatch-'));
-    const log = join(directory, 'gh.log');
-    writeFileSync(join(directory, 'gh'), `#!/bin/sh\necho "$@" >> "${log}"\n`, { mode: 0o755 });
-    const path = join(directory, 'dispatch.sh');
-    writeFileSync(path, step.run);
-    const result = spawnSync('bash', ['-e', path], {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        PATH: `${directory}:${process.env.PATH}`,
-        PUBLISH: JSON.stringify(PYTHON_PUBLISH_NAMES)
-      }
-    });
+    const result = dispatch();
 
     expect(result.status).toBe(0);
-    expect(readFileSync(log, 'utf8').trim().split('\n')).toEqual(
+    expect(result.log.filter((line) => line.startsWith('workflow run'))).toEqual(
       PYTHON_PUBLISH_NAMES.map(
         (name) =>
-          `workflow run publish-python-binding.yml --ref main -f binding=${name} -f dry_run=false`
+          `workflow run publish-python-binding.yml --ref main -f binding=${name} -f sha=${SHA} -f dry_run=false`
       )
     );
   });
 
-  test('one failed dispatch fails the job without skipping the rest', () => {
-    const directory = mkdtempSync(join(tmpdir(), 'dispatch-fail-'));
-    const log = join(directory, 'gh.log');
-    writeFileSync(join(directory, 'gh'), `#!/bin/sh\necho "$@" >> "${log}"\nexit 1\n`, {
-      mode: 0o755
-    });
-    const path = join(directory, 'dispatch.sh');
-    writeFileSync(path, release.jobs['python-pypi'].steps[0].run);
-    const result = spawnSync('bash', ['-e', path], {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        PATH: `${directory}:${process.env.PATH}`,
-        PUBLISH: JSON.stringify(PYTHON_PUBLISH_NAMES)
-      }
-    });
+  test('the wait finds each run by the title the publish workflow sets', () => {
+    expect(publish['run-name']).toBe(
+      'Publish betteroffice-${{ inputs.binding }} @ ${{ inputs.sha }}'
+    );
+    expect(dispatchStep.run).toContain('Publish betteroffice-$binding @ $SHA');
+  });
+
+  test('the release ends only once every dispatched run has', () => {
+    const result = dispatch();
+
+    expect(result.status).toBe(0);
+    expect(result.log.filter((line) => line.startsWith('run watch'))).toHaveLength(
+      PYTHON_PUBLISH_NAMES.length
+    );
+  });
+
+  test('a dispatched run that fails fails the release', () => {
+    const result = dispatch({ failing: RUN_IDS[0]! });
 
     expect(result.status).toBe(1);
-    expect(readFileSync(log, 'utf8').trim().split('\n')).toHaveLength(PYTHON_PUBLISH_NAMES.length);
+    expect(result.stdout).toContain(`::error::betteroffice-${PYTHON_PUBLISH_NAMES[0]} did not`);
+    expect(result.log.filter((line) => line.startsWith('run watch'))).toHaveLength(
+      PYTHON_PUBLISH_NAMES.length
+    );
+  });
+
+  test('one failed dispatch fails the job without skipping the rest', () => {
+    const result = dispatch({ dispatchStatus: 1 });
+
+    expect(result.status).toBe(1);
+    expect(result.log.filter((line) => line.startsWith('workflow run'))).toHaveLength(
+      PYTHON_PUBLISH_NAMES.length
+    );
+    expect(result.log.some((line) => line.startsWith('run watch'))).toBe(false);
   });
 
   test('the dispatched workflow is the one PyPI trusts', () => {
     expect(Object.keys(publish.on)).toEqual(['workflow_dispatch']);
-    expect(Object.keys(publish.on.workflow_dispatch.inputs)).toEqual(['binding', 'dry_run']);
+    expect(Object.keys(publish.on.workflow_dispatch.inputs)).toEqual(['binding', 'sha', 'dry_run']);
+    expect(publish.on.workflow_dispatch.inputs.sha.required).toBe(true);
     expect(publish.jobs.publish.environment).toBe('pypi-${{ inputs.binding }}');
     expect(publish.jobs.publish.permissions['id-token']).toBe('write');
+  });
+
+  test('the wheels are built from that commit, not from a branch that moves', () => {
+    expect(dist.on.workflow_call.inputs.sha.required).toBe(true);
+    expect(publish.jobs.dist.with.sha).toBe('${{ inputs.sha }}');
+
+    const checkouts = Object.values(dist.jobs).flatMap((job: any) =>
+      (job.steps ?? []).filter((step: any) => String(step.uses ?? '').startsWith('actions/checkout'))
+    );
+    expect(checkouts).toHaveLength(2);
+    for (const step of checkouts) expect(step.with.ref).toBe('${{ inputs.sha }}');
   });
 
   test('CI installs and tests every binding, publishable or not', () => {
@@ -208,7 +267,18 @@ describe('repository-scoped token guard', () => {
     expect(result.stdout).toContain('::error::');
     expect(result.stdout).toContain('pypi-<binding>');
     expect(result.stdout).toContain('Trusted Publisher');
-    expect(result.stdout).toContain('project-scoped');
     expect(result.stdout).not.toContain('AgEIcHlwaS5vcmc');
+  });
+
+  test('offers no token path, because the workflow that uploads refuses one', () => {
+    const result = runGuard('pypi-AgEIcHlwaS5vcmcSECAGENUINE-LOOKING-TOKEN');
+    expect(result.stdout).toContain('There is no token path');
+    expect(result.stdout).not.toContain('project-scoped');
+
+    const child = publish.jobs.publish.steps.find(
+      (step: any) => step.name === 'Refuse a repository-scoped PyPI token'
+    );
+    expect(child.env.TOKEN).toBe('${{ secrets.PYPI_API_TOKEN }}');
+    expect(child.run).toContain('exit 1');
   });
 });

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -34,24 +34,22 @@ const SHA = '9b3f0c1d2e4a5b6c7d8e9f0a1b2c3d4e5f607182';
 const dispatchStep = release.jobs['python-pypi'].steps[0];
 const RUN_IDS = PYTHON_PUBLISH_NAMES.map((_, index) => 4200 + index);
 
-/** The dispatch step against a `gh` that dispatches, lists, and watches. */
+/** The dispatch step against a `gh` that dispatches (returning a run id) and watches. */
 function dispatch({ dispatchStatus = 0, failing = 0 } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'dispatch-'));
   const log = join(directory, 'gh.log');
-  const runs = PYTHON_PUBLISH_NAMES.map((name, index) => ({
-    databaseId: RUN_IDS[index],
-    displayTitle: (publish['run-name'] as string)
-      .replace('${{ inputs.binding }}', name)
-      .replace('${{ inputs.sha }}', SHA)
-  }));
+  const ids = PYTHON_PUBLISH_NAMES.map(
+    (name, index) => `    *"inputs[binding]=${name}"*) echo ${RUN_IDS[index]} ;;`
+  );
   writeFileSync(
     join(directory, 'gh'),
     [
       '#!/bin/sh',
       `echo "$@" >> "${log}"`,
       'case "$1 $2" in',
-      `  "workflow run") exit ${dispatchStatus} ;;`,
-      `  "run list") echo '${JSON.stringify(runs)}' ;;`,
+      `  "api --method") [ ${dispatchStatus} -ne 0 ] && exit ${dispatchStatus}; case "$*" in`,
+      ...ids,
+      '    esac ;;',
       `  "run watch") [ "$3" = "${failing}" ] && exit 1 ;;`,
       'esac',
       'exit 0'
@@ -65,6 +63,7 @@ function dispatch({ dispatchStatus = 0, failing = 0 } = {}) {
     env: {
       ...process.env,
       PATH: `${directory}:${process.env.PATH}`,
+      GH_REPO: 'openooxml/betteroffice',
       PUBLISH: JSON.stringify(PYTHON_PUBLISH_NAMES),
       SHA
     }
@@ -167,19 +166,24 @@ describe('release wiring', () => {
     const result = dispatch();
 
     expect(result.status).toBe(0);
-    expect(result.log.filter((line) => line.startsWith('workflow run'))).toEqual(
+    expect(result.log.filter((line) => line.startsWith('api --method POST'))).toEqual(
       PYTHON_PUBLISH_NAMES.map(
         (name) =>
-          `workflow run publish-python-binding.yml --ref main -f binding=${name} -f sha=${SHA} -f dry_run=false`
+          `api --method POST -H X-GitHub-Api-Version: 2026-03-10 repos/openooxml/betteroffice/actions/workflows/publish-python-binding.yml/dispatches -f ref=main -f inputs[binding]=${name} -f inputs[sha]=${SHA} -F inputs[dry_run]=false --jq .workflow_run_id`
       )
     );
   });
 
-  test('the wait finds each run by the title the publish workflow sets', () => {
+  test('the wait watches exactly the runs the dispatch created', () => {
+    const result = dispatch();
+
+    expect(result.status).toBe(0);
+    expect(result.log.filter((line) => line.startsWith('run watch'))).toEqual(
+      RUN_IDS.map((id) => `run watch ${id} --exit-status`)
+    );
     expect(publish['run-name']).toBe(
       'Publish betteroffice-${{ inputs.binding }} @ ${{ inputs.sha }}'
     );
-    expect(dispatchStep.run).toContain('Publish betteroffice-$binding @ $SHA');
   });
 
   test('the release ends only once every dispatched run has', () => {
@@ -205,7 +209,7 @@ describe('release wiring', () => {
     const result = dispatch({ dispatchStatus: 1 });
 
     expect(result.status).toBe(1);
-    expect(result.log.filter((line) => line.startsWith('workflow run'))).toHaveLength(
+    expect(result.log.filter((line) => line.startsWith('api --method POST'))).toHaveLength(
       PYTHON_PUBLISH_NAMES.length
     );
     expect(result.log.some((line) => line.startsWith('run watch'))).toBe(false);


### PR DESCRIPTION
TL;DR:


Summary:
- The release job now checks every publish target against its registry before either publish runs, and fails naming the package to bootstrap by hand. `changeset publish` uploads every package in parallel and only then throws, so a new npm name that Trusted Publishing cannot create — `@betteroffice/fonts` and `fonts-cjk` are new this release — would have left `@betteroffice/docx@0.1.0` live with an optional peer on a 404 and skipped the deploy dispatch and the Python train. The crates publish stops at the first missing crate; `betteroffice-docx-raster` is new, and the guard defers to `CRATES_IO_BOOTSTRAP_TOKEN` when present because that token can create it. `RELEASING.md` said "Nothing in CI enforces this bootstrap ordering"; now something does.
- No scratch `changeset version` is needed for the npm check: on the publish path there are zero pending changesets, `changesets/action` runs no `version` command, and the checked-out manifests already carry the versions it publishes.
- The Python bindings publish through `publish-python-binding.yml`, the one file every PyPI Trusted Publisher is scoped to — the sigstore certificates on the live `betteroffice-docx` and `betteroffice-pptx` wheels name that workflow, and `betteroffice-xlsx` has no provenance at all. `release.yml` dispatches it once per publishable binding after the release commit is on `main` instead of uploading inline from a file no publisher names. The `python-dist` matrix and the inline token/OIDC upload steps are gone; the repository-scoped-token guard stays.
- Adds `scripts/check-publish-targets.mjs` with a fake-registry test suite; the release-wiring tests assert the dispatch loop.

Test plan:
- [x] `bun test scripts/` (37)
- [x] `node scripts/check-publish-targets.mjs --npm` against the live registry: exit 1 naming `@betteroffice/fonts` and `@betteroffice/fonts-cjk`
- [x] `node scripts/check-publish-targets.mjs --crates` live: exit 1 naming `betteroffice-docx-raster`; exit 0 with `CRATES_IO_BOOTSTRAP_TOKEN` set
- [x] `Bun.YAML.parse` on every workflow file
- [ ] After hand-publishing `@betteroffice/fonts` and `fonts-cjk`, the npm guard exits 0
