### PR TITLE
perf(docx): structural block comparison in resident layout

### DIFF
--- a/.changeset/docx-cheap-fingerprints.md
+++ b/.changeset/docx-cheap-fingerprints.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Compare layout blocks structurally instead of fingerprinting serialized JSON.

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -39,7 +39,9 @@ use crate::frame_delta::{
 struct LoweredStory {
     doc_epoch: u64,
     env: RenderEnv,
-    blocks: Vec<LayoutBlock>,
+    /// Shared so a reader can hold the lowering it asked for without the cache
+    /// borrow, and without copying the story.
+    blocks: Rc<Vec<LayoutBlock>>,
     /// Lazily serialized layout blocks.
     serialized_blocks: Option<String>,
 }
@@ -601,38 +603,69 @@ impl EngineSession {
         env: &RenderEnv,
         read: impl FnOnce(&[LayoutBlock]) -> T,
     ) -> Result<T, BridgeError> {
-        let epoch = self.doc_epoch();
-        let is_hit = self
-            .render
+        self.with_lowered_story_observed(story, env, &mut || {}, read)
+    }
+
+    /// Whether `story` is already lowered for this document epoch and
+    /// environment.
+    fn story_is_resident(&self, story: &str, epoch: u64, env: &RenderEnv) -> bool {
+        self.render
             .borrow()
             .stories
             .get(story)
-            .is_some_and(|cached| cached.doc_epoch == epoch && cached.env == *env);
+            .is_some_and(|cached| cached.doc_epoch == epoch && cached.env == *env)
+    }
 
-        if !is_hit {
-            let blocks = yrs_doc_to_layout_blocks(&self.doc, story, env)?;
-            let mut render = self.render.borrow_mut();
-            render.cache_misses = render.cache_misses.wrapping_add(1);
-            render.stories.insert(
-                story.to_owned(),
-                LoweredStory {
-                    doc_epoch: epoch,
-                    env: env.clone(),
-                    blocks,
-                    serialized_blocks: None,
-                },
-            );
-        } else {
+    fn lower_story_into_cache(
+        &self,
+        story: &str,
+        epoch: u64,
+        env: &RenderEnv,
+    ) -> Result<(), BridgeError> {
+        let blocks = yrs_doc_to_layout_blocks(&self.doc, story, env)?;
+        let mut render = self.render.borrow_mut();
+        render.cache_misses = render.cache_misses.wrapping_add(1);
+        render.stories.insert(
+            story.to_owned(),
+            LoweredStory {
+                doc_epoch: epoch,
+                env: env.clone(),
+                blocks: Rc::new(blocks),
+                serialized_blocks: None,
+            },
+        );
+        Ok(())
+    }
+
+    /// [`Self::with_lowered_story`] with a hook between lowering and the read.
+    /// The lowering is claimed before `after_lower` fires, so an observer
+    /// supplied by the host may re-enter the engine — even re-lowering this
+    /// story — without disturbing what the caller reads.
+    fn with_lowered_story_observed<T>(
+        &self,
+        story: &str,
+        env: &RenderEnv,
+        after_lower: &mut dyn FnMut(),
+        read: impl FnOnce(&[LayoutBlock]) -> T,
+    ) -> Result<T, BridgeError> {
+        let epoch = self.doc_epoch();
+        if self.story_is_resident(story, epoch, env) {
             let mut render = self.render.borrow_mut();
             render.cache_hits = render.cache_hits.wrapping_add(1);
+        } else {
+            self.lower_story_into_cache(story, epoch, env)?;
         }
-
-        let render = self.render.borrow();
-        let cached = render
-            .stories
-            .get(story)
-            .expect("resident story exists after lowering");
-        Ok(read(&cached.blocks))
+        let blocks = Rc::clone(
+            &self
+                .render
+                .borrow()
+                .stories
+                .get(story)
+                .expect("resident story exists after lowering")
+                .blocks,
+        );
+        after_lower();
+        Ok(read(&blocks))
     }
 
     /// Serializes resident lowered blocks.
@@ -1289,8 +1322,7 @@ impl EngineSession {
             .get(story)
             .map(|story| story.env.clone())
             .ok_or_else(|| format!("resident render environment missing for story {story:?}"))?;
-        self.with_lowered_story(story, &env, |blocks| {
-            after_lower();
+        self.with_lowered_story_observed(story, &env, after_lower, |blocks| {
             self.resident_layout_input_from_blocks(
                 blocks,
                 &mut |_, key, previous_block, next_block| {
@@ -1518,11 +1550,11 @@ impl EngineSession {
             lowered.env.clone()
         };
         let outcome = self
-            .with_lowered_story(
+            .with_lowered_story_observed(
                 story,
                 &env,
+                &mut || phase(RegionResidentPhase::Lowered),
                 |blocks| -> Result<Option<(ResidentLayoutInput, usize)>, String> {
-                    phase(RegionResidentPhase::Lowered);
                     let (widths, geometry, previous_pages) = {
                         let pagination = self.pagination.borrow();
                         let (Some(input), Some(layout)) =
@@ -2958,6 +2990,262 @@ mod tests {
         assert_eq!(stats.pagination_calls, 3);
         assert_eq!(stats.incremental_pagination_calls, 2);
         assert_eq!(stats.display_builds, 3);
+        docx_layout::clear_measure_fonts();
+    }
+
+    /// The profiler clock is host code: re-entering the engine from it must not
+    /// abort an edit the document has already committed.
+    #[test]
+    fn a_reentrant_profiler_clock_does_not_abort_the_edit() {
+        const FONT: &[u8] =
+            include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+        docx_layout::clear_measure_fonts();
+        let font_id = docx_layout::register_measure_font(FONT).unwrap();
+        let engine = EngineSession::new(4242);
+        engine
+            .doc()
+            .create_story("body", "hello", "Normal", "left")
+            .unwrap();
+        let env = RenderEnv::default();
+        let block = engine
+            .with_lowered_story("body", &env, |blocks| blocks[0].clone())
+            .unwrap();
+        let extent: ParagraphExtent = serde_json::from_str(
+            &engine
+                .measure_paragraph_json(
+                    &serde_json::json!({
+                        "block": block,
+                        "maxWidth": 180,
+                        "fontChains": { "liberation sans|0|0": [font_id] },
+                        "defaults": { "fontSize": 12, "fontFamily": "Liberation Sans" },
+                        "authoritativeShaping": true
+                    })
+                    .to_string(),
+                )
+                .unwrap(),
+        )
+        .unwrap();
+        engine
+            .layout_document_value(LayoutInput {
+                measured: vec![MeasuredBlock {
+                    block,
+                    measure: BlockExtent::Paragraph(extent),
+                }],
+                options: serde_json::from_value(serde_json::json!({
+                    "pageSize": { "w": 200, "h": 120 },
+                    "margins": { "top": 10, "right": 10, "bottom": 10, "left": 10 }
+                }))
+                .unwrap(),
+            })
+            .unwrap();
+        engine.build_display_list_frame("{}", 0).unwrap();
+        engine
+            .doc()
+            .insert_text(
+                &crate::EditCtx::local("", ""),
+                crate::Position::new("body", 5),
+                "!",
+                crate::FormatPolicy::Inherit,
+            )
+            .unwrap();
+
+        let foreign_env = RenderEnv {
+            default_tab_stop_twips: Some(720.0),
+            ..RenderEnv::default()
+        };
+        let mut ticks = 0_u32;
+        let mut clock = || {
+            ticks += 1;
+            // Tick 2 is the post-lowering hook; re-lowering under another
+            // environment there must not steal the story the edit is reading.
+            let env = if ticks == 2 { &foreign_env } else { &env };
+            engine.lower_story_json("body", env).unwrap();
+            ticks as f64
+        };
+        let (frame, _) = engine
+            .apply_and_layout_profiled("body", 1, &mut clock)
+            .unwrap();
+        assert!(!frame.is_empty());
+        let pagination = engine.pagination.borrow();
+        let LayoutBlock::Paragraph(paragraph) =
+            &pagination.input.as_ref().unwrap().measured[0].block
+        else {
+            panic!("paragraph expected");
+        };
+        assert_eq!(
+            paragraph
+                .attrs
+                .as_ref()
+                .and_then(|attrs| attrs.default_tab_stop_twips),
+            None,
+            "the edit keeps the environment it asked for, not the observer's"
+        );
+        drop(pagination);
+        docx_layout::clear_measure_fonts();
+    }
+
+    /// The region twin of [`a_reentrant_profiler_clock_does_not_abort_the_edit`].
+    #[test]
+    fn a_reentrant_profiler_clock_does_not_abort_a_region_edit() {
+        const FONT: &[u8] =
+            include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+        docx_layout::clear_measure_fonts();
+        let font_id = docx_layout::register_measure_font(FONT).unwrap();
+        let engine = EngineSession::new(4243);
+        engine
+            .doc()
+            .create_story("body", "AlphaBravo", "Normal", "left")
+            .unwrap();
+        engine
+            .doc()
+            .split_paragraph(
+                &crate::EditCtx::local("", ""),
+                crate::Position::new("body", 5),
+                None,
+            )
+            .unwrap();
+        let request = serde_json::json!({
+            "bodyStory": "body",
+            "regions": {"sections": [{"sectionId": "main", "properties": {}}]},
+            "measurement": {
+                "fontChains": {"calibri|0|0": [font_id]},
+                "defaults": {"fontSize": 11, "fontFamily": "Calibri"},
+                "authoritativeShaping": true
+            },
+            "renderEnv": {}
+        })
+        .to_string();
+        engine.layout_document_with_regions_json(&request).unwrap();
+        engine
+            .build_display_list_frame(
+                &serde_json::json!({"fontChains": {"calibri|0|0": [font_id]}}).to_string(),
+                0,
+            )
+            .unwrap();
+        engine
+            .doc()
+            .insert_text(
+                &crate::EditCtx::local("", ""),
+                crate::Position::new("body", 2),
+                "xx",
+                crate::FormatPolicy::Inherit,
+            )
+            .unwrap();
+
+        let env = RenderEnv::default();
+        let mut ticks = 0_u32;
+        let mut clock = || {
+            ticks += 1;
+            engine.lower_story_json("body", &env).unwrap();
+            ticks as f64
+        };
+        let (frame, _) = engine
+            .apply_and_layout_profiled("body", 1, &mut clock)
+            .unwrap();
+        assert!(!frame.is_empty());
+        docx_layout::clear_measure_fonts();
+    }
+
+    /// Rust float equality makes `-0.0 == 0.0`, so a sign-only change to a
+    /// layout number keeps its retained measurement. Signed zero measures
+    /// identically, so the reuse still matches a full pass.
+    #[test]
+    fn a_sign_only_zero_change_reuses_a_measurement_matching_the_full_pass() {
+        const FONT: &[u8] =
+            include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+        docx_layout::clear_measure_fonts();
+        let font_id = docx_layout::register_measure_font(FONT).unwrap();
+        let engine = EngineSession::new(777);
+        let ctx = crate::EditCtx::local("", "");
+        engine
+            .doc()
+            .create_story(
+                "body",
+                "Alpha bravo charlie delta echo foxtrot",
+                "Normal",
+                "left",
+            )
+            .unwrap();
+        engine
+            .doc()
+            .split_paragraph(&ctx, crate::Position::new("body", 5), None)
+            .unwrap();
+        let para_ids: Vec<String> = engine
+            .with_lowered_story("body", &RenderEnv::default(), |blocks| {
+                blocks
+                    .iter()
+                    .filter_map(|block| {
+                        paragraph_identity(block).map(|(id, _)| block_key(id).into_owned())
+                    })
+                    .collect()
+            })
+            .unwrap();
+        engine
+            .doc()
+            .set_paragraph_attr(&para_ids[0], "indentLeft", yrs::Any::Number(0.0))
+            .unwrap();
+        let request = serde_json::json!({
+            "bodyStory": "body",
+            "regions": {"sections": [{"sectionId": "main", "properties": {}}]},
+            "measurement": {
+                "fontChains": {"calibri|0|0": [font_id]},
+                "defaults": {"fontSize": 11, "fontFamily": "Calibri"},
+                "authoritativeShaping": true
+            },
+            "renderEnv": {}
+        })
+        .to_string();
+        engine.layout_document_with_regions_json(&request).unwrap();
+        engine
+            .build_display_list_frame(
+                &serde_json::json!({"fontChains": {"calibri|0|0": [font_id]}}).to_string(),
+                0,
+            )
+            .unwrap();
+
+        engine
+            .doc()
+            .set_paragraph_attr(&para_ids[0], "indentLeft", yrs::Any::Number(-0.0))
+            .unwrap();
+        let lowered = engine
+            .with_lowered_story("body", &RenderEnv::default(), |blocks| {
+                serde_json::to_string(&blocks[0]).unwrap()
+            })
+            .unwrap();
+        assert!(
+            lowered.contains("-0.0"),
+            "the sign-only change must reach the lowered block: {lowered}"
+        );
+
+        let before = engine.stats();
+        let epoch = engine.display.borrow().binary_frame_epoch;
+        engine.apply_and_layout("body", epoch).unwrap();
+        let after = engine.stats();
+        assert_eq!(
+            after.resident_measure_calls, before.resident_measure_calls,
+            "a sign-only zero change is structurally clean"
+        );
+        assert_eq!(
+            after.resident_reused_blocks,
+            before.resident_reused_blocks + 2,
+            "both paragraphs reuse their retained extents"
+        );
+        let fast_json = {
+            let pagination = engine.pagination.borrow();
+            let regions_state = engine.regions.borrow();
+            serialize_region_layout(
+                pagination.input.as_ref().unwrap(),
+                pagination.layout.as_ref().unwrap(),
+                regions_state.as_ref().unwrap().headers_footers.as_ref(),
+                true,
+            )
+            .unwrap()
+        };
+        let full_json = engine.layout_document_with_regions_json(&request).unwrap();
+        assert_eq!(
+            fast_json, full_json,
+            "the reused measurement matches a full pass"
+        );
         docx_layout::clear_measure_fonts();
     }
 

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -1,5 +1,6 @@
 //! Resident editor-engine state.
 
+use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::rc::Rc;
@@ -450,15 +451,6 @@ fn measured_fingerprints(input: &LayoutInput) -> Result<Vec<u64>, String> {
     input.measured.iter().map(measured_fingerprint).collect()
 }
 
-fn block_fingerprint(block: &LayoutBlock) -> Result<u64, String> {
-    let mut value = serde_json::to_value(block)
-        .map_err(|error| format!("fingerprint layout block: {error}"))?;
-    strip_absolute_positions(&mut value);
-    serde_json::to_vec(&value)
-        .map(|bytes| hash_bytes(&bytes))
-        .map_err(|error| format!("fingerprint layout block: {error}"))
-}
-
 fn value_block_key(value: &serde_json::Value) -> Option<String> {
     let id = value.get("block")?.get("id")?;
     match id {
@@ -485,11 +477,11 @@ fn options_fingerprint(input: &LayoutInput) -> Result<u64, String> {
         .map_err(|error| format!("fingerprint layout options: {error}"))
 }
 
-fn block_key(id: &BlockId) -> String {
+fn block_key(id: &BlockId) -> Cow<'_, str> {
     match id {
-        BlockId::Num(value) if value.fract() == 0.0 => format!("{}", *value as i64),
-        BlockId::Num(value) => value.to_string(),
-        BlockId::Str(value) => value.clone(),
+        BlockId::Num(value) if value.fract() == 0.0 => Cow::Owned(format!("{}", *value as i64)),
+        BlockId::Num(value) => Cow::Owned(value.to_string()),
+        BlockId::Str(value) => Cow::Borrowed(value),
     }
 }
 
@@ -530,7 +522,7 @@ fn position_deltas(previous: &LayoutInput, next: &LayoutInput) -> HashMap<String
                 return None;
             }
             let delta = next_start? as i64 - previous_start? as i64;
-            (delta != 0).then_some((key, delta))
+            (delta != 0).then_some((key.into_owned(), delta))
         })
         .collect()
 }
@@ -747,15 +739,13 @@ impl EngineSession {
         {
             return Some(template.envelope.clone());
         }
-        let previous_fingerprint = block_fingerprint(previous_block).ok()?;
         measurement.templates.values().find_map(|template| {
             if !template.resident_safe {
                 return None;
             }
             let block: LayoutBlock =
                 serde_json::from_value(template.envelope.get("block")?.clone()).ok()?;
-            (block_fingerprint(&block).ok()? == previous_fingerprint)
-                .then(|| template.envelope.clone())
+            (block == *previous_block).then(|| template.envelope.clone())
         })
     }
 
@@ -1299,40 +1289,43 @@ impl EngineSession {
             .get(story)
             .map(|story| story.env.clone())
             .ok_or_else(|| format!("resident render environment missing for story {story:?}"))?;
-        let blocks = self
-            .with_lowered_story(story, &env, <[LayoutBlock]>::to_vec)
-            .map_err(|error| error.to_string())?;
-        after_lower();
-        self.resident_layout_input_from_blocks(blocks, &mut |_, key, previous_block, next_block| {
-            let mut envelope = self
-                .measurement_envelope_for_block(key, previous_block)
-                .ok_or_else(|| {
-                    format!("resident measurement template missing for block {key:?}")
-                })?;
-            let fields = envelope
-                .as_object_mut()
-                .ok_or_else(|| "resident measurement envelope is not an object".to_owned())?;
-            fields.insert(
-                "block".to_owned(),
-                serde_json::to_value(&*next_block)
-                    .map_err(|error| format!("serialize dirty paragraph: {error}"))?,
-            );
-            let envelope_json = serde_json::to_string(&envelope)
-                .map_err(|error| format!("serialize measurement envelope: {error}"))?;
-            let extent_json = docx_layout::measure_paragraph_json_resident(&envelope_json)?;
-            let extent: ParagraphExtent = serde_json::from_str(&extent_json)
-                .map_err(|error| format!("parse resident paragraph extent: {error}"))?;
-            Ok(BlockExtent::Paragraph(extent))
+        self.with_lowered_story(story, &env, |blocks| {
+            after_lower();
+            self.resident_layout_input_from_blocks(
+                blocks,
+                &mut |_, key, previous_block, next_block| {
+                    let mut envelope = self
+                        .measurement_envelope_for_block(key, previous_block)
+                        .ok_or_else(|| {
+                            format!("resident measurement template missing for block {key:?}")
+                        })?;
+                    let fields = envelope.as_object_mut().ok_or_else(|| {
+                        "resident measurement envelope is not an object".to_owned()
+                    })?;
+                    fields.insert(
+                        "block".to_owned(),
+                        serde_json::to_value(&*next_block)
+                            .map_err(|error| format!("serialize dirty paragraph: {error}"))?,
+                    );
+                    let envelope_json = serde_json::to_string(&envelope)
+                        .map_err(|error| format!("serialize measurement envelope: {error}"))?;
+                    let extent_json = docx_layout::measure_paragraph_json_resident(&envelope_json)?;
+                    let extent: ParagraphExtent = serde_json::from_str(&extent_json)
+                        .map_err(|error| format!("parse resident paragraph extent: {error}"))?;
+                    Ok(BlockExtent::Paragraph(extent))
+                },
+            )
         })
+        .map_err(|error| error.to_string())?
     }
 
-    /// Shared dirty-block walk over a freshly lowered story: fingerprint-clean
+    /// Shared dirty-block walk over a freshly lowered story: structurally clean
     /// blocks reuse their retained extents (with fresh absolute positions),
     /// changed paragraph blocks are re-measured through `measure_dirty`
     /// (`(block_index, block_key, previous_block, next_block) -> extent`).
     fn resident_layout_input_from_blocks(
         &self,
-        blocks: Vec<LayoutBlock>,
+        blocks: &[LayoutBlock],
         measure_dirty: &mut dyn FnMut(
             usize,
             &str,
@@ -1340,16 +1333,12 @@ impl EngineSession {
             &mut LayoutBlock,
         ) -> Result<BlockExtent, String>,
     ) -> Result<ResidentLayoutInput, String> {
-        let (previous, previous_fingerprints) = {
-            let pagination = self.pagination.borrow();
-            (
-                pagination
-                    .input
-                    .clone()
-                    .ok_or_else(|| "resident pagination input is not built".to_owned())?,
-                pagination.block_fingerprints.clone(),
-            )
-        };
+        let pagination = self.pagination.borrow();
+        let previous = pagination
+            .input
+            .as_ref()
+            .ok_or_else(|| "resident pagination input is not built".to_owned())?;
+        let previous_fingerprints = &pagination.block_fingerprints;
         let paragraph_merge = blocks.len().checked_add(1) == Some(previous.measured.len());
         if blocks.len() != previous.measured.len() && !paragraph_merge {
             return Err("resident plain-text input changed the block structure".to_owned());
@@ -1358,22 +1347,17 @@ impl EngineSession {
             return Err("resident pagination fingerprints are not built".to_owned());
         }
 
-        let mut previous_blocks = previous
-            .measured
-            .into_iter()
-            .zip(previous_fingerprints)
-            .peekable();
+        let mut previous_blocks = previous.measured.iter().zip(previous_fingerprints);
         let mut skipped_merged_paragraph = false;
         let mut measured = Vec::with_capacity(blocks.len());
         let mut block_fingerprints = Vec::with_capacity(blocks.len());
         let mut resident_measure_calls = 0_u64;
         let mut resident_reused_blocks = 0_u64;
-        for (block_index, mut next_block) in blocks.into_iter().enumerate() {
+        for (block_index, next_block) in blocks.iter().enumerate() {
             let mut previous_entry = previous_blocks.next().ok_or_else(|| {
                 "resident plain-text input changed the block structure".to_owned()
             })?;
-            if paragraph_merge && !resident_block_slots_match(&previous_entry.0.block, &next_block)
-            {
+            if paragraph_merge && !resident_block_slots_match(&previous_entry.0.block, next_block) {
                 if skipped_merged_paragraph || paragraph_identity(&previous_entry.0.block).is_none()
                 {
                     return Err("resident plain-text input changed the block structure".to_owned());
@@ -1383,25 +1367,24 @@ impl EngineSession {
                     "resident plain-text input changed the block structure".to_owned()
                 })?;
             }
-            if paragraph_merge && !resident_block_slots_match(&previous_entry.0.block, &next_block)
-            {
+            if paragraph_merge && !resident_block_slots_match(&previous_entry.0.block, next_block) {
                 return Err("resident plain-text input changed stable block identity".to_owned());
             }
             let (previous_measured, previous_fingerprint) = previous_entry;
             let (Some((next_id, _)), Some((previous_id, _))) = (
-                paragraph_identity(&next_block),
+                paragraph_identity(next_block),
                 paragraph_identity(&previous_measured.block),
             ) else {
-                if block_fingerprint(&next_block)? != block_fingerprint(&previous_measured.block)? {
+                if *next_block != previous_measured.block {
                     return Err(
                         "resident plain-text input changed a non-paragraph block".to_owned()
                     );
                 }
                 measured.push(MeasuredBlock {
-                    block: next_block,
-                    measure: previous_measured.measure,
+                    block: next_block.clone(),
+                    measure: previous_measured.measure.clone(),
                 });
-                block_fingerprints.push(previous_fingerprint);
+                block_fingerprints.push(*previous_fingerprint);
                 resident_reused_blocks = resident_reused_blocks.wrapping_add(1);
                 continue;
             };
@@ -1409,20 +1392,25 @@ impl EngineSession {
             if key != block_key(previous_id) {
                 return Err("resident plain-text input changed stable block identity".to_owned());
             }
-            if block_fingerprint(&next_block)? == block_fingerprint(&previous_measured.block)? {
+            if *next_block == previous_measured.block {
                 measured.push(MeasuredBlock {
-                    block: next_block,
-                    measure: previous_measured.measure,
+                    block: next_block.clone(),
+                    measure: previous_measured.measure.clone(),
                 });
-                block_fingerprints.push(previous_fingerprint);
+                block_fingerprints.push(*previous_fingerprint);
                 resident_reused_blocks = resident_reused_blocks.wrapping_add(1);
                 continue;
             }
 
-            let measure =
-                measure_dirty(block_index, &key, &previous_measured.block, &mut next_block)?;
+            let mut next_measured_block = next_block.clone();
+            let measure = measure_dirty(
+                block_index,
+                &key,
+                &previous_measured.block,
+                &mut next_measured_block,
+            )?;
             let measured_block = MeasuredBlock {
-                block: next_block,
+                block: next_measured_block,
                 measure,
             };
             block_fingerprints.push(measured_fingerprint(&measured_block)?);
@@ -1453,7 +1441,7 @@ impl EngineSession {
         Ok(ResidentLayoutInput {
             input: LayoutInput {
                 measured,
-                options: previous.options,
+                options: previous.options.clone(),
             },
             block_fingerprints,
         })
@@ -1529,43 +1517,54 @@ impl EngineSession {
             };
             lowered.env.clone()
         };
-        let blocks = self
-            .with_lowered_story(story, &env, <[LayoutBlock]>::to_vec)
-            .map_err(|error| error.to_string())?;
-        phase(RegionResidentPhase::Lowered);
-        let (widths, geometry, previous_pages) = {
-            let pagination = self.pagination.borrow();
-            let (Some(input), Some(layout)) =
-                (pagination.input.as_ref(), pagination.layout.as_ref())
-            else {
-                return Ok(false);
-            };
-            (
-                region_measurement_widths(&blocks, input, &regions),
-                initial_float_page_geometry(input, &regions),
-                layout.pages.len(),
+        let outcome = self
+            .with_lowered_story(
+                story,
+                &env,
+                |blocks| -> Result<Option<(ResidentLayoutInput, usize)>, String> {
+                    phase(RegionResidentPhase::Lowered);
+                    let (widths, geometry, previous_pages) = {
+                        let pagination = self.pagination.borrow();
+                        let (Some(input), Some(layout)) =
+                            (pagination.input.as_ref(), pagination.layout.as_ref())
+                        else {
+                            return Ok(None);
+                        };
+                        (
+                            region_measurement_widths(blocks, input, &regions),
+                            initial_float_page_geometry(input, &regions),
+                            layout.pages.len(),
+                        )
+                    };
+                    let default_width = widths.first().copied().unwrap_or(0.0);
+                    if docx_layout::measure_blocks::has_floating_zones(
+                        blocks,
+                        default_width,
+                        measurement.as_ref(),
+                        Some(&geometry),
+                    )? {
+                        return Ok(None);
+                    }
+                    match self.resident_layout_input_from_blocks(
+                        blocks,
+                        &mut |index, _key, _previous_block, next_block| {
+                            let width = widths.get(index).copied().unwrap_or(default_width);
+                            docx_layout::measure_blocks::measure_block(
+                                next_block,
+                                width,
+                                measurement.as_ref(),
+                            )
+                        },
+                    ) {
+                        Ok(resident) => Ok(Some((resident, previous_pages))),
+                        Err(_) => Ok(None),
+                    }
+                },
             )
-        };
-        let default_width = widths.first().copied().unwrap_or(0.0);
-        if docx_layout::measure_blocks::has_floating_zones(
-            &blocks,
-            default_width,
-            measurement.as_ref(),
-            Some(&geometry),
-        )? {
-            return Ok(false);
-        }
-        let resident = match self.resident_layout_input_from_blocks(
-            blocks,
-            &mut |index, _key, _previous_block, next_block| {
-                let width = widths.get(index).copied().unwrap_or(default_width);
-                docx_layout::measure_blocks::measure_block(next_block, width, measurement.as_ref())
-            },
-        ) {
-            Ok(resident) => resident,
-            // Structural mismatch (beyond the supported plain-edit shapes) —
-            // the full pass handles it.
-            Err(_) => return Ok(false),
+            .map_err(|error| error.to_string())??;
+        let (resident, previous_pages) = match outcome {
+            Some(resident) => resident,
+            None => return Ok(false),
         };
         phase(RegionResidentPhase::Measured);
         self.layout_document_value_with_fingerprints(resident.input, resident.block_fingerprints)?;
@@ -2908,7 +2907,7 @@ mod tests {
                 .unwrap(),
         )
         .unwrap();
-        let para_id = block_key(paragraph_identity(&block).unwrap().0);
+        let para_id = block_key(paragraph_identity(&block).unwrap().0).into_owned();
         let initial_input = LayoutInput {
             measured: vec![MeasuredBlock {
                 block,
@@ -2960,6 +2959,192 @@ mod tests {
         assert_eq!(stats.incremental_pagination_calls, 2);
         assert_eq!(stats.display_builds, 3);
         docx_layout::clear_measure_fonts();
+    }
+
+    /// A paragraph-table-paragraph body for dirty-block detection checks.
+    fn resident_walk_fixture() -> String {
+        let paragraph = |id: &str, text: &str, start: f64| {
+            serde_json::json!({
+                "block": {
+                    "kind": "paragraph",
+                    "id": id,
+                    "runs": [{
+                        "kind": "text",
+                        "text": text,
+                        "pmStart": start + 1.0,
+                        "pmEnd": start + 2.0
+                    }],
+                    "pmStart": start,
+                    "pmEnd": start + 2.0
+                },
+                "measure": {
+                    "kind": "paragraph",
+                    "lines": [{
+                        "headRun": 0,
+                        "headChar": 0,
+                        "tailRun": 0,
+                        "tailChar": 1,
+                        "width": 10.0,
+                        "ascent": 8.0,
+                        "descent": 2.0,
+                        "lineHeight": 20.0
+                    }],
+                    "totalHeight": 20.0
+                }
+            })
+        };
+        let cell_paragraph = serde_json::json!({
+            "kind": "paragraph",
+            "id": "c0",
+            "runs": [{"kind": "text", "text": "cell", "pmStart": 2.0, "pmEnd": 6.0}],
+            "pmStart": 1.0,
+            "pmEnd": 6.0
+        });
+        serde_json::json!({
+            "measured": [
+                paragraph("p0", "alpha", 0.0),
+                {
+                    "block": {
+                        "kind": "table",
+                        "id": "t0",
+                        "rows": [{
+                            "id": "r0",
+                            "cells": [{"id": "c0-cell", "blocks": [cell_paragraph]}]
+                        }],
+                        "pmStart": 22.0,
+                        "pmEnd": 42.0
+                    },
+                    "measure": {
+                        "kind": "table",
+                        "rows": [{
+                            "cells": [{"blocks": [], "width": 100.0, "height": 20.0}],
+                            "height": 20.0
+                        }],
+                        "columnWidths": [100.0],
+                        "totalWidth": 100.0,
+                        "totalHeight": 20.0
+                    }
+                },
+                paragraph("p1", "omega", 42.0)
+            ],
+            "options": {
+                "pageSize": {"w": 200.0, "h": 120.0},
+                "margins": {"top": 10.0, "right": 10.0, "bottom": 10.0, "left": 10.0}
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn resident_walk_marks_only_structurally_changed_blocks_dirty() {
+        let engine = EngineSession::new(21);
+        engine
+            .layout_document_json(&resident_walk_fixture())
+            .unwrap();
+        let baseline: Vec<LayoutBlock> = {
+            let pagination = engine.pagination.borrow();
+            pagination
+                .input
+                .as_ref()
+                .unwrap()
+                .measured
+                .iter()
+                .map(|measured| measured.block.clone())
+                .collect()
+        };
+        let walk = |blocks: &[LayoutBlock]| {
+            let mut dirty: Vec<(usize, String)> = Vec::new();
+            engine
+                .resident_layout_input_from_blocks(blocks, &mut |index, key, _, _| {
+                    dirty.push((index, key.to_owned()));
+                    Ok(BlockExtent::Paragraph(ParagraphExtent {
+                        lines: Vec::new(),
+                        total_height: 20.0,
+                    }))
+                })
+                .map(|_| dirty)
+        };
+
+        assert_eq!(
+            walk(&baseline).unwrap(),
+            Vec::<(usize, String)>::new(),
+            "a no-op relower marks nothing dirty"
+        );
+
+        let edited_first = {
+            let mut blocks = baseline.clone();
+            let LayoutBlock::Paragraph(paragraph) = &mut blocks[0] else {
+                panic!("paragraph expected");
+            };
+            if let Run::Text(text) = &mut paragraph.runs[0] {
+                text.text.push('!');
+            }
+            blocks
+        };
+        assert_eq!(
+            walk(&edited_first).unwrap(),
+            vec![(0, "p0".to_owned())],
+            "an inserted character dirties exactly its own block"
+        );
+
+        let repositioned_tail = {
+            let mut blocks = baseline.clone();
+            let LayoutBlock::Paragraph(paragraph) = &mut blocks[2] else {
+                panic!("paragraph expected");
+            };
+            paragraph.pm_start = Some(60.0);
+            paragraph.pm_end = Some(64.0);
+            if let Run::Text(text) = &mut paragraph.runs[0] {
+                text.pm_start = Some(61.0);
+                text.pm_end = Some(63.0);
+            }
+            blocks
+        };
+        assert_eq!(
+            walk(&repositioned_tail).unwrap(),
+            Vec::<(usize, String)>::new(),
+            "fresh absolute positions alone never dirty a block"
+        );
+
+        let retitled_cell = {
+            let mut blocks = baseline.clone();
+            let LayoutBlock::Table(table) = &mut blocks[1] else {
+                panic!("table expected");
+            };
+            let LayoutBlock::Paragraph(cell_paragraph) = &mut table.rows[0].cells[0].blocks[0]
+            else {
+                panic!("cell paragraph expected");
+            };
+            if let Run::Text(text) = &mut cell_paragraph.runs[0] {
+                text.text.push('!');
+            }
+            blocks
+        };
+        let error = walk(&retitled_cell).unwrap_err();
+        assert!(error.contains("non-paragraph"), "{error}");
+
+        let repositioned_cell = {
+            let mut blocks = baseline.clone();
+            let LayoutBlock::Table(table) = &mut blocks[1] else {
+                panic!("table expected");
+            };
+            let LayoutBlock::Paragraph(cell_paragraph) = &mut table.rows[0].cells[0].blocks[0]
+            else {
+                panic!("cell paragraph expected");
+            };
+            cell_paragraph.pm_start = Some(30.0);
+            cell_paragraph.pm_end = Some(34.0);
+            if let Run::Text(text) = &mut cell_paragraph.runs[0] {
+                text.pm_start = Some(31.0);
+                text.pm_end = Some(35.0);
+            }
+            blocks
+        };
+        assert_eq!(
+            walk(&repositioned_cell).unwrap(),
+            Vec::<(usize, String)>::new(),
+            "absolute positions inside a table cell are ignored too"
+        );
     }
 
     #[test]

--- a/crates/docx-layout/src/types.rs
+++ b/crates/docx-layout/src/types.rs
@@ -1093,6 +1093,22 @@ pub enum LayoutBlock {
     Unsupported,
 }
 
+// ---------------------------------------------------------------------------
+// structural equality
+// ---------------------------------------------------------------------------
+//
+// Equality across the block tree masks `pm_start`, `pm_end`, `doc_start` and
+// `doc_end`: those absolute document positions shift on every edit without
+// changing how a block measures, and the resident layout walk reuses a retained
+// measurement for every block that compares equal. So that a new field cannot
+// silently escape that decision, each variant and each field is spelled out —
+// adding either stops compiling until it is classified.
+//
+// Numbers compare as numbers, so `-0.0` equals `0.0` where the serialized
+// fingerprint this replaced saw a change. Both measure identically, so the
+// retained measurement stays right, but a serialized zero can keep its old sign
+// until something else dirties its block.
+
 impl PartialEq for LayoutBlock {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -1106,7 +1122,16 @@ impl PartialEq for LayoutBlock {
             (Self::PageBreak(a), Self::PageBreak(b)) => a == b,
             (Self::ColumnBreak(a), Self::ColumnBreak(b)) => a == b,
             (Self::Unsupported, Self::Unsupported) => true,
-            _ => false,
+            (Self::Paragraph(_), _)
+            | (Self::Table(_), _)
+            | (Self::Image(_), _)
+            | (Self::Shape(_), _)
+            | (Self::Chart(_), _)
+            | (Self::TextBox(_), _)
+            | (Self::SectionBreak(_), _)
+            | (Self::PageBreak(_), _)
+            | (Self::ColumnBreak(_), _)
+            | (Self::Unsupported, _) => false,
         }
     }
 }
@@ -1120,7 +1145,12 @@ impl PartialEq for Run {
             (Self::LineBreak(a), Self::LineBreak(b)) => a == b,
             (Self::Field(a), Self::Field(b)) => a == b,
             (Self::Unsupported, Self::Unsupported) => true,
-            _ => false,
+            (Self::Text(_), _)
+            | (Self::Tab(_), _)
+            | (Self::Image(_), _)
+            | (Self::LineBreak(_), _)
+            | (Self::Field(_), _)
+            | (Self::Unsupported, _) => false,
         }
     }
 }
@@ -1237,7 +1267,11 @@ impl PartialEq for ImageRun {
 }
 
 impl PartialEq for LineBreakRun {
-    fn eq(&self, _: &Self) -> bool {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            pm_start: _,
+            pm_end: _,
+        } = other;
         true
     }
 }

--- a/crates/docx-layout/src/types.rs
+++ b/crates/docx-layout/src/types.rs
@@ -97,7 +97,7 @@ pub enum SectionBreakType {
 // runs
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum UnderlineSpec {
     Flag(bool),
@@ -109,7 +109,7 @@ pub enum UnderlineSpec {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct HyperlinkInfo {
     pub href: String,
@@ -125,7 +125,7 @@ pub struct HyperlinkInfo {
     pub doc_location: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RunFontSlots {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -148,7 +148,7 @@ pub struct RunFontSlots {
     pub hint: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RunLanguageSlots {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -159,7 +159,7 @@ pub struct RunLanguageSlots {
     pub bidi: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RunFormatting {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -277,7 +277,7 @@ pub struct TabRun {
     pub leader_glyphs: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AxisPosition {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -288,7 +288,7 @@ pub struct AxisPosition {
     pub relative_to: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageRunPosition {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -462,7 +462,7 @@ impl Run {
 // paragraph attributes
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParagraphSpacing {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -477,7 +477,7 @@ pub struct ParagraphSpacing {
     pub line_rule: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct SpacingExplicit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub before: Option<bool>,
@@ -485,7 +485,7 @@ pub struct SpacingExplicit {
     pub after: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParagraphIndent {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -498,7 +498,7 @@ pub struct ParagraphIndent {
     pub hanging: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TabStop {
     pub val: String,
     pub pos: f64,
@@ -506,7 +506,7 @@ pub struct TabStop {
     pub leader: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BorderStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
@@ -518,7 +518,7 @@ pub struct BorderStyle {
     pub space: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ParagraphBorders {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top: Option<BorderStyle>,
@@ -534,7 +534,7 @@ pub struct ParagraphBorders {
     pub bar: Option<BorderStyle>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ListNumPr {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -543,7 +543,7 @@ pub struct ListNumPr {
     pub ilvl: Option<f64>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParagraphAttrs {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -605,7 +605,7 @@ pub struct ParagraphAttrs {
     pub p_pr_del: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SdtGroup {
     pub id: String,
@@ -653,7 +653,7 @@ pub struct ParagraphBlock {
     pub pm_end: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CellBorderSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<f64>,
@@ -663,7 +663,7 @@ pub struct CellBorderSpec {
     pub style: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CellBorders {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top: Option<CellBorderSpec>,
@@ -675,7 +675,7 @@ pub struct CellBorders {
     pub left: Option<CellBorderSpec>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BoxEdges {
     pub top: f64,
     pub right: f64,
@@ -684,7 +684,7 @@ pub struct BoxEdges {
 }
 
 /// Typed `tblW`/`tcW`/row-before/after preferred width.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PreferredWidth {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
@@ -692,7 +692,7 @@ pub struct PreferredWidth {
     pub r#type: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TableCell {
     pub id: BlockId,
@@ -729,7 +729,7 @@ pub struct TableCell {
     pub tracked_marker: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TableRow {
     pub id: BlockId,
@@ -756,7 +756,7 @@ pub struct TableRow {
     pub tracked_del: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FloatingTablePosition {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -820,7 +820,7 @@ pub struct TableBlock {
     pub pm_end: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageAnchor {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -977,7 +977,7 @@ pub struct ChartBlock {
     pub pm_end: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionBreakBlock {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1093,11 +1093,451 @@ pub enum LayoutBlock {
     Unsupported,
 }
 
+impl PartialEq for LayoutBlock {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Paragraph(a), Self::Paragraph(b)) => a == b,
+            (Self::Table(a), Self::Table(b)) => a == b,
+            (Self::Image(a), Self::Image(b)) => a == b,
+            (Self::Shape(a), Self::Shape(b)) => a == b,
+            (Self::Chart(a), Self::Chart(b)) => a == b,
+            (Self::TextBox(a), Self::TextBox(b)) => a == b,
+            (Self::SectionBreak(a), Self::SectionBreak(b)) => a == b,
+            (Self::PageBreak(a), Self::PageBreak(b)) => a == b,
+            (Self::ColumnBreak(a), Self::ColumnBreak(b)) => a == b,
+            (Self::Unsupported, Self::Unsupported) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq for Run {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Text(a), Self::Text(b)) => a == b,
+            (Self::Tab(a), Self::Tab(b)) => a == b,
+            (Self::Image(a), Self::Image(b)) => a == b,
+            (Self::LineBreak(a), Self::LineBreak(b)) => a == b,
+            (Self::Field(a), Self::Field(b)) => a == b,
+            (Self::Unsupported, Self::Unsupported) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq for TextRun {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            fmt: _,
+            text: _,
+            inline_sdt_widget: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.fmt == other.fmt
+            && self.text == other.text
+            && self.inline_sdt_widget == other.inline_sdt_widget
+    }
+}
+
+impl PartialEq for TabRun {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            fmt: _,
+            width: _,
+            leader_glyphs: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.fmt == other.fmt
+            && self.width == other.width
+            && self.leader_glyphs == other.leader_glyphs
+    }
+}
+
+impl PartialEq for ImageRun {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            src: _,
+            width: _,
+            height: _,
+            alt: _,
+            transform: _,
+            position: _,
+            wrap_type: _,
+            display_mode: _,
+            css_float: _,
+            dist_top: _,
+            dist_bottom: _,
+            dist_left: _,
+            dist_right: _,
+            crop_top: _,
+            crop_right: _,
+            crop_bottom: _,
+            crop_left: _,
+            opacity: _,
+            rotation_deg: _,
+            flip_h: _,
+            flip_v: _,
+            rotation_bounds: _,
+            wrap_text: _,
+            wrap_polygon: _,
+            allow_overlap: _,
+            layout_in_cell: _,
+            effect_extent: _,
+            effects: _,
+            outline: _,
+            decorative: _,
+            hyperlink: _,
+            is_insertion: _,
+            is_deletion: _,
+            change_author: _,
+            change_date: _,
+            change_revision_id: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.src == other.src
+            && self.width == other.width
+            && self.height == other.height
+            && self.alt == other.alt
+            && self.transform == other.transform
+            && self.position == other.position
+            && self.wrap_type == other.wrap_type
+            && self.display_mode == other.display_mode
+            && self.css_float == other.css_float
+            && self.dist_top == other.dist_top
+            && self.dist_bottom == other.dist_bottom
+            && self.dist_left == other.dist_left
+            && self.dist_right == other.dist_right
+            && self.crop_top == other.crop_top
+            && self.crop_right == other.crop_right
+            && self.crop_bottom == other.crop_bottom
+            && self.crop_left == other.crop_left
+            && self.opacity == other.opacity
+            && self.rotation_deg == other.rotation_deg
+            && self.flip_h == other.flip_h
+            && self.flip_v == other.flip_v
+            && self.rotation_bounds == other.rotation_bounds
+            && self.wrap_text == other.wrap_text
+            && self.wrap_polygon == other.wrap_polygon
+            && self.allow_overlap == other.allow_overlap
+            && self.layout_in_cell == other.layout_in_cell
+            && self.effect_extent == other.effect_extent
+            && self.effects == other.effects
+            && self.outline == other.outline
+            && self.decorative == other.decorative
+            && self.hyperlink == other.hyperlink
+            && self.is_insertion == other.is_insertion
+            && self.is_deletion == other.is_deletion
+            && self.change_author == other.change_author
+            && self.change_date == other.change_date
+            && self.change_revision_id == other.change_revision_id
+    }
+}
+
+impl PartialEq for LineBreakRun {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl PartialEq for FieldRun {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            fmt: _,
+            field_type: _,
+            raw_type: _,
+            instruction: _,
+            fallback: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.fmt == other.fmt
+            && self.field_type == other.field_type
+            && self.raw_type == other.raw_type
+            && self.instruction == other.instruction
+            && self.fallback == other.fallback
+    }
+}
+
+impl PartialEq for ParagraphBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            para_id: _,
+            runs: _,
+            attrs: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups
+            && self.id == other.id
+            && self.para_id == other.para_id
+            && self.runs == other.runs
+            && self.attrs == other.attrs
+    }
+}
+
+impl PartialEq for TableBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            rows: _,
+            column_widths: _,
+            grid_widths: _,
+            width: _,
+            width_type: _,
+            preferred_width: _,
+            layout_mode: _,
+            width_algorithm: _,
+            style_cascade: _,
+            background: _,
+            justification: _,
+            bidi: _,
+            indent: _,
+            floating: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups
+            && self.id == other.id
+            && self.rows == other.rows
+            && self.column_widths == other.column_widths
+            && self.grid_widths == other.grid_widths
+            && self.width == other.width
+            && self.width_type == other.width_type
+            && self.preferred_width == other.preferred_width
+            && self.layout_mode == other.layout_mode
+            && self.width_algorithm == other.width_algorithm
+            && self.style_cascade == other.style_cascade
+            && self.background == other.background
+            && self.justification == other.justification
+            && self.bidi == other.bidi
+            && self.indent == other.indent
+            && self.floating == other.floating
+    }
+}
+
+impl PartialEq for ImageBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            src: _,
+            width: _,
+            height: _,
+            alt: _,
+            transform: _,
+            opacity: _,
+            rotation_deg: _,
+            flip_h: _,
+            flip_v: _,
+            rotation_bounds: _,
+            anchor: _,
+            hlink_href: _,
+            hlink_title: _,
+            decorative: _,
+            crop: _,
+            effects: _,
+            outline: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups
+            && self.id == other.id
+            && self.src == other.src
+            && self.width == other.width
+            && self.height == other.height
+            && self.alt == other.alt
+            && self.transform == other.transform
+            && self.opacity == other.opacity
+            && self.rotation_deg == other.rotation_deg
+            && self.flip_h == other.flip_h
+            && self.flip_v == other.flip_v
+            && self.rotation_bounds == other.rotation_bounds
+            && self.anchor == other.anchor
+            && self.hlink_href == other.hlink_href
+            && self.hlink_title == other.hlink_title
+            && self.decorative == other.decorative
+            && self.crop == other.crop
+            && self.effects == other.effects
+            && self.outline == other.outline
+    }
+}
+
+impl PartialEq for ShapeBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            shape_type: _,
+            geometry_path: _,
+            fill: _,
+            stroke: _,
+            transform: _,
+            width: _,
+            height: _,
+            x: _,
+            y: _,
+            inner_text: _,
+            inner_measures: _,
+            children: _,
+            scene: _,
+            effects: _,
+            text_body_properties: _,
+            position: _,
+            wrap_type: _,
+            wrap_text: _,
+            relative_height: _,
+            behind_doc: _,
+            decorative: _,
+            title: _,
+            description: _,
+            doc_start: _,
+            doc_end: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups
+            && self.id == other.id
+            && self.shape_type == other.shape_type
+            && self.geometry_path == other.geometry_path
+            && self.fill == other.fill
+            && self.stroke == other.stroke
+            && self.transform == other.transform
+            && self.width == other.width
+            && self.height == other.height
+            && self.x == other.x
+            && self.y == other.y
+            && self.inner_text == other.inner_text
+            && self.inner_measures == other.inner_measures
+            && self.children == other.children
+            && self.scene == other.scene
+            && self.effects == other.effects
+            && self.text_body_properties == other.text_body_properties
+            && self.position == other.position
+            && self.wrap_type == other.wrap_type
+            && self.wrap_text == other.wrap_text
+            && self.relative_height == other.relative_height
+            && self.behind_doc == other.behind_doc
+            && self.decorative == other.decorative
+            && self.title == other.title
+            && self.description == other.description
+    }
+}
+
+impl PartialEq for ChartBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            chart: _,
+            width: _,
+            height: _,
+            position: _,
+            wrap_type: _,
+            wrap_text: _,
+            relative_height: _,
+            behind_doc: _,
+            doc_start: _,
+            doc_end: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups
+            && self.id == other.id
+            && self.chart == other.chart
+            && self.width == other.width
+            && self.height == other.height
+            && self.position == other.position
+            && self.wrap_type == other.wrap_type
+            && self.wrap_text == other.wrap_text
+            && self.relative_height == other.relative_height
+            && self.behind_doc == other.behind_doc
+    }
+}
+
+impl PartialEq for PageBreakBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups && self.id == other.id
+    }
+}
+
+impl PartialEq for ColumnBreakBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups && self.id == other.id
+    }
+}
+
+impl PartialEq for TextBoxBlock {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            sdt_groups: _,
+            id: _,
+            width: _,
+            height: _,
+            fill_color: _,
+            outline_width: _,
+            outline_color: _,
+            outline_style: _,
+            margins: _,
+            content: _,
+            display_mode: _,
+            css_float: _,
+            wrap_type: _,
+            wrap_text: _,
+            anchor_target: _,
+            position: _,
+            dist_top: _,
+            dist_bottom: _,
+            dist_left: _,
+            dist_right: _,
+            pm_start: _,
+            pm_end: _,
+        } = other;
+        self.sdt_groups == other.sdt_groups
+            && self.id == other.id
+            && self.width == other.width
+            && self.height == other.height
+            && self.fill_color == other.fill_color
+            && self.outline_width == other.outline_width
+            && self.outline_color == other.outline_color
+            && self.outline_style == other.outline_style
+            && self.margins == other.margins
+            && self.content == other.content
+            && self.display_mode == other.display_mode
+            && self.css_float == other.css_float
+            && self.wrap_type == other.wrap_type
+            && self.wrap_text == other.wrap_text
+            && self.anchor_target == other.anchor_target
+            && self.position == other.position
+            && self.dist_top == other.dist_top
+            && self.dist_bottom == other.dist_bottom
+            && self.dist_left == other.dist_left
+            && self.dist_right == other.dist_right
+    }
+}
+
 // ---------------------------------------------------------------------------
 // extents (measurement results)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRowSegment {
     pub head_run: usize,
@@ -1109,7 +1549,7 @@ pub struct TypesetRowSegment {
     pub width: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRunAdvance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1124,7 +1564,7 @@ pub struct TypesetRunAdvance {
     pub logical_order: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetClusterAdvance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1143,7 +1583,7 @@ pub struct TypesetClusterAdvance {
     pub logical_order: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetBidiSlice {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1166,7 +1606,7 @@ pub struct TypesetBidiSlice {
 /// range, `float_skip_before` is vertical room the line had to skip past a
 /// float, and `left_offset` / `right_offset` are the exclusions measurement
 /// already applied.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TypesetRow {
     pub head_run: usize,
@@ -1195,7 +1635,7 @@ pub struct TypesetRow {
     pub bidi_slices: Option<Vec<TypesetBidiSlice>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParagraphExtent {
     pub lines: Vec<TypesetRow>,


### PR DESCRIPTION
TL;DR:

Summary:
- replace per-block serde fingerprinting with typed structural equality that masks the same absolute-position fields the old strip pass removed
- borrow the lowered story and measured blocks during the incremental walk instead of deep-cloning them each keystroke
- return Cow<str> from block_key to drop thousands of short-lived string allocations per edit
- changed-block predicate drops from ~2.35ms to ~49µs per edit at 1000 blocks
- claim the lowered story behind an Rc and fire the profiler's observer after it, so a host callback that re-enters the engine neither collides with the borrow the walk holds nor changes what it reads
- spell out every equality variant and field, so adding either stops compiling until it is classified

Test plan:
- [x] `cargo test -p betteroffice-docx-edit -p betteroffice-docx-layout` green
- [ ] keystroke latency spot-check on a large document (web + native)
- [ ] undo/redo and collab sessions unaffected after rapid typing
