### PR TITLE
fix(docx): fall back to a full display rebuild when pagination changes

### DIFF
--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -3343,6 +3343,127 @@ mod tests {
             .len()
     }
 
+    #[test]
+    fn resident_display_falls_back_when_input_adds_a_page() {
+        docx_layout::clear_measure_fonts();
+        let font_id = docx_layout::register_measure_font(LIBERATION).unwrap();
+        let engine = EngineSession::new(204);
+        let body = format!(
+            "{}<w:p><w:r><w:t>Editable paragraph</w:t></w:r></w:p>",
+            "<w:p><w:r><w:t>Filler paragraph</w:t></w:r></w:p>".repeat(6)
+        );
+        crate::seed::seed_from_docx(engine.doc(), &docx_bytes("", &body)).unwrap();
+        let request = serde_json::json!({
+            "bodyStory": "body",
+            "regions": { "sections": [{
+                "sectionId": "main",
+                "properties": {
+                    "pageWidth": 4320,
+                    "pageHeight": 2880,
+                    "marginTop": 300,
+                    "marginRight": 300,
+                    "marginBottom": 300,
+                    "marginLeft": 300
+                }
+            }] },
+            "measurement": {
+                "fontChains": { "liberation sans|0|0": [font_id] },
+                "defaults": { "fontSize": 11, "fontFamily": "Liberation Sans" },
+                "authoritativeShaping": true
+            },
+            "renderEnv": {}
+        });
+        let output: serde_json::Value = serde_json::from_str(
+            &engine
+                .layout_document_with_regions_json(&request.to_string())
+                .unwrap(),
+        )
+        .unwrap();
+        let measured = output["measured"].as_array().unwrap();
+        for measured_block in measured {
+            let template = serde_json::json!({
+                "block": measured_block["block"],
+                "maxWidth": 248,
+                "fontChains": { "liberation sans|0|0": [font_id] },
+                "defaults": { "fontSize": 11, "fontFamily": "Liberation Sans" },
+                "authoritativeShaping": true
+            });
+            engine
+                .measure_paragraph_json(&template.to_string())
+                .unwrap();
+        }
+        engine
+            .layout_document_json(
+                &serde_json::json!({
+                    "measured": output["measured"],
+                    "options": output["options"]
+                })
+                .to_string(),
+            )
+            .unwrap();
+        let extras =
+            serde_json::json!({ "fontChains": { "liberation sans|0|0": [font_id] } }).to_string();
+        engine.build_display_list_frame(&extras, 0).unwrap();
+
+        let initial_page_count = engine
+            .pagination
+            .borrow()
+            .layout
+            .as_ref()
+            .unwrap()
+            .pages
+            .len();
+        let paragraph = engine.doc().paragraphs("body").unwrap().pop().unwrap();
+        let insertion = " typed text that makes the editable paragraph wrap";
+        let mut offset = u32::try_from(paragraph.text.encode_utf16().count()).unwrap();
+        let mut frame_epoch = engine.display.borrow().binary_frame_epoch;
+        let mut page_count_changed = false;
+
+        for _ in 0..64 {
+            engine
+                .doc()
+                .insert_text(
+                    &crate::EditCtx::local("", ""),
+                    crate::Position::new("body", offset),
+                    insertion,
+                    crate::FormatPolicy::Inherit,
+                )
+                .unwrap();
+            offset += u32::try_from(insertion.encode_utf16().count()).unwrap();
+            let incremental_display_builds = engine.stats().incremental_display_builds;
+            engine.apply_and_layout("body", frame_epoch).unwrap();
+            frame_epoch = engine.display.borrow().binary_frame_epoch;
+
+            let retained = engine.with_display_list(Clone::clone).unwrap();
+            let rebuilt = {
+                let pagination = engine.pagination.borrow();
+                docx_layout::build_display_list_value_from_resident(
+                    pagination.input.as_ref().unwrap(),
+                    pagination.layout.as_ref().unwrap(),
+                    &extras,
+                )
+                .unwrap()
+            };
+            assert_eq!(retained.pages.len(), rebuilt.pages.len());
+            for (retained_page, rebuilt_page) in retained.pages.iter().zip(&rebuilt.pages) {
+                assert_eq!(retained_page, rebuilt_page);
+            }
+
+            if retained.pages.len() > initial_page_count {
+                assert!(engine.pagination.borrow().last_incremental);
+                assert_eq!(
+                    engine.stats().incremental_display_builds,
+                    incremental_display_builds
+                );
+                page_count_changed = true;
+                break;
+            }
+        }
+
+        assert!(page_count_changed, "the edit must add a page");
+        docx_layout::clear_measure_fonts();
+    }
+
     const WIDOW_STYLES: &str = r#"<w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/><w:pPr><w:widowControl w:val="0"/><w:spacing w:before="0" w:after="0"/></w:pPr></w:style>
 <w:style w:type="paragraph" w:styleId="Body"><w:name w:val="Body"/><w:basedOn w:val="Normal"/></w:style>"#;
 

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -9685,10 +9685,11 @@ pub fn update_resident_display_list_incremental_with_fonts_observed(
 ) -> Result<bool, String> {
     if previous.pages.len() != layout.pages.len()
         || resident.input.layout.pages.len() != layout.pages.len()
-        || rebuilt_page_start > rebuilt_page_end
-        || rebuilt_page_end > layout.pages.len()
     {
-        return Err("resident display input no longer matches pagination pages".to_owned());
+        return Ok(false);
+    }
+    if rebuilt_page_start > rebuilt_page_end || rebuilt_page_end > layout.pages.len() {
+        return Err("resident display incremental page range is invalid".to_owned());
     }
 
     refresh_resident_display_pages(


### PR DESCRIPTION
TL;DR:

Repro file:
`crates/ooxml-text/tests/fixtures/line-spacing-baseline.docx` reaches the failure through a non-region host; the regression test in `engine.rs` reproduces it synthetically.

Summary:
- `update_resident_display_list_incremental_observed` returned `Err` when an edit changed the page count, and `apply_and_layout` propagated it with `?` — even though a full-rebuild fallback already sat directly below, reachable only from `Ok(false)`
- a precondition that simply means "this optimisation does not apply right now" was being reported as a hard failure; it now returns `Ok(false)` and the existing fallback runs
- genuine failures stay errors: invalid incremental ranges and conversion or missing-block problems are unchanged
- adds a regression test that seeds a document, inserts text until pagination adds a page, asserts the build fell back rather than claiming an incremental build, and compares every retained page against an independent full rebuild. It fails on `origin/main` with `resident display input no longer matches pagination pages` and passes here.

Scope of the original defect: the shipped browser editor does not hit this path, because the React pipeline initializes resident sessions through `layoutDocumentWithRegionsJson` and the region path runs a full region layout when the page count changes. It surfaced in a host that drives `apply_and_layout` directly. Landing it anyway — the error was wrong on its own terms, and any host calling the engine deserves the fallback rather than a hard error.

Test plan:
- [ ] `cargo test -p betteroffice-docx-edit -p betteroffice-docx-layout`
- [ ] confirm the new test fails on `origin/main` and passes on this branch