### PR TITLE
perf(xlsx): memoize tokenized number formats

### DIFF
--- a/.changeset/xlsx-numfmt-cache.md
+++ b/.changeset/xlsx-numfmt-cache.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Cache tokenized number formats across renders.

--- a/crates/xlsx-model/src/numfmt.rs
+++ b/crates/xlsx-model/src/numfmt.rs
@@ -1,6 +1,9 @@
 //! number-format code interpreter (ecma-376 §18.8.30–31): value + format code
 //! -> display string and optional bracket color. unsupported degrades to general.
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
 use serde::{Deserialize, Serialize};
 
 use crate::date::DateSystem;
@@ -145,6 +148,74 @@ impl Section {
     fn has(&self, pred: impl Fn(&Tok) -> bool) -> bool {
         self.toks.iter().any(pred)
     }
+}
+
+/// process-wide memoized parses; capped so adversarial code variety can't grow it.
+const FORMAT_CACHE_CAP: usize = 256;
+
+/// codes longer than this parse fresh every call and are never retained; excel
+/// itself rejects format codes beyond ~255 chars.
+const MAX_CACHED_CODE_LEN: usize = 256;
+
+#[derive(Default)]
+struct FormatCache {
+    entries: HashMap<String, (u64, Arc<[Section]>)>,
+    clock: u64,
+}
+
+impl FormatCache {
+    fn get(&mut self, code: &str) -> Option<Arc<[Section]>> {
+        let entry = self.entries.get_mut(code)?;
+        self.clock += 1;
+        entry.0 = self.clock;
+        Some(entry.1.clone())
+    }
+
+    fn insert(&mut self, code: &str, parsed: Arc<[Section]>) {
+        self.clock += 1;
+        if self.entries.len() >= FORMAT_CACHE_CAP {
+            let oldest = self
+                .entries
+                .iter()
+                .min_by_key(|(_, (used, _))| *used)
+                .map(|(k, _)| k.clone());
+            if let Some(oldest) = oldest {
+                self.entries.remove(&oldest);
+            }
+        }
+        self.entries.insert(code.to_string(), (self.clock, parsed));
+    }
+}
+
+/// memoized `split_sections` + `tokenize`, keyed by the exact code string.
+fn parsed_sections(code: &str) -> Arc<[Section]> {
+    static CACHE: OnceLock<Mutex<FormatCache>> = OnceLock::new();
+    parsed_sections_in(
+        CACHE.get_or_init(|| Mutex::new(FormatCache::default())),
+        code,
+    )
+}
+
+/// the lock guards map operations only: on a miss it is released while the
+/// code is tokenized, then reacquired to insert (rechecking for a racing hit).
+fn parsed_sections_in(cache: &Mutex<FormatCache>, code: &str) -> Arc<[Section]> {
+    if code.len() > MAX_CACHED_CODE_LEN {
+        return tokenize_all(code);
+    }
+    if let Some(hit) = cache.lock().unwrap_or_else(|e| e.into_inner()).get(code) {
+        return hit;
+    }
+    let parsed = tokenize_all(code);
+    let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(raced) = guard.get(code) {
+        return raced;
+    }
+    guard.insert(code, parsed.clone());
+    parsed
+}
+
+fn tokenize_all(code: &str) -> Arc<[Section]> {
+    split_sections(code).iter().map(|s| tokenize(s)).collect()
 }
 
 /// split a code into sections on top-level `;` (quotes, brackets, and escapes guarded).
@@ -491,7 +562,7 @@ fn format_number_value(n: f64, code: &str, ds: DateSystem) -> FormattedValue {
             color: None,
         };
     }
-    let parsed: Vec<Section> = split_sections(code).iter().map(|s| tokenize(s)).collect();
+    let parsed = parsed_sections(code);
     let (idx, auto_minus) = select(&parsed, n);
     let sec = &parsed[idx];
     let color = sec.color.clone();
@@ -896,7 +967,7 @@ fn trim_trailing_zeros(s: &mut String) {
 }
 
 fn format_text_value(text: &str, code: &str) -> FormattedValue {
-    let parsed: Vec<Section> = split_sections(code).iter().map(|s| tokenize(s)).collect();
+    let parsed = parsed_sections(code);
     let sec = if parsed.len() >= 4 {
         Some(&parsed[3])
     } else {

--- a/crates/xlsx-model/src/numfmt.rs
+++ b/crates/xlsx-model/src/numfmt.rs
@@ -152,11 +152,14 @@ impl Section {
 }
 
 /// memoized parses per generation; capped so adversarial code variety can't grow the cache.
-const FORMAT_CACHE_CAP: usize = 256;
+const FORMAT_CACHE_CAP: usize = 128;
 
 /// codes longer than this parse fresh every call and are never retained; excel
 /// itself rejects format codes beyond ~255 chars.
 const MAX_CACHED_CODE_LEN: usize = 256;
+
+/// positive, negative, zero, text: the only sections any render path selects.
+const USED_SECTIONS: usize = 4;
 
 /// two generations, so making room costs one swap instead of a scan for a
 /// victim: inserts fill `hot`, a full `hot` ages into `cold`, and the next
@@ -191,8 +194,11 @@ thread_local! {
 }
 
 /// memoized `split_sections` + `tokenize`, keyed by the exact code string.
+/// falls back to parsing when the thread's cache is already torn down.
 fn parsed_sections(code: &str) -> Arc<[Section]> {
-    FORMAT_CACHE.with(|cache| parsed_sections_in(&mut cache.borrow_mut(), code))
+    FORMAT_CACHE
+        .try_with(|cache| parsed_sections_in(&mut cache.borrow_mut(), code))
+        .unwrap_or_else(|_| tokenize_all(code))
 }
 
 fn parsed_sections_in(cache: &mut FormatCache, code: &str) -> Arc<[Section]> {
@@ -207,8 +213,14 @@ fn parsed_sections_in(cache: &mut FormatCache, code: &str) -> Arc<[Section]> {
     parsed
 }
 
+/// `select` never looks past the third section and text never past the fourth,
+/// so deeper ones are dropped rather than parsed and retained.
 fn tokenize_all(code: &str) -> Arc<[Section]> {
-    split_sections(code).iter().map(|s| tokenize(s)).collect()
+    split_sections(code)
+        .iter()
+        .take(USED_SECTIONS)
+        .map(|s| tokenize(s))
+        .collect()
 }
 
 /// split a code into sections on top-level `;` (quotes, brackets, and escapes guarded).

--- a/crates/xlsx-model/src/numfmt.rs
+++ b/crates/xlsx-model/src/numfmt.rs
@@ -1,8 +1,9 @@
 //! number-format code interpreter (ecma-376 §18.8.30–31): value + format code
 //! -> display string and optional bracket color. unsupported degrades to general.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -122,7 +123,7 @@ impl Condition {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 struct Section {
     toks: Vec<Tok>,
     color: Option<String>,
@@ -150,67 +151,59 @@ impl Section {
     }
 }
 
-/// process-wide memoized parses; capped so adversarial code variety can't grow it.
+/// memoized parses per generation; capped so adversarial code variety can't grow the cache.
 const FORMAT_CACHE_CAP: usize = 256;
 
 /// codes longer than this parse fresh every call and are never retained; excel
 /// itself rejects format codes beyond ~255 chars.
 const MAX_CACHED_CODE_LEN: usize = 256;
 
+/// two generations, so making room costs one swap instead of a scan for a
+/// victim: inserts fill `hot`, a full `hot` ages into `cold`, and the next
+/// age-out drops it. holds at most `2 * FORMAT_CACHE_CAP` parses.
 #[derive(Default)]
 struct FormatCache {
-    entries: HashMap<String, (u64, Arc<[Section]>)>,
-    clock: u64,
+    hot: HashMap<String, Arc<[Section]>>,
+    cold: HashMap<String, Arc<[Section]>>,
 }
 
 impl FormatCache {
     fn get(&mut self, code: &str) -> Option<Arc<[Section]>> {
-        let entry = self.entries.get_mut(code)?;
-        self.clock += 1;
-        entry.0 = self.clock;
-        Some(entry.1.clone())
+        if let Some(hit) = self.hot.get(code) {
+            return Some(hit.clone());
+        }
+        let promoted = self.cold.get(code)?.clone();
+        self.insert(code, promoted.clone());
+        Some(promoted)
     }
 
     fn insert(&mut self, code: &str, parsed: Arc<[Section]>) {
-        self.clock += 1;
-        if self.entries.len() >= FORMAT_CACHE_CAP {
-            let oldest = self
-                .entries
-                .iter()
-                .min_by_key(|(_, (used, _))| *used)
-                .map(|(k, _)| k.clone());
-            if let Some(oldest) = oldest {
-                self.entries.remove(&oldest);
-            }
+        if self.hot.len() >= FORMAT_CACHE_CAP {
+            self.cold = std::mem::take(&mut self.hot);
         }
-        self.entries.insert(code.to_string(), (self.clock, parsed));
+        self.hot.insert(code.to_string(), parsed);
     }
+}
+
+thread_local! {
+    /// per thread, so concurrent renders never serialize on a shared lock.
+    static FORMAT_CACHE: RefCell<FormatCache> = RefCell::new(FormatCache::default());
 }
 
 /// memoized `split_sections` + `tokenize`, keyed by the exact code string.
 fn parsed_sections(code: &str) -> Arc<[Section]> {
-    static CACHE: OnceLock<Mutex<FormatCache>> = OnceLock::new();
-    parsed_sections_in(
-        CACHE.get_or_init(|| Mutex::new(FormatCache::default())),
-        code,
-    )
+    FORMAT_CACHE.with(|cache| parsed_sections_in(&mut cache.borrow_mut(), code))
 }
 
-/// the lock guards map operations only: on a miss it is released while the
-/// code is tokenized, then reacquired to insert (rechecking for a racing hit).
-fn parsed_sections_in(cache: &Mutex<FormatCache>, code: &str) -> Arc<[Section]> {
+fn parsed_sections_in(cache: &mut FormatCache, code: &str) -> Arc<[Section]> {
     if code.len() > MAX_CACHED_CODE_LEN {
         return tokenize_all(code);
     }
-    if let Some(hit) = cache.lock().unwrap_or_else(|e| e.into_inner()).get(code) {
+    if let Some(hit) = cache.get(code) {
         return hit;
     }
     let parsed = tokenize_all(code);
-    let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-    if let Some(raced) = guard.get(code) {
-        return raced;
-    }
-    guard.insert(code, parsed.clone());
+    cache.insert(code, parsed.clone());
     parsed
 }
 

--- a/crates/xlsx-model/src/numfmt/tests.rs
+++ b/crates/xlsx-model/src/numfmt/tests.rs
@@ -337,3 +337,114 @@ fn escaped_and_quoted_literals() {
     assert_eq!(fv(5.0, "0\\ \\k\\g"), "5 kg");
     assert_eq!(fv(100.0, "\"$\"#,##0"), "$100");
 }
+
+#[test]
+fn repeated_codes_render_identically_through_cache() {
+    let codes = [
+        "#,##0.00",
+        "[Red]0.00%;\"neg\";\"zero\";\"txt:\"@",
+        "m/d/yyyy h:mm",
+        "@",
+        "\"p\"0.00",
+    ];
+    for code in codes {
+        let expected = fv(1234.5678, code);
+        for i in 0..(FORMAT_CACHE_CAP * 2) {
+            let _ = fv(i as f64, "0.000");
+            assert_eq!(fv(1234.5678, code), expected);
+        }
+    }
+    let hello = CellValue::Text {
+        value: "hello".to_string(),
+    };
+    let expected = format_value(&hello, "[Red]\"pre \"@", DateSystem::V1900);
+    for _ in 0..(FORMAT_CACHE_CAP * 2) {
+        assert_eq!(
+            format_value(&hello, "[Red]\"pre \"@", DateSystem::V1900),
+            expected
+        );
+    }
+}
+
+#[test]
+fn eviction_past_capacity_keeps_outputs_identical() {
+    let rounds = FORMAT_CACHE_CAP * 3;
+    let codes: Vec<String> = (0..rounds).map(|i| format!("\"p{i}\"0.00")).collect();
+    let first: Vec<String> = codes.iter().map(|c| fv(7.625, c)).collect();
+    for (i, code) in codes.iter().enumerate() {
+        assert_eq!(fv(7.625, code), format!("p{i}7.63"));
+    }
+    for (code, expected) in codes.iter().zip(&first) {
+        assert_eq!(fv(-7.625, code), format!("-{expected}"));
+    }
+}
+
+fn parse_code(code: &str) -> Arc<[Section]> {
+    split_sections(code).iter().map(|s| tokenize(s)).collect()
+}
+
+#[test]
+fn distinct_insertions_track_min_n_cap() {
+    let mut cache = FormatCache::default();
+    for i in 0..=FORMAT_CACHE_CAP + 16 {
+        let key = format!("\"s{i}\"0");
+        cache.insert(&key, parse_code(&key));
+        assert_eq!(cache.entries.len(), (i + 1).min(FORMAT_CACHE_CAP));
+    }
+}
+
+#[test]
+fn repeat_lookup_returns_the_same_arc() {
+    let mut cache = FormatCache::default();
+    cache.insert("0.000", parse_code("0.000"));
+    let first = cache.get("0.000").unwrap();
+    for _ in 0..3 {
+        let again = cache.get("0.000").unwrap();
+        assert!(Arc::ptr_eq(&first, &again));
+    }
+    assert!(cache.get("0.00").is_none());
+}
+
+#[test]
+fn eviction_victim_is_oldest_stamp_and_size_stays_at_cap() {
+    let mut cache = FormatCache::default();
+    let keys: Vec<String> = (0..FORMAT_CACHE_CAP)
+        .map(|i| format!("\"e{i}\"0"))
+        .collect();
+    for key in &keys {
+        cache.insert(key, parse_code(key));
+    }
+    assert_eq!(cache.entries.len(), FORMAT_CACHE_CAP);
+    for key in keys.iter().skip(1) {
+        let _ = cache.get(key);
+    }
+    let newcomer = "\"fresh\"0";
+    cache.insert(newcomer, parse_code(newcomer));
+    assert_eq!(cache.entries.len(), FORMAT_CACHE_CAP);
+    assert!(!cache.entries.contains_key(&keys[0]));
+    assert!(cache.entries.contains_key(newcomer));
+    for key in keys.iter().skip(1) {
+        assert!(cache.entries.contains_key(key));
+    }
+}
+
+#[test]
+fn memoized_path_reuses_one_parse_across_lookups() {
+    let cache = Mutex::new(FormatCache::default());
+    let a = parsed_sections_in(&cache, "[Red]#,##0.00;(#,##0.00)");
+    let b = parsed_sections_in(&cache, "[Red]#,##0.00;(#,##0.00)");
+    assert!(Arc::ptr_eq(&a, &b));
+    assert_eq!(cache.lock().unwrap().entries.len(), 1);
+}
+
+#[test]
+fn oversize_codes_render_correctly_but_are_never_cached() {
+    let literal = "x".repeat(MAX_CACHED_CODE_LEN + 1);
+    let code = format!("\"{literal}\"0.00");
+    let cache = Mutex::new(FormatCache::default());
+    let a = parsed_sections_in(&cache, &code);
+    let b = parsed_sections_in(&cache, &code);
+    assert!(!Arc::ptr_eq(&a, &b));
+    assert!(cache.lock().unwrap().entries.is_empty());
+    assert_eq!(fv(7.625, &code), format!("{literal}7.63"));
+}

--- a/crates/xlsx-model/src/numfmt/tests.rs
+++ b/crates/xlsx-model/src/numfmt/tests.rs
@@ -350,7 +350,7 @@ fn repeated_codes_render_identically_through_cache() {
     for code in codes {
         let expected = fv(1234.5678, code);
         for i in 0..(FORMAT_CACHE_CAP * 2) {
-            let _ = fv(i as f64, "0.000");
+            let _ = fv(i as f64, &format!("\"churn{i}\"0.000"));
             assert_eq!(fv(1234.5678, code), expected);
         }
     }
@@ -384,12 +384,13 @@ fn parse_code(code: &str) -> Arc<[Section]> {
 }
 
 #[test]
-fn distinct_insertions_track_min_n_cap() {
+fn distinct_insertions_never_exceed_two_generations() {
     let mut cache = FormatCache::default();
-    for i in 0..=FORMAT_CACHE_CAP + 16 {
+    for i in 0..=FORMAT_CACHE_CAP * 4 {
         let key = format!("\"s{i}\"0");
         cache.insert(&key, parse_code(&key));
-        assert_eq!(cache.entries.len(), (i + 1).min(FORMAT_CACHE_CAP));
+        assert!(cache.hot.len() <= FORMAT_CACHE_CAP);
+        assert!(cache.hot.len() + cache.cold.len() <= FORMAT_CACHE_CAP * 2);
     }
 }
 
@@ -406,7 +407,7 @@ fn repeat_lookup_returns_the_same_arc() {
 }
 
 #[test]
-fn eviction_victim_is_oldest_stamp_and_size_stays_at_cap() {
+fn a_full_generation_ages_out_but_still_answers_once() {
     let mut cache = FormatCache::default();
     let keys: Vec<String> = (0..FORMAT_CACHE_CAP)
         .map(|i| format!("\"e{i}\"0"))
@@ -414,37 +415,106 @@ fn eviction_victim_is_oldest_stamp_and_size_stays_at_cap() {
     for key in &keys {
         cache.insert(key, parse_code(key));
     }
-    assert_eq!(cache.entries.len(), FORMAT_CACHE_CAP);
-    for key in keys.iter().skip(1) {
-        let _ = cache.get(key);
-    }
+    assert_eq!(cache.hot.len(), FORMAT_CACHE_CAP);
+    assert!(cache.cold.is_empty());
+
     let newcomer = "\"fresh\"0";
     cache.insert(newcomer, parse_code(newcomer));
-    assert_eq!(cache.entries.len(), FORMAT_CACHE_CAP);
-    assert!(!cache.entries.contains_key(&keys[0]));
-    assert!(cache.entries.contains_key(newcomer));
-    for key in keys.iter().skip(1) {
-        assert!(cache.entries.contains_key(key));
-    }
+    assert_eq!(cache.hot.len(), 1);
+    assert_eq!(cache.cold.len(), FORMAT_CACHE_CAP);
+    assert!(cache.hot.contains_key(newcomer));
+
+    assert!(cache.get(&keys[0]).is_some());
+    assert!(cache.hot.contains_key(&keys[0]));
 }
 
 #[test]
 fn memoized_path_reuses_one_parse_across_lookups() {
-    let cache = Mutex::new(FormatCache::default());
-    let a = parsed_sections_in(&cache, "[Red]#,##0.00;(#,##0.00)");
-    let b = parsed_sections_in(&cache, "[Red]#,##0.00;(#,##0.00)");
+    let mut cache = FormatCache::default();
+    let a = parsed_sections_in(&mut cache, "[Red]#,##0.00;(#,##0.00)");
+    let b = parsed_sections_in(&mut cache, "[Red]#,##0.00;(#,##0.00)");
     assert!(Arc::ptr_eq(&a, &b));
-    assert_eq!(cache.lock().unwrap().entries.len(), 1);
+    assert_eq!(cache.hot.len(), 1);
 }
 
 #[test]
 fn oversize_codes_render_correctly_but_are_never_cached() {
     let literal = "x".repeat(MAX_CACHED_CODE_LEN + 1);
     let code = format!("\"{literal}\"0.00");
-    let cache = Mutex::new(FormatCache::default());
-    let a = parsed_sections_in(&cache, &code);
-    let b = parsed_sections_in(&cache, &code);
+    let mut cache = FormatCache::default();
+    let a = parsed_sections_in(&mut cache, &code);
+    let b = parsed_sections_in(&mut cache, &code);
     assert!(!Arc::ptr_eq(&a, &b));
-    assert!(cache.lock().unwrap().entries.is_empty());
+    assert!(cache.hot.is_empty() && cache.cold.is_empty());
     assert_eq!(fv(7.625, &code), format!("{literal}7.63"));
+}
+
+/// the cache must return what a fresh parse would, however hard it is churned.
+#[test]
+fn a_cached_parse_matches_a_fresh_parse_under_churn() {
+    let corpus = [
+        "#,##0.00",
+        "[Red]0.00%;\"neg\";\"zero\";\"txt:\"@",
+        "m/d/yyyy h:mm",
+        "[$-409]dddd, mmmm d, yyyy",
+        "_($* #,##0.00_);_($* (#,##0.00);_($* \"-\"??_);_(@_)",
+        "0.00E+00",
+        "[>100]\"big\";[<0][Red]0.00;0.0",
+        "# ??/??",
+        "0\\ \\k\\g",
+        "@",
+        // pairs that diverge only late, so a partial key would alias them
+        "#,##0.00;[Red](#,##0.00)",
+        "#,##0.00;[Blue](#,##0.00)",
+        "0.000000000;;\"zero\";@",
+        "0.000000000;;\"nil\";@",
+    ];
+    let mut cache = FormatCache::default();
+    for round in 0..4 {
+        for (i, code) in corpus.iter().enumerate() {
+            for j in 0..FORMAT_CACHE_CAP / 2 {
+                let junk = format!("\"j{round}_{i}_{j}\"0");
+                let _ = parsed_sections_in(&mut cache, &junk);
+            }
+            assert_eq!(
+                *parsed_sections_in(&mut cache, code),
+                *tokenize_all(code),
+                "{code}"
+            );
+        }
+    }
+}
+
+/// the parse is shared but the date system is not: it is applied after lookup.
+#[test]
+fn one_cached_code_still_honours_both_date_systems() {
+    let code = "m/d/yyyy h:mm";
+    let serial = 45_000.5;
+    let v1900 = fv(serial, code);
+    let v1904 = fv04(serial, code);
+    assert_ne!(v1900, v1904);
+    for _ in 0..8 {
+        assert_eq!(fv04(serial, code), v1904);
+        assert_eq!(fv(serial, code), v1900);
+    }
+}
+
+#[test]
+fn concurrent_callers_agree_with_a_single_threaded_render() {
+    let codes: Vec<String> = (0..FORMAT_CACHE_CAP + 64)
+        .map(|i| format!("\"c{i}\"#,##0.00;[Red](#,##0.00)"))
+        .collect();
+    let expected: Vec<String> = codes.iter().map(|c| fv(-1234.5678, c)).collect();
+    std::thread::scope(|s| {
+        for _ in 0..4 {
+            let (codes, expected) = (&codes, &expected);
+            s.spawn(move || {
+                for _ in 0..4 {
+                    for (code, want) in codes.iter().zip(expected) {
+                        assert_eq!(&fv(-1234.5678, code), want);
+                    }
+                }
+            });
+        }
+    });
 }

--- a/crates/xlsx-model/src/numfmt/tests.rs
+++ b/crates/xlsx-model/src/numfmt/tests.rs
@@ -449,40 +449,103 @@ fn oversize_codes_render_correctly_but_are_never_cached() {
     assert_eq!(fv(7.625, &code), format!("{literal}7.63"));
 }
 
-/// the cache must return what a fresh parse would, however hard it is churned.
+const CACHE_CORPUS: [&str; 14] = [
+    "#,##0.00",
+    "[Red]0.00%;\"neg\";\"zero\";\"txt:\"@",
+    "m/d/yyyy h:mm",
+    "[$-409]dddd, mmmm d, yyyy",
+    "_($* #,##0.00_);_($* (#,##0.00);_($* \"-\"??_);_(@_)",
+    "0.00E+00",
+    "[>100]\"big\";[<0][Red]0.00;0.0",
+    "# ??/??",
+    "0\\ \\k\\g",
+    "@",
+    // pairs that diverge only late, so a partial key would alias them
+    "#,##0.00;[Red](#,##0.00)",
+    "#,##0.00;[Blue](#,##0.00)",
+    "0.000000000;;\"zero\";@",
+    "0.000000000;;\"nil\";@",
+];
+
+/// every lookup below is a proven hit, and each must equal a fresh parse.
 #[test]
-fn a_cached_parse_matches_a_fresh_parse_under_churn() {
-    let corpus = [
-        "#,##0.00",
-        "[Red]0.00%;\"neg\";\"zero\";\"txt:\"@",
-        "m/d/yyyy h:mm",
-        "[$-409]dddd, mmmm d, yyyy",
-        "_($* #,##0.00_);_($* (#,##0.00);_($* \"-\"??_);_(@_)",
-        "0.00E+00",
-        "[>100]\"big\";[<0][Red]0.00;0.0",
-        "# ??/??",
-        "0\\ \\k\\g",
-        "@",
-        // pairs that diverge only late, so a partial key would alias them
-        "#,##0.00;[Red](#,##0.00)",
-        "#,##0.00;[Blue](#,##0.00)",
-        "0.000000000;;\"zero\";@",
-        "0.000000000;;\"nil\";@",
-    ];
-    let mut cache = FormatCache::default();
-    for round in 0..4 {
-        for (i, code) in corpus.iter().enumerate() {
-            for j in 0..FORMAT_CACHE_CAP / 2 {
-                let junk = format!("\"j{round}_{i}_{j}\"0");
-                let _ = parsed_sections_in(&mut cache, &junk);
-            }
-            assert_eq!(
-                *parsed_sections_in(&mut cache, code),
-                *tokenize_all(code),
-                "{code}"
-            );
+fn a_cache_hit_returns_what_a_fresh_parse_would() {
+    for code in CACHE_CORPUS {
+        let mut cache = FormatCache::default();
+        let seeded = parsed_sections_in(&mut cache, code);
+        assert_eq!(*seeded, *tokenize_all(code), "{code}");
+
+        for j in 1..FORMAT_CACHE_CAP {
+            let _ = parsed_sections_in(&mut cache, &format!("\"j{j}\"0"));
         }
+        assert_eq!(cache.hot.len(), FORMAT_CACHE_CAP);
+        assert!(cache.hot.contains_key(code));
+        let hot_hit = parsed_sections_in(&mut cache, code);
+        assert!(Arc::ptr_eq(&seeded, &hot_hit), "{code}: not a hot hit");
+
+        let _ = parsed_sections_in(&mut cache, "\"flip\"0");
+        assert!(cache.cold.contains_key(code) && !cache.hot.contains_key(code));
+        let cold_hit = parsed_sections_in(&mut cache, code);
+        assert!(Arc::ptr_eq(&seeded, &cold_hit), "{code}: not a cold hit");
+        assert_eq!(*cold_hit, *tokenize_all(code), "{code}");
     }
+}
+
+#[test]
+fn a_cold_hit_promotes_even_when_hot_is_already_full() {
+    let code = "[Red]#,##0.00;(#,##0.00);\"-\";@";
+    let mut cache = FormatCache::default();
+    let seeded = parsed_sections_in(&mut cache, code);
+    for j in 1..FORMAT_CACHE_CAP {
+        let _ = parsed_sections_in(&mut cache, &format!("\"a{j}\"0"));
+    }
+    let _ = parsed_sections_in(&mut cache, "\"flip\"0");
+    assert!(cache.cold.contains_key(code));
+    for j in 1..FORMAT_CACHE_CAP {
+        let _ = parsed_sections_in(&mut cache, &format!("\"b{j}\"0"));
+    }
+    assert_eq!(cache.hot.len(), FORMAT_CACHE_CAP);
+
+    let promoted = parsed_sections_in(&mut cache, code);
+    assert!(Arc::ptr_eq(&seeded, &promoted));
+    assert!(cache.hot.contains_key(code));
+    assert_eq!(*promoted, *tokenize_all(code));
+}
+
+#[test]
+fn reinserting_a_present_key_at_capacity_loses_nothing() {
+    let mut cache = FormatCache::default();
+    let keys: Vec<String> = (0..FORMAT_CACHE_CAP)
+        .map(|i| format!("\"r{i}\"0"))
+        .collect();
+    for key in &keys {
+        cache.insert(key, parse_code(key));
+    }
+    let repeat = &keys[FORMAT_CACHE_CAP / 2];
+    cache.insert(repeat, parse_code(repeat));
+    assert!(cache.hot.contains_key(repeat));
+    for key in &keys {
+        assert!(
+            cache.hot.contains_key(key) || cache.cold.contains_key(key),
+            "{key} was dropped"
+        );
+    }
+}
+
+/// only the first four sections are ever selected, so the parse stops there.
+#[test]
+fn sections_past_the_fourth_are_never_selected() {
+    assert_eq!(fv(1.0, "\"a\";\"b\";\"c\";\"d\";\"e\";\"f\""), "a");
+    assert_eq!(fv(-1.0, "\"a\";\"b\";\"c\";\"d\";\"e\""), "b");
+    assert_eq!(fv(0.0, "\"a\";\"b\";\"c\";\"d\";\"e\""), "c");
+    let text = CellValue::Text {
+        value: "x".to_string(),
+    };
+    assert_eq!(
+        format_value(&text, "\"a\";\"b\";\"c\";\"d\"@;\"e\"@", DateSystem::V1900).text,
+        "dx"
+    );
+    assert_eq!(tokenize_all("0;0;0;0;0;0;0").len(), USED_SECTIONS);
 }
 
 /// the parse is shared but the date system is not: it is applied after lookup.


### PR DESCRIPTION
TL;DR:

Summary:
- tokenized format sections cache process-wide keyed by exact code string (LRU cap 256, codes >256 bytes never cached)
- lock guards map operations only; tokenization happens outside the mutex; callers receive Arc<[Section]>
- removes per-cell split/tokenize work on every repaint of numeric cells

Test plan:
- [ ] `cargo test -p betteroffice-xlsx-model -p betteroffice-xlsx-render` green
- [ ] scroll repaint on a dense formatted sheet feels snappier
- [ ] unusual custom formats render identically to main