### PR TITLE
perf(docx): typed paragraph measurement path

### DIFF
--- a/.changeset/docx-typed-measure.md
+++ b/.changeset/docx-typed-measure.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Measure paragraphs through a typed path instead of serializing to JSON per call.

--- a/crates/docx-layout/src/lib.rs
+++ b/crates/docx-layout/src/lib.rs
@@ -83,6 +83,8 @@ pub mod session;
 pub mod table_grid;
 pub mod table_row_break;
 
+mod typed_measure;
+
 use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
@@ -554,6 +556,14 @@ pub fn measure_paragraph_json(input: &str) -> Result<String, JsValue> {
 /// remeasures a dirty paragraph inside a larger operation.
 pub fn measure_paragraph_json_resident(input: &str) -> Result<String, String> {
     MEASURE_FONTS.with(|store| ooxml_text::measure_paragraph_json(&store.borrow(), input))
+}
+
+/// Typed form of [`measure_paragraph_json_resident`] against the same font
+/// store, skipping both JSON round trips.
+pub(crate) fn measure_paragraph_typed_resident(
+    request: &ooxml_text::MeasureRequest<'_>,
+) -> Result<ooxml_text::ParagraphExtentOut, ooxml_text::MeasureError> {
+    MEASURE_FONTS.with(|store| ooxml_text::measure_paragraph_typed(&store.borrow(), request))
 }
 
 /// wasm wrapper over [`ooxml_text::FontStore::outline_glyph_json`]: the outline

--- a/crates/docx-layout/src/measure_blocks.rs
+++ b/crates/docx-layout/src/measure_blocks.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::table_grid::{resolve_cell_grid, resolve_table_column_widths, resolve_table_width_px};
 use crate::types::{
@@ -15,15 +15,13 @@ const DEFAULT_CELL_PADDING_X: f64 = 7.0;
 const DEFAULT_CELL_PADDING_Y: f64 = 0.0;
 const ANCHOR_PROXIMITY: usize = 4;
 
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FloatingZone {
-    left_margin: f64,
-    right_margin: f64,
-    top_y: f64,
-    bottom_y: f64,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    full_width_block: bool,
+#[derive(Clone, Debug)]
+pub(crate) struct FloatingZone {
+    pub(crate) left_margin: f64,
+    pub(crate) right_margin: f64,
+    pub(crate) top_y: f64,
+    pub(crate) bottom_y: f64,
+    pub(crate) full_width_block: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -463,34 +461,16 @@ fn measure_paragraph_with_context(
     if !content_width.is_finite() || content_width <= 0.0 {
         return Ok(synthetic_paragraph_extent(paragraph, content_width));
     }
-    let mut envelope = json!({
-        "block": LayoutBlock::Paragraph(paragraph.clone()),
-        "maxWidth": content_width,
-        "fontChains": config.font_chains,
-        "authoritativeShaping": config.authoritative_shaping,
-    });
-    let fields = envelope
-        .as_object_mut()
-        .expect("measurement envelope object");
-    if !config.defaults.is_null() {
-        fields.insert("defaults".to_owned(), config.defaults.clone());
+    match crate::typed_measure::measure_paragraph(
+        paragraph,
+        content_width,
+        config,
+        floating_zones,
+        cumulative_y,
+    ) {
+        Some(extent) => Ok(extent),
+        None => Ok(synthetic_paragraph_extent(paragraph, content_width)),
     }
-    if !config.compat.is_null() {
-        fields.insert("compat".to_owned(), config.compat.clone());
-    }
-    if let Some(zones) = floating_zones {
-        fields.insert(
-            "floatingZones".to_owned(),
-            serde_json::to_value(zones).expect("floating zones serialize"),
-        );
-        fields.insert("paragraphYOffset".to_owned(), json!(cumulative_y));
-    }
-    let Ok(extent) = crate::measure_paragraph_json_resident(&envelope.to_string()) else {
-        return Ok(synthetic_paragraph_extent(paragraph, content_width));
-    };
-    serde_json::from_str(&extent)
-        .map_err(|error| format!("parse paragraph extent: {error}"))
-        .or_else(|_| Ok(synthetic_paragraph_extent(paragraph, content_width)))
 }
 
 const SYNTHETIC_ADVANCE_EM: f64 = 1.0;
@@ -1264,6 +1244,7 @@ fn cell_border_height(cell: &crate::types::TableCell) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn measures_non_text_blocks_without_host_callbacks() {

--- a/crates/docx-layout/src/typed_measure.rs
+++ b/crates/docx-layout/src/typed_measure.rs
@@ -10,6 +10,7 @@ use ooxml_text::measure::{
     AttrsIn, BlockIn, CompatIn, DefaultsIn, FloatZoneIn, FontChains, IndentIn, MeasureRequest,
     RotationBoundsIn, RunFontSlotsIn, RunIn, RunLanguageSlotsIn, SpacingIn, TabStopIn,
 };
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::measure_blocks::{FloatingZone, MeasurementConfig};
@@ -30,7 +31,15 @@ pub(crate) fn measure_paragraph(
     let block = block_in(paragraph)?;
     let defaults = defaults_in(&config.defaults)?;
     let compat = compat_in(&config.compat)?;
-    let zones = floating_zones.map(|zones| zones.iter().map(zone_in).collect::<Vec<FloatZoneIn>>());
+    let zones = match floating_zones {
+        None => None,
+        Some(zones) => Some(
+            zones
+                .iter()
+                .map(zone_in)
+                .collect::<Option<Vec<FloatZoneIn>>>()?,
+        ),
+    };
     let request = MeasureRequest {
         block: &block,
         max_width: content_width as f32,
@@ -38,7 +47,10 @@ pub(crate) fn measure_paragraph(
         defaults: &defaults,
         compat,
         floating_zones: zones.as_deref(),
-        paragraph_y_offset: floating_zones.is_some().then(|| cumulative_y as f32),
+        paragraph_y_offset: floating_zones
+            .is_some()
+            .then_some(cumulative_y)
+            .and_then(finite),
         authoritative_shaping: config.authoritative_shaping,
     };
     let extent = crate::measure_paragraph_typed_resident(&request).ok()?;
@@ -53,96 +65,79 @@ fn block_in(paragraph: &ParagraphBlock) -> Option<BlockIn> {
             .iter()
             .map(run_in)
             .collect::<Option<Vec<_>>>()?,
-        attrs: paragraph.attrs.as_ref().map(attrs_in),
+        attrs: match paragraph.attrs.as_ref() {
+            None => None,
+            Some(attrs) => Some(attrs_in(attrs)?),
+        },
     })
+}
+
+/// A non-finite float serialized as `null`, which the JSON boundary read back
+/// as absent; the typed path drops it the same way.
+fn finite(value: f64) -> Option<f32> {
+    value.is_finite().then_some(value as f32)
 }
 
 fn defaults_in(defaults: &Value) -> Option<DefaultsIn> {
-    let fields = defaults.as_object()?;
-    Some(DefaultsIn {
-        font_size: fields.get("fontSize")?.as_f64()? as f32,
-        font_family: fields.get("fontFamily")?.as_str()?.to_owned(),
-    })
+    DefaultsIn::deserialize(defaults).ok()
 }
 
 fn compat_in(compat: &Value) -> Option<CompatIn> {
-    match compat {
-        Value::Null => Some(CompatIn::default()),
-        Value::Object(fields) => {
-            let mut parsed = CompatIn::default();
-            parsed.no_leading = bool_flag(fields.get("noLeading"))?;
-            parsed.do_not_expand_shift_return = bool_flag(fields.get("doNotExpandShiftReturn"))?;
-            Some(parsed)
-        }
-        _ => None,
+    if compat.is_null() {
+        return Some(CompatIn::default());
     }
+    CompatIn::deserialize(compat).ok()
 }
 
-fn bool_flag(value: Option<&Value>) -> Option<bool> {
-    match value {
-        None => Some(false),
-        Some(Value::Bool(flag)) => Some(*flag),
-        Some(_) => None,
-    }
-}
-
-fn number_f32(value: Option<&Value>) -> Option<Option<f32>> {
-    match value {
-        None | Some(Value::Null) => Some(None),
-        Some(Value::Number(number)) => Some(Some(number.as_f64()? as f32)),
-        Some(_) => None,
-    }
-}
-
-fn zone_in(zone: &FloatingZone) -> FloatZoneIn {
-    FloatZoneIn {
-        left_margin: zone.left_margin as f32,
-        right_margin: zone.right_margin as f32,
-        top_y: zone.top_y as f32,
-        bottom_y: zone.bottom_y as f32,
+fn zone_in(zone: &FloatingZone) -> Option<FloatZoneIn> {
+    Some(FloatZoneIn {
+        left_margin: finite(zone.left_margin)?,
+        right_margin: finite(zone.right_margin)?,
+        top_y: finite(zone.top_y)?,
+        bottom_y: finite(zone.bottom_y)?,
         segments: None,
         full_width_block: zone.full_width_block,
-    }
+    })
 }
 
-fn attrs_in(attrs: &ParagraphAttrs) -> AttrsIn {
-    AttrsIn {
+fn attrs_in(attrs: &ParagraphAttrs) -> Option<AttrsIn> {
+    Some(AttrsIn {
         alignment: attrs.alignment.clone(),
         spacing: attrs.spacing.as_ref().map(|spacing| SpacingIn {
-            before: spacing.before.map(|px| px as f32),
-            after: spacing.after.map(|px| px as f32),
-            line: spacing.line.map(|px| px as f32),
+            before: spacing.before.and_then(finite),
+            after: spacing.after.and_then(finite),
+            line: spacing.line.and_then(finite),
             line_unit: spacing.line_unit.clone(),
             line_rule: spacing.line_rule.clone(),
         }),
         indent: attrs.indent.as_ref().map(|indent| IndentIn {
-            left: indent.left.map(|px| px as f32),
-            right: indent.right.map(|px| px as f32),
-            first_line: indent.first_line.map(|px| px as f32),
-            hanging: indent.hanging.map(|px| px as f32),
+            left: indent.left.and_then(finite),
+            right: indent.right.and_then(finite),
+            first_line: indent.first_line.and_then(finite),
+            hanging: indent.hanging.and_then(finite),
         }),
-        tabs: attrs
-            .tabs
-            .as_ref()
-            .map(|stops| stops.iter().map(tab_stop_in).collect()),
+        tabs: match attrs.tabs.as_ref() {
+            None => None,
+            Some(stops) => Some(stops.iter().map(tab_stop_in).collect::<Option<Vec<_>>>()?),
+        },
         bidi: attrs.bidi.unwrap_or(false),
-        default_font_size: attrs.default_font_size.map(|pt| pt as f32),
+        default_font_size: attrs.default_font_size.and_then(finite),
         default_font_family: attrs.default_font_family.clone(),
         suppress_empty_paragraph_height: attrs.suppress_empty_paragraph_height.unwrap_or(false),
         list_marker: attrs.list_marker.clone(),
         list_marker_hidden: attrs.list_marker_hidden.unwrap_or(false),
         list_marker_font_family: attrs.list_marker_font_family.clone(),
-        list_marker_font_size: attrs.list_marker_font_size.map(|pt| pt as f32),
+        list_marker_font_size: attrs.list_marker_font_size.and_then(finite),
         list_marker_suffix: attrs.list_marker_suffix.clone(),
-        default_tab_stop_twips: attrs.default_tab_stop_twips.map(|twips| twips as f32),
-    }
+        default_tab_stop_twips: attrs.default_tab_stop_twips.and_then(finite),
+    })
 }
 
-fn tab_stop_in(stop: &TabStop) -> TabStopIn {
-    TabStopIn {
+fn tab_stop_in(stop: &TabStop) -> Option<TabStopIn> {
+    Some(TabStopIn {
         val: stop.val.clone(),
-        pos: stop.pos as f32,
-    }
+        pos: finite(stop.pos)?,
+    })
 }
 
 fn run_in(run: &Run) -> Option<RunIn> {
@@ -170,8 +165,8 @@ fn formatted_run(kind: &str, fmt: &RunFormatting) -> RunIn {
     out.italic = fmt.italic.unwrap_or(false);
     out.bold_cs = fmt.bold_cs;
     out.italic_cs = fmt.italic_cs;
-    out.font_size = fmt.font_size.map(|pt| pt as f32);
-    out.font_size_cs = fmt.font_size_cs.map(|pt| pt as f32);
+    out.font_size = fmt.font_size.and_then(finite);
+    out.font_size_cs = fmt.font_size_cs.and_then(finite);
     out.font_family = fmt.font_family.clone();
     out.font_slots = fmt.font_slots.as_ref().map(|slots| RunFontSlotsIn {
         ascii: slots.ascii.clone(),
@@ -186,11 +181,11 @@ fn formatted_run(kind: &str, fmt: &RunFormatting) -> RunIn {
         east_asia: slots.east_asia.clone(),
         bidi: slots.bidi.clone(),
     });
-    out.letter_spacing = fmt.letter_spacing.map(|spacing| spacing as f32);
+    out.letter_spacing = fmt.letter_spacing.and_then(finite);
     out.all_caps = fmt.all_caps.unwrap_or(false);
     out.small_caps = fmt.small_caps.unwrap_or(false);
-    out.horizontal_scale = fmt.horizontal_scale.map(|scale| scale as f32);
-    out.kerning_min_pt = fmt.kerning_min_pt.map(|kerning| kerning as f32);
+    out.horizontal_scale = fmt.horizontal_scale.and_then(finite);
+    out.kerning_min_pt = fmt.kerning_min_pt.and_then(finite);
     out.superscript = fmt.superscript.unwrap_or(false);
     out.subscript = fmt.subscript.unwrap_or(false);
     out.hidden = fmt.hidden.unwrap_or(false);
@@ -235,39 +230,23 @@ fn bare_run(kind: &str) -> RunIn {
 
 fn image_run(image: &ImageRun) -> Option<RunIn> {
     let mut out = bare_run("image");
-    out.width = Some(image.width as f32);
-    out.height = Some(image.height as f32);
+    out.width = finite(image.width);
+    out.height = finite(image.height);
     out.rotation_bounds = rotation_bounds_in(image.rotation_bounds.as_ref())?;
-    out.dist_top = image.dist_top.map(|distance| distance as f32);
-    out.dist_bottom = image.dist_bottom.map(|distance| distance as f32);
+    out.dist_top = image.dist_top.and_then(finite);
+    out.dist_bottom = image.dist_bottom.and_then(finite);
     out.wrap_type = image.wrap_type.clone();
     out.display_mode = image.display_mode.clone();
     out.position = image.position.as_ref().map(|_| serde::de::IgnoredAny);
     Some(out)
 }
 
-/// Mirrors serde's strictness at the old JSON boundary: absent or `null` is
-/// no bounds; anything else must be an object or a positional sequence of
-/// the two optional dimensions, exactly as serde's derived `Deserialize`
-/// accepts — any deviation fails the whole request (`None`) where envelope
-/// parsing used to.
+/// Defers to the same derived `Deserialize` the envelope parse used, so
+/// object, positional-sequence and rejected forms all behave as before.
 fn rotation_bounds_in(bounds: Option<&Value>) -> Option<Option<RotationBoundsIn>> {
     match bounds {
-        None | Some(Value::Null) => Some(None),
-        Some(Value::Object(fields)) => Some(Some(RotationBoundsIn {
-            width: number_f32(fields.get("width"))?,
-            height: number_f32(fields.get("height"))?,
-        })),
-        Some(Value::Array(items)) => {
-            if items.len() > 2 {
-                return None;
-            }
-            Some(Some(RotationBoundsIn {
-                width: number_f32(items.first())?,
-                height: number_f32(items.get(1))?,
-            }))
-        }
-        Some(_) => None,
+        None => Some(None),
+        Some(value) => Option::<RotationBoundsIn>::deserialize(value).ok(),
     }
 }
 
@@ -778,5 +757,604 @@ mod parity_tests {
         let fixture = fixture();
         let block = paragraph(vec![Run::Unsupported, text_run("after")], None);
         assert_parity("unsupported", &block, 200.0, &fixture.config, None, 0.0);
+    }
+
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+        fn chance(&mut self, n: u64) -> bool {
+            self.below(n) == 0
+        }
+    }
+
+    const FAMILIES: [&str; 4] = ["Liberation Sans", "Arial", "MS Mincho", ""];
+    const TEXTS: [&str; 8] = [
+        "The quick brown fox jumps over the lazy dog",
+        "short",
+        "",
+        " ",
+        "\t\t",
+        "\u{5e9}\u{5dc}\u{5d5}\u{5dd} mixed \u{627}\u{644}\u{639}",
+        "\u{65e5}\u{672c}\u{8a9e}\u{306e}\u{30c6}\u{30ad}\u{30b9}\u{30c8}",
+        "ligature ffi fi fl and combining e\u{301}",
+    ];
+
+    fn num(rng: &mut Rng) -> f64 {
+        match rng.below(7) {
+            0 => 0.0,
+            1 => 1.0,
+            2 => 12.0,
+            3 => 720.0,
+            4 => (rng.below(4000) as f64) / 16.0,
+            5 => -((rng.below(400) as f64) / 8.0),
+            _ => (rng.below(100_000) as f64) / 1000.0,
+        }
+    }
+
+    fn maybe_num(rng: &mut Rng) -> Option<Value> {
+        (!rng.chance(3)).then(|| json!(num(rng)))
+    }
+
+    fn maybe_bool(rng: &mut Rng) -> Option<Value> {
+        (!rng.chance(3)).then(|| json!(rng.chance(2)))
+    }
+
+    fn maybe_str(rng: &mut Rng, pool: &[&str]) -> Option<Value> {
+        (!rng.chance(3)).then(|| json!(pool[rng.below(pool.len() as u64) as usize]))
+    }
+
+    fn put(map: &mut serde_json::Map<String, Value>, key: &str, value: Option<Value>) {
+        if let Some(value) = value {
+            map.insert(key.to_owned(), value);
+        }
+    }
+
+    /// `RunFormatting` is `#[serde(flatten)]`, so its fields sit at run level;
+    /// nesting them under `fmt` would silently drop every one.
+    fn formatting(rng: &mut Rng, target: &mut serde_json::Map<String, Value>) {
+        put(target, "bold", maybe_bool(rng));
+        put(target, "italic", maybe_bool(rng));
+        put(target, "boldCs", maybe_bool(rng));
+        put(target, "italicCs", maybe_bool(rng));
+        put(target, "fontSize", maybe_num(rng));
+        put(target, "fontSizeCs", maybe_num(rng));
+        put(target, "fontFamily", maybe_str(rng, &FAMILIES));
+        put(target, "complexScript", maybe_bool(rng));
+        put(target, "letterSpacing", maybe_num(rng));
+        put(target, "allCaps", maybe_bool(rng));
+        put(target, "smallCaps", maybe_bool(rng));
+        put(target, "horizontalScale", maybe_num(rng));
+        put(target, "kerningMinPt", maybe_num(rng));
+        put(target, "superscript", maybe_bool(rng));
+        put(target, "subscript", maybe_bool(rng));
+        put(target, "hidden", maybe_bool(rng));
+        put(target, "rtl", maybe_bool(rng));
+        if !rng.chance(3) {
+            let mut slots = serde_json::Map::new();
+            put(&mut slots, "ascii", maybe_str(rng, &FAMILIES));
+            put(&mut slots, "hAnsi", maybe_str(rng, &FAMILIES));
+            put(&mut slots, "eastAsia", maybe_str(rng, &FAMILIES));
+            put(&mut slots, "cs", maybe_str(rng, &FAMILIES));
+            put(&mut slots, "hint", maybe_str(rng, &["eastAsia", "default"]));
+            target.insert("fontSlots".to_owned(), Value::Object(slots));
+        }
+        if !rng.chance(4) {
+            let mut lang = serde_json::Map::new();
+            put(&mut lang, "latin", maybe_str(rng, &["en-US"]));
+            put(&mut lang, "eastAsia", maybe_str(rng, &["ja-JP"]));
+            put(&mut lang, "bidi", maybe_str(rng, &["he-IL"]));
+            target.insert("language".to_owned(), Value::Object(lang));
+        }
+    }
+
+    fn random_run(rng: &mut Rng) -> Value {
+        let mut m = serde_json::Map::new();
+        match rng.below(7) {
+            0..=2 => {
+                m.insert("kind".to_owned(), json!("text"));
+                let text = TEXTS[rng.below(TEXTS.len() as u64) as usize];
+                m.insert("text".to_owned(), json!(text));
+                formatting(rng, &mut m);
+            }
+            3 => {
+                m.insert("kind".to_owned(), json!("tab"));
+                formatting(rng, &mut m);
+            }
+            4 => {
+                m.insert("kind".to_owned(), json!("lineBreak"));
+            }
+            5 => {
+                m.insert("kind".to_owned(), json!("field"));
+                m.insert("fieldType".to_owned(), json!("PAGE"));
+                put(&mut m, "fallback", maybe_str(rng, &["42", "", "iv"]));
+                formatting(rng, &mut m);
+            }
+            _ => {
+                m.insert("kind".to_owned(), json!("image"));
+                m.insert("src".to_owned(), json!("a.png"));
+                m.insert("width".to_owned(), json!(num(rng)));
+                m.insert("height".to_owned(), json!(num(rng)));
+                put(&mut m, "distTop", maybe_num(rng));
+                put(&mut m, "distBottom", maybe_num(rng));
+                put(&mut m, "wrapType", maybe_str(rng, &["inline", "square"]));
+                put(&mut m, "displayMode", maybe_str(rng, &["inline", "block"]));
+                if !rng.chance(3) {
+                    m.insert("position".to_owned(), json!({ "behindDoc": false }));
+                }
+                if !rng.chance(3) {
+                    let bounds = match rng.below(5) {
+                        0 => json!({ "width": num(rng), "height": num(rng) }),
+                        1 => json!([num(rng), num(rng)]),
+                        2 => json!([]),
+                        3 => Value::Null,
+                        _ => json!({ "width": num(rng) }),
+                    };
+                    m.insert("rotationBounds".to_owned(), bounds);
+                }
+            }
+        }
+        Value::Object(m)
+    }
+
+    fn random_attrs(rng: &mut Rng) -> Value {
+        let mut m = serde_json::Map::new();
+        put(
+            &mut m,
+            "alignment",
+            maybe_str(rng, &["left", "center", "both"]),
+        );
+        if !rng.chance(3) {
+            let mut sp = serde_json::Map::new();
+            put(&mut sp, "before", maybe_num(rng));
+            put(&mut sp, "after", maybe_num(rng));
+            put(&mut sp, "line", maybe_num(rng));
+            put(&mut sp, "lineUnit", maybe_str(rng, &["px", "multiple"]));
+            put(
+                &mut sp,
+                "lineRule",
+                maybe_str(rng, &["auto", "exact", "atLeast"]),
+            );
+            m.insert("spacing".to_owned(), Value::Object(sp));
+        }
+        if !rng.chance(3) {
+            let mut ind = serde_json::Map::new();
+            put(&mut ind, "left", maybe_num(rng));
+            put(&mut ind, "right", maybe_num(rng));
+            put(&mut ind, "firstLine", maybe_num(rng));
+            put(&mut ind, "hanging", maybe_num(rng));
+            m.insert("indent".to_owned(), Value::Object(ind));
+        }
+        if !rng.chance(3) {
+            let stops: Vec<Value> = (0..rng.below(4))
+                .map(|_| {
+                    let val = ["start", "end", "center", "decimal"][rng.below(4) as usize];
+                    let pos = num(rng);
+                    json!({ "val": val, "pos": pos })
+                })
+                .collect();
+            m.insert("tabs".to_owned(), json!(stops));
+        }
+        put(&mut m, "bidi", maybe_bool(rng));
+        put(&mut m, "defaultFontSize", maybe_num(rng));
+        put(&mut m, "defaultFontFamily", maybe_str(rng, &FAMILIES));
+        put(&mut m, "suppressEmptyParagraphHeight", maybe_bool(rng));
+        put(
+            &mut m,
+            "listMarker",
+            maybe_str(rng, &["1.", "\u{2022}", ""]),
+        );
+        put(&mut m, "listMarkerHidden", maybe_bool(rng));
+        put(&mut m, "listMarkerFontFamily", maybe_str(rng, &FAMILIES));
+        put(&mut m, "listMarkerFontSize", maybe_num(rng));
+        put(
+            &mut m,
+            "listMarkerSuffix",
+            maybe_str(rng, &["tab", "space"]),
+        );
+        put(&mut m, "defaultTabStopTwips", maybe_num(rng));
+        Value::Object(m)
+    }
+
+    fn random_paragraph(rng: &mut Rng) -> Value {
+        let runs: Vec<Value> = (0..1 + rng.below(4)).map(|_| random_run(rng)).collect();
+        let mut m = serde_json::Map::new();
+        m.insert("id".to_owned(), json!(0.0));
+        m.insert("runs".to_owned(), json!(runs));
+        if !rng.chance(4) {
+            m.insert("attrs".to_owned(), random_attrs(rng));
+        }
+        Value::Object(m)
+    }
+
+    /// The `BlockIn` the legacy envelope actually delivered to the engine.
+    fn legacy_block_in(paragraph: &ParagraphBlock) -> Option<ooxml_text::measure::BlockIn> {
+        let envelope = json!({ "block": LayoutBlock::Paragraph(paragraph.clone()) }).to_string();
+        let parsed: Value = serde_json::from_str(&envelope).ok()?;
+        serde_json::from_value(parsed.get("block")?.clone()).ok()
+    }
+
+    /// Re-narrows to f32 so the JSON path's f32 -> shortest-decimal -> f64
+    /// widening cannot mask a real difference.
+    fn narrow(value: &Value) -> Value {
+        match value {
+            Value::Number(n) => json!(format!("{:?}", n.as_f64().unwrap_or(f64::NAN) as f32)),
+            Value::Array(items) => Value::Array(items.iter().map(narrow).collect()),
+            Value::Object(map) => {
+                Value::Object(map.iter().map(|(k, v)| (k.clone(), narrow(v))).collect())
+            }
+            other => other.clone(),
+        }
+    }
+
+    fn legacy_measure(
+        paragraph: &ParagraphBlock,
+        content_width: f64,
+        config: &MeasurementConfig,
+        zones: Option<&[FloatingZone]>,
+        cumulative_y: f64,
+    ) -> Option<ParagraphExtent> {
+        let envelope = legacy_envelope(paragraph, content_width, config, zones, cumulative_y);
+        let extent = crate::measure_paragraph_json_resident(&envelope).ok()?;
+        serde_json::from_str::<ParagraphExtent>(&extent).ok()
+    }
+
+    /// Randomised whole-surface differential. Every mapped field varies, so a
+    /// dropped or mistyped mapping shows up as a `BlockIn` difference before it
+    /// can reach measurement.
+    #[test]
+    fn randomised_paragraphs_match_the_json_path() {
+        let fixture = fixture();
+        let mut rng = Rng(0x2f6e_2b13);
+        let mut measured = 0usize;
+        let mut fell_back = 0usize;
+        for case in 0..3000 {
+            let spec = random_paragraph(&mut rng);
+            let paragraph: ParagraphBlock =
+                serde_json::from_value(spec.clone()).expect("generated paragraph parses");
+            let width = [200.0_f64, 60.0, 1000.0, 13.5][rng.below(4) as usize];
+            let size = [8.0_f64, 11.0, 12.0, 24.0][rng.below(4) as usize];
+            let family = FAMILIES[rng.below(FAMILIES.len() as u64) as usize];
+            let no_leading = rng.chance(2);
+            let no_expand = rng.chance(2);
+            let config = MeasurementConfig {
+                font_chains: fixture.config.font_chains.clone(),
+                defaults: json!({ "fontSize": size, "fontFamily": family }),
+                compat: json!({
+                    "noLeading": no_leading,
+                    "doNotExpandShiftReturn": no_expand,
+                }),
+                authoritative_shaping: rng.chance(2),
+            };
+            let full_width = rng.chance(2);
+            let zones = rng.chance(4).then(|| {
+                vec![FloatingZone {
+                    left_margin: 40.0,
+                    right_margin: 8.0,
+                    top_y: -4.0,
+                    bottom_y: 60.0,
+                    full_width_block: full_width,
+                }]
+            });
+
+            assert_eq!(
+                legacy_block_in(&paragraph).map(|b| format!("{b:?}")),
+                block_in(&paragraph).map(|b| format!("{b:?}")),
+                "case {case}: BlockIn differs for {spec}"
+            );
+
+            let legacy = legacy_measure(&paragraph, width, &config, zones.as_deref(), 12.0);
+            let typed = measure_paragraph(&paragraph, width, &config, zones.as_deref(), 12.0);
+            match (&legacy, &typed) {
+                (None, None) => fell_back += 1,
+                (Some(a), Some(b)) => {
+                    measured += 1;
+                    assert_eq!(
+                        narrow(&serde_json::to_value(a).unwrap()),
+                        narrow(&serde_json::to_value(b).unwrap()),
+                        "case {case}: extent differs for {spec}"
+                    );
+                }
+                _ => panic!(
+                    "case {case}: fallback differs (legacy {}, typed {}) for {spec}",
+                    legacy.is_some(),
+                    typed.is_some()
+                ),
+            }
+        }
+        assert!(measured > 500, "corpus measured only {measured} paragraphs");
+        assert!(
+            fell_back > 100,
+            "corpus exercised only {fell_back} fallbacks"
+        );
+    }
+
+    /// `serde_json` writes a non-finite float as `null`, which the envelope read
+    /// back as absent. Every site that crosses the boundary must still do that.
+    #[test]
+    fn non_finite_numbers_match_the_json_path() {
+        use crate::types::{ParagraphIndent, ParagraphSpacing};
+        let fixture = fixture();
+        for site in 0..24 {
+            for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                let mut fmt = RunFormatting::default();
+                let mut attrs = crate::types::ParagraphAttrs::default();
+                let mut spacing = ParagraphSpacing {
+                    before: Some(2.0),
+                    after: Some(3.0),
+                    line: Some(1.0),
+                    line_unit: Some("multiple".to_owned()),
+                    line_rule: Some("auto".to_owned()),
+                };
+                let mut indent = ParagraphIndent {
+                    left: Some(4.0),
+                    right: Some(2.0),
+                    first_line: Some(6.0),
+                    hanging: Some(0.0),
+                };
+                let mut tab = crate::types::TabStop {
+                    val: "end".to_owned(),
+                    pos: 2000.0,
+                    leader: None,
+                };
+                let mut image: crate::types::ImageRun = serde_json::from_value(json!({
+                    "src": "a.png", "width": 20.0, "height": 14.0,
+                    "displayMode": "inline", "distTop": 1.0, "distBottom": 1.0,
+                }))
+                .unwrap();
+                let mut cumulative_y = 10.0_f64;
+                let mut zone = [40.0_f64, 8.0, -4.0, 60.0];
+                let mut width = 200.0_f64;
+                let mut with_image = false;
+                let mut with_zones = false;
+
+                let name = match site {
+                    0 => {
+                        fmt.font_size = Some(value);
+                        "run.fontSize"
+                    }
+                    1 => {
+                        fmt.font_size_cs = Some(value);
+                        "run.fontSizeCs"
+                    }
+                    2 => {
+                        fmt.letter_spacing = Some(value);
+                        "run.letterSpacing"
+                    }
+                    3 => {
+                        fmt.horizontal_scale = Some(value);
+                        "run.horizontalScale"
+                    }
+                    4 => {
+                        fmt.kerning_min_pt = Some(value);
+                        "run.kerningMinPt"
+                    }
+                    5 => {
+                        attrs.default_font_size = Some(value);
+                        "attrs.defaultFontSize"
+                    }
+                    6 => {
+                        attrs.list_marker = Some("1.".to_owned());
+                        attrs.list_marker_font_size = Some(value);
+                        "attrs.listMarkerFontSize"
+                    }
+                    7 => {
+                        attrs.default_tab_stop_twips = Some(value);
+                        "attrs.defaultTabStopTwips"
+                    }
+                    8 => {
+                        spacing.before = Some(value);
+                        attrs.spacing = Some(spacing);
+                        "spacing.before"
+                    }
+                    9 => {
+                        spacing.after = Some(value);
+                        attrs.spacing = Some(spacing);
+                        "spacing.after"
+                    }
+                    10 => {
+                        spacing.line = Some(value);
+                        attrs.spacing = Some(spacing);
+                        "spacing.line"
+                    }
+                    11 => {
+                        indent.left = Some(value);
+                        attrs.indent = Some(indent);
+                        "indent.left"
+                    }
+                    12 => {
+                        indent.right = Some(value);
+                        attrs.indent = Some(indent);
+                        "indent.right"
+                    }
+                    13 => {
+                        indent.first_line = Some(value);
+                        attrs.indent = Some(indent);
+                        "indent.firstLine"
+                    }
+                    14 => {
+                        indent.hanging = Some(value);
+                        attrs.indent = Some(indent);
+                        "indent.hanging"
+                    }
+                    15 => {
+                        tab.pos = value;
+                        attrs.tabs = Some(vec![tab]);
+                        "tab.pos"
+                    }
+                    16 => {
+                        image.width = value;
+                        with_image = true;
+                        "image.width"
+                    }
+                    17 => {
+                        image.height = value;
+                        with_image = true;
+                        "image.height"
+                    }
+                    18 => {
+                        image.dist_top = Some(value);
+                        with_image = true;
+                        "image.distTop"
+                    }
+                    19 => {
+                        image.dist_bottom = Some(value);
+                        with_image = true;
+                        "image.distBottom"
+                    }
+                    20 => {
+                        cumulative_y = value;
+                        with_zones = true;
+                        "paragraphYOffset"
+                    }
+                    21 => {
+                        zone[0] = value;
+                        with_zones = true;
+                        "zone.leftMargin"
+                    }
+                    22 => {
+                        zone[2] = value;
+                        with_zones = true;
+                        "zone.topY"
+                    }
+                    _ => {
+                        width = value;
+                        "maxWidth"
+                    }
+                };
+
+                let mut runs = vec![Run::Text(TextRun {
+                    fmt,
+                    text: "hello world wrapping across a few lines".to_owned(),
+                    pm_start: None,
+                    pm_end: None,
+                    inline_sdt_widget: None,
+                })];
+                if with_image {
+                    runs.push(Run::Image(image));
+                }
+                let block = paragraph(runs, Some(attrs));
+                let zones = with_zones.then(|| {
+                    vec![FloatingZone {
+                        left_margin: zone[0],
+                        right_margin: zone[1],
+                        top_y: zone[2],
+                        bottom_y: zone[3],
+                        full_width_block: false,
+                    }]
+                });
+                assert_eq!(
+                    legacy_block_in(&block).map(|b| format!("{b:?}")),
+                    block_in(&block).map(|b| format!("{b:?}")),
+                    "{name} = {value}: BlockIn differs"
+                );
+                let legacy = legacy_measure(
+                    &block,
+                    width,
+                    &fixture.config,
+                    zones.as_deref(),
+                    cumulative_y,
+                );
+                let typed = measure_paragraph(
+                    &block,
+                    width,
+                    &fixture.config,
+                    zones.as_deref(),
+                    cumulative_y,
+                );
+                match (&legacy, &typed) {
+                    (None, None) => {}
+                    (Some(a), Some(b)) => assert_eq!(
+                        narrow(&serde_json::to_value(a).unwrap()),
+                        narrow(&serde_json::to_value(b).unwrap()),
+                        "{name} = {value}: extent differs"
+                    ),
+                    _ => panic!(
+                        "{name} = {value}: fallback differs (legacy {}, typed {})",
+                        legacy.is_some(),
+                        typed.is_some()
+                    ),
+                }
+            }
+        }
+    }
+
+    /// serde's derived `Deserialize` also takes a struct from a positional
+    /// sequence, so the envelope accepted these and the typed path must too.
+    #[test]
+    fn sequence_form_defaults_and_compat_match_the_json_path() {
+        let base = fixture();
+        let block = paragraph(vec![text_run("hello world")], None);
+        for (name, defaults, compat) in [
+            ("defaults-seq", json!([12.0, "Liberation Sans"]), json!({})),
+            (
+                "compat-seq",
+                json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                json!([true, false]),
+            ),
+            (
+                "compat-seq-one",
+                json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                json!([true]),
+            ),
+            (
+                "compat-seq-empty",
+                json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                json!([]),
+            ),
+            ("defaults-null", Value::Null, json!({})),
+            (
+                "compat-null",
+                json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                Value::Null,
+            ),
+            ("defaults-scalar", json!(3), json!({})),
+            (
+                "compat-scalar",
+                json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                json!(3),
+            ),
+            (
+                "defaults-missing-key",
+                json!({ "fontSize": 12.0 }),
+                json!({}),
+            ),
+            (
+                "defaults-wrong-type",
+                json!({ "fontSize": "big", "fontFamily": "Liberation Sans" }),
+                json!({}),
+            ),
+            (
+                "compat-wrong-type",
+                json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                json!({ "noLeading": "yes" }),
+            ),
+        ] {
+            let config = MeasurementConfig {
+                font_chains: base.config.font_chains.clone(),
+                defaults,
+                compat,
+                authoritative_shaping: true,
+            };
+            let legacy = legacy_measure(&block, 200.0, &config, None, 0.0);
+            let typed = measure_paragraph(&block, 200.0, &config, None, 0.0);
+            assert_eq!(
+                legacy.is_some(),
+                typed.is_some(),
+                "{name}: fallback differs (legacy {}, typed {})",
+                legacy.is_some(),
+                typed.is_some()
+            );
+        }
     }
 }

--- a/crates/docx-layout/src/typed_measure.rs
+++ b/crates/docx-layout/src/typed_measure.rs
@@ -1,0 +1,782 @@
+//! Typed bridge between layout blocks and `ooxml-text` measurement.
+//!
+//! Field-for-field equivalent of the JSON envelope this used to serialize:
+//! every mapping here mirrors what serde did at that boundary, including its
+//! strictness — a value the JSON parse would have rejected makes
+//! [`measure_paragraph`] return `None` so the caller falls back to the
+//! synthetic extent, exactly as an `"invalid: "` error used to.
+
+use ooxml_text::measure::{
+    AttrsIn, BlockIn, CompatIn, DefaultsIn, FloatZoneIn, FontChains, IndentIn, MeasureRequest,
+    RotationBoundsIn, RunFontSlotsIn, RunIn, RunLanguageSlotsIn, SpacingIn, TabStopIn,
+};
+use serde_json::Value;
+
+use crate::measure_blocks::{FloatingZone, MeasurementConfig};
+use crate::types::{
+    ImageRun, ParagraphAttrs, ParagraphBlock, Run, RunFormatting, TabStop, TypesetBidiSlice,
+    TypesetClusterAdvance, TypesetRow, TypesetRowSegment, TypesetRunAdvance,
+};
+
+/// Measure one paragraph through the typed path; `None` mirrors the old
+/// fallbacks (unparseable envelope, `UNSUPPORTED`, or a measurement error).
+pub(crate) fn measure_paragraph(
+    paragraph: &ParagraphBlock,
+    content_width: f64,
+    config: &MeasurementConfig,
+    floating_zones: Option<&[FloatingZone]>,
+    cumulative_y: f64,
+) -> Option<crate::types::ParagraphExtent> {
+    let block = block_in(paragraph)?;
+    let defaults = defaults_in(&config.defaults)?;
+    let compat = compat_in(&config.compat)?;
+    let zones = floating_zones.map(|zones| zones.iter().map(zone_in).collect::<Vec<FloatZoneIn>>());
+    let request = MeasureRequest {
+        block: &block,
+        max_width: content_width as f32,
+        font_chains: FontChains::BTree(&config.font_chains),
+        defaults: &defaults,
+        compat,
+        floating_zones: zones.as_deref(),
+        paragraph_y_offset: floating_zones.is_some().then(|| cumulative_y as f32),
+        authoritative_shaping: config.authoritative_shaping,
+    };
+    let extent = crate::measure_paragraph_typed_resident(&request).ok()?;
+    Some(extent_from_out(extent))
+}
+
+fn block_in(paragraph: &ParagraphBlock) -> Option<BlockIn> {
+    Some(BlockIn {
+        kind: "paragraph".to_owned(),
+        runs: paragraph
+            .runs
+            .iter()
+            .map(run_in)
+            .collect::<Option<Vec<_>>>()?,
+        attrs: paragraph.attrs.as_ref().map(attrs_in),
+    })
+}
+
+fn defaults_in(defaults: &Value) -> Option<DefaultsIn> {
+    let fields = defaults.as_object()?;
+    Some(DefaultsIn {
+        font_size: fields.get("fontSize")?.as_f64()? as f32,
+        font_family: fields.get("fontFamily")?.as_str()?.to_owned(),
+    })
+}
+
+fn compat_in(compat: &Value) -> Option<CompatIn> {
+    match compat {
+        Value::Null => Some(CompatIn::default()),
+        Value::Object(fields) => {
+            let mut parsed = CompatIn::default();
+            parsed.no_leading = bool_flag(fields.get("noLeading"))?;
+            parsed.do_not_expand_shift_return = bool_flag(fields.get("doNotExpandShiftReturn"))?;
+            Some(parsed)
+        }
+        _ => None,
+    }
+}
+
+fn bool_flag(value: Option<&Value>) -> Option<bool> {
+    match value {
+        None => Some(false),
+        Some(Value::Bool(flag)) => Some(*flag),
+        Some(_) => None,
+    }
+}
+
+fn number_f32(value: Option<&Value>) -> Option<Option<f32>> {
+    match value {
+        None | Some(Value::Null) => Some(None),
+        Some(Value::Number(number)) => Some(Some(number.as_f64()? as f32)),
+        Some(_) => None,
+    }
+}
+
+fn zone_in(zone: &FloatingZone) -> FloatZoneIn {
+    FloatZoneIn {
+        left_margin: zone.left_margin as f32,
+        right_margin: zone.right_margin as f32,
+        top_y: zone.top_y as f32,
+        bottom_y: zone.bottom_y as f32,
+        segments: None,
+        full_width_block: zone.full_width_block,
+    }
+}
+
+fn attrs_in(attrs: &ParagraphAttrs) -> AttrsIn {
+    AttrsIn {
+        alignment: attrs.alignment.clone(),
+        spacing: attrs.spacing.as_ref().map(|spacing| SpacingIn {
+            before: spacing.before.map(|px| px as f32),
+            after: spacing.after.map(|px| px as f32),
+            line: spacing.line.map(|px| px as f32),
+            line_unit: spacing.line_unit.clone(),
+            line_rule: spacing.line_rule.clone(),
+        }),
+        indent: attrs.indent.as_ref().map(|indent| IndentIn {
+            left: indent.left.map(|px| px as f32),
+            right: indent.right.map(|px| px as f32),
+            first_line: indent.first_line.map(|px| px as f32),
+            hanging: indent.hanging.map(|px| px as f32),
+        }),
+        tabs: attrs
+            .tabs
+            .as_ref()
+            .map(|stops| stops.iter().map(tab_stop_in).collect()),
+        bidi: attrs.bidi.unwrap_or(false),
+        default_font_size: attrs.default_font_size.map(|pt| pt as f32),
+        default_font_family: attrs.default_font_family.clone(),
+        suppress_empty_paragraph_height: attrs.suppress_empty_paragraph_height.unwrap_or(false),
+        list_marker: attrs.list_marker.clone(),
+        list_marker_hidden: attrs.list_marker_hidden.unwrap_or(false),
+        list_marker_font_family: attrs.list_marker_font_family.clone(),
+        list_marker_font_size: attrs.list_marker_font_size.map(|pt| pt as f32),
+        list_marker_suffix: attrs.list_marker_suffix.clone(),
+        default_tab_stop_twips: attrs.default_tab_stop_twips.map(|twips| twips as f32),
+    }
+}
+
+fn tab_stop_in(stop: &TabStop) -> TabStopIn {
+    TabStopIn {
+        val: stop.val.clone(),
+        pos: stop.pos as f32,
+    }
+}
+
+fn run_in(run: &Run) -> Option<RunIn> {
+    match run {
+        Run::Text(text) => {
+            let mut out = formatted_run("text", &text.fmt);
+            out.text = Some(text.text.clone());
+            Some(out)
+        }
+        Run::Tab(tab) => Some(formatted_run("tab", &tab.fmt)),
+        Run::LineBreak(_) => Some(bare_run("lineBreak")),
+        Run::Field(field) => {
+            let mut out = formatted_run("field", &field.fmt);
+            out.fallback = field.fallback.clone();
+            Some(out)
+        }
+        Run::Image(image) => image_run(image),
+        Run::Unsupported => Some(bare_run("unsupported")),
+    }
+}
+
+fn formatted_run(kind: &str, fmt: &RunFormatting) -> RunIn {
+    let mut out = bare_run(kind);
+    out.bold = fmt.bold.unwrap_or(false);
+    out.italic = fmt.italic.unwrap_or(false);
+    out.bold_cs = fmt.bold_cs;
+    out.italic_cs = fmt.italic_cs;
+    out.font_size = fmt.font_size.map(|pt| pt as f32);
+    out.font_size_cs = fmt.font_size_cs.map(|pt| pt as f32);
+    out.font_family = fmt.font_family.clone();
+    out.font_slots = fmt.font_slots.as_ref().map(|slots| RunFontSlotsIn {
+        ascii: slots.ascii.clone(),
+        h_ansi: slots.h_ansi.clone(),
+        east_asia: slots.east_asia.clone(),
+        cs: slots.cs.clone(),
+        hint: slots.hint.clone(),
+    });
+    out.complex_script = fmt.complex_script.unwrap_or(false);
+    out.language = fmt.language.as_ref().map(|slots| RunLanguageSlotsIn {
+        latin: slots.latin.clone(),
+        east_asia: slots.east_asia.clone(),
+        bidi: slots.bidi.clone(),
+    });
+    out.letter_spacing = fmt.letter_spacing.map(|spacing| spacing as f32);
+    out.all_caps = fmt.all_caps.unwrap_or(false);
+    out.small_caps = fmt.small_caps.unwrap_or(false);
+    out.horizontal_scale = fmt.horizontal_scale.map(|scale| scale as f32);
+    out.kerning_min_pt = fmt.kerning_min_pt.map(|kerning| kerning as f32);
+    out.superscript = fmt.superscript.unwrap_or(false);
+    out.subscript = fmt.subscript.unwrap_or(false);
+    out.hidden = fmt.hidden.unwrap_or(false);
+    out.rtl = fmt.rtl.unwrap_or(false);
+    out
+}
+
+fn bare_run(kind: &str) -> RunIn {
+    RunIn {
+        kind: kind.to_owned(),
+        text: None,
+        bold: false,
+        italic: false,
+        bold_cs: None,
+        italic_cs: None,
+        font_size: None,
+        font_size_cs: None,
+        font_family: None,
+        font_slots: None,
+        complex_script: false,
+        language: None,
+        letter_spacing: None,
+        all_caps: false,
+        small_caps: false,
+        horizontal_scale: None,
+        kerning_min_pt: None,
+        superscript: false,
+        subscript: false,
+        hidden: false,
+        rtl: false,
+        fallback: None,
+        width: None,
+        height: None,
+        rotation_bounds: None,
+        dist_top: None,
+        dist_bottom: None,
+        wrap_type: None,
+        display_mode: None,
+        position: None,
+    }
+}
+
+fn image_run(image: &ImageRun) -> Option<RunIn> {
+    let mut out = bare_run("image");
+    out.width = Some(image.width as f32);
+    out.height = Some(image.height as f32);
+    out.rotation_bounds = rotation_bounds_in(image.rotation_bounds.as_ref())?;
+    out.dist_top = image.dist_top.map(|distance| distance as f32);
+    out.dist_bottom = image.dist_bottom.map(|distance| distance as f32);
+    out.wrap_type = image.wrap_type.clone();
+    out.display_mode = image.display_mode.clone();
+    out.position = image.position.as_ref().map(|_| serde::de::IgnoredAny);
+    Some(out)
+}
+
+/// Mirrors serde's strictness at the old JSON boundary: absent or `null` is
+/// no bounds; anything else must be an object or a positional sequence of
+/// the two optional dimensions, exactly as serde's derived `Deserialize`
+/// accepts — any deviation fails the whole request (`None`) where envelope
+/// parsing used to.
+fn rotation_bounds_in(bounds: Option<&Value>) -> Option<Option<RotationBoundsIn>> {
+    match bounds {
+        None | Some(Value::Null) => Some(None),
+        Some(Value::Object(fields)) => Some(Some(RotationBoundsIn {
+            width: number_f32(fields.get("width"))?,
+            height: number_f32(fields.get("height"))?,
+        })),
+        Some(Value::Array(items)) => {
+            if items.len() > 2 {
+                return None;
+            }
+            Some(Some(RotationBoundsIn {
+                width: number_f32(items.first())?,
+                height: number_f32(items.get(1))?,
+            }))
+        }
+        Some(_) => None,
+    }
+}
+
+fn extent_from_out(extent: ooxml_text::ParagraphExtentOut) -> crate::types::ParagraphExtent {
+    crate::types::ParagraphExtent {
+        lines: extent.lines.into_iter().map(row_from_out).collect(),
+        total_height: extent.total_height as f64,
+    }
+}
+
+fn row_from_out(row: ooxml_text::TypesetRowOut) -> TypesetRow {
+    TypesetRow {
+        head_run: row.head_run as usize,
+        head_char: row.head_char as usize,
+        tail_run: row.tail_run as usize,
+        tail_char: row.tail_char as usize,
+        width: row.width as f64,
+        ascent: row.ascent as f64,
+        descent: row.descent as f64,
+        line_height: row.line_height as f64,
+        synthetic_fallback: None,
+        left_offset: row.left_offset.map(f64::from),
+        right_offset: row.right_offset.map(f64::from),
+        segments: row.segments.map(|segments| {
+            segments
+                .into_iter()
+                .map(|segment| TypesetRowSegment {
+                    head_run: segment.head_run as usize,
+                    head_char: segment.head_char as usize,
+                    tail_run: segment.tail_run as usize,
+                    tail_char: segment.tail_char as usize,
+                    left_offset: segment.left_offset as f64,
+                    available_width: segment.available_width as f64,
+                    width: segment.width as f64,
+                })
+                .collect()
+        }),
+        float_skip_before: row.float_skip_before.map(f64::from),
+        run_advances: row.run_advances.map(|advances| {
+            advances
+                .into_iter()
+                .map(|advance| TypesetRunAdvance {
+                    run_index: Some(u64::from(advance.run_index)),
+                    start_char: Some(u64::from(advance.start_char)),
+                    end_char: Some(u64::from(advance.end_char)),
+                    advance: Some(advance.advance as f64),
+                    logical_order: Some(u64::from(advance.logical_order)),
+                })
+                .collect()
+        }),
+        cluster_advances: row.cluster_advances.map(|clusters| {
+            clusters
+                .into_iter()
+                .map(|cluster| TypesetClusterAdvance {
+                    run_index: Some(u64::from(cluster.run_index)),
+                    start_char: Some(u64::from(cluster.start_char)),
+                    end_char: Some(u64::from(cluster.end_char)),
+                    advance: Some(cluster.advance as f64),
+                    x_offset: Some(cluster.x_offset as f64),
+                    bidi_level: Some(cluster.bidi_level),
+                    logical_order: Some(u64::from(cluster.logical_order)),
+                })
+                .collect()
+        }),
+        bidi_slices: row.bidi_slices.map(|slices| {
+            slices
+                .into_iter()
+                .map(|slice| TypesetBidiSlice {
+                    run_index: Some(u64::from(slice.run_index)),
+                    start_char: Some(u64::from(slice.start_char)),
+                    end_char: Some(u64::from(slice.end_char)),
+                    advance: Some(slice.advance as f64),
+                    bidi_level: Some(slice.bidi_level),
+                    visual_order: Some(u64::from(slice.visual_order)),
+                    logical_order: Some(u64::from(slice.logical_order)),
+                })
+                .collect()
+        }),
+    }
+}
+
+#[cfg(test)]
+mod parity_tests {
+    use super::*;
+    use crate::measure_blocks::measure_paragraph as measure_paragraph_entry;
+    use crate::types::{BlockId, FieldRun, LayoutBlock, ParagraphExtent, TabRun, TextRun};
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    const FIXTURE: &[u8] =
+        include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+
+    struct Fixture {
+        config: MeasurementConfig,
+    }
+
+    fn fixture() -> Fixture {
+        crate::clear_measure_fonts();
+        let id = crate::register_measure_font(FIXTURE).expect("register fixture font");
+        let mut font_chains = BTreeMap::new();
+        for bold in 0..2 {
+            for italic in 0..2 {
+                font_chains.insert(format!("liberation sans|{bold}|{italic}"), vec![id]);
+            }
+        }
+        Fixture {
+            config: MeasurementConfig {
+                font_chains,
+                defaults: json!({ "fontSize": 12.0, "fontFamily": "Liberation Sans" }),
+                compat: json!({}),
+                authoritative_shaping: true,
+            },
+        }
+    }
+
+    fn text_run(text: &str) -> Run {
+        Run::Text(TextRun {
+            fmt: RunFormatting::default(),
+            text: text.to_owned(),
+            pm_start: None,
+            pm_end: None,
+            inline_sdt_widget: None,
+        })
+    }
+
+    fn paragraph(runs: Vec<Run>, attrs: Option<crate::types::ParagraphAttrs>) -> ParagraphBlock {
+        ParagraphBlock {
+            sdt_groups: None,
+            id: BlockId::Num(0.0),
+            para_id: None,
+            runs,
+            attrs,
+            pm_start: None,
+            pm_end: None,
+        }
+    }
+
+    fn legacy_envelope(
+        paragraph: &ParagraphBlock,
+        content_width: f64,
+        config: &MeasurementConfig,
+        floating_zones: Option<&[FloatingZone]>,
+        cumulative_y: f64,
+    ) -> String {
+        let mut envelope = json!({
+            "block": LayoutBlock::Paragraph(paragraph.clone()),
+            "maxWidth": content_width,
+            "fontChains": config.font_chains,
+            "authoritativeShaping": config.authoritative_shaping,
+        });
+        let fields = envelope.as_object_mut().unwrap();
+        if !config.defaults.is_null() {
+            fields.insert("defaults".to_owned(), config.defaults.clone());
+        }
+        if !config.compat.is_null() {
+            fields.insert("compat".to_owned(), config.compat.clone());
+        }
+        if let Some(zones) = floating_zones {
+            fields.insert(
+                "floatingZones".to_owned(),
+                json!(
+                    zones
+                        .iter()
+                        .map(|zone| {
+                            json!({
+                                "leftMargin": zone.left_margin,
+                                "rightMargin": zone.right_margin,
+                                "topY": zone.top_y,
+                                "bottomY": zone.bottom_y,
+                                "fullWidthBlock": zone.full_width_block,
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                ),
+            );
+            fields.insert("paragraphYOffset".to_owned(), json!(cumulative_y));
+        }
+        envelope.to_string()
+    }
+
+    fn assert_close(name: &str, left: &Value, right: &Value, path: &str) {
+        match (left, right) {
+            (Value::Number(left), Value::Number(right)) => {
+                let left = left.as_f64().unwrap();
+                let right = right.as_f64().unwrap();
+                let tolerance = 1e-4_f64.max(left.abs() * 1e-5);
+                assert!(
+                    (left - right).abs() <= tolerance,
+                    "{name}: {path} {left} != {right}"
+                );
+            }
+            (Value::Array(left), Value::Array(right)) => {
+                assert_eq!(left.len(), right.len(), "{name}: {path} length");
+                for (index, (a, b)) in left.iter().zip(right).enumerate() {
+                    assert_close(name, a, b, &format!("{path}[{index}]"));
+                }
+            }
+            (Value::Object(left), Value::Object(right)) => {
+                assert_eq!(left.len(), right.len(), "{name}: {path} keys");
+                for (key, value) in left {
+                    let other = right
+                        .get(key)
+                        .unwrap_or_else(|| panic!("{name}: {path}.{key} missing"));
+                    assert_close(name, value, other, &format!("{path}.{key}"));
+                }
+            }
+            (left, right) => assert_eq!(left, right, "{name}: {path}"),
+        }
+    }
+
+    fn assert_parity(
+        name: &str,
+        block: &ParagraphBlock,
+        content_width: f64,
+        config: &MeasurementConfig,
+        floating_zones: Option<&[FloatingZone]>,
+        cumulative_y: f64,
+    ) {
+        let legacy = crate::measure_paragraph_json_resident(&legacy_envelope(
+            block,
+            content_width,
+            config,
+            floating_zones,
+            cumulative_y,
+        ))
+        .ok()
+        .and_then(|out| serde_json::from_str::<ParagraphExtent>(&out).ok());
+        let typed = measure_paragraph(block, content_width, config, floating_zones, cumulative_y);
+        match (legacy, typed) {
+            (Some(legacy), Some(typed)) => {
+                // The JSON path quantized every f32 through its shortest
+                // decimal form before widening to f64; the typed path widens
+                // exactly, so compare numerically with a tight tolerance.
+                assert_close(
+                    name,
+                    &serde_json::to_value(&legacy).unwrap(),
+                    &serde_json::to_value(&typed).unwrap(),
+                    "$",
+                );
+            }
+            (None, None) => {}
+            (legacy, typed) => {
+                panic!("{name}: fallback divergence — legacy {legacy:?}, typed {typed:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn plain_wrapping_text_matches_the_json_path() {
+        let fixture = fixture();
+        let block = paragraph(
+            vec![text_run("The quick brown fox jumps over the lazy dog")],
+            None,
+        );
+        assert_parity("plain", &block, 200.0, &fixture.config, None, 0.0);
+        let via_entry = measure_paragraph_entry(&block, 200.0, &fixture.config).unwrap();
+        let via_typed = measure_paragraph(&block, 200.0, &fixture.config, None, 0.0).unwrap();
+        assert_eq!(
+            serde_json::to_value(&via_entry).unwrap(),
+            serde_json::to_value(&via_typed).unwrap(),
+            "the production entry point must agree bit-for-bit with the typed path"
+        );
+    }
+
+    #[test]
+    fn cjk_and_bidi_runs_match_the_json_path() {
+        let fixture = fixture();
+        let attrs = crate::types::ParagraphAttrs {
+            bidi: Some(true),
+            ..Default::default()
+        };
+        let mut rtl = RunFormatting::default();
+        rtl.rtl = Some(true);
+        let runs = vec![
+            text_run("שלום"),
+            Run::Text(TextRun {
+                fmt: rtl,
+                text: " mixed 世界".to_owned(),
+                pm_start: None,
+                pm_end: None,
+                inline_sdt_widget: None,
+            }),
+        ];
+        assert_parity(
+            "cjk-bidi",
+            &paragraph(runs, Some(attrs)),
+            240.0,
+            &fixture.config,
+            None,
+            0.0,
+        );
+    }
+
+    #[test]
+    fn tab_stops_match_the_json_path() {
+        let fixture = fixture();
+        let attrs = crate::types::ParagraphAttrs {
+            tabs: Some(vec![crate::types::TabStop {
+                val: "end".to_owned(),
+                pos: 4000.0,
+                leader: None,
+            }]),
+            ..Default::default()
+        };
+        let runs = vec![
+            text_run("before"),
+            Run::Tab(TabRun {
+                fmt: RunFormatting::default(),
+                pm_start: None,
+                pm_end: None,
+                width: None,
+                leader_glyphs: None,
+            }),
+            text_run("after the stop"),
+        ];
+        assert_parity(
+            "tabs",
+            &paragraph(runs, Some(attrs)),
+            400.0,
+            &fixture.config,
+            None,
+            0.0,
+        );
+    }
+
+    #[test]
+    fn list_marker_matches_the_json_path() {
+        let fixture = fixture();
+        let attrs = crate::types::ParagraphAttrs {
+            list_marker: Some("7.".to_owned()),
+            list_marker_font_family: Some("Liberation Sans".to_owned()),
+            list_marker_font_size: Some(12.0),
+            indent: Some(crate::types::ParagraphIndent {
+                left: Some(20.0),
+                right: None,
+                first_line: None,
+                hanging: None,
+            }),
+            default_tab_stop_twips: Some(720.0),
+            ..Default::default()
+        };
+        assert_parity(
+            "list-marker",
+            &paragraph(vec![text_run("numbered item text")], Some(attrs)),
+            220.0,
+            &fixture.config,
+            None,
+            0.0,
+        );
+    }
+
+    #[test]
+    fn field_run_matches_the_json_path() {
+        let fixture = fixture();
+        let runs = vec![Run::Field(FieldRun {
+            fmt: RunFormatting::default(),
+            field_type: "PAGE".to_owned(),
+            raw_type: None,
+            instruction: None,
+            fallback: Some("42".to_owned()),
+            pm_start: None,
+            pm_end: None,
+        })];
+        assert_parity(
+            "field",
+            &paragraph(runs, None),
+            150.0,
+            &fixture.config,
+            None,
+            0.0,
+        );
+    }
+
+    fn img_run(rotation_bounds: Value) -> Run {
+        Run::Image(
+            serde_json::from_value(json!({
+                "src": "a.png",
+                "width": 24.0,
+                "height": 18.0,
+                "displayMode": "inline",
+                "rotationBounds": rotation_bounds,
+            }))
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn inline_image_matches_the_json_path() {
+        let fixture = fixture();
+        let block = paragraph(
+            vec![img_run(json!({ "width": 30.0, "height": 22.0 }))],
+            None,
+        );
+        assert_parity("image", &block, 200.0, &fixture.config, None, 0.0);
+    }
+
+    /// serde's derived `Deserialize` also takes a struct from a positional
+    /// sequence, so `[width, height]` bounds must measure identically.
+    #[test]
+    fn positional_sequence_rotation_bounds_match_the_json_path() {
+        let fixture = fixture();
+        for bounds in [json!([]), json!([30.0]), json!([30.0, 22.0])] {
+            assert_parity(
+                "image-seq-bounds",
+                &paragraph(vec![img_run(bounds)], None),
+                200.0,
+                &fixture.config,
+                None,
+                0.0,
+            );
+        }
+    }
+
+    /// Absent and explicit-`null` bounds are not malformed: serde parses
+    /// `null` into `None`, so both paths must keep measuring.
+    #[test]
+    fn absent_and_null_rotation_bounds_measure_on_both_paths() {
+        let fixture = fixture();
+        let bare = Run::Image(
+            serde_json::from_value(json!({
+                "src": "a.png",
+                "width": 24.0,
+                "height": 18.0,
+                "displayMode": "inline",
+            }))
+            .unwrap(),
+        );
+        assert_parity(
+            "image-no-bounds",
+            &paragraph(vec![bare], None),
+            200.0,
+            &fixture.config,
+            None,
+            0.0,
+        );
+        let null = paragraph(vec![img_run(Value::Null)], None);
+        assert_parity(
+            "image-null-bounds",
+            &null,
+            200.0,
+            &fixture.config,
+            None,
+            0.0,
+        );
+        assert!(measure_paragraph(&null, 200.0, &fixture.config, None, 0.0).is_some());
+    }
+
+    /// Values the old envelope's serde pass rejected — a non-object bounds
+    /// value, or an object with a non-number dimension — must fall back on
+    /// both paths; the typed conversion may not quietly drop them and measure.
+    #[test]
+    fn malformed_rotation_bounds_fall_back_on_both_paths() {
+        let fixture = fixture();
+        for bounds in [
+            json!(1),
+            json!("bad"),
+            json!(true),
+            json!({ "width": "bad" }),
+            json!({ "width": true }),
+            json!({ "height": [] }),
+            json!(["x"]),
+            json!([1, "x"]),
+            json!([1, 2, 3]),
+        ] {
+            let block = paragraph(vec![img_run(bounds.clone())], None);
+            let legacy = crate::measure_paragraph_json_resident(&legacy_envelope(
+                &block,
+                200.0,
+                &fixture.config,
+                None,
+                0.0,
+            ))
+            .ok()
+            .and_then(|out| serde_json::from_str::<ParagraphExtent>(&out).ok());
+            let typed = measure_paragraph(&block, 200.0, &fixture.config, None, 0.0);
+            assert!(legacy.is_none(), "{bounds}: legacy must fall back");
+            assert!(typed.is_none(), "{bounds}: typed must fall back");
+        }
+    }
+
+    #[test]
+    fn floating_zones_match_the_json_path() {
+        let fixture = fixture();
+        let zones = [FloatingZone {
+            left_margin: 60.0,
+            right_margin: 10.0,
+            top_y: -5.0,
+            bottom_y: 40.0,
+            full_width_block: false,
+        }];
+        assert_parity(
+            "zones",
+            &paragraph(
+                vec![text_run(
+                    "flowing around a floating image with several words",
+                )],
+                None,
+            ),
+            260.0,
+            &fixture.config,
+            Some(&zones),
+            12.0,
+        );
+    }
+
+    #[test]
+    fn unsupported_run_falls_back_on_both_paths() {
+        let fixture = fixture();
+        let block = paragraph(vec![Run::Unsupported, text_run("after")], None);
+        assert_parity("unsupported", &block, 200.0, &fixture.config, None, 0.0);
+    }
+}

--- a/crates/docx-layout/src/typed_measure.rs
+++ b/crates/docx-layout/src/typed_measure.rs
@@ -507,7 +507,7 @@ mod parity_tests {
         assert_eq!(
             serde_json::to_value(&via_entry).unwrap(),
             serde_json::to_value(&via_typed).unwrap(),
-            "the production entry point must agree bit-for-bit with the typed path"
+            "the production entry point must delegate to the typed core"
         );
     }
 

--- a/crates/ooxml-text/src/lib.rs
+++ b/crates/ooxml-text/src/lib.rs
@@ -48,8 +48,8 @@ pub use bidi::{
 pub use font_store::{FontError, FontId, FontMetrics, FontStore};
 pub use line_break::{BreakOpportunity, break_opportunities};
 pub use measure::{
-    MeasureError, MeasureInput, ParagraphExtentOut, TypesetRowOut, measure_paragraph,
-    measure_paragraph_json,
+    FontChains, MeasureError, MeasureInput, MeasureRequest, ParagraphExtentOut, TypesetRowOut,
+    measure_paragraph, measure_paragraph_json, measure_paragraph_typed,
 };
 pub use outline::{GlyphOutline, PathCmd};
 pub use shape::{ShapeDirection, ShapeFeature, ShapedGlyph, shape, shape_with_direction};

--- a/crates/ooxml-text/src/measure/input.rs
+++ b/crates/ooxml-text/src/measure/input.rs
@@ -36,7 +36,7 @@
 //! `floatingZones` and `paragraphYOffset` are optional; absent means no float
 //! context. See [`FloatZoneIn`] for their coordinate space.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::Deserialize;
 
@@ -72,6 +72,58 @@ pub struct MeasureInput {
 }
 
 impl MeasureInput {
+    /// Borrowed view consumed by [`super::measure_paragraph_typed`].
+    pub(super) fn as_request(&self) -> MeasureRequest<'_> {
+        MeasureRequest {
+            block: &self.block,
+            max_width: self.max_width,
+            font_chains: FontChains::Hash(&self.font_chains),
+            defaults: &self.defaults,
+            compat: self.compat,
+            floating_zones: self.floating_zones.as_deref(),
+            paragraph_y_offset: self.paragraph_y_offset,
+            authoritative_shaping: self.authoritative_shaping,
+        }
+    }
+}
+
+/// Borrowed measurement request, field-for-field equivalent to
+/// [`MeasureInput`]. The JSON boundary borrows an owned [`MeasureInput`] via
+/// [`MeasureInput::as_request`]; hosts with typed blocks (docx-layout)
+/// construct it directly so nothing is serialized or cloned on the way in.
+///
+/// `font_chains` is a borrowed table rather than a `Cow` because the two
+/// boundaries own different map types (`HashMap` parsed from JSON,
+/// docx-layout's `BTreeMap` config) and both must stay zero-copy.
+#[derive(Debug, Clone, Copy)]
+pub struct MeasureRequest<'a> {
+    pub block: &'a BlockIn,
+    pub max_width: f32,
+    pub font_chains: FontChains<'a>,
+    pub defaults: &'a DefaultsIn,
+    pub compat: CompatIn,
+    pub floating_zones: Option<&'a [FloatZoneIn]>,
+    pub paragraph_y_offset: Option<f32>,
+    pub authoritative_shaping: bool,
+}
+
+/// Borrowed fallback-chain table for [`MeasureRequest`].
+#[derive(Debug, Clone, Copy)]
+pub enum FontChains<'a> {
+    Hash(&'a HashMap<String, Vec<u32>>),
+    BTree(&'a BTreeMap<String, Vec<u32>>),
+}
+
+impl FontChains<'_> {
+    fn get(&self, key: &str) -> Option<&[u32]> {
+        match self {
+            FontChains::Hash(map) => map.get(key).map(Vec::as_slice),
+            FontChains::BTree(map) => map.get(key).map(Vec::as_slice),
+        }
+    }
+}
+
+impl MeasureRequest<'_> {
     /// Look up the fallback chain for a `(family, bold, italic)` combination.
     pub(super) fn chain_for(
         &self,

--- a/crates/ooxml-text/src/measure/list_marker.rs
+++ b/crates/ooxml-text/src/measure/list_marker.rs
@@ -13,7 +13,7 @@
 
 use crate::font_store::FontStore;
 
-use super::input::{AttrsIn, MeasureInput};
+use super::input::{AttrsIn, MeasureRequest};
 use super::tabs::twips_to_px;
 use super::{MeasureError, pt_to_px};
 
@@ -24,7 +24,7 @@ const DEFAULT_TAB_STOP_TWIPS: f32 = 720.0;
 /// the marker is hidden; callers apply it only at zero hanging indent.
 pub(super) fn list_marker_inline_width(
     store: &FontStore,
-    input: &MeasureInput,
+    input: &MeasureRequest<'_>,
     attrs: &AttrsIn,
 ) -> Result<f32, MeasureError> {
     let marker = match attrs.list_marker.as_deref() {

--- a/crates/ooxml-text/src/measure/mod.rs
+++ b/crates/ooxml-text/src/measure/mod.rs
@@ -124,8 +124,9 @@ mod prepare;
 mod tabs;
 
 pub use input::{
-    AttrsIn, BlockIn, CompatIn, DefaultsIn, FloatSegmentIn, FloatZoneIn, IndentIn, MeasureInput,
-    RunIn, SpacingIn, TabStopIn,
+    AttrsIn, BlockIn, CompatIn, DefaultsIn, FloatSegmentIn, FloatZoneIn, FontChains, IndentIn,
+    MeasureInput, MeasureRequest, RotationBoundsIn, RunFontSlotsIn, RunIn, RunLanguageSlotsIn,
+    SpacingIn, TabStopIn,
 };
 
 use crate::font_store::{FontId, FontStore};
@@ -289,18 +290,29 @@ pub fn measure_paragraph(
     store: &FontStore,
     input: &MeasureInput,
 ) -> Result<ParagraphExtentOut, MeasureError> {
-    if input.block.kind != "paragraph" {
+    measure_paragraph_typed(store, &input.as_request())
+}
+
+/// Typed boundary: a borrowed [`MeasureRequest`] in, a [`ParagraphExtentOut`]
+/// out — no JSON round trip on either side. Semantics are identical to
+/// [`measure_paragraph_json`]; an `Err` starting with `"UNSUPPORTED"` means
+/// the host must measure this block with the browser.
+pub fn measure_paragraph_typed(
+    store: &FontStore,
+    request: &MeasureRequest<'_>,
+) -> Result<ParagraphExtentOut, MeasureError> {
+    if request.block.kind != "paragraph" {
         return Err(MeasureError::Unsupported(format!(
             "block kind {:?}",
-            input.block.kind
+            request.block.kind
         )));
     }
-    if !input.max_width.is_finite() {
+    if !request.max_width.is_finite() {
         return Err(MeasureError::Unsupported("non-finite maxWidth".to_string()));
     }
-    input::validate_pt_size(input.defaults.font_size, "defaults.fontSize")?;
+    input::validate_pt_size(request.defaults.font_size, "defaults.fontSize")?;
 
-    let runs = &input.block.runs;
+    let runs = &request.block.runs;
     if runs.len() > MAX_RUNS {
         return Err(MeasureError::Unsupported(format!(
             "too many runs ({} > {MAX_RUNS})",
@@ -308,7 +320,7 @@ pub fn measure_paragraph(
         )));
     }
 
-    let attrs = input.block.attrs.as_ref();
+    let attrs = request.block.attrs.as_ref();
     let spacing = attrs.and_then(|a| a.spacing.as_ref());
     if let Some(sp) = spacing {
         sp.validate()?;
@@ -319,8 +331,8 @@ pub fn measure_paragraph(
     if let Some(tabs) = attrs.and_then(|a| a.tabs.as_deref()) {
         input::validate_tabs(tabs)?;
     }
-    let zones = input.floating_zones.as_deref().unwrap_or(&[]);
-    let paragraph_y_offset = input.paragraph_y_offset.unwrap_or(0.0);
+    let zones = request.floating_zones.unwrap_or(&[]);
+    let paragraph_y_offset = request.paragraph_y_offset.unwrap_or(0.0);
     input::validate_float_context(zones, paragraph_y_offset)?;
 
     if runs.is_empty() {
@@ -333,14 +345,14 @@ pub fn measure_paragraph(
         }
         let size_pt = attrs
             .and_then(|a| a.default_font_size)
-            .unwrap_or(input.defaults.font_size);
+            .unwrap_or(request.defaults.font_size);
         input::validate_pt_size(size_pt, "attrs.defaultFontSize")?;
         let family = attrs
             .and_then(|a| a.default_font_family.as_deref())
-            .unwrap_or(&input.defaults.font_family);
+            .unwrap_or(&request.defaults.font_family);
         // Empty paragraphs use the regular face.
-        let font = regular_chain_head(store, input, family)?;
-        return line_filler::empty_paragraph_extent(store, font, size_pt, spacing, &input.compat);
+        let font = regular_chain_head(store, request, family)?;
+        return line_filler::empty_paragraph_extent(store, font, size_pt, spacing, &request.compat);
     }
 
     // ---- single whitespace-only text run measures like an empty paragraph ----
@@ -349,26 +361,26 @@ pub fn measure_paragraph(
         let size_pt = run
             .font_size
             .or_else(|| attrs.and_then(|a| a.default_font_size))
-            .unwrap_or(input.defaults.font_size);
+            .unwrap_or(request.defaults.font_size);
         input::validate_pt_size(size_pt, "run.fontSize")?;
         let family = run
             .font_family
             .as_deref()
             .or_else(|| attrs.and_then(|a| a.default_font_family.as_deref()))
-            .unwrap_or(&input.defaults.font_family);
-        let font = regular_chain_head(store, input, family)?;
-        return line_filler::empty_paragraph_extent(store, font, size_pt, spacing, &input.compat);
+            .unwrap_or(&request.defaults.font_family);
+        let font = regular_chain_head(store, request, family)?;
+        return line_filler::empty_paragraph_extent(store, font, size_pt, spacing, &request.compat);
     }
 
     // Visible markers consume width only at zero hanging.
     let marker_inline_width = match attrs {
         Some(a) if a.indent.as_ref().and_then(|i| i.hanging).unwrap_or(0.0) == 0.0 => {
-            list_marker::list_marker_inline_width(store, input, a)?
+            list_marker::list_marker_inline_width(store, request, a)?
         }
         _ => 0.0,
     };
 
-    let prepared = prepare::prepare_runs(store, input)?;
+    let prepared = prepare::prepare_runs(store, request)?;
 
     // Left and right indents shrink both edges; first-line offset affects only the first line.
     let indent = attrs.and_then(|a| a.indent.as_ref());
@@ -376,7 +388,7 @@ pub fn measure_paragraph(
     let indent_right = indent.and_then(|i| i.right).unwrap_or(0.0);
     let first_line_offset = indent.and_then(|i| i.first_line).unwrap_or(0.0)
         - indent.and_then(|i| i.hanging).unwrap_or(0.0);
-    let body_width = (input.max_width - indent_left - indent_right).max(1.0);
+    let body_width = (request.max_width - indent_left - indent_right).max(1.0);
     let first_line_width = (body_width - first_line_offset - marker_inline_width).max(1.0);
 
     line_filler::fill(line_filler::FillParams {
@@ -385,14 +397,14 @@ pub fn measure_paragraph(
         spacing,
         body_width,
         first_line_width,
-        default_font_size_pt: input.defaults.font_size,
-        compat: &input.compat,
+        default_font_size_pt: request.defaults.font_size,
+        compat: &request.compat,
         tabs: attrs.and_then(|a| a.tabs.as_deref()).unwrap_or(&[]),
         indent_left_px: indent_left,
         first_line_offset_px: first_line_offset,
         zones,
         paragraph_y_offset,
-        authoritative_shaping: input.authoritative_shaping,
+        authoritative_shaping: request.authoritative_shaping,
     })
 }
 
@@ -403,7 +415,7 @@ pub fn measure_paragraph(
 pub fn measure_paragraph_json(store: &FontStore, input: &str) -> Result<String, String> {
     let parsed: MeasureInput =
         serde_json::from_str(input).map_err(|e| format!("invalid: parse: {e}"))?;
-    let extent = measure_paragraph(store, &parsed).map_err(|e| e.to_string())?;
+    let extent = measure_paragraph_typed(store, &parsed.as_request()).map_err(|e| e.to_string())?;
     serde_json::to_string(&extent).map_err(|e| format!("invalid: serialize: {e}"))
 }
 
@@ -440,7 +452,7 @@ fn is_whitespace_only(run: &RunIn) -> bool {
 /// italic.
 fn regular_chain_head(
     store: &FontStore,
-    input: &MeasureInput,
+    input: &MeasureRequest<'_>,
     family: &str,
 ) -> Result<FontId, MeasureError> {
     let chain = input.chain_for(family, false, false)?;

--- a/crates/ooxml-text/src/measure/prepare.rs
+++ b/crates/ooxml-text/src/measure/prepare.rs
@@ -37,7 +37,7 @@ use crate::line_break::break_opportunities;
 use crate::shape::{ShapeDirection, ShapeFeature, shape_with_direction, shape_with_properties};
 use crate::word_metrics::{kern_enabled, kern_features};
 
-use super::input::{MeasureInput, RunIn, validate_pt_size};
+use super::input::{MeasureRequest, RunIn, validate_pt_size};
 use super::{MAX_RUN_TEXT_BYTES, MeasureError, pt_to_px};
 
 /// Longest fallback chain a run keeps resolved per slot. Chains past it are
@@ -195,7 +195,7 @@ fn shape_direction(level: u8) -> ShapeDirection {
 /// (a Word paragraph is LTR unless `bidi` is set — never first-strong).
 /// The base only affects neutral characters' levels, i.e. segmentation,
 /// never advance sums.
-fn base_direction(run_rtl: bool, input: &MeasureInput) -> crate::bidi::BaseDirection {
+fn base_direction(run_rtl: bool, input: &MeasureRequest<'_>) -> crate::bidi::BaseDirection {
     if run_rtl || input.block.attrs.as_ref().is_some_and(|a| a.bidi) {
         crate::bidi::BaseDirection::Rtl
     } else {
@@ -221,7 +221,7 @@ pub(super) fn validate_chain(store: &FontStore, chain: &[FontId]) -> Result<(), 
 /// An unrecognized `kind` is refused.
 pub(super) fn prepare_runs(
     store: &FontStore,
-    input: &MeasureInput,
+    input: &MeasureRequest<'_>,
 ) -> Result<Vec<PreparedRun>, MeasureError> {
     let bidi_levels = paragraph_run_levels(input);
     let mut prepared = Vec::with_capacity(input.block.runs.len());
@@ -267,7 +267,7 @@ pub(super) fn prepare_runs(
 /// concatenated text so neutrals see their real context. Non-text runs stand
 /// in as one object-replacement character each. A run carrying `w:rtl`
 /// re-resolves on its own text under an RTL base instead.
-fn paragraph_run_levels(input: &MeasureInput) -> Vec<Vec<u8>> {
+fn paragraph_run_levels(input: &MeasureRequest<'_>) -> Vec<Vec<u8>> {
     let mut combined = String::new();
     let mut spans = Vec::with_capacity(input.block.runs.len());
     let mut char_cursor = 0usize;
@@ -312,7 +312,7 @@ fn paragraph_run_levels(input: &MeasureInput) -> Vec<Vec<u8>> {
 /// Resolves a tab run's font for line metrics.
 fn prepare_tab_run(
     store: &FontStore,
-    input: &MeasureInput,
+    input: &MeasureRequest<'_>,
     run: &RunIn,
     bidi_level: u8,
 ) -> Result<PreparedTab, MeasureError> {
@@ -427,7 +427,7 @@ fn prepare_image_run(run: &RunIn, bidi_level: u8) -> Result<PreparedRun, Measure
 /// to fields; super/subscript scaling does.
 fn prepare_field_run(
     store: &FontStore,
-    input: &MeasureInput,
+    input: &MeasureRequest<'_>,
     run: &RunIn,
     bidi_level: u8,
 ) -> Result<PreparedField, MeasureError> {
@@ -539,7 +539,7 @@ pub(super) fn measure_plain_text(
 /// and record the UAX-14 break opportunities.
 fn prepare_text_run(
     store: &FontStore,
-    input: &MeasureInput,
+    input: &MeasureRequest<'_>,
     run: &RunIn,
     resolved_levels: &[u8],
 ) -> Result<PreparedText, MeasureError> {
@@ -988,6 +988,7 @@ fn prepare_text_run(
 
 #[cfg(test)]
 mod tests {
+    use super::super::input::MeasureInput;
     use super::*;
     use crate::font_store::FontStore;
 
@@ -1013,7 +1014,7 @@ mod tests {
         // 'é' is 2 UTF-8 bytes but 1 UTF-16 unit: byte offsets [0, 2, 3],
         // UTF-16 offsets must be [0, 1, 2].
         let input = input_with(serde_json::json!([{ "kind": "text", "text": "éab" }]));
-        let prepared = prepare_runs(&store, &input).unwrap();
+        let prepared = prepare_runs(&store, &input.as_request()).unwrap();
         let PreparedRun::Text(t) = &prepared[0] else {
             panic!("expected text run");
         };
@@ -1032,7 +1033,8 @@ mod tests {
         let mut store = FontStore::new();
         store.register(FIXTURE.to_vec()).unwrap();
         let input = input_with(serde_json::json!([{ "kind": "text", "text": "a😀b" }]));
-        let prepared = prepare_runs(&store, &input).expect("uncovered char no longer bails");
+        let prepared =
+            prepare_runs(&store, &input.as_request()).expect("uncovered char no longer bails");
         assert!(!prepared.is_empty());
     }
 
@@ -1046,7 +1048,7 @@ mod tests {
             "letterSpacing": 2.0
         }]));
         input.authoritative_shaping = true;
-        let prepared = prepare_runs(&store, &input).unwrap();
+        let prepared = prepare_runs(&store, &input.as_request()).unwrap();
         let PreparedRun::Text(text) = &prepared[0] else {
             panic!("expected text run");
         };


### PR DESCRIPTION
TL;DR:

Summary:
- paragraphs measure through a typed request (`MeasureRequest<'a>`) instead of serializing block+font-chains to JSON and parsing them back per call
- drops the whole-paragraph clone, font-chain map copy, envelope serialize/parse and extent serialize/parse on every measurement (open, keystroke, headers, table cells)
- public `MeasureInput`/`measure_paragraph` unchanged; wasm JSON path delegates to the same typed core; malformed-input fallback parity pinned by tests incl. serde struct-from-seq quirks

Test plan:
- [ ] `cargo test -p betteroffice-ooxml-text -p betteroffice-docx-layout` green
- [ ] open + typing latency spot-check on a large document
- [ ] canvas fallback path (UNSUPPORTED) still triggers where it did before