### PR TITLE
feat(apps): ship one native app per format

### DIFF
--- a/apps/native-viewer/Cargo.lock
+++ b/apps/native-viewer/Cargo.lock
@@ -243,6 +243,8 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.3",
  "image",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "pollster",
  "rustybuzz",
  "serde",

--- a/apps/native-viewer/Cargo.toml
+++ b/apps/native-viewer/Cargo.toml
@@ -7,23 +7,47 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = ["docx", "xlsx", "pptx"]
+docx = [
+    "dep:base64",
+    "dep:docx-edit",
+    "dep:docx-layout",
+    "dep:docx-parse",
+    "dep:docx-raster",
+    "dep:ooxml-opc",
+    "dep:ooxml-text",
+]
+xlsx = [
+    "dep:betteroffice-xlsx",
+    "dep:ooxml-opc",
+    "dep:xlsx-raster",
+    "dep:xlsx-render",
+]
+pptx = [
+    "dep:betteroffice-pptx",
+    "dep:ooxml-drawingml",
+    "dep:ooxml-opc",
+    "dep:pptx-render",
+]
+
 [dependencies]
 anyhow = "=1.0.104"
-base64 = "=0.22.1"
-betteroffice-pptx = { path = "../../crates/betteroffice-pptx" }
-betteroffice-xlsx = { path = "../../crates/betteroffice-xlsx", default-features = false }
-docx-edit = { package = "betteroffice-docx-edit", path = "../../crates/docx-edit" }
-docx-layout = { package = "betteroffice-docx-layout", path = "../../crates/docx-layout" }
-docx-parse = { package = "betteroffice-docx-parse", path = "../../crates/docx-parse", default-features = false }
-docx-raster = { package = "betteroffice-docx-raster", path = "../../crates/docx-raster" }
+base64 = { version = "=0.22.1", optional = true }
+betteroffice-pptx = { path = "../../crates/betteroffice-pptx", optional = true }
+betteroffice-xlsx = { path = "../../crates/betteroffice-xlsx", default-features = false, optional = true }
+docx-edit = { package = "betteroffice-docx-edit", path = "../../crates/docx-edit", optional = true }
+docx-layout = { package = "betteroffice-docx-layout", path = "../../crates/docx-layout", optional = true }
+docx-parse = { package = "betteroffice-docx-parse", path = "../../crates/docx-parse", default-features = false, optional = true }
+docx-raster = { package = "betteroffice-docx-raster", path = "../../crates/docx-raster", optional = true }
 futures-util = { version = "=0.3.33", features = ["sink"] }
 getrandom = "=0.4.3"
 image = { version = "=0.25.10", default-features = false, features = ["bmp", "gif", "jpeg", "png", "tiff", "webp"] }
-ooxml-drawingml = { package = "betteroffice-drawingml", path = "../../crates/ooxml-drawingml" }
-ooxml-opc = { package = "betteroffice-opc", path = "../../crates/ooxml-opc", default-features = false }
-ooxml-text = { package = "betteroffice-ooxml-text", path = "../../crates/ooxml-text" }
+ooxml-drawingml = { package = "betteroffice-drawingml", path = "../../crates/ooxml-drawingml", optional = true }
+ooxml-opc = { package = "betteroffice-opc", path = "../../crates/ooxml-opc", default-features = false, optional = true }
+ooxml-text = { package = "betteroffice-ooxml-text", path = "../../crates/ooxml-text", optional = true }
 pollster = "=0.4.0"
-pptx-render = { package = "betteroffice-pptx-render", path = "../../crates/pptx-render" }
+pptx-render = { package = "betteroffice-pptx-render", path = "../../crates/pptx-render", optional = true }
 rustybuzz = "=0.20.1"
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
@@ -34,9 +58,13 @@ url = "=2.5.8"
 vello = "=0.10.0"
 wgpu = "=29.0.3"
 winit = "=0.30.13"
-xlsx-raster = { package = "betteroffice-xlsx-raster", path = "../../crates/xlsx-raster" }
-xlsx-render = { package = "betteroffice-xlsx-render", path = "../../crates/xlsx-render" }
+xlsx-raster = { package = "betteroffice-xlsx-raster", path = "../../crates/xlsx-raster", optional = true }
+xlsx-render = { package = "betteroffice-xlsx-render", path = "../../crates/xlsx-render", optional = true }
 yrs = "=0.27.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "=0.5.2"
+objc2-foundation = { version = "=0.2.2", features = ["NSArray", "NSURL"] }
 
 [patch.crates-io]
 yrs = { path = "vendor/yrs" }

--- a/apps/native-viewer/macos/Info.plist
+++ b/apps/native-viewer/macos/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>BetterOffice</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>docx</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>AppIcon</string>
+			<key>CFBundleTypeName</key>
+			<string>Office document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>betteroffice-native-viewer</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>dev.betteroffice.viewer</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>BetterOffice</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/native-viewer/macos/README.md
+++ b/apps/native-viewer/macos/README.md
@@ -1,0 +1,39 @@
+# macOS app
+
+`build-app.sh FORMAT OUTPUT_DIR VERSION BUILD_VERSION` builds one of `docx`,
+`xlsx`, or `pptx` for both architectures, merges it into a universal binary,
+and assembles the matching BetterOffice app with its icon and Welcome file.
+`package-dmg.sh DOCS_APP SHEETS_APP SLIDES_APP DMG` packages the suite with an
+`/Applications` symlink.
+
+The `macOS app` workflow runs for `@betteroffice/docx@<version>` tags, pull
+requests and manual dispatches. Every run uploads an artifact suffixed
+`-unsigned`. Non-PR runs can pass the `apple-signing` environment gate to also
+sign, notarize, and staple all three apps and the disk image, then upload a
+signed artifact. Tagged signed runs attach the disk image to that GitHub
+release. A prerelease tag such as `@betteroffice/docx@0.2.0-rc.1` uses `0.2.0`
+as the numeric macOS bundle version and keeps the full version in artifact
+names.
+
+## Secrets
+
+Create an `apple-signing` environment with required reviewers, then create
+these as environment secrets. All six are required for the signed path; if any
+is missing the workflow retains only the unsigned artifact.
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_CERTIFICATE_P12` | Base64 of a Developer ID Application certificate exported as `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | The password chosen during that export |
+| `APPLE_TEAM_ID` | The ten-character team id, shown in the Apple Developer account page |
+| `APPLE_API_KEY_ID` | Key id of an App Store Connect API key |
+| `APPLE_API_ISSUER_ID` | Issuer id shown above the key list |
+| `APPLE_API_KEY_P8` | Base64 of the `.p8` file, which downloads exactly once |
+
+To export the certificate: request a Developer ID Application certificate in
+Keychain Access, install it, then right-click it under My Certificates and
+export as `.p12`. Encode both it and the `.p8` with `base64 -i FILE | pbcopy`.
+
+An App Store Connect API key is used instead of an app-specific password so no
+individual's Apple ID is embedded in CI. Create one under Users and Access >
+Integrations with the Developer role.

--- a/apps/native-viewer/macos/build-app.sh
+++ b/apps/native-viewer/macos/build-app.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "usage: $0 FORMAT OUTPUT_DIR VERSION BUILD_VERSION" >&2
+    exit 2
+fi
+
+format=$1
+output_dir=$2
+version=$3
+build_version=$4
+
+case "$format" in
+    docx)
+        app_name="BetterOffice Docs"
+        bundle_id=dev.betteroffice.docs
+        extension=docx
+        icon_variant=doc
+        type_name="Word document"
+        content_type=org.openxmlformats.wordprocessingml.document
+        welcome=betteroffice-demo.docx
+        ;;
+    xlsx)
+        app_name="BetterOffice Sheets"
+        bundle_id=dev.betteroffice.sheets
+        extension=xlsx
+        icon_variant=sheet
+        type_name="Excel workbook"
+        content_type=org.openxmlformats.spreadsheetml.sheet
+        welcome=sample.xlsx
+        ;;
+    pptx)
+        app_name="BetterOffice Slides"
+        bundle_id=dev.betteroffice.slides
+        extension=pptx
+        icon_variant=deck
+        type_name="PowerPoint presentation"
+        content_type=org.openxmlformats.presentationml.presentation
+        welcome=betteroffice-demo.pptx
+        ;;
+    *)
+        echo "FORMAT must be docx, xlsx, or pptx" >&2
+        exit 2
+        ;;
+esac
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$script_dir/../../.." && pwd)
+target_dir=${CARGO_TARGET_DIR:-"$repo_root/apps/native-viewer/target"}
+deployment_target=${MACOSX_DEPLOYMENT_TARGET:-12.0}
+binary_name=betteroffice-native-viewer
+app_path="$output_dir/$app_name.app"
+
+if [[ ! $version =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
+    echo "VERSION must contain one to three numeric components" >&2
+    exit 2
+fi
+
+if [[ ! $build_version =~ ^[0-9]+([.][0-9]+)*$ ]]; then
+    echo "BUILD_VERSION must contain numeric components" >&2
+    exit 2
+fi
+
+mkdir -p "$output_dir"
+rm -rf "$app_path"
+
+export CARGO_TARGET_DIR="$target_dir"
+export MACOSX_DEPLOYMENT_TARGET="$deployment_target"
+
+for target in aarch64-apple-darwin x86_64-apple-darwin; do
+    cargo build \
+        --locked \
+        --release \
+        --no-default-features \
+        --features "$format" \
+        --target "$target" \
+        --manifest-path "$repo_root/apps/native-viewer/Cargo.toml"
+done
+
+mkdir -p "$app_path/Contents/MacOS" "$app_path/Contents/Resources"
+xcrun lipo -create \
+    "$target_dir/aarch64-apple-darwin/release/$binary_name" \
+    "$target_dir/x86_64-apple-darwin/release/$binary_name" \
+    -output "$app_path/Contents/MacOS/$binary_name"
+chmod 755 "$app_path/Contents/MacOS/$binary_name"
+
+cp "$script_dir/Info.plist" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleDisplayName -string "$app_name" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleName -string "$app_name" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleIdentifier -string "$bundle_id" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleShortVersionString -string "$version" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleVersion -string "$build_version" "$app_path/Contents/Info.plist"
+plutil -replace LSMinimumSystemVersion -string "$deployment_target" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleDocumentTypes.0.CFBundleTypeExtensions -json "[\"$extension\"]" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleDocumentTypes.0.CFBundleTypeName -string "$type_name" "$app_path/Contents/Info.plist"
+plutil -replace CFBundleDocumentTypes.0.LSItemContentTypes -json "[\"$content_type\"]" "$app_path/Contents/Info.plist"
+
+icon_dir=$(mktemp -d "${TMPDIR:-/tmp}/betteroffice-icon.XXXXXX")
+trap 'rm -rf "$icon_dir"' EXIT
+
+swift "$script_dir/generate-icon.swift" "$icon_variant" "$icon_dir/icon.png"
+icon_set="$icon_dir/AppIcon.iconset"
+mkdir "$icon_set"
+for spec in \
+    icon_16x16.png:16 \
+    icon_16x16@2x.png:32 \
+    icon_32x32.png:32 \
+    icon_32x32@2x.png:64 \
+    icon_128x128.png:128 \
+    icon_128x128@2x.png:256 \
+    icon_256x256.png:256 \
+    icon_256x256@2x.png:512 \
+    icon_512x512.png:512 \
+    icon_512x512@2x.png:1024
+do
+    name=${spec%%:*}
+    pixels=${spec##*:}
+    sips -z "$pixels" "$pixels" "$icon_dir/icon.png" --out "$icon_set/$name" >/dev/null
+done
+swift "$script_dir/package-icns.swift" \
+    "$icon_set" "$app_path/Contents/Resources/AppIcon.icns"
+
+cp "$repo_root/apps/demo/public/$welcome" "$app_path/Contents/Resources/Welcome.$extension"
+plutil -lint "$app_path/Contents/Info.plist" >/dev/null
+xcrun lipo "$app_path/Contents/MacOS/$binary_name" -verify_arch arm64 x86_64
+printf '%s\n' "$app_path"

--- a/apps/native-viewer/macos/generate-icon.swift
+++ b/apps/native-viewer/macos/generate-icon.swift
@@ -1,0 +1,111 @@
+import AppKit
+import Foundation
+
+let variants = ["doc", "sheet", "deck"]
+
+guard CommandLine.arguments.count == 3, variants.contains(CommandLine.arguments[1]) else {
+    FileHandle.standardError.write(Data("usage: generate-icon.swift \(variants.joined(separator: "|")) OUT.png\n".utf8))
+    exit(2)
+}
+
+let variant = CommandLine.arguments[1]
+let side = 1024
+let unit = CGFloat(side) / 32
+
+struct Block {
+    let x: CGFloat
+    let y: CGFloat
+    let w: CGFloat
+    let h: CGFloat
+    let alpha: CGFloat
+    let white: Bool
+
+    init(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat, _ alpha: CGFloat = 1, white: Bool = true) {
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.alpha = alpha
+        self.white = white
+    }
+}
+
+func frame(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat, _ t: CGFloat, _ alpha: CGFloat = 1) -> [Block] {
+    [
+        Block(x, y, w, t, alpha),
+        Block(x, y + h - t, w, t, alpha),
+        Block(x, y + t, t, h - 2 * t, alpha),
+        Block(x + w - t, y + t, t, h - 2 * t, alpha),
+    ]
+}
+
+let blocks: [Block]
+switch variant {
+case "doc":
+    blocks = [
+        Block(6, 4, 20, 3),
+        Block(6, 11, 20, 3),
+        Block(6, 18, 20, 3),
+        Block(10, 25, 12, 3, 0.55),
+    ]
+case "sheet":
+    blocks = [
+        Block(5, 11, 6, 14),
+        Block(13, 5, 6, 20),
+        Block(21, 15, 6, 10, 0.55),
+        Block(4, 25, 24, 2),
+    ]
+case "deck":
+    blocks = [Block(11, 6, 18, 12, 1, white: false)] + frame(11, 6, 18, 12, 2, 0.55)
+        + [Block(7, 10, 18, 12, 1, white: false)] + frame(7, 10, 18, 12, 2)
+        + [Block(3, 14, 18, 12, 1, white: false)] + frame(3, 14, 18, 12, 2)
+default:
+    preconditionFailure("unsupported icon variant")
+}
+
+guard
+    let context = CGContext(
+        data: nil,
+        width: side,
+        height: side,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )
+else {
+    exit(1)
+}
+
+context.setShouldAntialias(false)
+context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+let ground = CGPath(
+    roundedRect: CGRect(x: 0, y: 0, width: CGFloat(side), height: CGFloat(side)),
+    cornerWidth: unit * 7,
+    cornerHeight: unit * 7,
+    transform: nil
+)
+context.addPath(ground)
+context.fillPath()
+
+for block in blocks {
+    let level: CGFloat = block.white ? 1 : 0
+    context.setFillColor(CGColor(red: level, green: level, blue: level, alpha: block.alpha))
+    context.fill(
+        CGRect(
+            x: block.x * unit,
+            y: (32 - block.y - block.h) * unit,
+            width: block.w * unit,
+            height: block.h * unit
+        )
+    )
+}
+
+guard
+    let image = context.makeImage(),
+    let png = NSBitmapImageRep(cgImage: image).representation(using: .png, properties: [:])
+else {
+    exit(1)
+}
+
+try png.write(to: URL(fileURLWithPath: CommandLine.arguments[2]), options: .atomic)

--- a/apps/native-viewer/macos/package-dmg.sh
+++ b/apps/native-viewer/macos/package-dmg.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "usage: $0 DOCS_APP SHEETS_APP SLIDES_APP DMG_PATH" >&2
+    exit 2
+fi
+
+apps=("$1" "$2" "$3")
+expected=("BetterOffice Docs.app" "BetterOffice Sheets.app" "BetterOffice Slides.app")
+dmg_path=$4
+
+for index in "${!apps[@]}"; do
+    if [[ ! -d ${apps[$index]} || ${apps[$index]##*/} != "${expected[$index]}" ]]; then
+        echo "expected ${expected[$index]}" >&2
+        exit 2
+    fi
+done
+
+staging_dir=$(mktemp -d "${TMPDIR:-/tmp}/betteroffice-dmg.XXXXXX")
+trap 'rm -rf "$staging_dir"' EXIT
+
+mkdir -p "$(dirname "$dmg_path")"
+for app in "${apps[@]}"; do
+    ditto "$app" "$staging_dir/${app##*/}"
+done
+ln -s /Applications "$staging_dir/Applications"
+hdiutil create \
+    -volname BetterOffice \
+    -srcfolder "$staging_dir" \
+    -format UDZO \
+    -ov \
+    "$dmg_path"

--- a/apps/native-viewer/macos/package-icns.swift
+++ b/apps/native-viewer/macos/package-icns.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+guard CommandLine.arguments.count == 3 else {
+    FileHandle.standardError.write(Data("usage: package-icns.swift ICONSET OUTPUT.icns\n".utf8))
+    exit(2)
+}
+
+let iconset = URL(fileURLWithPath: CommandLine.arguments[1])
+let output = URL(fileURLWithPath: CommandLine.arguments[2])
+let entries = [
+    ("icp4", "icon_16x16.png"),
+    ("icp5", "icon_32x32.png"),
+    ("ic07", "icon_128x128.png"),
+    ("ic08", "icon_256x256.png"),
+    ("ic09", "icon_512x512.png"),
+    ("ic11", "icon_16x16@2x.png"),
+    ("ic12", "icon_32x32@2x.png"),
+    ("ic13", "icon_128x128@2x.png"),
+    ("ic14", "icon_256x256@2x.png"),
+    ("ic10", "icon_512x512@2x.png"),
+]
+
+func appendSize(_ count: Int, to data: inout Data) {
+    var size = UInt32(count).bigEndian
+    Swift.withUnsafeBytes(of: &size) { data.append(contentsOf: $0) }
+}
+
+var chunks = Data()
+for (type, name) in entries {
+    let image = try Data(contentsOf: iconset.appendingPathComponent(name))
+    chunks.append(contentsOf: type.utf8)
+    appendSize(image.count + 8, to: &chunks)
+    chunks.append(image)
+}
+
+var icns = Data("icns".utf8)
+appendSize(chunks.count + 8, to: &icns)
+icns.append(chunks)
+try icns.write(to: output, options: .atomic)

--- a/apps/native-viewer/src/chrome.rs
+++ b/apps/native-viewer/src/chrome.rs
@@ -38,6 +38,7 @@ pub enum Alignment {
 }
 
 impl Alignment {
+    #[cfg(feature = "docx")]
     pub fn from_engine(value: Option<&str>) -> Option<Self> {
         match value {
             Some("left" | "start") => Some(Self::Left),
@@ -48,6 +49,7 @@ impl Alignment {
         }
     }
 
+    #[cfg(feature = "docx")]
     pub fn engine_value(self) -> &'static str {
         match self {
             Self::Left => "left",

--- a/apps/native-viewer/src/collaboration_document.rs
+++ b/apps/native-viewer/src/collaboration_document.rs
@@ -164,7 +164,7 @@ pub fn forward_local_updates(document: &DocumentView, collaboration: &mut Collab
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "docx", feature = "xlsx", feature = "pptx"))]
 mod tests {
     use std::path::Path;
 

--- a/apps/native-viewer/src/collaboration_test_peer.rs
+++ b/apps/native-viewer/src/collaboration_test_peer.rs
@@ -6,16 +6,22 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+#[cfg(feature = "pptx")]
 use betteroffice_pptx::ShapeSnapshot;
+#[cfg(feature = "xlsx")]
 use betteroffice_xlsx::{CellRef, SheetId};
+#[cfg(feature = "docx")]
 use docx_edit::story_checksum;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "docx")]
 use sha2::{Digest, Sha256};
+#[cfg(feature = "docx")]
 use yrs::{Map, ReadTxn, Transact};
 
 use crate::collaboration::{CollaborationClient, CollaborationConfig, TransportEvent};
 use crate::collaboration_document;
 use crate::document::{DocumentView, ReferenceDocument, load_collaborative_document};
+#[cfg(feature = "docx")]
 use crate::editing::TextLoc;
 
 #[derive(Deserialize)]
@@ -230,6 +236,7 @@ fn connect(config: &CollaborationConfig) -> Result<Connection> {
     Ok(Connection { client, events })
 }
 
+#[allow(irrefutable_let_patterns)]
 fn apply_command(
     command: PeerCommand,
     config: &CollaborationConfig,
@@ -244,12 +251,20 @@ fn apply_command(
             text,
             ..
         } => {
-            document.docx_select_point(TextLoc { para_id, offset }, false, false)?;
-            if !document.docx_insert_text(&text)? {
-                bail!("native insert made no change");
+            #[cfg(feature = "docx")]
+            {
+                document.docx_select_point(TextLoc { para_id, offset }, false, false)?;
+                if !document.docx_insert_text(&text)? {
+                    bail!("native insert made no change");
+                }
+                if let Some(active) = connection {
+                    collaboration_document::forward_local_updates(document, &mut active.client);
+                }
             }
-            if let Some(active) = connection {
-                collaboration_document::forward_local_updates(document, &mut active.client);
+            #[cfg(not(feature = "docx"))]
+            {
+                let _ = (para_id, offset, text);
+                bail!("native insert requires BetterOffice Docs");
             }
         }
         PeerCommand::SetCell {
@@ -259,21 +274,29 @@ fn apply_command(
             input,
             ..
         } => {
-            let ReferenceDocument::Xlsx(reference) = &document.reference else {
-                bail!("native setCell requires XLSX");
-            };
-            if reference.editor.sheet() != SheetId(sheet) {
-                bail!(
-                    "native peer has not opened sheet {}",
-                    sheet.saturating_add(1)
-                );
+            #[cfg(feature = "xlsx")]
+            {
+                let ReferenceDocument::Xlsx(reference) = &document.reference else {
+                    bail!("native setCell requires XLSX");
+                };
+                if reference.editor.sheet() != SheetId(sheet) {
+                    bail!(
+                        "native peer has not opened sheet {}",
+                        sheet.saturating_add(1)
+                    );
+                }
+                document.xlsx_select_cell(CellRef::new(row, col));
+                if !document.xlsx_begin_edit(Some(&input))? || !document.xlsx_commit(None)? {
+                    bail!("native cell edit made no change");
+                }
+                if let Some(active) = connection {
+                    collaboration_document::forward_local_updates(document, &mut active.client);
+                }
             }
-            document.xlsx_select_cell(CellRef::new(row, col));
-            if !document.xlsx_begin_edit(Some(&input))? || !document.xlsx_commit(None)? {
-                bail!("native cell edit made no change");
-            }
-            if let Some(active) = connection {
-                collaboration_document::forward_local_updates(document, &mut active.client);
+            #[cfg(not(feature = "xlsx"))]
+            {
+                let _ = (sheet, row, col, input);
+                bail!("native setCell requires BetterOffice Sheets");
             }
         }
         PeerCommand::InsertPptx {
@@ -282,14 +305,22 @@ fn apply_command(
             text,
             ..
         } => {
-            if !document.pptx_select_story_position(&story_id, index)? {
-                bail!("native PPTX story position is not rendered");
+            #[cfg(feature = "pptx")]
+            {
+                if !document.pptx_select_story_position(&story_id, index)? {
+                    bail!("native PPTX story position is not rendered");
+                }
+                if !document.pptx_insert_text(&text)? {
+                    bail!("native PPTX insert made no change");
+                }
+                if let Some(active) = connection {
+                    collaboration_document::forward_local_updates(document, &mut active.client);
+                }
             }
-            if !document.pptx_insert_text(&text)? {
-                bail!("native PPTX insert made no change");
-            }
-            if let Some(active) = connection {
-                collaboration_document::forward_local_updates(document, &mut active.client);
+            #[cfg(not(feature = "pptx"))]
+            {
+                let _ = (story_id, index, text);
+                bail!("native insertPptx requires BetterOffice Slides");
             }
         }
         PeerCommand::Disconnect { .. } => {
@@ -309,12 +340,16 @@ fn apply_command(
 
 fn snapshot(document: &DocumentView, connection: Option<&Connection>) -> Result<PeerSnapshot> {
     match &document.reference {
+        #[cfg(feature = "docx")]
         ReferenceDocument::Docx(reference) => snapshot_docx(document, reference, connection),
+        #[cfg(feature = "xlsx")]
         ReferenceDocument::Xlsx(reference) => snapshot_xlsx(document, reference, connection),
+        #[cfg(feature = "pptx")]
         ReferenceDocument::Pptx(reference) => snapshot_pptx(document, reference, connection),
     }
 }
 
+#[cfg(feature = "docx")]
 fn snapshot_docx(
     document: &DocumentView,
     reference: &crate::document::DocxReference,
@@ -363,6 +398,7 @@ fn snapshot_docx(
     })
 }
 
+#[cfg(feature = "xlsx")]
 fn snapshot_xlsx(
     document: &DocumentView,
     reference: &crate::document::XlsxReference,
@@ -395,6 +431,7 @@ fn snapshot_xlsx(
     })
 }
 
+#[cfg(feature = "pptx")]
 fn snapshot_pptx(
     document: &DocumentView,
     reference: &crate::document::PptxReference,
@@ -418,6 +455,7 @@ fn snapshot_pptx(
     })
 }
 
+#[cfg(feature = "pptx")]
 fn collect_pptx_stories(target: &mut Vec<PptxStoryState>, slide: usize, shapes: &[ShapeSnapshot]) {
     for shape in shapes {
         target.extend(shape.text_stories.iter().map(|story| PptxStoryState {
@@ -431,6 +469,7 @@ fn collect_pptx_stories(target: &mut Vec<PptxStoryState>, slide: usize, shapes: 
     }
 }
 
+#[cfg(feature = "docx")]
 fn canonical_checksum(stories: &[StoryState]) -> String {
     let mut checksum = Sha256::new();
     checksum.update(b"canonical-document-checksums-v1\n");

--- a/apps/native-viewer/src/document.rs
+++ b/apps/native-viewer/src/document.rs
@@ -1,26 +1,40 @@
+#[cfg(feature = "docx")]
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+#[cfg(feature = "xlsx")]
 use betteroffice_xlsx::CellRef;
+#[cfg(feature = "docx")]
 use docx_edit::{EditingDoc, EngineSession, SimpleFormat, seed_from_docx};
+#[cfg(feature = "docx")]
 use docx_layout::display_list::DisplayList;
+#[cfg(feature = "docx")]
 use docx_parse::{S9PackageWire, S9ParseOptions, parse_docx_s9_wire};
+#[cfg(feature = "docx")]
 use serde_json::{Value, json};
 use vello::kurbo::Affine;
 
-use crate::chrome::{Alignment, EditingState};
+#[cfg(feature = "docx")]
+use crate::chrome::Alignment;
+use crate::chrome::EditingState;
+#[cfg(feature = "docx")]
 use crate::collaboration::BROWSER_SEED_CLIENT_ID;
+#[cfg(feature = "docx")]
 use crate::docx_scene::translate_document;
-use crate::editing::{
-    DeleteDirection, DocxEditor, MoveDirection, SceneChange, SelectionRect, TextLoc,
-};
+#[cfg(feature = "docx")]
+use crate::editing::{DocxEditor, SceneChange, SelectionRect, TextLoc};
+#[cfg(feature = "docx")]
 use crate::fonts::FontRegistry;
+#[cfg(feature = "docx")]
 use crate::images::ImageRegistry;
+#[cfg(feature = "pptx")]
 use crate::pptx_editing::{PptxEditChange, PptxEditor, PptxHit, PptxRemoteChange, PptxTextHit};
 use crate::scene_shared::PageScene;
+#[cfg(feature = "xlsx")]
 use crate::xlsx_editing::{CellMove, XlsxEditor};
+#[cfg(feature = "xlsx")]
 use crate::xlsx_scene::translate_sheet;
 
 pub struct DocumentView {
@@ -31,11 +45,15 @@ pub struct DocumentView {
 }
 
 pub enum ReferenceDocument {
+    #[cfg(feature = "docx")]
     Docx(Box<DocxReference>),
+    #[cfg(feature = "xlsx")]
     Xlsx(Box<XlsxReference>),
+    #[cfg(feature = "pptx")]
     Pptx(Box<PptxReference>),
 }
 
+#[cfg(feature = "docx")]
 pub struct DocxReference {
     pub display_list: DisplayList,
     pub fonts: FontRegistry,
@@ -43,6 +61,7 @@ pub struct DocxReference {
     pub editor: DocxEditor,
 }
 
+#[cfg(feature = "xlsx")]
 pub struct XlsxReference {
     pub editor: XlsxEditor,
     pub sheet_index: usize,
@@ -52,11 +71,13 @@ pub struct XlsxReference {
     pub chart_placeholders: usize,
 }
 
+#[cfg(feature = "xlsx")]
 pub struct XlsxOverlay {
     pub rect: xlsx_render::Rect,
     pub draft: Option<String>,
 }
 
+#[cfg(feature = "pptx")]
 pub struct PptxReference {
     pub editor: PptxEditor,
 }
@@ -71,10 +92,29 @@ pub struct ViewerCaretGeometry {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum DocumentFormat {
     Docx,
     Xlsx,
     Pptx,
+}
+
+#[cfg(any(feature = "docx", feature = "pptx"))]
+#[derive(Clone, Copy, Debug)]
+pub enum MoveDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+}
+
+#[cfg(any(feature = "docx", feature = "pptx"))]
+#[derive(Clone, Copy, Debug)]
+pub enum DeleteDirection {
+    Backward,
+    Forward,
 }
 
 impl DocumentFormat {
@@ -85,45 +125,87 @@ impl DocumentFormat {
             .map(str::to_ascii_lowercase)
             .as_deref()
         {
-            Some("docx") => Ok(Self::Docx),
-            Some("xlsx") => Ok(Self::Xlsx),
-            Some("pptx") => Ok(Self::Pptx),
+            Some("docx") => {
+                #[cfg(feature = "docx")]
+                {
+                    Ok(Self::Docx)
+                }
+                #[cfg(not(feature = "docx"))]
+                {
+                    bail!(
+                        ".docx files open in BetterOffice Docs; this build does not include the DOCX engine"
+                    )
+                }
+            }
+            Some("xlsx") => {
+                #[cfg(feature = "xlsx")]
+                {
+                    Ok(Self::Xlsx)
+                }
+                #[cfg(not(feature = "xlsx"))]
+                {
+                    bail!(
+                        ".xlsx files open in BetterOffice Sheets; this build does not include the XLSX engine"
+                    )
+                }
+            }
+            Some("pptx") => {
+                #[cfg(feature = "pptx")]
+                {
+                    Ok(Self::Pptx)
+                }
+                #[cfg(not(feature = "pptx"))]
+                {
+                    bail!(
+                        ".pptx files open in BetterOffice Slides; this build does not include the PPTX engine"
+                    )
+                }
+            }
             _ => bail!("--document must be a .docx, .xlsx, or .pptx file"),
         }
     }
 }
 
+#[allow(irrefutable_let_patterns)]
 impl DocumentView {
-    pub fn scene_label(&self, index: usize) -> String {
+    pub fn scene_label(&self, _index: usize) -> String {
         match &self.reference {
-            ReferenceDocument::Docx(_) => format!("page {}", index + 1),
+            #[cfg(feature = "docx")]
+            ReferenceDocument::Docx(_) => format!("page {}", _index + 1),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => {
                 format!("sheet {}", reference.sheet_index + 1)
             }
-            ReferenceDocument::Pptx(_) => format!("slide {}", index + 1),
+            #[cfg(feature = "pptx")]
+            ReferenceDocument::Pptx(_) => format!("slide {}", _index + 1),
         }
     }
 
     pub fn title_summary(&self) -> String {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => format!("{} pages", self.pages.len()),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => format!(
                 "sheet {} of {} ({})",
                 reference.sheet_index + 1,
                 reference.sheet_count,
                 reference.sheet_name
             ),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => {
                 format!("{} slides", reference.editor.slide_count())
             }
         }
     }
 
-    pub fn status_position(&self, page_index: usize) -> String {
+    pub fn status_position(&self, _page_index: usize) -> String {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => {
-                format!("Page {} of {}", page_index + 1, self.pages.len())
+                format!("Page {} of {}", _page_index + 1, self.pages.len())
             }
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => {
                 let cell = reference
                     .editor
@@ -135,10 +217,11 @@ impl DocumentView {
                     reference.sheet_count
                 )
             }
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => {
                 format!(
                     "Slide {} of {}",
-                    page_index + 1,
+                    _page_index + 1,
                     reference.editor.slide_count()
                 )
             }
@@ -147,11 +230,14 @@ impl DocumentView {
 
     pub fn editing_state(&self) -> Result<EditingState> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.editing_state(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => Ok(EditingState::editable_without_selection(
                 reference.editor.can_undo(),
                 reference.editor.can_redo(),
             )),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => Ok(EditingState::editable_without_selection(
                 reference.editor.can_undo(),
                 reference.editor.can_redo(),
@@ -161,12 +247,16 @@ impl DocumentView {
 
     pub fn display_item_name(&self) -> &'static str {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => "primitives",
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => "commands",
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) => "primitives",
         }
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_hit_test(&self, page_index: usize, x: f64, y: f64) -> Result<Option<TextLoc>> {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             return Ok(None);
@@ -174,6 +264,7 @@ impl DocumentView {
         reference.editor.hit_test(page_index, x, y)
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_select_point(&mut self, loc: TextLoc, extend: bool, word: bool) -> Result<bool> {
         let ReferenceDocument::Docx(reference) = &mut self.reference else {
             return Ok(false);
@@ -182,6 +273,7 @@ impl DocumentView {
         Ok(true)
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_extend_to(&mut self, loc: TextLoc) -> Result<bool> {
         let ReferenceDocument::Docx(reference) = &mut self.reference else {
             return Ok(false);
@@ -190,6 +282,7 @@ impl DocumentView {
         Ok(true)
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_move_selection(&mut self, direction: MoveDirection, extend: bool) -> Result<bool> {
         let ReferenceDocument::Docx(reference) = &mut self.reference else {
             return Ok(false);
@@ -197,35 +290,42 @@ impl DocumentView {
         reference.editor.move_selection(direction, extend)
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_insert_text(&mut self, text: &str) -> Result<bool> {
         self.apply_docx_edit(|editor| editor.insert_text(text))
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_delete(&mut self, direction: DeleteDirection) -> Result<bool> {
         self.apply_docx_edit(|editor| editor.delete(direction))
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_enter(&mut self) -> Result<bool> {
         self.apply_docx_edit(DocxEditor::enter)
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_toggle_format(&mut self, format: SimpleFormat) -> Result<bool> {
         self.apply_docx_edit(|editor| editor.toggle_format(format))
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_set_alignment(&mut self, alignment: Alignment) -> Result<bool> {
         self.apply_docx_edit(|editor| editor.set_alignment(alignment))
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_undo(&mut self) -> Result<bool> {
         self.apply_docx_edit(DocxEditor::undo)
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_redo(&mut self) -> Result<bool> {
         self.apply_docx_edit(DocxEditor::redo)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "docx"))]
     pub fn docx_state_vector(&self) -> Result<Vec<u8>> {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             bail!("collaboration is available only for DOCX");
@@ -233,11 +333,12 @@ impl DocumentView {
         Ok(reference.editor.state_vector())
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_apply_remote_update(&mut self, update: &[u8]) -> Result<bool> {
         self.apply_docx_edit(|editor| editor.apply_remote_update(update).map(Some))
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "docx"))]
     pub fn docx_drain_local_updates(&self) -> Vec<Vec<u8>> {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             return Vec::new();
@@ -245,7 +346,7 @@ impl DocumentView {
         reference.editor.drain_local_updates()
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "docx"))]
     pub fn docx_fingerprint(&self) -> Result<[u8; 32]> {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             bail!("collaboration is available only for DOCX");
@@ -255,23 +356,31 @@ impl DocumentView {
 
     pub fn collaboration_state_vector(&self) -> Result<Vec<u8>> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => Ok(reference.editor.state_vector()),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.state_vector(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.state_vector(),
         }
     }
 
     pub fn collaboration_encode_diff(&self, state_vector: &[u8]) -> Result<Vec<u8>> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.encode_diff(state_vector),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.encode_diff(state_vector),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.encode_diff(state_vector),
         }
     }
 
     pub fn collaboration_apply_remote_update(&mut self, update: &[u8]) -> Result<bool> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => self.docx_apply_remote_update(update),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => {
                 let changed = {
                     let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
@@ -284,6 +393,7 @@ impl DocumentView {
                 }
                 Ok(changed)
             }
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) => {
                 let change = {
                     let ReferenceDocument::Pptx(reference) = &mut self.reference else {
@@ -309,21 +419,27 @@ impl DocumentView {
 
     pub fn collaboration_drain_local_updates(&self) -> Vec<Vec<u8>> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.drain_local_updates(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.drain_local_updates(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.drain_local_updates(),
         }
     }
 
     pub fn collaboration_fingerprint(&self) -> Result<[u8; 32]> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => Ok(reference.editor.source_fingerprint()),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.source_fingerprint(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.source_fingerprint(),
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "docx"))]
     pub fn docx_canonical_checksum(&self) -> Result<[u8; 32]> {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             bail!("collaboration is available only for DOCX");
@@ -331,7 +447,7 @@ impl DocumentView {
         reference.editor.canonical_checksum()
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "docx"))]
     pub fn docx_relayout_count(&self) -> usize {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             return 0;
@@ -342,8 +458,11 @@ impl DocumentView {
     #[cfg(test)]
     pub fn collaboration_canonical_checksum(&self) -> Result<[u8; 32]> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.canonical_checksum(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.canonical_checksum(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.canonical_checksum(),
         }
     }
@@ -351,12 +470,16 @@ impl DocumentView {
     #[cfg(test)]
     pub fn collaboration_relayout_count(&self) -> usize {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.relayout_count(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.relayout_count(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.relayout_count(),
         }
     }
 
+    #[cfg(feature = "docx")]
     pub fn docx_selection_rects(&self) -> &[SelectionRect] {
         let ReferenceDocument::Docx(reference) = &self.reference else {
             return &[];
@@ -366,6 +489,7 @@ impl DocumentView {
 
     pub fn caret_geometry(&self) -> Result<Option<ViewerCaretGeometry>> {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => {
                 Ok(reference
                     .editor
@@ -378,6 +502,7 @@ impl DocumentView {
                         transform: Affine::IDENTITY,
                     }))
             }
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => {
                 Ok(reference
                     .editor
@@ -390,36 +515,47 @@ impl DocumentView {
                         transform: caret.transform,
                     }))
             }
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => Ok(None),
         }
     }
 
     pub fn has_text_caret(&self) -> bool {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.has_collapsed_selection(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.has_caret(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => false,
         }
     }
 
     pub fn is_dirty(&self) -> bool {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.is_dirty(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => {
                 reference.editor.is_dirty() || reference.editor.is_editing()
             }
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.is_dirty(),
         }
     }
 
     pub fn is_remote_only_dirty(&self) -> bool {
         match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => reference.editor.is_remote_only_dirty(),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => reference.editor.is_remote_only_dirty(),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => reference.editor.is_remote_only_dirty(),
         }
     }
 
+    #[cfg(feature = "docx")]
     pub fn save_docx_to(&mut self, path: &Path) -> Result<()> {
         let ReferenceDocument::Docx(reference) = &mut self.reference else {
             bail!("only DOCX documents are editable");
@@ -427,6 +563,7 @@ impl DocumentView {
         reference.editor.save_to(path)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_hit_test(&self, slide_index: usize, x: f64, y: f64) -> Option<PptxHit> {
         let ReferenceDocument::Pptx(reference) = &self.reference else {
             return None;
@@ -434,6 +571,7 @@ impl DocumentView {
         reference.editor.hit_test(slide_index, x as f32, y as f32)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_select_hit(&mut self, hit: PptxTextHit) -> bool {
         let ReferenceDocument::Pptx(reference) = &mut self.reference else {
             return false;
@@ -441,6 +579,7 @@ impl DocumentView {
         reference.editor.select_hit(hit)
     }
 
+    #[cfg(feature = "pptx")]
     pub(crate) fn pptx_select_story_position(
         &mut self,
         story_id: &str,
@@ -452,6 +591,7 @@ impl DocumentView {
         reference.editor.select_story_position(story_id, position)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_clear_caret(&mut self) -> bool {
         let ReferenceDocument::Pptx(reference) = &mut self.reference else {
             return false;
@@ -459,6 +599,7 @@ impl DocumentView {
         reference.editor.clear_caret()
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_move_caret(&mut self, direction: MoveDirection) -> bool {
         let ReferenceDocument::Pptx(reference) = &mut self.reference else {
             return false;
@@ -466,18 +607,22 @@ impl DocumentView {
         reference.editor.move_caret(direction)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_insert_text(&mut self, text: &str) -> Result<bool> {
         self.apply_pptx_edit(|editor| editor.insert_text(text))
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_delete(&mut self, direction: DeleteDirection) -> Result<bool> {
         self.apply_pptx_edit(|editor| editor.delete(direction))
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_enter(&mut self) -> Result<bool> {
         self.apply_pptx_edit(PptxEditor::enter)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_undo(&mut self) -> Result<bool> {
         let pages = {
             let ReferenceDocument::Pptx(reference) = &mut self.reference else {
@@ -492,6 +637,7 @@ impl DocumentView {
         Ok(true)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_redo(&mut self) -> Result<bool> {
         let pages = {
             let ReferenceDocument::Pptx(reference) = &mut self.reference else {
@@ -506,6 +652,7 @@ impl DocumentView {
         Ok(true)
     }
 
+    #[cfg(feature = "pptx")]
     pub fn pptx_is_dirty(&self) -> bool {
         matches!(
             &self.reference,
@@ -513,6 +660,7 @@ impl DocumentView {
         )
     }
 
+    #[cfg(feature = "pptx")]
     pub fn save_pptx_to(&mut self, path: &Path) -> Result<()> {
         let ReferenceDocument::Pptx(reference) = &mut self.reference else {
             bail!("only PPTX decks use the PPTX save path");
@@ -520,6 +668,7 @@ impl DocumentView {
         reference.editor.save_to(path)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_hit_test(&self, page_index: usize, x: f64, y: f64) -> Option<CellRef> {
         let ReferenceDocument::Xlsx(reference) = &self.reference else {
             return None;
@@ -529,6 +678,7 @@ impl DocumentView {
             .flatten()
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_select_cell(&mut self, cell: CellRef) -> bool {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return false;
@@ -536,6 +686,7 @@ impl DocumentView {
         reference.editor.select(cell)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_move_selection(&mut self, movement: CellMove) -> bool {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return false;
@@ -543,6 +694,7 @@ impl DocumentView {
         reference.editor.move_selection(movement)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_begin_edit(&mut self, seed: Option<&str>) -> Result<bool> {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return Ok(false);
@@ -550,6 +702,7 @@ impl DocumentView {
         reference.editor.begin_edit(seed)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_insert_text(&mut self, text: &str) -> bool {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return false;
@@ -557,6 +710,7 @@ impl DocumentView {
         reference.editor.insert_text(text)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_backspace(&mut self) -> bool {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return false;
@@ -564,6 +718,7 @@ impl DocumentView {
         reference.editor.backspace()
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_cancel_edit(&mut self) -> bool {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return false;
@@ -571,6 +726,7 @@ impl DocumentView {
         reference.editor.cancel()
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_commit(&mut self, movement: Option<CellMove>) -> Result<bool> {
         let changed = {
             let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
@@ -584,6 +740,7 @@ impl DocumentView {
         Ok(changed)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_undo(&mut self) -> Result<bool> {
         let changed = {
             let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
@@ -597,6 +754,7 @@ impl DocumentView {
         Ok(changed)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_redo(&mut self) -> Result<bool> {
         let changed = {
             let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
@@ -610,6 +768,7 @@ impl DocumentView {
         Ok(changed)
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_is_editing(&self) -> bool {
         matches!(
             &self.reference,
@@ -617,6 +776,7 @@ impl DocumentView {
         )
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_is_dirty(&self) -> bool {
         matches!(
             &self.reference,
@@ -624,6 +784,7 @@ impl DocumentView {
         )
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn xlsx_overlay(&self) -> Option<XlsxOverlay> {
         let ReferenceDocument::Xlsx(reference) = &self.reference else {
             return None;
@@ -634,6 +795,7 @@ impl DocumentView {
         })
     }
 
+    #[cfg(feature = "xlsx")]
     pub fn save_xlsx_to(&mut self, path: &Path) -> Result<()> {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             bail!("only XLSX workbooks use the XLSX save path");
@@ -643,8 +805,11 @@ impl DocumentView {
 
     pub fn edited_path(&self) -> Result<PathBuf> {
         let extension = match &self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => "docx",
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => "xlsx",
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) => "pptx",
         };
         let stem = self
@@ -658,6 +823,7 @@ impl DocumentView {
 
     pub fn recover_after_edit_error(&mut self) -> Result<()> {
         match &mut self.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) => {
                 reference.editor.recover_layout()?;
                 let display_list = reference
@@ -669,6 +835,7 @@ impl DocumentView {
                     translate_document(&display_list, &reference.fonts, &reference.images)?;
                 reference.display_list = display_list;
             }
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => {
                 reference.editor.recover_layout()?;
                 let display_list = reference.editor.display_list();
@@ -680,6 +847,7 @@ impl DocumentView {
                     .filter(|chart| chart.placeholder)
                     .count();
             }
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(reference) => {
                 self.pages = reference.editor.recover_layout()?;
             }
@@ -687,6 +855,7 @@ impl DocumentView {
         Ok(())
     }
 
+    #[cfg(feature = "docx")]
     fn apply_docx_edit(
         &mut self,
         edit: impl FnOnce(&mut DocxEditor) -> Result<Option<SceneChange>>,
@@ -718,6 +887,7 @@ impl DocumentView {
         Ok(true)
     }
 
+    #[cfg(feature = "pptx")]
     fn apply_pptx_edit(
         &mut self,
         edit: impl FnOnce(&mut PptxEditor) -> Result<Option<PptxEditChange>>,
@@ -735,6 +905,7 @@ impl DocumentView {
         Ok(true)
     }
 
+    #[cfg(feature = "xlsx")]
     fn refresh_xlsx_scene(&mut self) -> Result<()> {
         let ReferenceDocument::Xlsx(reference) = &mut self.reference else {
             return Ok(());
@@ -768,7 +939,7 @@ pub fn load_document_for_export(
     load_document_with_xlsx_mode(path, sheet_index, max_texture_dimension_2d, false)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "docx"))]
 pub fn load_collaborative_docx(
     path: &Path,
     max_texture_dimension_2d: u32,
@@ -780,7 +951,7 @@ pub fn load_collaborative_docx(
     load_docx(path, max_texture_dimension_2d, Some(client_id))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "xlsx"))]
 pub fn load_collaborative_xlsx(
     path: &Path,
     sheet_index: usize,
@@ -799,7 +970,7 @@ pub fn load_collaborative_xlsx(
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "pptx"))]
 pub fn load_collaborative_pptx(
     path: &Path,
     max_texture_dimension_2d: u32,
@@ -813,42 +984,61 @@ pub fn load_collaborative_pptx(
 
 pub fn load_collaborative_document(
     path: &Path,
-    sheet_index: usize,
+    _sheet_index: usize,
     max_texture_dimension_2d: u32,
     client_id: u64,
 ) -> Result<DocumentView> {
     match DocumentFormat::from_path(path)? {
+        #[cfg(feature = "docx")]
         DocumentFormat::Docx => load_docx(path, max_texture_dimension_2d, Some(client_id)),
+        #[cfg(feature = "xlsx")]
         DocumentFormat::Xlsx => load_xlsx(
             path,
-            sheet_index,
+            _sheet_index,
             max_texture_dimension_2d,
             true,
             Some(client_id),
         ),
+        #[cfg(feature = "pptx")]
         DocumentFormat::Pptx => load_pptx(path, max_texture_dimension_2d, Some(client_id)),
+        #[cfg(not(feature = "docx"))]
+        DocumentFormat::Docx => unreachable!("DocumentFormat::from_path returned DOCX"),
+        #[cfg(not(feature = "xlsx"))]
+        DocumentFormat::Xlsx => unreachable!("DocumentFormat::from_path returned XLSX"),
+        #[cfg(not(feature = "pptx"))]
+        DocumentFormat::Pptx => unreachable!("DocumentFormat::from_path returned PPTX"),
     }
 }
 
 fn load_document_with_xlsx_mode(
     path: &Path,
-    sheet_index: usize,
+    _sheet_index: usize,
     max_texture_dimension_2d: u32,
-    recalculate_xlsx: bool,
+    _recalculate_xlsx: bool,
 ) -> Result<DocumentView> {
     match DocumentFormat::from_path(path)? {
+        #[cfg(feature = "docx")]
         DocumentFormat::Docx => load_docx(path, max_texture_dimension_2d, None),
+        #[cfg(feature = "xlsx")]
         DocumentFormat::Xlsx => load_xlsx(
             path,
-            sheet_index,
+            _sheet_index,
             max_texture_dimension_2d,
-            recalculate_xlsx,
+            _recalculate_xlsx,
             None,
         ),
+        #[cfg(feature = "pptx")]
         DocumentFormat::Pptx => load_pptx(path, max_texture_dimension_2d, None),
+        #[cfg(not(feature = "docx"))]
+        DocumentFormat::Docx => unreachable!("DocumentFormat::from_path returned DOCX"),
+        #[cfg(not(feature = "xlsx"))]
+        DocumentFormat::Xlsx => unreachable!("DocumentFormat::from_path returned XLSX"),
+        #[cfg(not(feature = "pptx"))]
+        DocumentFormat::Pptx => unreachable!("DocumentFormat::from_path returned PPTX"),
     }
 }
 
+#[cfg(feature = "pptx")]
 fn load_pptx(
     path: &Path,
     max_texture_dimension_2d: u32,
@@ -870,6 +1060,7 @@ fn load_pptx(
     })
 }
 
+#[cfg(feature = "docx")]
 fn load_docx(
     path: &Path,
     max_texture_dimension_2d: u32,
@@ -935,6 +1126,7 @@ fn load_docx(
     })
 }
 
+#[cfg(feature = "xlsx")]
 fn load_xlsx(
     path: &Path,
     sheet_index: usize,
@@ -975,6 +1167,7 @@ fn load_xlsx(
     })
 }
 
+#[cfg(feature = "docx")]
 fn region_request(
     package: &S9PackageWire,
     font_chains: Option<&BTreeMap<String, Vec<u32>>>,
@@ -1041,6 +1234,7 @@ fn region_request(
     Ok(request)
 }
 
+#[cfg(feature = "docx")]
 fn push_notes(target: &mut Vec<Value>, notes: Option<&[docx_parse::Note]>, note_kind: &str) {
     for note in notes.unwrap_or_default() {
         if !note.is_separator() {
@@ -1053,7 +1247,7 @@ fn push_notes(target: &mut Vec<Value>, notes: Option<&[docx_parse::Note]>, note_
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "docx", feature = "xlsx", feature = "pptx"))]
 mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/apps/native-viewer/src/editing.rs
+++ b/apps/native-viewer/src/editing.rs
@@ -31,6 +31,7 @@ use yrs::{
 };
 
 use crate::chrome::{Alignment, EditingState, ToggleState};
+use crate::document::{DeleteDirection, MoveDirection};
 
 const BODY_STORY: &str = "body";
 const SAVE_TIME: &str = "1970-01-01T00:00:00.000Z";
@@ -180,22 +181,6 @@ pub struct CaretGeometry {
 pub struct SceneChange {
     pub rebuild_all: bool,
     pub changed_pages: Vec<usize>,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum MoveDirection {
-    Left,
-    Right,
-    Up,
-    Down,
-    Home,
-    End,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum DeleteDirection {
-    Backward,
-    Forward,
 }
 
 pub struct DocxEditor {

--- a/apps/native-viewer/src/fonts.rs
+++ b/apps/native-viewer/src/fonts.rs
@@ -1,420 +1,427 @@
-use std::collections::{BTreeMap, HashMap};
-use std::fs;
-use std::path::Path;
+#[cfg(feature = "docx")]
+mod docx {
+    use std::collections::{BTreeMap, HashMap};
+    use std::fs;
+    use std::path::Path;
 
-use anyhow::{Context, Result, anyhow};
-use docx_raster::FontChains;
-use ooxml_text::{FontId, FontStore, ShapeDirection, ShapeFeature, shape_with_direction};
-use serde_json::Value;
-use vello::Glyph;
-use vello::peniko::{Blob, FontData};
+    use anyhow::{Context, Result, anyhow};
+    use docx_raster::FontChains;
+    use ooxml_text::{FontId, FontStore, ShapeDirection, ShapeFeature, shape_with_direction};
+    use serde_json::Value;
+    use vello::Glyph;
+    use vello::peniko::{Blob, FontData};
 
-const FACES: &[(&str, &str, bool, bool)] = &[
-    ("Caladea-Regular.ttf", "Caladea", false, false),
-    ("Caladea-Bold.ttf", "Caladea", true, false),
-    ("Caladea-Italic.ttf", "Caladea", false, true),
-    ("Caladea-BoldItalic.ttf", "Caladea", true, true),
-    ("Carlito-Regular.ttf", "Carlito", false, false),
-    ("Carlito-Bold.ttf", "Carlito", true, false),
-    ("Carlito-Italic.ttf", "Carlito", false, true),
-    ("Carlito-BoldItalic.ttf", "Carlito", true, true),
-    (
-        "LiberationSans-Regular.ttf",
-        "Liberation Sans",
-        false,
-        false,
-    ),
-    ("LiberationSans-Bold.ttf", "Liberation Sans", true, false),
-    ("LiberationSans-Italic.ttf", "Liberation Sans", false, true),
-    (
-        "LiberationSans-BoldItalic.ttf",
-        "Liberation Sans",
-        true,
-        true,
-    ),
-    (
-        "LiberationSerif-Regular.ttf",
-        "Liberation Serif",
-        false,
-        false,
-    ),
-    ("LiberationSerif-Bold.ttf", "Liberation Serif", true, false),
-    (
-        "LiberationSerif-Italic.ttf",
-        "Liberation Serif",
-        false,
-        true,
-    ),
-    (
-        "LiberationSerif-BoldItalic.ttf",
-        "Liberation Serif",
-        true,
-        true,
-    ),
-    (
-        "LiberationMono-Regular.ttf",
-        "Liberation Mono",
-        false,
-        false,
-    ),
-    ("LiberationMono-Bold.ttf", "Liberation Mono", true, false),
-    ("LiberationMono-Italic.ttf", "Liberation Mono", false, true),
-    (
-        "LiberationMono-BoldItalic.ttf",
-        "Liberation Mono",
-        true,
-        true,
-    ),
-    (
-        "NotoNaskhArabic-Regular.ttf",
-        "Noto Naskh Arabic",
-        false,
-        false,
-    ),
-    (
-        "NotoSansArabic-Regular.ttf",
-        "Noto Sans Arabic",
-        false,
-        false,
-    ),
-    ("NotoSansArabic-Bold.ttf", "Noto Sans Arabic", true, false),
-    (
-        "NotoSansHebrew-Regular.ttf",
-        "Noto Sans Hebrew",
-        false,
-        false,
-    ),
-    ("NotoSansHebrew-Bold.ttf", "Noto Sans Hebrew", true, false),
-];
+    const FACES: &[(&str, &str, bool, bool)] = &[
+        ("Caladea-Regular.ttf", "Caladea", false, false),
+        ("Caladea-Bold.ttf", "Caladea", true, false),
+        ("Caladea-Italic.ttf", "Caladea", false, true),
+        ("Caladea-BoldItalic.ttf", "Caladea", true, true),
+        ("Carlito-Regular.ttf", "Carlito", false, false),
+        ("Carlito-Bold.ttf", "Carlito", true, false),
+        ("Carlito-Italic.ttf", "Carlito", false, true),
+        ("Carlito-BoldItalic.ttf", "Carlito", true, true),
+        (
+            "LiberationSans-Regular.ttf",
+            "Liberation Sans",
+            false,
+            false,
+        ),
+        ("LiberationSans-Bold.ttf", "Liberation Sans", true, false),
+        ("LiberationSans-Italic.ttf", "Liberation Sans", false, true),
+        (
+            "LiberationSans-BoldItalic.ttf",
+            "Liberation Sans",
+            true,
+            true,
+        ),
+        (
+            "LiberationSerif-Regular.ttf",
+            "Liberation Serif",
+            false,
+            false,
+        ),
+        ("LiberationSerif-Bold.ttf", "Liberation Serif", true, false),
+        (
+            "LiberationSerif-Italic.ttf",
+            "Liberation Serif",
+            false,
+            true,
+        ),
+        (
+            "LiberationSerif-BoldItalic.ttf",
+            "Liberation Serif",
+            true,
+            true,
+        ),
+        (
+            "LiberationMono-Regular.ttf",
+            "Liberation Mono",
+            false,
+            false,
+        ),
+        ("LiberationMono-Bold.ttf", "Liberation Mono", true, false),
+        ("LiberationMono-Italic.ttf", "Liberation Mono", false, true),
+        (
+            "LiberationMono-BoldItalic.ttf",
+            "Liberation Mono",
+            true,
+            true,
+        ),
+        (
+            "NotoNaskhArabic-Regular.ttf",
+            "Noto Naskh Arabic",
+            false,
+            false,
+        ),
+        (
+            "NotoSansArabic-Regular.ttf",
+            "Noto Sans Arabic",
+            false,
+            false,
+        ),
+        ("NotoSansArabic-Bold.ttf", "Noto Sans Arabic", true, false),
+        (
+            "NotoSansHebrew-Regular.ttf",
+            "Noto Sans Hebrew",
+            false,
+            false,
+        ),
+        ("NotoSansHebrew-Bold.ttf", "Noto Sans Hebrew", true, false),
+    ];
 
-pub struct FontFace {
-    pub id: u32,
-    pub data: FontData,
-    family: &'static str,
-    bold: bool,
-    italic: bool,
-}
+    pub struct FontFace {
+        pub id: u32,
+        pub data: FontData,
+        family: &'static str,
+        bold: bool,
+        italic: bool,
+    }
 
-pub struct FontRegistry {
-    pub faces: Vec<FontFace>,
-    pub store: FontStore,
-    pub chains: FontChains,
-    pub chain_ids: BTreeMap<String, Vec<u32>>,
-    pub requirements: Vec<String>,
-}
+    pub struct FontRegistry {
+        pub faces: Vec<FontFace>,
+        pub store: FontStore,
+        pub chains: FontChains,
+        pub chain_ids: BTreeMap<String, Vec<u32>>,
+        pub requirements: Vec<String>,
+    }
 
-impl FontRegistry {
-    pub fn load(requirements: &Value) -> Result<Self> {
-        docx_layout::clear_measure_fonts();
-        let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/fonts/assets");
-        let mut store = FontStore::new();
-        let mut faces = Vec::with_capacity(FACES.len());
-        for &(file, family, bold, italic) in FACES {
-            let path = assets.join(file);
-            let bytes = fs::read(&path).with_context(|| format!("read font {}", path.display()))?;
-            let engine_id = docx_layout::register_measure_font(&bytes)
-                .map_err(|_| anyhow!("register measurement font {}", path.display()))?;
-            let raster_id = store
-                .register(bytes.clone())
-                .with_context(|| format!("register raster font {}", path.display()))?;
-            if engine_id != raster_id.to_u32() {
-                return Err(anyhow!("font registry ids diverged at {file}"));
+    impl FontRegistry {
+        pub fn load(requirements: &Value) -> Result<Self> {
+            docx_layout::clear_measure_fonts();
+            let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/fonts/assets");
+            let mut store = FontStore::new();
+            let mut faces = Vec::with_capacity(FACES.len());
+            for &(file, family, bold, italic) in FACES {
+                let path = assets.join(file);
+                let bytes =
+                    fs::read(&path).with_context(|| format!("read font {}", path.display()))?;
+                let engine_id = docx_layout::register_measure_font(&bytes)
+                    .map_err(|_| anyhow!("register measurement font {}", path.display()))?;
+                let raster_id = store
+                    .register(bytes.clone())
+                    .with_context(|| format!("register raster font {}", path.display()))?;
+                if engine_id != raster_id.to_u32() {
+                    return Err(anyhow!("font registry ids diverged at {file}"));
+                }
+                faces.push(FontFace {
+                    id: engine_id,
+                    data: FontData::new(Blob::from(bytes), 0),
+                    family,
+                    bold,
+                    italic,
+                });
             }
-            faces.push(FontFace {
-                id: engine_id,
-                data: FontData::new(Blob::from(bytes), 0),
-                family,
-                bold,
-                italic,
-            });
-        }
 
-        let mut chain_ids = BTreeMap::new();
-        let mut labels = Vec::new();
-        for requirement in requirements
-            .as_array()
-            .context("font requirements are not an array")?
-        {
-            let key = requirement["key"]
-                .as_str()
-                .context("font requirement has no key")?;
-            let family = requirement["family"]
-                .as_str()
-                .context("font requirement has no family")?;
-            let bold = requirement["bold"].as_bool().unwrap_or(false);
-            let italic = requirement["italic"].as_bool().unwrap_or(false);
-            let scripts = requirement["scripts"]
+            let mut chain_ids = BTreeMap::new();
+            let mut labels = Vec::new();
+            for requirement in requirements
                 .as_array()
-                .cloned()
-                .unwrap_or_default();
-            let mut chain = vec![pick_face(&faces, family, bold, italic)];
-            for script in scripts.iter().filter_map(Value::as_str) {
-                match script {
-                    "arabic" => {
-                        push_unique(
-                            &mut chain,
-                            pick_exact(&faces, "Noto Sans Arabic", bold, false),
-                        );
-                        push_unique(
-                            &mut chain,
-                            pick_exact(&faces, "Noto Naskh Arabic", false, false),
-                        );
+                .context("font requirements are not an array")?
+            {
+                let key = requirement["key"]
+                    .as_str()
+                    .context("font requirement has no key")?;
+                let family = requirement["family"]
+                    .as_str()
+                    .context("font requirement has no family")?;
+                let bold = requirement["bold"].as_bool().unwrap_or(false);
+                let italic = requirement["italic"].as_bool().unwrap_or(false);
+                let scripts = requirement["scripts"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                let mut chain = vec![pick_face(&faces, family, bold, italic)];
+                for script in scripts.iter().filter_map(Value::as_str) {
+                    match script {
+                        "arabic" => {
+                            push_unique(
+                                &mut chain,
+                                pick_exact(&faces, "Noto Sans Arabic", bold, false),
+                            );
+                            push_unique(
+                                &mut chain,
+                                pick_exact(&faces, "Noto Naskh Arabic", false, false),
+                            );
+                        }
+                        "hebrew" => {
+                            push_unique(
+                                &mut chain,
+                                pick_exact(&faces, "Noto Sans Hebrew", bold, false),
+                            );
+                        }
+                        _ => {}
                     }
-                    "hebrew" => {
-                        push_unique(
-                            &mut chain,
-                            pick_exact(&faces, "Noto Sans Hebrew", bold, false),
-                        );
-                    }
-                    _ => {}
                 }
+                push_unique(
+                    &mut chain,
+                    pick_exact(&faces, "Liberation Sans", bold, italic),
+                );
+                labels.push(format!(
+                    "{family}{}{}",
+                    if bold { " bold" } else { "" },
+                    if italic { " italic" } else { "" }
+                ));
+                chain_ids.insert(key.to_owned(), chain);
             }
-            push_unique(
-                &mut chain,
-                pick_exact(&faces, "Liberation Sans", bold, italic),
-            );
-            labels.push(format!(
-                "{family}{}{}",
-                if bold { " bold" } else { "" },
-                if italic { " italic" } else { "" }
-            ));
-            chain_ids.insert(key.to_owned(), chain);
-        }
-        if chain_ids.is_empty() {
-            chain_ids.insert(
-                "calibri|0|0".to_owned(),
-                vec![pick_exact(&faces, "Carlito", false, false)],
-            );
-        }
-        let chains = chain_ids
-            .iter()
-            .map(|(key, ids)| {
-                (
-                    key.clone(),
-                    ids.iter().copied().map(FontId::from_u32).collect(),
-                )
-            })
-            .collect::<HashMap<_, _>>();
-        Ok(Self {
-            faces,
-            store,
-            chains,
-            chain_ids,
-            requirements: labels,
-        })
-    }
-
-    pub fn face(&self, id: u32) -> Option<&FontFace> {
-        self.faces.get(id as usize).filter(|face| face.id == id)
-    }
-
-    pub fn shape_fallback(
-        &self,
-        text: &str,
-        font: &str,
-        rtl: bool,
-        small_caps: bool,
-        letter_spacing: f32,
-        word_spacing: f32,
-    ) -> Result<(u32, f32, Vec<Glyph>)> {
-        let spec = parse_css_font(font)?;
-        let key = format!(
-            "{}|{}|{}",
-            spec.family.to_lowercase(),
-            u8::from(spec.bold),
-            u8::from(spec.italic)
-        );
-        let font_id = self
-            .chain_ids
-            .get(&key)
-            .and_then(|chain| chain.first())
-            .copied()
-            .unwrap_or_else(|| pick_face(&self.faces, &spec.family, spec.bold, spec.italic));
-        let direction = if rtl {
-            ShapeDirection::Rtl
-        } else {
-            ShapeDirection::Ltr
-        };
-        let features = if spec.small_caps || small_caps {
-            vec![ShapeFeature {
-                tag: *b"smcp",
-                value: 1,
-            }]
-        } else {
-            Vec::new()
-        };
-        let shaped = shape_with_direction(
-            &self.store,
-            FontId::from_u32(font_id),
-            text,
-            spec.size,
-            &features,
-            direction,
-        )?;
-        let mut pen = 0.0f32;
-        let glyph_count = shaped.len();
-        let glyphs = shaped
-            .iter()
-            .enumerate()
-            .map(|(index, glyph)| {
-                let placed = Glyph {
-                    id: glyph.glyph_id,
-                    x: pen + glyph.x_offset,
-                    y: -glyph.y_offset,
-                };
-                pen += glyph.x_advance;
-                let cluster_ends = shaped
-                    .get(index + 1)
-                    .is_none_or(|next| next.cluster != glyph.cluster);
-                if cluster_ends {
-                    let source = text
-                        .get(glyph.cluster as usize..)
-                        .and_then(|tail| tail.chars().next());
-                    if source == Some(' ') {
-                        pen += word_spacing;
-                    }
-                    if index + 1 < glyph_count {
-                        pen += letter_spacing;
-                    }
-                }
-                placed
-            })
-            .collect();
-        Ok((font_id, spec.size, glyphs))
-    }
-}
-
-fn pick_face(faces: &[FontFace], family: &str, bold: bool, italic: bool) -> u32 {
-    let family = family.to_lowercase();
-    let metric_family = if family.contains("calibri") || family.contains("carlito") {
-        "Carlito"
-    } else if family.contains("cambria") || family.contains("caladea") {
-        "Caladea"
-    } else if family.contains("courier") || family.contains("mono") {
-        "Liberation Mono"
-    } else if family.contains("times") || family.contains("serif") {
-        "Liberation Serif"
-    } else {
-        "Liberation Sans"
-    };
-    pick_exact(faces, metric_family, bold, italic)
-}
-
-fn pick_exact(faces: &[FontFace], family: &str, bold: bool, italic: bool) -> u32 {
-    faces
-        .iter()
-        .find(|face| face.family == family && face.bold == bold && face.italic == italic)
-        .or_else(|| {
-            faces
+            if chain_ids.is_empty() {
+                chain_ids.insert(
+                    "calibri|0|0".to_owned(),
+                    vec![pick_exact(&faces, "Carlito", false, false)],
+                );
+            }
+            let chains = chain_ids
                 .iter()
-                .find(|face| face.family == family && face.bold == bold)
-        })
-        .or_else(|| faces.iter().find(|face| face.family == family))
-        .map(|face| face.id)
-        .unwrap_or(0)
-}
+                .map(|(key, ids)| {
+                    (
+                        key.clone(),
+                        ids.iter().copied().map(FontId::from_u32).collect(),
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            Ok(Self {
+                faces,
+                store,
+                chains,
+                chain_ids,
+                requirements: labels,
+            })
+        }
 
-fn push_unique(chain: &mut Vec<u32>, id: u32) {
-    if !chain.contains(&id) {
-        chain.push(id);
-    }
-}
+        pub fn face(&self, id: u32) -> Option<&FontFace> {
+            self.faces.get(id as usize).filter(|face| face.id == id)
+        }
 
-struct CssFont {
-    family: String,
-    size: f32,
-    bold: bool,
-    italic: bool,
-    small_caps: bool,
-}
-
-fn parse_css_font(font: &str) -> Result<CssFont> {
-    let mut size_match = None;
-    let mut cursor = 0usize;
-    for token in font.split_whitespace() {
-        let relative = font[cursor..]
-            .find(token)
-            .with_context(|| format!("unsupported font shorthand {font}"))?;
-        let index = cursor + relative;
-        cursor = index + token.len();
-        if token.ends_with("px") {
-            size_match = Some((index, token));
-            break;
+        pub fn shape_fallback(
+            &self,
+            text: &str,
+            font: &str,
+            rtl: bool,
+            small_caps: bool,
+            letter_spacing: f32,
+            word_spacing: f32,
+        ) -> Result<(u32, f32, Vec<Glyph>)> {
+            let spec = parse_css_font(font)?;
+            let key = format!(
+                "{}|{}|{}",
+                spec.family.to_lowercase(),
+                u8::from(spec.bold),
+                u8::from(spec.italic)
+            );
+            let font_id = self
+                .chain_ids
+                .get(&key)
+                .and_then(|chain| chain.first())
+                .copied()
+                .unwrap_or_else(|| pick_face(&self.faces, &spec.family, spec.bold, spec.italic));
+            let direction = if rtl {
+                ShapeDirection::Rtl
+            } else {
+                ShapeDirection::Ltr
+            };
+            let features = if spec.small_caps || small_caps {
+                vec![ShapeFeature {
+                    tag: *b"smcp",
+                    value: 1,
+                }]
+            } else {
+                Vec::new()
+            };
+            let shaped = shape_with_direction(
+                &self.store,
+                FontId::from_u32(font_id),
+                text,
+                spec.size,
+                &features,
+                direction,
+            )?;
+            let mut pen = 0.0f32;
+            let glyph_count = shaped.len();
+            let glyphs = shaped
+                .iter()
+                .enumerate()
+                .map(|(index, glyph)| {
+                    let placed = Glyph {
+                        id: glyph.glyph_id,
+                        x: pen + glyph.x_offset,
+                        y: -glyph.y_offset,
+                    };
+                    pen += glyph.x_advance;
+                    let cluster_ends = shaped
+                        .get(index + 1)
+                        .is_none_or(|next| next.cluster != glyph.cluster);
+                    if cluster_ends {
+                        let source = text
+                            .get(glyph.cluster as usize..)
+                            .and_then(|tail| tail.chars().next());
+                        if source == Some(' ') {
+                            pen += word_spacing;
+                        }
+                        if index + 1 < glyph_count {
+                            pen += letter_spacing;
+                        }
+                    }
+                    placed
+                })
+                .collect();
+            Ok((font_id, spec.size, glyphs))
         }
     }
-    let (size_index, size_token) =
-        size_match.with_context(|| format!("font has no size: {font}"))?;
-    let size = size_token
-        .strip_suffix("px")
-        .and_then(|value| value.parse::<f32>().ok())
-        .filter(|value| value.is_finite() && *value > 0.0)
-        .with_context(|| format!("invalid font size {size_token}"))?;
-    let mut bold = false;
-    let mut italic = false;
-    let mut small_caps = false;
-    for token in font[..size_index].split_whitespace() {
-        match token {
-            "normal" => {}
-            "italic" | "oblique" => italic = true,
-            "small-caps" => small_caps = true,
-            "bold" | "bolder" => bold = true,
-            value => {
-                let weight = value
-                    .parse::<u16>()
-                    .with_context(|| format!("unsupported font token {value}"))?;
-                if !(1..=1000).contains(&weight) {
-                    return Err(anyhow!("invalid font weight {value}"));
-                }
-                bold = weight >= 600;
+
+    fn pick_face(faces: &[FontFace], family: &str, bold: bool, italic: bool) -> u32 {
+        let family = family.to_lowercase();
+        let metric_family = if family.contains("calibri") || family.contains("carlito") {
+            "Carlito"
+        } else if family.contains("cambria") || family.contains("caladea") {
+            "Caladea"
+        } else if family.contains("courier") || family.contains("mono") {
+            "Liberation Mono"
+        } else if family.contains("times") || family.contains("serif") {
+            "Liberation Serif"
+        } else {
+            "Liberation Sans"
+        };
+        pick_exact(faces, metric_family, bold, italic)
+    }
+
+    fn pick_exact(faces: &[FontFace], family: &str, bold: bool, italic: bool) -> u32 {
+        faces
+            .iter()
+            .find(|face| face.family == family && face.bold == bold && face.italic == italic)
+            .or_else(|| {
+                faces
+                    .iter()
+                    .find(|face| face.family == family && face.bold == bold)
+            })
+            .or_else(|| faces.iter().find(|face| face.family == family))
+            .map(|face| face.id)
+            .unwrap_or(0)
+    }
+
+    fn push_unique(chain: &mut Vec<u32>, id: u32) {
+        if !chain.contains(&id) {
+            chain.push(id);
+        }
+    }
+
+    struct CssFont {
+        family: String,
+        size: f32,
+        bold: bool,
+        italic: bool,
+        small_caps: bool,
+    }
+
+    fn parse_css_font(font: &str) -> Result<CssFont> {
+        let mut size_match = None;
+        let mut cursor = 0usize;
+        for token in font.split_whitespace() {
+            let relative = font[cursor..]
+                .find(token)
+                .with_context(|| format!("unsupported font shorthand {font}"))?;
+            let index = cursor + relative;
+            cursor = index + token.len();
+            if token.ends_with("px") {
+                size_match = Some((index, token));
+                break;
             }
         }
+        let (size_index, size_token) =
+            size_match.with_context(|| format!("font has no size: {font}"))?;
+        let size = size_token
+            .strip_suffix("px")
+            .and_then(|value| value.parse::<f32>().ok())
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .with_context(|| format!("invalid font size {size_token}"))?;
+        let mut bold = false;
+        let mut italic = false;
+        let mut small_caps = false;
+        for token in font[..size_index].split_whitespace() {
+            match token {
+                "normal" => {}
+                "italic" | "oblique" => italic = true,
+                "small-caps" => small_caps = true,
+                "bold" | "bolder" => bold = true,
+                value => {
+                    let weight = value
+                        .parse::<u16>()
+                        .with_context(|| format!("unsupported font token {value}"))?;
+                    if !(1..=1000).contains(&weight) {
+                        return Err(anyhow!("invalid font weight {value}"));
+                    }
+                    bold = weight >= 600;
+                }
+            }
+        }
+        let family = first_family(font[size_index + size_token.len()..].trim())
+            .trim_matches(['\'', '"'])
+            .trim()
+            .to_owned();
+        if family.is_empty() {
+            return Err(anyhow!("font has no family: {font}"));
+        }
+        Ok(CssFont {
+            family,
+            size,
+            bold,
+            italic,
+            small_caps,
+        })
     }
-    let family = first_family(font[size_index + size_token.len()..].trim())
-        .trim_matches(['\'', '"'])
-        .trim()
-        .to_owned();
-    if family.is_empty() {
-        return Err(anyhow!("font has no family: {font}"));
-    }
-    Ok(CssFont {
-        family,
-        size,
-        bold,
-        italic,
-        small_caps,
-    })
-}
 
-fn first_family(value: &str) -> &str {
-    let mut quote = None;
-    for (index, character) in value.char_indices() {
-        match character {
-            '\'' | '"' if quote == Some(character) => quote = None,
-            '\'' | '"' if quote.is_none() => quote = Some(character),
-            ',' if quote.is_none() => return &value[..index],
-            _ => {}
+    fn first_family(value: &str) -> &str {
+        let mut quote = None;
+        for (index, character) in value.char_indices() {
+            match character {
+                '\'' | '"' if quote == Some(character) => quote = None,
+                '\'' | '"' if quote.is_none() => quote = Some(character),
+                ',' if quote.is_none() => return &value[..index],
+                _ => {}
+            }
+        }
+        value
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn parses_layout_font_shorthand() {
+            let font = parse_css_font("italic small-caps 700 12.5px \"Aptos Display\", sans-serif")
+                .unwrap();
+            assert_eq!(font.family, "Aptos Display");
+            assert_eq!(font.size, 12.5);
+            assert!(font.bold);
+            assert!(font.italic);
+            assert!(font.small_caps);
+        }
+
+        #[test]
+        fn rejects_unknown_font_tokens() {
+            assert!(parse_css_font("condensed 12px Carlito").is_err());
         }
     }
-    value
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_layout_font_shorthand() {
-        let font =
-            parse_css_font("italic small-caps 700 12.5px \"Aptos Display\", sans-serif").unwrap();
-        assert_eq!(font.family, "Aptos Display");
-        assert_eq!(font.size, 12.5);
-        assert!(font.bold);
-        assert!(font.italic);
-        assert!(font.small_caps);
-    }
-
-    #[test]
-    fn rejects_unknown_font_tokens() {
-        assert!(parse_css_font("condensed 12px Carlito").is_err());
-    }
-}
+#[cfg(feature = "docx")]
+pub use docx::FontRegistry;

--- a/apps/native-viewer/src/gpu.rs
+++ b/apps/native-viewer/src/gpu.rs
@@ -1,10 +1,16 @@
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(any(feature = "docx", feature = "xlsx"))]
+use std::path::PathBuf;
 use std::sync::mpsc;
 
 use anyhow::{Context, Result, anyhow, bail};
+#[cfg(feature = "docx")]
 use docx_raster::RenderResources;
-use image::{DynamicImage, ImageFormat};
+#[cfg(any(feature = "docx", feature = "xlsx"))]
+use image::DynamicImage;
+use image::ImageFormat;
 use vello::kurbo::Affine;
 use vello::peniko::Color;
 use vello::util::RenderContext;
@@ -13,6 +19,7 @@ use vello::{AaConfig, RenderParams, Renderer, RendererOptions, Scene};
 use crate::document::{DocumentView, ReferenceDocument};
 use crate::scene_shared::PageScene;
 
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 const DIFFERENCE_THRESHOLD: u8 = 8;
 const MAX_HEADLESS_PIXELS: u64 = 33_000_000;
 
@@ -33,10 +40,13 @@ pub fn render_comparison(
     output: &Path,
     scale: f64,
 ) -> Result<()> {
-    let selection = if matches!(&document.reference, ReferenceDocument::Pptx(_)) {
-        "slide"
-    } else {
-        "page"
+    let selection = match &document.reference {
+        #[cfg(feature = "docx")]
+        ReferenceDocument::Docx(_) => "page",
+        #[cfg(feature = "xlsx")]
+        ReferenceDocument::Xlsx(_) => "sheet",
+        #[cfg(feature = "pptx")]
+        ReferenceDocument::Pptx(_) => "slide",
     };
     let page = document
         .pages
@@ -53,102 +63,124 @@ pub fn render_comparison(
     )
     .with_context(|| format!("write Vello PNG {}", output.display()))?;
 
-    if let ReferenceDocument::Pptx(reference) = &document.reference {
-        let summary = reference
-            .editor
-            .summaries()
-            .get(page_index)
-            .context("PPTX slide has no translation summary")?;
-        println!("document: {}", document.source.display());
-        println!(
-            "slide: {} of {}",
-            page_index + 1,
-            reference.editor.slide_count()
-        );
-        println!("gpu: {}", rendered.adapter);
-        println!("font faces: {:?}", reference.editor.font_faces());
-        println!("vello PNG: {}", output.display());
-        println!("raster PNG: not produced (PPTX has no raster backend)");
-        println!(
-            "pptx summary: {}",
-            serde_json::to_string(&summary.structured(&page.skipped))?
-        );
-        return Ok(());
-    }
-
-    let (raster_bytes, skipped_raster_images) = match &document.reference {
-        ReferenceDocument::Docx(reference) => {
-            let resources = RenderResources::new(
-                &reference.fonts.store,
-                &reference.fonts.chains,
-                &reference.images.raw,
-            );
-            let raster = docx_raster::render_page(&reference.display_list, page_index, &resources)
-                .map_err(anyhow::Error::msg)?;
-            (raster.bytes, Some(raster.skipped_images))
-        }
-        ReferenceDocument::Xlsx(reference) => (
-            xlsx_raster::render_png(reference.editor.display_list()).map_err(anyhow::Error::msg)?,
-            None,
-        ),
-        ReferenceDocument::Pptx(_) => unreachable!(),
-    };
-    let reference_path = raster_path(output);
-    fs::write(&reference_path, &raster_bytes)
-        .with_context(|| format!("write raster PNG {}", reference_path.display()))?;
-    let reference = image::load_from_memory_with_format(&raster_bytes, ImageFormat::Png)?;
-    let metrics = compare(&rendered.rgba, rendered.width, rendered.height, reference)?;
-
-    println!("document: {}", document.source.display());
+    #[cfg(feature = "pptx")]
     match &document.reference {
-        ReferenceDocument::Docx(reference) => {
-            println!("page: {} of {}", page_index + 1, document.pages.len());
-            println!("gpu: {}", rendered.adapter);
-            println!("font requirements: {:?}", reference.fonts.requirements);
-        }
-        ReferenceDocument::Xlsx(reference) => {
+        ReferenceDocument::Pptx(reference) => {
+            let summary = reference
+                .editor
+                .summaries()
+                .get(page_index)
+                .context("PPTX slide has no translation summary")?;
+            println!("document: {}", document.source.display());
             println!(
-                "sheet: {} of {} ({})",
-                reference.sheet_index + 1,
-                reference.sheet_count,
-                reference.sheet_name
+                "slide: {} of {}",
+                page_index + 1,
+                reference.editor.slide_count()
             );
             println!("gpu: {}", rendered.adapter);
+            println!("font faces: {:?}", reference.editor.font_faces());
+            println!("vello PNG: {}", output.display());
+            println!("raster PNG: not produced (PPTX has no raster backend)");
             println!(
-                "charts: {}, placeholders: {}",
-                reference.chart_count, reference.chart_placeholders
+                "pptx summary: {}",
+                serde_json::to_string(&summary.structured(&page.skipped))?
             );
+            return Ok(());
         }
-        ReferenceDocument::Pptx(_) => unreachable!(),
+        #[cfg(any(feature = "docx", feature = "xlsx"))]
+        _ => {}
     }
-    println!("vello PNG: {}", output.display());
-    println!("raster PNG: {}", reference_path.display());
-    let skipped_label = match &document.reference {
-        ReferenceDocument::Docx(_) => "primitives",
-        ReferenceDocument::Xlsx(_) => "commands",
-        ReferenceDocument::Pptx(_) => unreachable!(),
-    };
-    println!(
-        "skipped Vello {skipped_label}: {} {:?}",
-        page.skipped.total(),
-        page.skipped.counts
-    );
-    if !page.skipped.reasons.is_empty() {
-        println!("skip reasons: {:?}", page.skipped.reasons);
+
+    #[cfg(any(feature = "docx", feature = "xlsx"))]
+    {
+        let (raster_bytes, skipped_raster_images) = match &document.reference {
+            #[cfg(feature = "docx")]
+            ReferenceDocument::Docx(reference) => {
+                let resources = RenderResources::new(
+                    &reference.fonts.store,
+                    &reference.fonts.chains,
+                    &reference.images.raw,
+                );
+                let raster =
+                    docx_raster::render_page(&reference.display_list, page_index, &resources)
+                        .map_err(anyhow::Error::msg)?;
+                (raster.bytes, Some(raster.skipped_images))
+            }
+            #[cfg(feature = "xlsx")]
+            ReferenceDocument::Xlsx(reference) => (
+                xlsx_raster::render_png(reference.editor.display_list())
+                    .map_err(anyhow::Error::msg)?,
+                None::<usize>,
+            ),
+            #[cfg(feature = "pptx")]
+            ReferenceDocument::Pptx(_) => unreachable!(),
+        };
+        let reference_path = raster_path(output);
+        fs::write(&reference_path, &raster_bytes)
+            .with_context(|| format!("write raster PNG {}", reference_path.display()))?;
+        let reference = image::load_from_memory_with_format(&raster_bytes, ImageFormat::Png)?;
+        let metrics = compare(&rendered.rgba, rendered.width, rendered.height, reference)?;
+
+        println!("document: {}", document.source.display());
+        match &document.reference {
+            #[cfg(feature = "docx")]
+            ReferenceDocument::Docx(reference) => {
+                println!("page: {} of {}", page_index + 1, document.pages.len());
+                println!("gpu: {}", rendered.adapter);
+                println!("font requirements: {:?}", reference.fonts.requirements);
+            }
+            #[cfg(feature = "xlsx")]
+            ReferenceDocument::Xlsx(reference) => {
+                println!(
+                    "sheet: {} of {} ({})",
+                    reference.sheet_index + 1,
+                    reference.sheet_count,
+                    reference.sheet_name
+                );
+                println!("gpu: {}", rendered.adapter);
+                println!(
+                    "charts: {}, placeholders: {}",
+                    reference.chart_count, reference.chart_placeholders
+                );
+            }
+            #[cfg(feature = "pptx")]
+            ReferenceDocument::Pptx(_) => unreachable!(),
+        }
+        println!("vello PNG: {}", output.display());
+        println!("raster PNG: {}", reference_path.display());
+        let skipped_label = match &document.reference {
+            #[cfg(feature = "docx")]
+            ReferenceDocument::Docx(_) => "primitives",
+            #[cfg(feature = "xlsx")]
+            ReferenceDocument::Xlsx(_) => "commands",
+            #[cfg(feature = "pptx")]
+            ReferenceDocument::Pptx(_) => unreachable!(),
+        };
+        println!(
+            "skipped Vello {skipped_label}: {} {:?}",
+            page.skipped.total(),
+            page.skipped.counts
+        );
+        if !page.skipped.reasons.is_empty() {
+            println!("skip reasons: {:?}", page.skipped.reasons);
+        }
+        if let Some(skipped_images) = skipped_raster_images {
+            println!("skipped raster images: {skipped_images}");
+        }
+        println!(
+            "mean absolute difference RGBA: {:.4}, {:.4}, {:.4}, {:.4}",
+            metrics.mean[0], metrics.mean[1], metrics.mean[2], metrics.mean[3]
+        );
+        println!(
+            "pixels differing above threshold {}: {:.4}%",
+            DIFFERENCE_THRESHOLD,
+            metrics.fraction * 100.0
+        );
+        Ok(())
     }
-    if let Some(skipped_images) = skipped_raster_images {
-        println!("skipped raster images: {skipped_images}");
-    }
-    println!(
-        "mean absolute difference RGBA: {:.4}, {:.4}, {:.4}, {:.4}",
-        metrics.mean[0], metrics.mean[1], metrics.mean[2], metrics.mean[3]
-    );
-    println!(
-        "pixels differing above threshold {}: {:.4}%",
-        DIFFERENCE_THRESHOLD,
-        metrics.fraction * 100.0
-    );
-    Ok(())
+
+    #[cfg(not(any(feature = "docx", feature = "xlsx")))]
+    unreachable!("PPTX export returned before raster comparison")
 }
 
 struct GpuImage {
@@ -306,11 +338,13 @@ fn validate_readback(rgba: &[u8], width: u32, height: u32) -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 struct DifferenceMetrics {
     mean: [f64; 4],
     fraction: f64,
 }
 
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 fn compare(
     vello: &[u8],
     width: u32,
@@ -347,6 +381,7 @@ fn compare(
     })
 }
 
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 fn raster_path(output: &Path) -> PathBuf {
     let stem = output
         .file_stem()
@@ -355,7 +390,7 @@ fn raster_path(output: &Path) -> PathBuf {
     output.with_file_name(format!("{stem}.raster.png"))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "docx"))]
 mod tests {
     use super::*;
     use crate::document::{ReferenceDocument, load_document};

--- a/apps/native-viewer/src/main.rs
+++ b/apps/native-viewer/src/main.rs
@@ -6,20 +6,30 @@ mod collaboration_document;
 mod collaboration_protocol;
 mod collaboration_test_peer;
 mod document;
+#[cfg(feature = "docx")]
 #[path = "scene.rs"]
 mod docx_scene;
+#[cfg(feature = "docx")]
 mod editing;
 mod fonts;
 mod gpu;
+#[cfg(feature = "docx")]
 mod images;
+#[cfg(feature = "pptx")]
 mod pptx_editing;
+#[cfg(feature = "pptx")]
 mod pptx_scene;
 mod scene_shared;
 #[cfg(test)]
 mod test_fixtures;
 mod window;
+#[cfg(feature = "xlsx")]
 mod xlsx_editing;
+#[cfg(feature = "xlsx")]
 mod xlsx_scene;
+
+#[cfg(not(any(feature = "docx", feature = "xlsx", feature = "pptx")))]
+compile_error!("enable at least one of the docx, xlsx, or pptx features");
 
 use std::env;
 use std::ffi::OsString;
@@ -31,6 +41,19 @@ use collaboration::{CollaborationConfig, DEFAULT_RELAY_ORIGIN};
 use document::{
     DocumentFormat, load_collaborative_document, load_document, load_document_for_export,
 };
+
+#[cfg(feature = "docx")]
+const WELCOME_DOCUMENT: &str = "Welcome.docx";
+#[cfg(feature = "docx")]
+const DEVELOPMENT_DOCUMENT: &str = "../demo/public/betteroffice-demo.docx";
+#[cfg(all(not(feature = "docx"), feature = "xlsx"))]
+const WELCOME_DOCUMENT: &str = "Welcome.xlsx";
+#[cfg(all(not(feature = "docx"), feature = "xlsx"))]
+const DEVELOPMENT_DOCUMENT: &str = "../demo/public/sample.xlsx";
+#[cfg(all(not(feature = "docx"), not(feature = "xlsx"), feature = "pptx"))]
+const WELCOME_DOCUMENT: &str = "Welcome.pptx";
+#[cfg(all(not(feature = "docx"), not(feature = "xlsx"), feature = "pptx"))]
+const DEVELOPMENT_DOCUMENT: &str = "../demo/public/betteroffice-demo.pptx";
 
 fn main() -> Result<()> {
     let options = Options::parse()?;
@@ -80,7 +103,7 @@ impl Options {
     }
 
     fn parse_from(args: impl IntoIterator<Item = OsString>) -> Result<Self> {
-        let mut document = default_document();
+        let mut document = None;
         let mut png = None;
         let mut page = None;
         let mut sheet = None;
@@ -98,10 +121,8 @@ impl Options {
         while let Some(arg) = args.next() {
             match arg.to_str() {
                 Some("--document") => {
-                    document = args
-                        .next()
-                        .map(PathBuf::from)
-                        .context("--document needs a path")?;
+                    let path = args.next().context("--document needs a path")?;
+                    set_document(&mut document, path)?;
                 }
                 Some("--png") => {
                     png = Some(
@@ -148,15 +169,21 @@ impl Options {
                 }
                 Some("--help" | "-h") => {
                     println!(
-                        "Usage: betteroffice-native-viewer [--document FILE] [--png OUT] [--page N | --sheet N | --slide N] [--scale N] [--room ID] [--relay-origin URL]"
+                        "Usage: betteroffice-native-viewer [FILE | --document FILE] [--png OUT] [--page N | --sheet N | --slide N] [--scale N] [--room ID] [--relay-origin URL]"
                     );
                     std::process::exit(0);
+                }
+                Some(value) if !value.starts_with('-') => {
+                    set_document(&mut document, arg)?;
+                }
+                None => {
+                    set_document(&mut document, arg)?;
                 }
                 _ => bail!("unknown argument {}", arg.to_string_lossy()),
             }
         }
         Ok(Self {
-            document,
+            document: document.unwrap_or_else(default_document),
             png,
             page,
             sheet,
@@ -202,6 +229,13 @@ impl Options {
     }
 }
 
+fn set_document(document: &mut Option<PathBuf>, path: OsString) -> Result<()> {
+    if document.replace(PathBuf::from(path)).is_some() {
+        bail!("document path specified more than once");
+    }
+    Ok(())
+}
+
 fn one_based_index(value: Option<OsString>, flag: &str) -> Result<usize> {
     let value = value
         .and_then(|value| value.into_string().ok())
@@ -216,7 +250,16 @@ fn one_based_index(value: Option<OsString>, flag: &str) -> Result<usize> {
 }
 
 fn default_document() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("../demo/public/betteroffice-demo.docx")
+    if let Some(resource) = env::current_exe()
+        .ok()
+        .and_then(|executable| executable.parent().map(Path::to_path_buf))
+        .and_then(|directory| directory.parent().map(Path::to_path_buf))
+        .map(|contents| contents.join("Resources").join(WELCOME_DOCUMENT))
+        .filter(|resource| resource.is_file())
+    {
+        return resource;
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(DEVELOPMENT_DOCUMENT)
 }
 
 #[cfg(test)]
@@ -261,6 +304,20 @@ mod tests {
     fn rejects_zero_sheet() {
         assert!(Options::parse_from(["--sheet".into(), "0".into()]).is_err());
         assert!(Options::parse_from(["--slide".into(), "0".into()]).is_err());
+    }
+
+    #[test]
+    fn accepts_one_positional_document_path() {
+        let options = Options::parse_from(["document.docx".into()]).unwrap();
+        assert_eq!(options.document, Path::new("document.docx"));
+        assert!(
+            Options::parse_from([
+                "document.docx".into(),
+                "--document".into(),
+                "other.docx".into(),
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/apps/native-viewer/src/pptx_editing.rs
+++ b/apps/native-viewer/src/pptx_editing.rs
@@ -13,7 +13,7 @@ use betteroffice_pptx::{
 use sha2::{Digest, Sha256};
 use vello::kurbo::{Affine, Point};
 
-use crate::editing::{DeleteDirection, MoveDirection};
+use crate::document::{DeleteDirection, MoveDirection};
 use crate::pptx_scene::{PptxSceneResources, PptxSlideSummary};
 use crate::scene_shared::PageScene;
 

--- a/apps/native-viewer/src/scene_shared.rs
+++ b/apps/native-viewer/src/scene_shared.rs
@@ -29,6 +29,7 @@ pub struct PageScene {
     pub skipped: SkipStats,
 }
 
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 pub fn with_clip_layers<T>(
     scene: &mut Scene,
     layers: &[(Affine, Rect)],
@@ -51,6 +52,7 @@ where
     stroke.with_dashes(0.0, dashes)
 }
 
+#[cfg(any(feature = "docx", feature = "xlsx"))]
 pub fn draw_placeholder(scene: &mut Scene, bounds: Option<Rect>) {
     draw_transformed_placeholder(scene, bounds, Affine::IDENTITY);
 }
@@ -94,12 +96,14 @@ pub fn draw_transformed_placeholder(scene: &mut Scene, bounds: Option<Rect>, tra
     );
 }
 
+#[cfg(any(feature = "docx", feature = "pptx"))]
 pub fn color(value: &str, opacity: f32) -> Result<Color, String> {
     let (red, green, blue, alpha) = parse_color(value)?;
     let alpha = (f32::from(alpha) * opacity.clamp(0.0, 1.0)).round() as u8;
     Ok(Color::from_rgba8(red, green, blue, alpha))
 }
 
+#[cfg(feature = "xlsx")]
 pub fn strict_color(value: &str) -> Result<Color, String> {
     let hex = value
         .strip_prefix('#')
@@ -203,6 +207,7 @@ mod tests {
         assert!(parse_color("navy").is_err());
     }
 
+    #[cfg(feature = "xlsx")]
     #[test]
     fn xlsx_colors_are_strict() {
         assert_eq!(

--- a/apps/native-viewer/src/window.rs
+++ b/apps/native-viewer/src/window.rs
@@ -1,16 +1,36 @@
+#[cfg(target_os = "macos")]
+use std::ffi::{CStr, OsString};
+#[cfg(target_os = "macos")]
+use std::os::unix::ffi::OsStringExt;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+#[cfg(feature = "xlsx")]
 use betteroffice_xlsx::CellRef;
+#[cfg(feature = "docx")]
 use docx_edit::SimpleFormat;
-use vello::kurbo::{Affine, Point, Rect, Stroke};
+#[cfg(target_os = "macos")]
+use objc2::runtime::{AnyClass, AnyObject, Sel};
+#[cfg(target_os = "macos")]
+use objc2::{ffi, sel};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSArray, NSURL};
+#[cfg(feature = "xlsx")]
+use vello::kurbo::Stroke;
+use vello::kurbo::{Affine, Point, Rect};
 use vello::peniko::{Color, Fill};
 use vello::util::{RenderContext, RenderSurface};
 use vello::{AaConfig, RenderParams, Renderer, RendererOptions, Scene};
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
 use winit::event::{ElementState, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent};
+#[cfg(target_os = "macos")]
+use winit::event_loop::EventLoopProxy;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key, ModifiersState, NamedKey};
 use winit::window::{Window, WindowId};
@@ -24,22 +44,37 @@ use crate::collaboration::{
     transport_event_channel,
 };
 use crate::collaboration_document;
+#[cfg(any(feature = "docx", feature = "pptx"))]
+use crate::document::{DeleteDirection, MoveDirection};
 use crate::document::{DocumentView, ReferenceDocument, load_document};
-use crate::editing::{DeleteDirection, MoveDirection, TextLoc};
+#[cfg(feature = "docx")]
+use crate::editing::TextLoc;
+#[cfg(feature = "pptx")]
 use crate::pptx_editing::PptxHit;
+#[cfg(feature = "xlsx")]
 use crate::xlsx_editing::CellMove;
+#[cfg(feature = "xlsx")]
 use crate::xlsx_scene::paint_cell_editor;
 
 const MARGIN: f64 = 40.0;
 const PAGE_GAP: f64 = 24.0;
 const CARET_BLINK: Duration = Duration::from_millis(530);
+#[cfg(feature = "docx")]
 const DOUBLE_CLICK: Duration = Duration::from_millis(500);
+#[cfg(feature = "docx")]
 const DOUBLE_CLICK_DISTANCE: f64 = 5.0;
 const STATUS_DURATION: Duration = Duration::from_secs(6);
 const UNSAVED_EXIT_REASON: &str = "Unsaved changes: save or undo them before closing the viewer.";
 
-#[derive(Clone, Copy, Debug)]
-struct CollaborationWake;
+#[derive(Debug)]
+enum ViewerEvent {
+    Collaboration,
+    #[cfg(target_os = "macos")]
+    OpenDocument(PathBuf),
+}
+
+#[cfg(target_os = "macos")]
+static OPEN_DOCUMENT_PROXY: OnceLock<EventLoopProxy<ViewerEvent>> = OnceLock::new();
 
 pub fn run(
     document: DocumentView,
@@ -48,36 +83,46 @@ pub fn run(
 ) -> Result<()> {
     for (index, page) in document.pages.iter().enumerate() {
         let label = document.scene_label(index);
-        if let ReferenceDocument::Pptx(reference) = &document.reference {
-            let summary = reference
-                .editor
-                .summaries()
-                .get(index)
-                .ok_or_else(|| anyhow::anyhow!("PPTX slide has no translation summary"))?;
-            println!(
-                "{label} PPTX summary: {}",
-                serde_json::to_string(&summary.structured(&page.skipped))?
-            );
-            continue;
+        #[cfg(feature = "pptx")]
+        match &document.reference {
+            ReferenceDocument::Pptx(reference) => {
+                let summary = reference
+                    .editor
+                    .summaries()
+                    .get(index)
+                    .ok_or_else(|| anyhow::anyhow!("PPTX slide has no translation summary"))?;
+                println!(
+                    "{label} PPTX summary: {}",
+                    serde_json::to_string(&summary.structured(&page.skipped))?
+                );
+                continue;
+            }
+            #[cfg(any(feature = "docx", feature = "xlsx"))]
+            _ => {}
         }
-        println!(
-            "{label} skipped Vello {}: {} {:?}",
-            document.display_item_name(),
-            page.skipped.total(),
-            page.skipped.counts
-        );
-        if !page.skipped.reasons.is_empty() {
-            println!("{label} skip reasons: {:?}", page.skipped.reasons);
+        #[cfg(any(feature = "docx", feature = "xlsx"))]
+        {
+            println!(
+                "{label} skipped Vello {}: {} {:?}",
+                document.display_item_name(),
+                page.skipped.total(),
+                page.skipped.counts
+            );
+            if !page.skipped.reasons.is_empty() {
+                println!("{label} skip reasons: {:?}", page.skipped.reasons);
+            }
         }
     }
-    let event_loop = EventLoop::<CollaborationWake>::with_user_event().build()?;
+    let event_loop = EventLoop::<ViewerEvent>::with_user_event().build()?;
+    #[cfg(target_os = "macos")]
+    install_open_document_handler(event_loop.create_proxy())?;
     let (event_sender, event_receiver) = transport_event_channel();
     let client = collaboration
         .map(|config| {
             let proxy = event_loop.create_proxy();
             let event_sender = event_sender.clone();
             CollaborationClient::start(config, move |event| {
-                event_sender.try_send(event) && proxy.send_event(CollaborationWake).is_ok()
+                event_sender.try_send(event) && proxy.send_event(ViewerEvent::Collaboration).is_ok()
             })
         })
         .transpose()?;
@@ -88,6 +133,54 @@ pub fn run(
         bail!(error);
     }
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn install_open_document_handler(proxy: EventLoopProxy<ViewerEvent>) -> Result<()> {
+    OPEN_DOCUMENT_PROXY
+        .set(proxy)
+        .map_err(|_| anyhow::anyhow!("macOS document handler is already installed"))?;
+    let class = AnyClass::get("WinitApplicationDelegate")
+        .context("Winit application delegate is unavailable")?;
+    let selector = sel!(application:openURLs:);
+    type OpenUrls = unsafe extern "C" fn(&AnyObject, Sel, &AnyObject, &NSArray<NSURL>);
+    let implementation =
+        unsafe { std::mem::transmute::<OpenUrls, unsafe extern "C" fn()>(application_open_urls) };
+    let added = unsafe {
+        ffi::class_addMethod(
+            (class as *const AnyClass).cast_mut().cast(),
+            selector.as_ptr(),
+            Some(implementation),
+            c"v@:@@".as_ptr(),
+        )
+    };
+    if added == ffi::NO {
+        bail!("install macOS document handler");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn application_open_urls(
+    _delegate: &AnyObject,
+    _selector: Sel,
+    _application: &AnyObject,
+    urls: &NSArray<NSURL>,
+) {
+    let Some(url) = urls.get(0) else {
+        return;
+    };
+    if !unsafe { url.isFileURL() } {
+        return;
+    }
+    let representation = unsafe { url.fileSystemRepresentation() };
+    let bytes = unsafe { CStr::from_ptr(representation.as_ptr()) }
+        .to_bytes()
+        .to_vec();
+    let path = PathBuf::from(OsString::from_vec(bytes));
+    if let Some(proxy) = OPEN_DOCUMENT_PROXY.get() {
+        let _ = proxy.send_event(ViewerEvent::OpenDocument(path));
+    }
 }
 
 struct Viewer {
@@ -283,8 +376,11 @@ impl ViewportGeometry {
 
 enum PointerTarget {
     Chrome(Option<ToolbarCommand>),
+    #[cfg(feature = "docx")]
     Docx(TextLoc),
+    #[cfg(feature = "xlsx")]
     Xlsx(CellRef),
+    #[cfg(feature = "pptx")]
     Pptx(PptxHit),
     None,
 }
@@ -306,15 +402,26 @@ fn pointer_target(
     else {
         return Ok(PointerTarget::None);
     };
-    if let Some(loc) = document.docx_hit_test(page_index, local_x, local_y)? {
-        return Ok(PointerTarget::Docx(loc));
+    #[cfg(feature = "docx")]
+    {
+        if let Some(loc) = document.docx_hit_test(page_index, local_x, local_y)? {
+            return Ok(PointerTarget::Docx(loc));
+        }
     }
-    if let Some(hit) = document.pptx_hit_test(page_index, local_x, local_y) {
-        return Ok(PointerTarget::Pptx(hit));
+    #[cfg(feature = "pptx")]
+    {
+        if let Some(hit) = document.pptx_hit_test(page_index, local_x, local_y) {
+            return Ok(PointerTarget::Pptx(hit));
+        }
     }
-    Ok(document
-        .xlsx_hit_test(page_index, local_x, local_y)
-        .map_or(PointerTarget::None, PointerTarget::Xlsx))
+    #[cfg(feature = "xlsx")]
+    {
+        return Ok(document
+            .xlsx_hit_test(page_index, local_x, local_y)
+            .map_or(PointerTarget::None, PointerTarget::Xlsx));
+    }
+    #[cfg(not(feature = "xlsx"))]
+    Ok(PointerTarget::None)
 }
 
 impl Viewer {
@@ -379,8 +486,35 @@ impl Viewer {
         Ok(())
     }
 
+    #[cfg(target_os = "macos")]
+    fn open_document(&mut self, path: PathBuf) -> Result<()> {
+        if self.document.is_dirty() && !self.document.is_remote_only_dirty() {
+            bail!("save or undo changes before opening another document");
+        }
+        if self.collaboration.is_some() {
+            bail!("leave the collaboration room before opening another document");
+        }
+        let document = load_document(&path, 0, self.document.max_texture_dimension_2d)
+            .with_context(|| format!("open {}", path.display()))?;
+        let save_target = Some(document.edited_path()?);
+        self.document = document;
+        self.save_target = save_target;
+        self.zoom = 1.0;
+        self.scroll = 0.0;
+        self.cursor = None;
+        self.dragging = false;
+        self.last_click = None;
+        self.status_message = None;
+        self.reset_caret_blink();
+        self.update_title();
+        self.request_redraw();
+        Ok(())
+    }
+
     fn render(&mut self) -> Result<()> {
+        #[cfg(feature = "docx")]
         let selection_rects = self.document.docx_selection_rects().to_vec();
+        #[cfg(feature = "xlsx")]
         let xlsx_overlay = self.document.xlsx_overlay();
         let caret = if self.focused && self.caret_visible {
             self.document.caret_geometry()?
@@ -416,6 +550,7 @@ impl Viewer {
             let transform = Affine::translate((origin.x * device_scale, origin.y * device_scale))
                 * Affine::scale(scale);
             scene.append(&page.background, Some(transform));
+            #[cfg(feature = "docx")]
             for rect in selection_rects
                 .iter()
                 .filter(|rect| rect.page_index == page_index)
@@ -429,6 +564,7 @@ impl Viewer {
                 );
             }
             scene.append(&page.scene, Some(transform));
+            #[cfg(feature = "xlsx")]
             if page_index == 0
                 && let Some(overlay) = &xlsx_overlay
             {
@@ -613,6 +749,7 @@ impl Viewer {
         })
     }
 
+    #[cfg(feature = "docx")]
     fn document_point(&self, x: f64, y: f64, clamp: bool) -> Option<(usize, f64, f64)> {
         self.geometry()?
             .document_point(&self.document.pages, x, y, clamp)
@@ -631,24 +768,27 @@ impl Viewer {
             geometry,
             Point::new(x, y),
         )?;
-        let loc = match target {
+        match target {
             PointerTarget::Chrome(command) => {
                 self.dragging = false;
                 self.last_click = None;
+                #[cfg(feature = "pptx")]
                 self.document.pptx_clear_caret();
                 if let Some(command) = command {
                     self.execute_toolbar_command(command)?;
                 }
-                return Ok(true);
+                Ok(true)
             }
+            #[cfg(feature = "xlsx")]
             PointerTarget::Xlsx(cell) => {
                 let committed = self.document.xlsx_commit(None)?;
                 let selected = self.document.xlsx_select_cell(cell);
                 self.dragging = false;
                 self.last_click = None;
                 self.update_title();
-                return Ok(committed || selected);
+                Ok(committed || selected)
             }
+            #[cfg(feature = "pptx")]
             PointerTarget::Pptx(PptxHit::Text(hit)) => {
                 self.dragging = false;
                 self.last_click = None;
@@ -656,32 +796,43 @@ impl Viewer {
                 if selected {
                     self.reset_caret_blink();
                 }
-                return Ok(selected);
+                Ok(selected)
             }
+            #[cfg(feature = "pptx")]
             PointerTarget::Pptx(PptxHit::Other) => {
                 self.dragging = false;
                 self.last_click = None;
-                return Ok(self.document.pptx_clear_caret());
+                Ok(self.document.pptx_clear_caret())
             }
-            PointerTarget::Docx(loc) => loc,
-            PointerTarget::None => return Ok(self.document.pptx_clear_caret()),
-        };
-        let now = Instant::now();
-        let word = self.last_click.is_some_and(|(last, last_x, last_y)| {
-            now.duration_since(last) <= DOUBLE_CLICK
-                && (x - last_x).hypot(y - last_y) <= DOUBLE_CLICK_DISTANCE
-        });
-        self.last_click = Some((now, x, y));
-        self.dragging = true;
-        let selected = self
-            .document
-            .docx_select_point(loc, self.modifiers.shift_key(), word)?;
-        if selected {
-            self.reset_caret_blink();
+            #[cfg(feature = "docx")]
+            PointerTarget::Docx(loc) => {
+                let now = Instant::now();
+                let word = self.last_click.is_some_and(|(last, last_x, last_y)| {
+                    now.duration_since(last) <= DOUBLE_CLICK
+                        && (x - last_x).hypot(y - last_y) <= DOUBLE_CLICK_DISTANCE
+                });
+                self.last_click = Some((now, x, y));
+                self.dragging = true;
+                let selected =
+                    self.document
+                        .docx_select_point(loc, self.modifiers.shift_key(), word)?;
+                if selected {
+                    self.reset_caret_blink();
+                }
+                Ok(selected)
+            }
+            PointerTarget::None => {
+                #[cfg(feature = "pptx")]
+                {
+                    return Ok(self.document.pptx_clear_caret());
+                }
+                #[cfg(not(feature = "pptx"))]
+                Ok(false)
+            }
         }
-        Ok(selected)
     }
 
+    #[cfg(feature = "docx")]
     fn pointer_drag(&mut self) -> Result<bool> {
         if !self.dragging {
             return Ok(false);
@@ -702,6 +853,11 @@ impl Viewer {
         Ok(selected)
     }
 
+    #[cfg(not(feature = "docx"))]
+    fn pointer_drag(&mut self) -> Result<bool> {
+        Ok(false)
+    }
+
     fn execute_toolbar_command(&mut self, command: ToolbarCommand) -> Result<()> {
         if command == ToolbarCommand::Save {
             let editing = self.document.editing_state()?;
@@ -715,24 +871,58 @@ impl Viewer {
                 return Ok(());
             }
         }
-        if self.document.xlsx_is_editing() {
-            self.document.xlsx_commit(None)?;
+        #[cfg(feature = "xlsx")]
+        {
+            if self.document.xlsx_is_editing() {
+                self.document.xlsx_commit(None)?;
+            }
         }
-        let xlsx = matches!(&self.document.reference, ReferenceDocument::Xlsx(_));
-        let pptx = matches!(&self.document.reference, ReferenceDocument::Pptx(_));
         let changed = match command {
-            ToolbarCommand::Undo if xlsx => self.document.xlsx_undo()?,
-            ToolbarCommand::Redo if xlsx => self.document.xlsx_redo()?,
-            ToolbarCommand::Undo if pptx => self.document.pptx_undo()?,
-            ToolbarCommand::Redo if pptx => self.document.pptx_redo()?,
+            #[cfg(feature = "xlsx")]
+            ToolbarCommand::Undo
+                if matches!(&self.document.reference, ReferenceDocument::Xlsx(_)) =>
+            {
+                self.document.xlsx_undo()?
+            }
+            #[cfg(feature = "xlsx")]
+            ToolbarCommand::Redo
+                if matches!(&self.document.reference, ReferenceDocument::Xlsx(_)) =>
+            {
+                self.document.xlsx_redo()?
+            }
+            #[cfg(feature = "pptx")]
+            ToolbarCommand::Undo
+                if matches!(&self.document.reference, ReferenceDocument::Pptx(_)) =>
+            {
+                self.document.pptx_undo()?
+            }
+            #[cfg(feature = "pptx")]
+            ToolbarCommand::Redo
+                if matches!(&self.document.reference, ReferenceDocument::Pptx(_)) =>
+            {
+                self.document.pptx_redo()?
+            }
+            #[cfg(feature = "docx")]
             ToolbarCommand::Undo => self.document.docx_undo()?,
+            #[cfg(feature = "docx")]
             ToolbarCommand::Redo => self.document.docx_redo()?,
+            #[cfg(feature = "docx")]
             ToolbarCommand::Bold => self.document.docx_toggle_format(SimpleFormat::Bold)?,
+            #[cfg(feature = "docx")]
             ToolbarCommand::Italic => self.document.docx_toggle_format(SimpleFormat::Italic)?,
+            #[cfg(feature = "docx")]
             ToolbarCommand::Underline => {
                 self.document.docx_toggle_format(SimpleFormat::Underline)?
             }
+            #[cfg(feature = "docx")]
             ToolbarCommand::Align(alignment) => self.document.docx_set_alignment(alignment)?,
+            #[cfg(not(feature = "docx"))]
+            ToolbarCommand::Undo
+            | ToolbarCommand::Redo
+            | ToolbarCommand::Bold
+            | ToolbarCommand::Italic
+            | ToolbarCommand::Underline
+            | ToolbarCommand::Align(_) => false,
             ToolbarCommand::ZoomOut => {
                 self.zoom_by(1.0 / 1.1);
                 return Ok(());
@@ -766,10 +956,12 @@ impl Viewer {
         let command = self.modifiers.super_key() || self.modifiers.control_key();
         let key = event.logical_key.as_ref();
         if matches!(key, Key::Named(NamedKey::Escape)) {
+            #[cfg(feature = "pptx")]
             if self.document.pptx_clear_caret() {
                 self.request_redraw();
                 return Ok(());
             }
+            #[cfg(feature = "xlsx")]
             if self.document.xlsx_cancel_edit() {
                 self.update_title();
                 self.request_redraw();
@@ -826,6 +1018,7 @@ impl Viewer {
             command,
             self.modifiers.alt_key(),
         );
+        #[cfg(feature = "docx")]
         if matches!(&self.document.reference, ReferenceDocument::Docx(_)) {
             let changed = match key {
                 Key::Named(NamedKey::ArrowLeft) => self
@@ -865,6 +1058,7 @@ impl Viewer {
             }
             return Ok(());
         }
+        #[cfg(feature = "xlsx")]
         if matches!(&self.document.reference, ReferenceDocument::Xlsx(_)) {
             let editing = self.document.xlsx_is_editing();
             let changed = if editing {
@@ -906,6 +1100,7 @@ impl Viewer {
             }
             return Ok(());
         }
+        #[cfg(feature = "pptx")]
         if matches!(&self.document.reference, ReferenceDocument::Pptx(_))
             && self.document.has_text_caret()
         {
@@ -974,12 +1169,18 @@ impl Viewer {
     }
 
     fn save_and_verify(&mut self) -> std::result::Result<std::path::PathBuf, SaveFailure> {
-        if self.document.xlsx_is_editing() {
-            self.document.xlsx_commit(None).map_err(SaveFailure::Save)?;
+        #[cfg(feature = "xlsx")]
+        {
+            if self.document.xlsx_is_editing() {
+                self.document.xlsx_commit(None).map_err(SaveFailure::Save)?;
+            }
         }
         let (format, sheet_index) = match &self.document.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => ("DOCX", 0),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(reference) => ("XLSX", reference.sheet_index),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) => ("PPTX", 0),
         };
         let path = self
@@ -988,8 +1189,11 @@ impl Viewer {
             .context("save target is unavailable")
             .map_err(SaveFailure::Save)?;
         match &self.document.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => self.document.save_docx_to(&path),
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => self.document.save_xlsx_to(&path),
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) => self.document.save_pptx_to(&path),
         }
         .map_err(SaveFailure::Save)?;
@@ -1107,11 +1311,17 @@ impl Viewer {
             .map(|page| page.skipped.total())
             .sum::<usize>();
         let edit_state = match &self.document.reference {
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(reference) if reference.editor.is_dirty() => " — edited",
+            #[cfg(feature = "docx")]
             ReferenceDocument::Docx(_) => " — editable",
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) if self.document.xlsx_is_dirty() => " — edited",
+            #[cfg(feature = "xlsx")]
             ReferenceDocument::Xlsx(_) => " — editable",
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) if self.document.pptx_is_dirty() => " — edited",
+            #[cfg(feature = "pptx")]
             ReferenceDocument::Pptx(_) => " — editable",
         };
         window.set_title(&format!(
@@ -1155,7 +1365,7 @@ impl Viewer {
     }
 }
 
-impl ApplicationHandler<CollaborationWake> for Viewer {
+impl ApplicationHandler<ViewerEvent> for Viewer {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if let Err(error) = self.create_window(event_loop) {
             self.handle_error(event_loop, WindowErrorPath::Startup, error);
@@ -1251,16 +1461,27 @@ impl ApplicationHandler<CollaborationWake> for Viewer {
         }
     }
 
-    fn user_event(&mut self, event_loop: &ActiveEventLoop, _event: CollaborationWake) {
-        let Some(event) = self
-            .collaboration_events
-            .as_ref()
-            .and_then(TransportEventReceiver::try_recv)
-        else {
-            return;
-        };
-        if let Err(error) = self.handle_collaboration_event(event) {
-            self.handle_error(event_loop, WindowErrorPath::Edit, error);
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: ViewerEvent) {
+        match event {
+            ViewerEvent::Collaboration => {
+                let Some(event) = self
+                    .collaboration_events
+                    .as_ref()
+                    .and_then(TransportEventReceiver::try_recv)
+                else {
+                    return;
+                };
+                if let Err(error) = self.handle_collaboration_event(event) {
+                    self.handle_error(event_loop, WindowErrorPath::Edit, error);
+                }
+            }
+            #[cfg(target_os = "macos")]
+            ViewerEvent::OpenDocument(path) => {
+                if let Err(error) = self.open_document(path) {
+                    self.set_status(format!("Open failed: {error:#}"));
+                    self.request_redraw();
+                }
+            }
         }
     }
 
@@ -1299,7 +1520,7 @@ impl ApplicationHandler<CollaborationWake> for Viewer {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "docx", feature = "xlsx", feature = "pptx"))]
 mod tests {
     use std::path::Path;
 


### PR DESCRIPTION
TL;DR:

Repro file:
`apps/demo/public/betteroffice-demo.docx`, `showcase.xlsx`, `betteroffice-demo.pptx`.

Summary:
- splits the native viewer into **BetterOffice Docs, Sheets and Slides**, each built from the same source behind a cargo feature so an app ships only the engine it needs. A single app can only ever have one Dock icon; three apps means the icon in the Dock, the app switcher and Finder's "Open With" is the one for the format in front of you.
- each bundle declares only its own document type, uses that format's mark as its **app** icon, and carries a matching Welcome document for the no-arguments launch
- **Finder now actually opens the file you clicked.** The bundle previously advertised itself as an editor for all three formats and then ignored the document Launch Services handed it, showing the bundled Welcome file instead — worse than not registering at all.
- opening a file an app was not built for fails with a message naming the app that handles it, rather than a parse error
- redraws the icons on the same 32-unit grid as the kyora mark — black ground, white blocks, one element at 55% — and centres every mark on both axes. They were all horizontally centred but vertically off (7/4, 9/3 and 4/7 top-to-bottom), which reads as subtly wrong without being obvious.
- adds `apps/native-viewer/macos/` — bundle assembly, icon generation and dmg packaging, usable locally without CI

Measured, universal binaries:

| Build | Size | Saving |
| --- | ---: | ---: |
| All formats | 74.6 MB | — |
| Docs | 57.2 MB | 23% |
| Sheets | 38.4 MB | 49% |
| Slides | 37.9 MB | 49% |

wgpu and Vello impose a shared floor of roughly 31 MB stripped, so the saving is bounded — Sheets and Slides halve, Docs drops a quarter. Stripping is deliberately not applied: it would save another ~20% but make crash reports unsymbolicatable without archiving dSYMs.

The signing and notarization workflow is deliberately **not** in this PR — it is in #225 and waits on Apple credentials. Nothing here depends on it; `build-app.sh` and `package-dmg.sh` produce a working unsigned bundle on their own.

Test plan:
- [ ] `cargo test --manifest-path apps/native-viewer/Cargo.toml` — 113 tests
- [ ] each single-feature build compiles: `--no-default-features --features docx|xlsx|pptx`
- [ ] `apps/native-viewer/macos/build-app.sh docx dist 0.1.0 1` and the same for xlsx and pptx
- [ ] each app opens its own format and rejects the other two with a clear message
- [ ] double-clicking a document opens that document