### PR TITLE
perf(xlsx): reuse formula parses during structural remaps

### DIFF
--- a/.changeset/xlsx-remap-dedupe.md
+++ b/.changeset/xlsx-remap-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Reuse formula parses and shift cell maps in place during structural edits.

--- a/crates/xlsx-model/src/workbook.rs
+++ b/crates/xlsx-model/src/workbook.rs
@@ -54,6 +54,10 @@ pub struct Cell {
     pub style: Option<u32>,
 }
 
+/// cells to relocate: each source address with the address it moves to, or
+/// `None` when the cell is refused.
+type CellMoves = Vec<((RowId, ColId), Option<(RowId, ColId)>)>;
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Sheet {
     pub name: String,
@@ -84,6 +88,64 @@ impl Sheet {
         } else {
             self.cells.insert((at.row, at.col), cell);
         }
+    }
+
+    /// moves every occupied cell to the address `remap` names; the cells it
+    /// refuses come back in address order. cells already at their target are
+    /// left untouched, and a target several cells reach keeps the one from the
+    /// largest source address.
+    pub fn remap_cells(
+        &mut self,
+        remap: impl Fn(CellRef) -> Option<CellRef>,
+    ) -> Vec<(CellRef, Cell)> {
+        let mut dropped = Vec::new();
+        self.cells.retain(|_, cell| *cell != Cell::default());
+        let mut plan: CellMoves = Vec::new();
+        let mut split: Option<(RowId, ColId)> = None;
+        let mut suffix = true;
+        for &at in self.cells.keys() {
+            let target = match remap(CellRef::new(at.0, at.1)) {
+                Some(to) if (to.row, to.col) != at => Some((to.row, to.col)),
+                Some(_) => {
+                    if split.is_some() {
+                        suffix = false;
+                    }
+                    continue;
+                }
+                None => None,
+            };
+            if split.is_none() {
+                split = Some(at);
+            }
+            plan.push((at, target));
+        }
+        let Some(split) = split else {
+            return dropped;
+        };
+        if suffix && plan.iter().all(|(_, to)| to.is_none_or(|to| to >= split)) {
+            let mut rebuilt = BTreeMap::new();
+            let mut tail = self.cells.split_off(&split).into_iter();
+            for ((row, col), target) in plan {
+                let (_, cell) = tail.next().expect("plan covers every split-off cell");
+                match target {
+                    Some(to) => {
+                        rebuilt.insert(to, cell);
+                    }
+                    None => dropped.push((CellRef::new(row, col), cell)),
+                }
+            }
+            self.cells.append(&mut rebuilt);
+        } else {
+            let old = std::mem::take(&mut self.cells);
+            for ((row, col), cell) in old {
+                let Some(to) = remap(CellRef::new(row, col)) else {
+                    dropped.push((CellRef::new(row, col), cell));
+                    continue;
+                };
+                self.cells.insert((to.row, to.col), cell);
+            }
+        }
+        dropped
     }
 
     /// ordered iteration over occupied cells (row-major).

--- a/crates/xlsx-ops/src/apply.rs
+++ b/crates/xlsx-ops/src/apply.rs
@@ -629,25 +629,10 @@ fn delete_cols(
     Ok(InvertedOp(inv))
 }
 
-/// remap every occupied cell through `op`, rebuilding storage. returns the
-/// cells whose address was dropped, for the inverse.
+/// remap every occupied cell through `op` in place. returns the cells whose
+/// address was dropped, for the inverse.
 fn shift_cells(s: &mut Sheet, op: &Op) -> Vec<(CellRef, Cell)> {
-    let old: Vec<(CellRef, Cell)> = s.iter_cells().map(|(r, c)| (r, c.clone())).collect();
-    let mut moved = Vec::new();
-    let mut dropped = Vec::new();
-    for (r, c) in &old {
-        match remap_ref(*r, op) {
-            Some(nr) => moved.push((nr, c.clone())),
-            None => dropped.push((*r, c.clone())),
-        }
-    }
-    for (r, _) in &old {
-        s.set_cell(*r, Cell::default());
-    }
-    for (nr, c) in moved {
-        s.set_cell(nr, c);
-    }
-    dropped
+    s.remap_cells(|at| remap_ref(at, op))
 }
 
 fn shift_row_heights_up(s: &mut Sheet, at: RowId, count: u32) {
@@ -1670,5 +1655,182 @@ mod tests {
             assert!(matches!(error, OpError::ChartFrameShifted { .. }));
             assert_eq!(wb.sheets[0].charts[0].anchor, anchor(0, 0));
         }
+    }
+
+    fn filled(at: &str, value: f64) -> (CellRef, Cell) {
+        (
+            r(at),
+            Cell {
+                value: CellValue::Number { value },
+                ..Cell::default()
+            },
+        )
+    }
+
+    /// two cells land on one target; today's clear-then-reinsert order made
+    /// the largest source address win.
+    #[test]
+    fn remap_cells_contested_target_keeps_the_largest_source() {
+        let mut sheet = Sheet::new("S");
+        let (a1, c1) = filled("A1", 1.0);
+        let (_, c2) = filled("A6", 2.0);
+        sheet.set_cell(a1, c1.clone());
+        sheet.set_cell(r("A6"), c2.clone());
+        let dropped = sheet.remap_cells(|at| match at.row {
+            0 => Some(CellRef::new(5, 0)),
+            5 => Some(CellRef::new(5, 0)),
+            _ => Some(at),
+        });
+        assert!(dropped.is_empty());
+        assert_eq!(sheet.cell(CellRef::new(5, 0)), Some(&c2));
+        assert_eq!(sheet.iter_cells().count(), 1);
+    }
+
+    /// the same contest when every touched cell moves, so the split-off
+    /// fast path runs instead of the full-rebuild fallback.
+    #[test]
+    fn remap_cells_contested_target_resolves_on_the_fast_path_too() {
+        let mut sheet = Sheet::new("S");
+        let (_, c5) = filled("A5", 5.0);
+        let (_, c7) = filled("A7", 7.0);
+        sheet.set_cell(r("A5"), c5);
+        sheet.set_cell(r("A7"), c7.clone());
+        let dropped = sheet.remap_cells(|at| {
+            if at.row >= 4 {
+                Some(CellRef::new(6, at.col))
+            } else {
+                Some(at)
+            }
+        });
+        assert!(dropped.is_empty());
+        assert_eq!(sheet.cell(CellRef::new(6, 0)), Some(&c7));
+        assert_eq!(sheet.iter_cells().count(), 1);
+    }
+
+    /// cells that keep their address stay put, refused ones come back in
+    /// address order, and survivors move down past the refused span.
+    #[test]
+    fn remap_cells_keeps_stays_and_reports_drops_in_address_order() {
+        let mut sheet = Sheet::new("S");
+        for (at, value) in [("A1", 1.0), ("A2", 2.0), ("A3", 3.0), ("B7", 7.0)] {
+            let (at, cell) = filled(at, value);
+            sheet.set_cell(at, cell);
+        }
+        let dropped = sheet.remap_cells(|at| {
+            if at.row == 1 {
+                None
+            } else if at.row == 0 {
+                Some(at)
+            } else {
+                Some(CellRef::new(at.row - 1, at.col))
+            }
+        });
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].0, r("A2"));
+        assert_eq!(dropped[0].1.value, CellValue::Number { value: 2.0 });
+        assert_eq!(
+            sheet.cell(r("A1")).unwrap().value,
+            CellValue::Number { value: 1.0 }
+        );
+        assert_eq!(
+            sheet.cell(r("A2")).unwrap().value,
+            CellValue::Number { value: 3.0 }
+        );
+        assert_eq!(
+            sheet.cell(r("B6")).unwrap().value,
+            CellValue::Number { value: 7.0 }
+        );
+        assert_eq!(sheet.iter_cells().count(), 3);
+    }
+
+    /// rows and columns shift through the new storage path and invert back to
+    /// exactly the workbook they started from.
+    #[test]
+    fn structural_shifts_round_trip_exactly_on_both_axes() {
+        let mut wb = wb_one_sheet();
+        wb.sheets.push(Sheet::new("Data"));
+        for row in 1..=12 {
+            for col in ["A", "C", "F"] {
+                let at = format!("{col}{row}");
+                let (cell_ref, cell) = filled(&at, f64::from(row));
+                wb.sheet_mut(SheetId(0)).unwrap().set_cell(cell_ref, cell);
+            }
+            wb.sheet_mut(SheetId(1)).unwrap().set_cell(
+                r(&format!("B{row}")),
+                Cell {
+                    formula: Some("Sheet1!A1+Sheet1!$E$9".into()),
+                    ..Cell::default()
+                },
+            );
+        }
+        let before = wb.clone();
+
+        let edits = [
+            Op::InsertRows {
+                sheet: SheetId(0),
+                at: 4,
+                count: 3,
+            },
+            Op::DeleteRows {
+                sheet: SheetId(0),
+                at: 1,
+                count: 2,
+            },
+            Op::InsertCols {
+                sheet: SheetId(0),
+                at: 1,
+                count: 2,
+            },
+            Op::DeleteCols {
+                sheet: SheetId(0),
+                at: 3,
+                count: 1,
+            },
+        ];
+        for op in &edits {
+            let inverse = apply(&mut wb, op).unwrap();
+            apply_ops(&mut wb, &inverse.0).unwrap();
+            assert_eq!(wb, before, "{op:?} must invert exactly");
+        }
+    }
+
+    /// a deletion whose span holds contents must report them for the inverse,
+    /// whatever sits above or below the span.
+    #[test]
+    fn deleting_rows_reports_every_dropped_cell_for_undo() {
+        let mut wb = wb_one_sheet();
+        for (at, value) in [("A1", 1.0), ("A3", 3.0), ("A4", 4.0), ("A6", 6.0)] {
+            let (at, cell) = filled(at, value);
+            wb.sheets[0].set_cell(at, cell);
+        }
+        let inverse = apply(
+            &mut wb,
+            &Op::DeleteRows {
+                sheet: SheetId(0),
+                at: 2,
+                count: 2,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            wb.value(SheetId(0), r("A4")),
+            CellValue::Number { value: 6.0 }
+        );
+        assert!(wb.sheet(SheetId(0)).unwrap().cell(r("A3")).is_none());
+        let restores = inverse
+            .0
+            .iter()
+            .filter(|op| matches!(op, Op::SetCell { .. }))
+            .count();
+        assert_eq!(restores, 2, "rows 3 and 4 must come back");
+        apply_ops(&mut wb, &inverse.0).unwrap();
+        assert_eq!(
+            wb.value(SheetId(0), r("A3")),
+            CellValue::Number { value: 3.0 }
+        );
+        assert_eq!(
+            wb.value(SheetId(0), r("A4")),
+            CellValue::Number { value: 4.0 }
+        );
     }
 }

--- a/crates/xlsx-ops/src/remap.rs
+++ b/crates/xlsx-ops/src/remap.rs
@@ -1,7 +1,8 @@
 //! rewriting stored formulas on row/column insert/delete: refs shift, ranges
 //! clip, wholly deleted refs collapse to `#REF!`. runs before cells shift.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::rc::Rc;
 
 use xlsx_calc::lexer::MAX_FORMULA_BYTES;
 use xlsx_calc::parse_formula;
@@ -15,6 +16,9 @@ use xlsx_model::{
 use crate::apply::OpError;
 use crate::apply::remap_ref;
 use crate::op::{CellState, Op};
+
+/// distinct parsed formulas kept in the memo before oldest-entry eviction.
+const PARSE_MEMO_CAP: usize = 1024;
 
 /// the outcome of remapping one reference or range under a structural op.
 enum Remapped<T> {
@@ -62,6 +66,8 @@ pub(crate) fn remap_formulas(wb: &mut Workbook, op: &Op) -> Result<Vec<Op>, OpEr
 
     let mut restores: Vec<Op> = Vec::new();
     let mut edits: Vec<(SheetId, CellRef, String)> = Vec::new();
+    let mut parsed: HashMap<&str, Rc<Expr>> = HashMap::new();
+    let mut parsed_order: VecDeque<&str> = VecDeque::new();
     for (i, sheet) in wb.sheets.iter().enumerate() {
         let owner = SheetId(i as u32);
         let matches = |ref_sheet: &Option<String>| resolves_to_target(ref_sheet, owner, &index);
@@ -72,8 +78,22 @@ pub(crate) fn remap_formulas(wb: &mut Workbook, op: &Op) -> Result<Vec<Op>, OpEr
             if has_unresolvable_binding(src, &index) {
                 return Err(OpError::FormulaNotRewritable { sheet: owner, cell });
             }
-            let expr = parse_formula(src)
-                .map_err(|_| OpError::FormulaNotRewritable { sheet: owner, cell })?;
+            let expr = if let Some(expr) = parsed.get(src.as_str()) {
+                Rc::clone(expr)
+            } else {
+                let expr = Rc::new(
+                    parse_formula(src)
+                        .map_err(|_| OpError::FormulaNotRewritable { sheet: owner, cell })?,
+                );
+                if parsed.len() >= PARSE_MEMO_CAP
+                    && let Some(oldest) = parsed_order.pop_front()
+                {
+                    parsed.remove(oldest);
+                }
+                parsed.insert(src.as_str(), Rc::clone(&expr));
+                parsed_order.push_back(src.as_str());
+                expr
+            };
             let mut changed = false;
             let new_expr = transform(&expr, op, &matches, &mut changed);
             if changed {
@@ -3452,5 +3472,121 @@ mod tests {
         assert_eq!(clip_interval(4, 6, 4, 3), None);
         assert_eq!(clip_interval(2, 9, 2, 4), Some((2, 5)));
         assert_eq!(clip_interval(0, 1, 5, 2), Some((0, 1)));
+    }
+
+    /// a filled-down column parses one text many times; every copy must come
+    /// out rewritten alike.
+    #[test]
+    fn identical_formulas_in_many_cells_all_rewrite_alike() {
+        let mut w = wb(&["Data", "Other"]);
+        for row in 1..=40 {
+            set_formula(&mut w, SheetId(0), &format!("C{row}"), "SUM($A$1:$A$10)+B5");
+            set_formula(
+                &mut w,
+                SheetId(1),
+                &format!("C{row}"),
+                "Data!$A$1:$A$10+Data!B5",
+            );
+        }
+        let op = Op::InsertRows {
+            sheet: SheetId(0),
+            at: 0,
+            count: 3,
+        };
+        let inv = remap_formulas(&mut w, &op).unwrap();
+        for row in 1..=40 {
+            assert_eq!(
+                formula(&w, SheetId(0), &format!("C{row}")).as_deref(),
+                Some("SUM($A$4:$A$13)+B8")
+            );
+            assert_eq!(
+                formula(&w, SheetId(1), &format!("C{row}")).as_deref(),
+                Some("Data!$A$4:$A$13+Data!B8")
+            );
+        }
+        assert_eq!(inv.len(), 80);
+        apply_inverse_removes(&mut w, &inv);
+        for row in 1..=40 {
+            assert_eq!(
+                formula(&w, SheetId(0), &format!("C{row}")).as_deref(),
+                Some("SUM($A$1:$A$10)+B5")
+            );
+            assert_eq!(
+                formula(&w, SheetId(1), &format!("C{row}")).as_deref(),
+                Some("Data!$A$1:$A$10+Data!B5")
+            );
+        }
+    }
+
+    fn apply_inverse_removes(w: &mut Workbook, inv: &[Op]) {
+        let restores = inv
+            .iter()
+            .filter_map(|op| match op {
+                Op::SetCell { sheet, at, cell } => Some((*sheet, *at, cell.clone())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for (sheet, at, cell) in restores {
+            w.sheet_mut(sheet)
+                .expect("sheet exists during restore")
+                .set_cell(at, cell.into());
+        }
+    }
+
+    /// the parse cache is keyed on text alone; the rewrite must still resolve
+    /// against each owning sheet, so identical text can diverge per sheet.
+    #[test]
+    fn duplicated_formula_text_is_rewritten_per_owning_sheet() {
+        let mut w = wb(&["Data", "Other"]);
+        set_formula(&mut w, SheetId(0), "B1", "A5*2");
+        set_formula(&mut w, SheetId(0), "B9", "A5*2");
+        set_formula(&mut w, SheetId(1), "B1", "A5*2");
+        set_formula(&mut w, SheetId(1), "B9", "Data!A5*2");
+        remap_formulas(
+            &mut w,
+            &Op::DeleteRows {
+                sheet: SheetId(0),
+                at: 4,
+                count: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(formula(&w, SheetId(0), "B1").as_deref(), Some("#REF!*2"));
+        assert_eq!(formula(&w, SheetId(0), "B9").as_deref(), Some("#REF!*2"));
+        assert_eq!(formula(&w, SheetId(1), "B1").as_deref(), Some("A5*2"));
+        assert_eq!(
+            formula(&w, SheetId(1), "B9").as_deref(),
+            Some("#REF!*2"),
+            "a deleted qualified ref collapses like an unqualified one"
+        );
+    }
+
+    /// more distinct formulas than the memo can hold: entries evicted before
+    /// their cell is reached must still rewrite exactly as if parsed fresh.
+    #[test]
+    fn distinct_formulas_beyond_memo_cap_all_rewrite_correctly() {
+        let count = PARSE_MEMO_CAP * 2 + 7;
+        let mut w = wb(&["Sheet1"]);
+        for row in 1..=count {
+            set_formula(
+                &mut w,
+                SheetId(0),
+                &format!("A{row}"),
+                &format!("B{row}+{row}"),
+            );
+        }
+        let op = Op::InsertRows {
+            sheet: SheetId(0),
+            at: 0,
+            count: 3,
+        };
+        let inv = remap_formulas(&mut w, &op).unwrap();
+        assert_eq!(inv.len(), count);
+        for row in 1..=count {
+            assert_eq!(
+                formula(&w, SheetId(0), &format!("A{row}")).as_deref(),
+                Some(format!("B{}+{row}", row + 3)).as_deref()
+            );
+        }
     }
 }


### PR DESCRIPTION
TL;DR:

Summary:
- structural edits parse each distinct formula once per remap (FIFO-bounded memo, cap 1024) instead of re-parsing every occurrence
- row shifts rebuild only the BTreeMap suffix past the split point instead of clone-clear-reinsert of all cells; column ops take a move-only ascending pass
- collision semantics preserved exactly (largest source address wins), pinned by non-injective-closure tests

Test plan:
- [ ] `cargo test -p betteroffice-xlsx-ops -p betteroffice-xlsx-model` green
- [ ] insert/delete rows+cols on a formula-heavy workbook: results match main
- [ ] undo/redo across structural edits unchanged