### PR TITLE
fix(python): bump the docx binding to 0.0.2

### DIFF
--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "betteroffice-docx-python"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "betteroffice-docx",
  "betteroffice-python-common",

--- a/bindings/python-docx/Cargo.toml
+++ b/bindings/python-docx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "betteroffice-docx-python"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://betteroffice.dev"


### PR DESCRIPTION
TL;DR:

Summary:
- `bindings/python-docx/Cargo.toml` version 0.0.1 → 0.0.2, matching python-xlsx and python-pptx
- the 0.1.0 release train dispatched all three binding publishes, but betteroffice-docx 0.0.1 already existed on PyPI, so its upload was a skip-existing no-op and today's engine went out for xlsx/pptx only
- binding versions are hand-set (the crates are not workspace members, and pyproject reads the crate version dynamically); aligning them with the workspace version is a follow-up

Test plan:
- [ ] CI green
- [ ] after merge: dispatch `publish-python-binding.yml` for docx at the merge sha and confirm betteroffice-docx 0.0.2 lands on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)