### PR TITLE
perf(xlsx): single-pass sheetData writer

### DIFF
--- a/.changeset/xlsx-single-pass-write.md
+++ b/.changeset/xlsx-single-pass-write.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Write sheetData in one pass instead of rescanning cells per row.

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -5161,3 +5161,63 @@ fn a_save_keeps_its_own_cache_bound_rather_than_the_projections() {
     refs[2].formula = format!("Data!$B$2:$B${}", each + 1);
     patch_refs(CHART, &refs).expect("the save bound is charged per reference, not across the part");
 }
+
+/// Sparse cell runs, height-only rows and the stream boundaries must serialize
+/// as one ascending `sheetData` pass with byte-stable output.
+#[test]
+fn writes_sparse_and_height_only_rows_in_one_ascending_pass() {
+    let mut wb = Workbook::default();
+    let mut sheet = xlsx_model::Sheet::new("Sheet1");
+    for (a1, v) in [("A1", 7.5), ("B5", 1.0), ("C100", 42.0)] {
+        sheet.set_cell(
+            CellRef::parse_a1(a1).unwrap(),
+            Cell {
+                value: CellValue::Number { value: v },
+                ..Cell::default()
+            },
+        );
+    }
+    sheet.row_heights.insert(0, 20.0);
+    sheet.row_heights.insert(2, 15.0);
+    sheet.row_heights.insert(119, 0.0);
+    wb.sheets.push(sheet);
+
+    let parts = serialize_workbook(&wb).unwrap();
+    let written = String::from_utf8(part_bytes(&parts, "xl/worksheets/sheet1.xml")).unwrap();
+
+    let expected = concat!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>"#,
+        r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">"#,
+        r#"<sheetData>"#,
+        r#"<row r="1" ht="20" customHeight="1"><c r="A1"><v>7.5</v></c></row>"#,
+        r#"<row r="3" ht="15" customHeight="1"></row>"#,
+        r#"<row r="5"><c r="B5"><v>1</v></c></row>"#,
+        r#"<row r="100"><c r="C100"><v>42</v></c></row>"#,
+        r#"<row r="120" ht="0" customHeight="1" hidden="1"></row>"#,
+        r#"</sheetData></worksheet>"#,
+    );
+    assert_eq!(written, expected);
+
+    let reparsed = parse_workbook(&parts).unwrap();
+    assert_eq!(
+        reparsed.sheets[0]
+            .cell(CellRef::parse_a1("A1").unwrap())
+            .map(|c| c.value.clone()),
+        Some(CellValue::Number { value: 7.5 })
+    );
+    assert_eq!(
+        reparsed.sheets[0]
+            .cell(CellRef::parse_a1("B5").unwrap())
+            .map(|c| c.value.clone()),
+        Some(CellValue::Number { value: 1.0 })
+    );
+    assert_eq!(
+        reparsed.sheets[0]
+            .cell(CellRef::parse_a1("C100").unwrap())
+            .map(|c| c.value.clone()),
+        Some(CellValue::Number { value: 42.0 })
+    );
+    assert_eq!(reparsed.sheets[0].row_heights.get(&0), Some(&20.0));
+    assert_eq!(reparsed.sheets[0].row_heights.get(&2), Some(&15.0));
+    assert_eq!(reparsed.sheets[0].row_heights.get(&119), Some(&0.0));
+}

--- a/crates/xlsx-parse/src/write.rs
+++ b/crates/xlsx-parse/src/write.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque, btree_map};
 use std::io;
+use std::iter::Peekable;
 
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::{Reader, Writer};
@@ -2593,24 +2594,33 @@ fn write_sheet_data(
         }
     }
 
-    let mut rows: Vec<RowId> = sheet.iter_cells().map(|(r, _)| r.row).collect();
-    rows.extend(sheet.row_heights.keys().copied());
-    rows.sort_unstable();
-    rows.dedup();
+    let mut cells = sheet.iter_cells().peekable();
+    let mut heights = sheet.row_heights.keys().copied().peekable();
 
     writer
         .create_element("sheetData")
         .write_inner_content(|writer| {
-            for &row in &rows {
+            loop {
+                let cell_row = cells.peek().map(|(addr, _)| addr.row);
+                let height_row = heights.peek().copied();
+                let row = match (cell_row, height_row) {
+                    (Some(a), Some(b)) => a.min(b),
+                    (Some(a), None) | (None, Some(a)) => a,
+                    (None, None) => break,
+                };
                 write_row(
                     writer,
                     sheet,
                     row,
+                    &mut cells,
                     wb,
                     &sst_index,
                     retained,
                     shared_string_plan,
                 )?;
+                if height_row == Some(row) {
+                    heights.next();
+                }
             }
             Ok(())
         })?;
@@ -2717,15 +2727,20 @@ fn write_cols(w: &mut Writer<Vec<u8>>, sheet: &Sheet) -> io::Result<()> {
     Ok(())
 }
 
-fn write_row(
+#[allow(clippy::too_many_arguments)]
+fn write_row<'a, I>(
     w: &mut Writer<Vec<u8>>,
     sheet: &Sheet,
     row: RowId,
+    cells: &mut Peekable<I>,
     wb: &Workbook,
     sst_index: &HashMap<&str, usize>,
     retained: &SharedStringCells,
     shared_string_plan: Option<&SharedStringPlan>,
-) -> io::Result<()> {
+) -> io::Result<()>
+where
+    I: Iterator<Item = (CellRef, &'a Cell)>,
+{
     let r = (row as u64 + 1).to_string();
     let mut start = BytesStart::new("row");
     start.push_attribute(("r", r.as_str()));
@@ -2738,7 +2753,7 @@ fn write_row(
         }
     }
     w.write_event(Event::Start(start))?;
-    for (addr, cell) in sheet.iter_cells().filter(|(a, _)| a.row == row) {
+    while let Some((addr, cell)) = cells.next_if(|(addr, _)| addr.row == row) {
         let source = retained.get(&(addr.row, addr.col)).copied();
         let retained = match (&cell.value, shared_string_plan) {
             (CellValue::Text { value }, Some(plan)) => {


### PR DESCRIPTION
TL;DR:

Summary:
- write sheetData in one ordered pass over the cell map instead of rescanning every cell per row
- merges height-only rows into the same ascending stream, dropping the collect/sort/dedup step entirely
- output verified byte-identical against the previous writer, O(cells + rows) instead of O(rows x cells)

Test plan:
- [x] `cargo test -p betteroffice-xlsx-parse` green
- [x] save fidelity spot-check on a large real-world workbook (untouched sheets stay byte-identical)
- [x] save timing on a 100k+ row sheet before/after