### PR TITLE
ci(apps): rename the signing environment to native-macos

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -127,7 +127,7 @@ jobs:
     needs: build
     runs-on: macos-15
     timeout-minutes: 180
-    environment: apple-signing
+    environment: native-macos
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -143,10 +143,14 @@ jobs:
           KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/@betteroffice/docx@') }}
         run: |
           if [ -n "$CERT" ] && [ -n "$CERT_PASSWORD" ] && [ -n "$ISSUER_ID" ] && \
              [ -n "$KEY_ID" ] && [ -n "$KEY_P8" ] && [ -n "$TEAM_ID" ]; then
             echo "signing=true" >> "$GITHUB_OUTPUT"
+          elif [ "$RELEASE_TAG" = "true" ]; then
+            echo "::error::Apple credentials unavailable; refusing to publish this release unsigned."
+            exit 1
           else
             echo "signing=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Apple credentials incomplete; retaining only the unsigned artifact."

--- a/apps/native-viewer/macos/README.md
+++ b/apps/native-viewer/macos/README.md
@@ -8,7 +8,7 @@ and assembles the matching BetterOffice app with its icon and Welcome file.
 
 The `macOS app` workflow runs for `@betteroffice/docx@<version>` tags, pull
 requests and manual dispatches. Every run uploads an artifact suffixed
-`-unsigned`. Non-PR runs can pass the `apple-signing` environment gate to also
+`-unsigned`. Non-PR runs can pass the `native-macos` environment gate to also
 sign, notarize, and staple all three apps and the disk image, then upload a
 signed artifact. Tagged signed runs attach the disk image to that GitHub
 release. A prerelease tag such as `@betteroffice/docx@0.2.0-rc.1` uses `0.2.0`
@@ -17,7 +17,7 @@ names.
 
 ## Secrets
 
-Create an `apple-signing` environment with required reviewers, then create
+Create an `native-macos` environment with required reviewers, then create
 these as environment secrets. All six are required for the signed path; if any
 is missing the workflow retains only the unsigned artifact.
 


### PR DESCRIPTION
TL;DR:

Summary:
- renames the deployment environment the signing job declares from `apple-signing` to `native-macos`, and updates the reference in `apps/native-viewer/macos/README.md`
- `native-*` groups the native apps as one family, so a future Linux pipeline sits alongside as `native-linux` rather than scattering by platform

**Merge only after the environment exists under the new name.** Otherwise the signing job resolves an environment with no secrets and quietly produces an unsigned build instead of failing. Either rename `apple-signing` in place from Settings → Environments, which preserves the secrets, or create `native-macos` and re-add the six secrets first.

Test plan:
- [ ] the environment `native-macos` exists and holds all six Apple secrets
- [ ] run the workflow manually and confirm the artifact name has no `-unsigned` suffix
- [ ] delete the now-unused `apple-signing` environment