### PR TITLE
fix(ci): unblock the release train and fail on an unreadable registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - id: registry
-        run: echo "publish=$(node scripts/python-bindings.mjs --pending)" >> "$GITHUB_OUTPUT"
+        run: |
+          publish=$(node scripts/python-bindings.mjs --pending)
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
   # A PyPI Trusted Publisher is scoped to the file that runs the upload, and every
   # publisher here names publish-python-binding.yml, so the release dispatches that

--- a/bindings/python-docx/package.json
+++ b/bindings/python-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betteroffice/python-docx",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "typecheck": "true"

--- a/scripts/python-bindings.test.ts
+++ b/scripts/python-bindings.test.ts
@@ -144,6 +144,25 @@ describe('release wiring', () => {
     expect(PYTHON_PUBLISH_NAMES.filter((name) => pending.includes(name))).toEqual(pending);
   });
 
+  test('a registry lookup failure fails the step instead of publishing nothing', () => {
+    const step = release.jobs['python-bindings'].steps.find((s: any) => s.id === 'registry');
+    const directory = mkdtempSync(join(tmpdir(), 'registry-fail-'));
+    writeFileSync(join(directory, 'node'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    const path = join(directory, 'registry.sh');
+    writeFileSync(path, step.run);
+    const result = spawnSync('bash', ['-e', path], {
+      encoding: 'utf8',
+      cwd: repository,
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH}`,
+        GITHUB_OUTPUT: join(directory, 'outputs')
+      }
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+
   test('the release train exposes the publish list', () => {
     expect(release.jobs['python-bindings'].outputs).toEqual({
       publish: '${{ steps.registry.outputs.publish }}'


### PR DESCRIPTION
TL;DR:

Summary:
- `bindings/python-docx/package.json` 0.0.1 → 0.0.2 to match the Cargo version #215 bumped; `version-packages.mjs --check` currently throws on `main` (`changeset marker is 0.0.1, but Cargo is 0.0.2`), so the next release is blocked until this lands
- the release registry step captures the publish list into a variable before writing it: `echo "publish=$(node …)"` kept the step green when the script failed, so an unreadable PyPI would have dispatched nothing and left the release green
- adds a regression test that runs the real step with a failing `node` on PATH and asserts a non-zero exit

Test plan:
- [ ] CI green
- [ ] `node scripts/version-packages.mjs --check` passes on the merge commit