### PR TITLE
fix(deps): adopt as_chunks for rust 1.98 clippy

### DIFF
--- a/crates/betteroffice-docx/tests/render.rs
+++ b/crates/betteroffice-docx/tests/render.rs
@@ -240,10 +240,8 @@ fn renders_text_only_once_its_family_is_registered() {
     let rendered = document.render_png(&text_page(), 0).unwrap();
     assert_eq!(&rendered.bytes[..8], PNG_MAGIC);
     let (_, _, pixels) = decode(&rendered.bytes);
-    let painted = pixels
-        .chunks_exact(4)
-        .filter(|p| *p != [255, 255, 255, 255])
-        .count();
+    let (quads, _) = pixels.as_chunks::<4>();
+    let painted = quads.iter().filter(|p| **p != [255, 255, 255, 255]).count();
     assert!(painted > 0, "no glyphs were painted");
 }
 

--- a/crates/betteroffice-xlsx/tests/chart_render.rs
+++ b/crates/betteroffice-xlsx/tests/chart_render.rs
@@ -153,8 +153,9 @@ fn decode_rgba(bytes: &[u8]) -> Vec<[u8; 3]> {
         .unwrap();
     let mut buffer = vec![0; reader.output_buffer_size().unwrap()];
     let info = reader.next_frame(&mut buffer).unwrap();
-    buffer[..info.buffer_size()]
-        .chunks_exact(4)
+    let (pixels, _) = buffer[..info.buffer_size()].as_chunks::<4>();
+    pixels
+        .iter()
         .map(|pixel| [pixel[0], pixel[1], pixel[2]])
         .collect()
 }

--- a/crates/docx-raster/src/lib.rs
+++ b/crates/docx-raster/src/lib.rs
@@ -1343,9 +1343,10 @@ impl<'k> ImageCache<'k> {
         decoded.apply_orientation(orientation);
         let size = IntSize::from_wh(decoded.width(), decoded.height())?;
         let mut data = decoded.into_rgba8().into_raw();
-        for pixel in data.chunks_exact_mut(4) {
+        let (pixels, _) = data.as_chunks_mut::<4>();
+        for pixel in pixels {
             let color = ColorU8::from_rgba(pixel[0], pixel[1], pixel[2], pixel[3]).premultiply();
-            pixel.copy_from_slice(&[color.red(), color.green(), color.blue(), color.alpha()]);
+            *pixel = [color.red(), color.green(), color.blue(), color.alpha()];
         }
         Pixmap::from_vec(data, size)
     }

--- a/crates/xlsx-parse/src/tree.rs
+++ b/crates/xlsx-parse/src/tree.rs
@@ -486,12 +486,12 @@ fn decode_utf16(data: &[u8], big_endian: bool) -> Result<String, ParseError> {
             "utf-16 part has an odd byte length".into(),
         ));
     }
-    let units = data.chunks_exact(2).map(|pair| {
-        let pair = [pair[0], pair[1]];
+    let (pairs, _) = data.as_chunks::<2>();
+    let units = pairs.iter().map(|pair| {
         if big_endian {
-            u16::from_be_bytes(pair)
+            u16::from_be_bytes(*pair)
         } else {
-            u16::from_le_bytes(pair)
+            u16::from_le_bytes(*pair)
         }
     });
     char::decode_utf16(units)


### PR DESCRIPTION
TL;DR:

Summary:
- Rust 1.98 (released 2026-08-18) added lints for `chunks_exact` and `chunks_exact_mut` with a constant chunk size, and CI tracks `stable`, so the Rust gate now fails on every branch — this is pre-existing code, not something any PR introduced
- switches the four call sites to `as_chunks::<N>()` / `as_chunks_mut::<N>()`: the UTF-16 decoder in `xlsx-parse` (which already rejects odd lengths, so the remainder is provably empty), the premultiply loop in `docx-raster`, and two render tests clippy reaches through `--all-targets`
- verified against the actual 1.98 toolchain rather than assuming: `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean

Test plan:
- [ ] CI Rust gate green
- [ ] `cargo test -p betteroffice-xlsx-parse -p betteroffice-docx-raster`
- [ ] `cargo test -p betteroffice-docx --features raster --test render`