### PR TITLE
ci(release): dispatch only the python bindings missing from pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - id: registry
-        run: echo "publish=$(node scripts/python-bindings.mjs --publish)" >> "$GITHUB_OUTPUT"
+        run: echo "publish=$(node scripts/python-bindings.mjs --pending)" >> "$GITHUB_OUTPUT"
 
   # A PyPI Trusted Publisher is scoped to the file that runs the upload, and every
   # publisher here names publish-python-binding.yml, so the release dispatches that

--- a/scripts/python-bindings.mjs
+++ b/scripts/python-bindings.mjs
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 // The Python release train. Adding a distribution here enrols it in versioning,
@@ -24,16 +25,66 @@ export const PYTHON_PUBLISH_NAMES = REGISTRY.filter((entry) => entry.publish).ma
 /** The PyPI projects that exist, so a `publish: false` binding is absent. */
 export const PYPI_DISTRIBUTIONS = PYTHON_PUBLISH_NAMES.map((name) => `betteroffice-${name}`);
 
+/** The crate version maturin stamps on the wheel; bindings version independently of the workspace. */
+export function bindingVersion(path) {
+  const manifest = readFileSync(new URL(`../${path}/Cargo.toml`, import.meta.url), 'utf8');
+  const version = manifest.match(/^version = "([^"]+)"$/m);
+  if (!version) throw new Error(`${path}/Cargo.toml declares no version`);
+  return version[1];
+}
+
+/** Publish-enabled bindings whose crate version PyPI does not serve yet. */
+export async function pendingPublishNames({
+  fetchImpl = fetch,
+  attempts = 3,
+  retryDelayMs = 2000
+} = {}) {
+  const pending = [];
+  for (const entry of REGISTRY) {
+    if (!entry.publish) continue;
+    const name = bindingName(entry.path);
+    const released = await pypiVersions(`betteroffice-${name}`, { fetchImpl, attempts, retryDelayMs });
+    if (released === null || !released.includes(bindingVersion(entry.path))) pending.push(name);
+  }
+  return pending;
+}
+
+/** null when the project does not exist yet; throws when PyPI cannot be read at all. */
+async function pypiVersions(project, { fetchImpl, attempts, retryDelayMs }) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(`https://pypi.org/pypi/${project}/json`, {
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(15_000)
+      });
+      if (response.status === 404) return null;
+      if (!response.ok) throw new Error(`PyPI answered ${response.status} for ${project}`);
+      return Object.keys((await response.json()).releases ?? {});
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs * attempt));
+      }
+    }
+  }
+  throw new Error(`cannot read PyPI for ${project}: ${lastError}`, { cause: lastError });
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
   // Falling through to the full list would publish bindings deliberately held back.
-  const unknown = args.find((arg) => arg !== '--paths' && arg !== '--publish');
+  const unknown = args.find((arg) => !['--paths', '--publish', '--pending'].includes(arg));
   if (unknown) {
-    console.error(`python-bindings.mjs: unknown argument ${unknown}; expected --paths or --publish`);
+    console.error(
+      `python-bindings.mjs: unknown argument ${unknown}; expected --paths, --publish or --pending`
+    );
     process.exit(1);
   }
   if (args.includes('--paths')) {
     console.log(PYTHON_BINDINGS.join('\n'));
+  } else if (args.includes('--pending')) {
+    console.log(JSON.stringify(await pendingPublishNames()));
   } else if (args.includes('--publish')) {
     console.log(JSON.stringify(PYTHON_PUBLISH_NAMES));
   } else {

--- a/scripts/python-bindings.mjs
+++ b/scripts/python-bindings.mjs
@@ -28,8 +28,9 @@ export const PYPI_DISTRIBUTIONS = PYTHON_PUBLISH_NAMES.map((name) => `betteroffi
 /** The crate version maturin stamps on the wheel; bindings version independently of the workspace. */
 export function bindingVersion(path) {
   const manifest = readFileSync(new URL(`../${path}/Cargo.toml`, import.meta.url), 'utf8');
-  const version = manifest.match(/^version = "([^"]+)"$/m);
-  if (!version) throw new Error(`${path}/Cargo.toml declares no version`);
+  const table = manifest.split(/^\[/m).find((section) => section.startsWith('package]'));
+  const version = table?.match(/^\s*version\s*=\s*"([^"]+)"/m);
+  if (!version) throw new Error(`${path}/Cargo.toml declares no literal [package] version`);
   return version[1];
 }
 
@@ -43,14 +44,25 @@ export async function pendingPublishNames({
   for (const entry of REGISTRY) {
     if (!entry.publish) continue;
     const name = bindingName(entry.path);
-    const released = await pypiVersions(`betteroffice-${name}`, { fetchImpl, attempts, retryDelayMs });
-    if (released === null || !released.includes(bindingVersion(entry.path))) pending.push(name);
+    const project = `betteroffice-${name}`;
+    const releases = await pypiReleases(project, { fetchImpl, attempts, retryDelayMs });
+    const version = bindingVersion(entry.path);
+    const files = releases?.[version];
+    if (releases === null || files === undefined) {
+      pending.push(name);
+      continue;
+    }
+    if (!files.some((file) => file?.yanked !== true)) {
+      throw new Error(
+        `${project} ${version} exists on PyPI with no installable file; bump the binding version`
+      );
+    }
   }
   return pending;
 }
 
 /** null when the project does not exist yet; throws when PyPI cannot be read at all. */
-async function pypiVersions(project, { fetchImpl, attempts, retryDelayMs }) {
+async function pypiReleases(project, { fetchImpl, attempts, retryDelayMs }) {
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
@@ -60,7 +72,7 @@ async function pypiVersions(project, { fetchImpl, attempts, retryDelayMs }) {
       });
       if (response.status === 404) return null;
       if (!response.ok) throw new Error(`PyPI answered ${response.status} for ${project}`);
-      return Object.keys((await response.json()).releases ?? {});
+      return (await response.json()).releases ?? {};
     } catch (error) {
       lastError = error;
       if (attempt < attempts) {

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -8,7 +8,9 @@ import {
   PYPI_DISTRIBUTIONS,
   PYTHON_BINDINGS,
   PYTHON_BINDING_NAMES,
-  PYTHON_PUBLISH_NAMES
+  PYTHON_PUBLISH_NAMES,
+  bindingVersion,
+  pendingPublishNames
 } from './python-bindings.mjs';
 
 const script = fileURLToPath(new URL('./python-bindings.mjs', import.meta.url));
@@ -121,9 +123,9 @@ describe('registry', () => {
 });
 
 describe('release wiring', () => {
-  test('the registry step computes the publish list from the registry', () => {
+  test('the registry step computes the publish list from PyPI state', () => {
     const step = release.jobs['python-bindings'].steps.find((s: any) => s.id === 'registry');
-    expect(step.run).toContain('scripts/python-bindings.mjs --publish');
+    expect(step.run).toContain('scripts/python-bindings.mjs --pending');
 
     const directory = mkdtempSync(join(tmpdir(), 'registry-'));
     const outputs = join(directory, 'outputs');
@@ -136,9 +138,10 @@ describe('release wiring', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(readFileSync(outputs, 'utf8').trim().split('\n')).toEqual([
-      `publish=${JSON.stringify(PYTHON_PUBLISH_NAMES)}`
-    ]);
+    const lines = readFileSync(outputs, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const pending = JSON.parse(lines[0]!.replace(/^publish=/, '')) as string[];
+    expect(PYTHON_PUBLISH_NAMES.filter((name) => pending.includes(name))).toEqual(pending);
   });
 
   test('the release train exposes the publish list', () => {
@@ -284,5 +287,73 @@ describe('repository-scoped token guard', () => {
     );
     expect(child.env.TOKEN).toBe('${{ secrets.PYPI_API_TOKEN }}');
     expect(child.run).toContain('exit 1');
+  });
+});
+
+describe('pending publish selection', () => {
+  const live = () =>
+    Object.fromEntries(
+      PYTHON_BINDINGS.map((path) => [
+        `betteroffice-${path.replace('bindings/python-', '')}`,
+        [bindingVersion(path)]
+      ])
+    );
+
+  function pypi(releases: Record<string, string[] | null>) {
+    const requested: string[] = [];
+    const fetchImpl = async (url: string) => {
+      requested.push(url);
+      const project = url.match(/\/pypi\/([^/]+)\/json$/)?.[1] ?? '';
+      const versions = releases[project];
+      if (versions == null) return { status: 404, ok: false } as Response;
+      return {
+        status: 200,
+        ok: true,
+        json: async () => ({ releases: Object.fromEntries(versions.map((v) => [v, []])) })
+      } as unknown as Response;
+    };
+    return { fetchImpl, requested };
+  }
+
+  test('every binding version is a semver', () => {
+    for (const path of PYTHON_BINDINGS) expect(bindingVersion(path)).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  test('nothing is pending when PyPI serves every version', async () => {
+    const { fetchImpl, requested } = pypi(live());
+    expect(await pendingPublishNames({ fetchImpl })).toEqual([]);
+    expect(requested).toEqual(PYPI_DISTRIBUTIONS.map((d) => `https://pypi.org/pypi/${d}/json`));
+  });
+
+  test('a version PyPI does not serve is pending', async () => {
+    const releases = live();
+    releases['betteroffice-docx'] = ['0.0.0'];
+    const { fetchImpl } = pypi(releases);
+    expect(await pendingPublishNames({ fetchImpl })).toEqual(['docx']);
+  });
+
+  test('a project PyPI does not know is pending', async () => {
+    const releases = live();
+    releases['betteroffice-xlsx'] = null;
+    const { fetchImpl } = pypi(releases);
+    expect(await pendingPublishNames({ fetchImpl })).toEqual(['xlsx']);
+  });
+
+  test('an unreadable PyPI fails the run instead of skipping a publish', async () => {
+    const fetchImpl = async () => ({ status: 503, ok: false }) as Response;
+    await expect(
+      pendingPublishNames({ fetchImpl, attempts: 2, retryDelayMs: 0 })
+    ).rejects.toThrow('cannot read PyPI');
+  });
+
+  test('a transient error is retried', async () => {
+    let calls = 0;
+    const good = pypi(live()).fetchImpl;
+    const fetchImpl = async (url: string) => {
+      calls += 1;
+      if (calls === 1) throw new Error('reset');
+      return good(url);
+    };
+    expect(await pendingPublishNames({ fetchImpl, retryDelayMs: 0 })).toEqual([]);
   });
 });

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -299,17 +299,22 @@ describe('pending publish selection', () => {
       ])
     );
 
-  function pypi(releases: Record<string, string[] | null>) {
+  type Files = { yanked?: boolean }[];
+
+  function pypi(releases: Record<string, string[] | Record<string, Files> | null>) {
     const requested: string[] = [];
     const fetchImpl = async (url: string) => {
       requested.push(url);
       const project = url.match(/\/pypi\/([^/]+)\/json$/)?.[1] ?? '';
-      const versions = releases[project];
-      if (versions == null) return { status: 404, ok: false } as Response;
+      const entry = releases[project];
+      if (entry == null) return { status: 404, ok: false } as Response;
+      const map = Array.isArray(entry)
+        ? Object.fromEntries(entry.map((version) => [version, [{ yanked: false }]]))
+        : entry;
       return {
         status: 200,
         ok: true,
-        json: async () => ({ releases: Object.fromEntries(versions.map((v) => [v, []])) })
+        json: async () => ({ releases: map })
       } as unknown as Response;
     };
     return { fetchImpl, requested };
@@ -337,6 +342,55 @@ describe('pending publish selection', () => {
     releases['betteroffice-xlsx'] = null;
     const { fetchImpl } = pypi(releases);
     expect(await pendingPublishNames({ fetchImpl })).toEqual(['xlsx']);
+  });
+
+  test('a version whose files are all deleted fails instead of counting as released', async () => {
+    const releases = live();
+    releases['betteroffice-docx'] = { [bindingVersion('bindings/python-docx')]: [] };
+    const { fetchImpl } = pypi(releases);
+    await expect(pendingPublishNames({ fetchImpl })).rejects.toThrow('no installable file');
+  });
+
+  test('a version whose files are all yanked fails instead of counting as released', async () => {
+    const releases = live();
+    releases['betteroffice-docx'] = {
+      [bindingVersion('bindings/python-docx')]: [{ yanked: true }, { yanked: true }]
+    };
+    const { fetchImpl } = pypi(releases);
+    await expect(pendingPublishNames({ fetchImpl })).rejects.toThrow('no installable file');
+  });
+
+  test('one live file among yanked ones counts as released', async () => {
+    const releases = live();
+    releases['betteroffice-docx'] = {
+      [bindingVersion('bindings/python-docx')]: [{ yanked: true }, { yanked: false }]
+    };
+    const { fetchImpl } = pypi(releases);
+    expect(await pendingPublishNames({ fetchImpl })).toEqual([]);
+  });
+
+  test('a version is read from [package], not another table', () => {
+    const fixture = 'scripts/.manifest-fixture';
+    const directory = join(repository, fixture);
+    const read = (body: string) => {
+      mkdirSync(directory, { recursive: true });
+      writeFileSync(join(directory, 'Cargo.toml'), body);
+      try {
+        return bindingVersion(fixture);
+      } catch (error) {
+        return `THROWS: ${(error as Error).message}`;
+      }
+    };
+
+    try {
+      expect(read('[package]\nversion = "1.2.3" # release\n')).toBe('1.2.3');
+      expect(read('[other]\nversion = "9.9.9"\n\n[package]\nversion = "1.2.3"\n')).toBe('1.2.3');
+      expect(read('[package]\nversion.workspace = true\n\n[other]\nversion = "9.9.9"\n')).toContain(
+        'THROWS'
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   test('an unreadable PyPI fails the run instead of skipping a publish', async () => {


### PR DESCRIPTION
TL;DR:

Summary:
- the release train's publish list is now computed from PyPI state: a binding is dispatched only when its crate version is absent from its PyPI project
- `scripts/python-bindings.mjs` gains `bindingVersion` and `pendingPublishNames` (per-project PyPI lookup with timeout and retries; a 404 project counts as pending; an unreadable PyPI fails the release run instead of silently skipping a publish)
- `release.yml` registry step switches from the static `--publish` list to `--pending`
- background: the 0.1.0 train dispatched all three bindings; xlsx/pptx re-uploads were skip-existing no-ops and the unbumped docx binding shipped nothing while its run stayed green (#215 fixes the version; this PR makes the train notice desyncs)

Test plan:
- [ ] CI green (the wiring test executes the real registry step against live PyPI)
- [ ] after merge: next publish-mode push dispatches only bindings whose version is new