### PR TITLE
perf(docx-raster): share caches across pages and runs

### DIFF
--- a/.changeset/docx-raster-caches.md
+++ b/.changeset/docx-raster-caches.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Share glyph caches across pages and stop re-parsing fonts per run.

--- a/crates/betteroffice-docx/src/render.rs
+++ b/crates/betteroffice-docx/src/render.rs
@@ -4,7 +4,7 @@ use std::sync::{Mutex, PoisonError};
 
 use docx_layout::display_list::DisplayList;
 use docx_raster::{
-    FontChains, ImageMap, ImageScope, RenderResources, RenderedPage, scoped_image_key,
+    FontChains, GlyphCache, ImageMap, ImageScope, RenderResources, RenderedPage, scoped_image_key,
 };
 use ooxml_text::FontStore;
 use serde_json::Number;
@@ -19,13 +19,14 @@ pub const MAX_PIXMAP_DIM: u32 = docx_raster::MAX_PAGE_DIM;
 pub const MAX_PIXMAP_PIXELS: u64 = docx_raster::MAX_PAGE_PIXELS;
 
 /// Registered faces plus the `family|bold|italic` chains the raster backend
-/// resolves runs against. The store sits behind a `Mutex` so a [`Document`]
-/// holding one stays `Send + Sync`.
+/// resolves runs against. The store and glyph cache sit behind a `Mutex` so a
+/// [`Document`] holding one stays `Send + Sync`.
 #[derive(Default)]
 pub(crate) struct FontRegistry {
     store: Mutex<FontStore>,
     chains: FontChains,
     faces: usize,
+    glyphs: Mutex<GlyphCache>,
 }
 
 impl FontRegistry {
@@ -153,6 +154,8 @@ impl Document {
     /// Rasterizes one display-list page to deterministic PNG bytes. A page past
     /// [`MAX_PIXMAP_DIM`] or [`MAX_PIXMAP_PIXELS`] is refused before any surface
     /// is allocated; an image the backend cannot draw is skipped and counted.
+    /// Glyph outlines are cached on the document, so rendering every page of an
+    /// export extracts each outline once.
     pub fn render_png(
         &self,
         display_list: &DisplayList,
@@ -169,7 +172,13 @@ impl Document {
             .store
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
+        let mut glyphs = self
+            .fonts
+            .glyphs
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         let resources = RenderResources::new(&store, &self.fonts.chains, &self.images.entries);
-        docx_raster::render_page(display_list, page_ordinal, &resources).map_err(Error::Render)
+        docx_raster::render_page_cached(display_list, page_ordinal, &resources, &mut glyphs)
+            .map_err(Error::Render)
     }
 }

--- a/crates/betteroffice-docx/src/render.rs
+++ b/crates/betteroffice-docx/src/render.rs
@@ -154,8 +154,9 @@ impl Document {
     /// Rasterizes one display-list page to deterministic PNG bytes. A page past
     /// [`MAX_PIXMAP_DIM`] or [`MAX_PIXMAP_PIXELS`] is refused before any surface
     /// is allocated; an image the backend cannot draw is skipped and counted.
-    /// Glyph outlines are cached on the document, so rendering every page of an
-    /// export extracts each outline once.
+    /// Glyph outlines are cached on the document, so a page reuses the outlines
+    /// earlier pages extracted. The cache is bounded, so an export needing more
+    /// outlines than it retains re-extracts the ones it evicted.
     pub fn render_png(
         &self,
         display_list: &DisplayList,

--- a/crates/betteroffice-docx/src/render.rs
+++ b/crates/betteroffice-docx/src/render.rs
@@ -154,9 +154,9 @@ impl Document {
     /// Rasterizes one display-list page to deterministic PNG bytes. A page past
     /// [`MAX_PIXMAP_DIM`] or [`MAX_PIXMAP_PIXELS`] is refused before any surface
     /// is allocated; an image the backend cannot draw is skipped and counted.
-    /// Glyph outlines are cached on the document, so a page reuses the outlines
-    /// earlier pages extracted. The cache is bounded, so an export needing more
-    /// outlines than it retains re-extracts the ones it evicted.
+    /// Glyph outlines are cached on the document, so a page reuses what earlier
+    /// pages extracted; an export past the cache's cap re-extracts what it
+    /// evicted.
     pub fn render_png(
         &self,
         display_list: &DisplayList,

--- a/crates/betteroffice-docx/tests/render.rs
+++ b/crates/betteroffice-docx/tests/render.rs
@@ -199,6 +199,23 @@ fn text_page() -> DisplayList {
     })])
 }
 
+/// Latin and Hebrew in one run, so the chain resolves a glyph per face.
+fn mixed_script_page() -> DisplayList {
+    sized_page(
+        96,
+        32,
+        vec![json!({
+            "kind": "text",
+            "text": "A\u{05d0}o\u{05d1}",
+            "x": 2,
+            "baselineY": 20,
+            "width": 90,
+            "font": "400 16px Carlito, sans-serif",
+            "color": "#101010"
+        })],
+    )
+}
+
 fn decode(bytes: &[u8]) -> (u32, u32, Vec<u8>) {
     let mut reader = png::Decoder::new(std::io::Cursor::new(bytes))
         .read_info()
@@ -243,6 +260,62 @@ fn renders_text_only_once_its_family_is_registered() {
     let (quads, _) = pixels.as_chunks::<4>();
     let painted = quads.iter().filter(|p| **p != [255, 255, 255, 255]).count();
     assert!(painted > 0, "no glyphs were painted");
+}
+
+/// The glyph cache outlives every page and keys on font id, so a face
+/// registered mid-export must take a new id rather than renumber the outlines
+/// already cached under the old ones. A document whose cache was warmed before
+/// the registration has to paint what one that registered both faces up front
+/// paints.
+#[test]
+fn a_face_registered_between_pages_leaves_the_cached_outlines_alone() {
+    let mut warmed = document();
+    assert_eq!(
+        warmed
+            .register_font("Carlito", false, false, CARLITO)
+            .unwrap(),
+        0
+    );
+    let latin = warmed.render_png(&text_page(), 0).unwrap().bytes;
+    assert_eq!(
+        warmed
+            .register_font("Carlito", false, false, SMALL_FONT)
+            .unwrap(),
+        1
+    );
+
+    let mut cold = document();
+    cold.register_font("Carlito", false, false, CARLITO)
+        .unwrap();
+    cold.register_font("Carlito", false, false, SMALL_FONT)
+        .unwrap();
+
+    let page = mixed_script_page();
+    assert_eq!(
+        warmed.render_png(&page, 0).unwrap().bytes,
+        cold.render_png(&page, 0).unwrap().bytes
+    );
+    assert_eq!(warmed.render_png(&text_page(), 0).unwrap().bytes, latin);
+}
+
+/// Font ids are store-local. Two documents registering different faces under
+/// one family name must not paint each other's outlines.
+#[test]
+fn two_documents_sharing_a_family_name_paint_their_own_faces() {
+    let mut latin = document();
+    latin
+        .register_font("Carlito", false, false, CARLITO)
+        .unwrap();
+    let mut hebrew = document();
+    hebrew
+        .register_font("Carlito", false, false, SMALL_FONT)
+        .unwrap();
+
+    let page = mixed_script_page();
+    assert_ne!(
+        latin.render_png(&page, 0).unwrap().bytes,
+        hebrew.render_png(&page, 0).unwrap().bytes
+    );
 }
 
 #[test]

--- a/crates/docx-raster/src/font.rs
+++ b/crates/docx-raster/src/font.rs
@@ -36,9 +36,8 @@ pub fn measure_text(
 const MAX_CACHED_GLYPH_OUTLINES: usize = 8_192;
 
 /// Extracted glyph outlines keyed by font and glyph id, reusable across pages.
-/// Bound to the first [`FontStore`] that fills it — ids are store-local, so a
-/// render against another store is refused — and capped at
-/// [`MAX_CACHED_GLYPH_OUTLINES`] entries with oldest-insert-first eviction.
+/// Ids are store-local, so the cache binds to the store that fills it and
+/// refuses any other; entries past the cap evict oldest-first.
 #[derive(Default)]
 pub struct GlyphCache {
     entries: HashMap<(u32, u32), CachedGlyph>,

--- a/crates/docx-raster/src/font.rs
+++ b/crates/docx-raster/src/font.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::collections::hash_map::Entry;
 use std::rc::Rc;
 
 use docx_layout::display_list::{
@@ -82,26 +81,43 @@ struct ParsedFont {
     chain_key: String,
 }
 
+/// Distinct shorthands one page keeps parsed, and the raw bytes their keys may
+/// copy out of the display list. A `font` string is untrusted and unbounded, so
+/// the cache stops keeping them rather than growing with the page.
+const MAX_CACHED_FONT_SPECS: usize = 256;
+const MAX_FONT_SPEC_KEY_BYTES: usize = 65_536;
+
 /// Parsed font shorthands keyed by the raw display-list string.
 #[derive(Default)]
 pub(crate) struct FontSpecCache {
     entries: HashMap<Box<str>, Rc<ParsedFont>>,
+    key_bytes: usize,
 }
 
 impl FontSpecCache {
     fn font(&mut self, font: &str) -> Result<Rc<ParsedFont>, String> {
-        match self.entries.entry(font.into()) {
-            Entry::Occupied(entry) => Ok(entry.get().clone()),
-            Entry::Vacant(entry) => {
-                let spec = parse_font(font)?;
-                let parsed = Rc::new(ParsedFont {
-                    chain_key: chain_key(&spec),
-                    spec,
-                });
-                entry.insert(parsed.clone());
-                Ok(parsed)
-            }
+        if let Some(parsed) = self.entries.get(font) {
+            return Ok(parsed.clone());
         }
+        let spec = parse_font(font)?;
+        let parsed = Rc::new(ParsedFont {
+            chain_key: chain_key(&spec),
+            spec,
+        });
+        self.remember(font, &parsed);
+        Ok(parsed)
+    }
+
+    /// Keeps one parse against its raw shorthand, while the map has room. The
+    /// key is a copy of display-list bytes, so it is the copy that is budgeted.
+    fn remember(&mut self, font: &str, parsed: &Rc<ParsedFont>) {
+        if self.entries.len() >= MAX_CACHED_FONT_SPECS
+            || self.key_bytes + font.len() > MAX_FONT_SPEC_KEY_BYTES
+        {
+            return;
+        }
+        self.key_bytes += font.len();
+        self.entries.insert(font.into(), parsed.clone());
     }
 }
 
@@ -710,12 +726,8 @@ fn cached_glyph<'a>(
     font: FontId,
     glyph_id: u32,
 ) -> Result<&'a CachedGlyph, String> {
-    match cache.store {
-        Some(bound) if bound != fonts.id() => {
-            return Err("glyph cache is bound to another font store".to_string());
-        }
-        None => cache.store = Some(fonts.id()),
-        _ => {}
+    if cache.store.is_some_and(|bound| bound != fonts.id()) {
+        return Err("glyph cache is bound to another font store".to_string());
     }
     let key = (font.to_u32(), glyph_id);
     if !cache.entries.contains_key(&key) {
@@ -725,6 +737,7 @@ fn cached_glyph<'a>(
             .outline_glyph(font, id)
             .map_err(|error| error.to_string())?;
         let path = outline_path(&outline.cmds)?;
+        cache.store = Some(fonts.id());
         cache.remember(
             key,
             CachedGlyph {
@@ -955,6 +968,28 @@ mod tests {
         assert!(cache.font("16 Liberation Sans").is_err());
         assert!(cache.font("px").is_err());
         assert_eq!(cache.entries.len(), 3);
+    }
+
+    /// Shorthands are untrusted display-list strings, so the cache parses every
+    /// one but stops copying them once either budget is spent.
+    #[test]
+    fn the_spec_cache_stops_keeping_shorthands_past_its_budgets() {
+        let mut counted = FontSpecCache::default();
+        for index in 0..MAX_CACHED_FONT_SPECS + 8 {
+            let font = format!("400 {}12px Carlito, sans-serif", " ".repeat(index));
+            assert_eq!(counted.font(&font).expect("parse").spec.family, "Carlito");
+        }
+        assert_eq!(counted.entries.len(), MAX_CACHED_FONT_SPECS);
+        assert!(counted.key_bytes <= MAX_FONT_SPEC_KEY_BYTES);
+
+        let mut oversized = FontSpecCache::default();
+        let padding = " ".repeat(MAX_FONT_SPEC_KEY_BYTES);
+        for index in 0..4 {
+            let font = format!("400 {padding}{}12px Carlito, sans-serif", " ".repeat(index));
+            assert_eq!(oversized.font(&font).expect("parse").spec.family, "Carlito");
+        }
+        assert!(oversized.entries.is_empty());
+        assert_eq!(oversized.key_bytes, 0);
     }
 
     #[test]

--- a/crates/docx-raster/src/font.rs
+++ b/crates/docx-raster/src/font.rs
@@ -1,13 +1,16 @@
 //! Shared-store text shaping and glyph rasterization.
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
+use std::rc::Rc;
 
 use docx_layout::display_list::{
     ClipRect, GlyphRunPrimitive, LeaderGlyphMetadata, PlacedGlyph, TextRunPrimitive,
 };
 use ooxml_text::{
-    FontId, FontStore, PathCmd, ShapeDirection, ShapeFeature, shape, shape::shape_with_properties,
+    FontId, FontStore, PathCmd, ShapeDirection, ShapeFeature, ShapedGlyph, shape,
+    shape::shape_with_properties,
 };
 use tiny_skia::{FillRule, Mask, Paint, Path, PathBuilder, Pixmap, Rect, Transform};
 
@@ -30,9 +33,33 @@ pub fn measure_text(
     Ok(glyphs.iter().map(|glyph| glyph.x_advance).sum())
 }
 
+/// Most glyph outlines one cache retains; the oldest insertion evicts first.
+const MAX_CACHED_GLYPH_OUTLINES: usize = 8_192;
+
+/// Extracted glyph outlines keyed by font and glyph id, reusable across pages.
+/// Bound to the first [`FontStore`] that fills it — ids are store-local, so a
+/// render against another store is refused — and capped at
+/// [`MAX_CACHED_GLYPH_OUTLINES`] entries with oldest-insert-first eviction.
 #[derive(Default)]
-pub(crate) struct GlyphCache {
+pub struct GlyphCache {
     entries: HashMap<(u32, u32), CachedGlyph>,
+    order: VecDeque<(u32, u32)>,
+    store: Option<u64>,
+}
+
+impl GlyphCache {
+    fn remember(&mut self, key: (u32, u32), glyph: CachedGlyph) {
+        if self.entries.insert(key, glyph).is_none() {
+            self.order.push_back(key);
+        }
+        while self.order.len() > MAX_CACHED_GLYPH_OUTLINES {
+            let oldest = self
+                .order
+                .pop_front()
+                .expect("the queue tracks every cached entry");
+            self.entries.remove(&oldest);
+        }
+    }
 }
 
 struct CachedGlyph {
@@ -49,6 +76,44 @@ struct FontSpec {
     small_caps: bool,
 }
 
+/// A parsed shorthand plus the font-chain key its family resolves under.
+struct ParsedFont {
+    spec: FontSpec,
+    chain_key: String,
+}
+
+/// Parsed font shorthands keyed by the raw display-list string.
+#[derive(Default)]
+pub(crate) struct FontSpecCache {
+    entries: HashMap<Box<str>, Rc<ParsedFont>>,
+}
+
+impl FontSpecCache {
+    fn font(&mut self, font: &str) -> Result<Rc<ParsedFont>, String> {
+        match self.entries.entry(font.into()) {
+            Entry::Occupied(entry) => Ok(entry.get().clone()),
+            Entry::Vacant(entry) => {
+                let spec = parse_font(font)?;
+                let parsed = Rc::new(ParsedFont {
+                    chain_key: chain_key(&spec),
+                    spec,
+                });
+                entry.insert(parsed.clone());
+                Ok(parsed)
+            }
+        }
+    }
+}
+
+fn chain_key(spec: &FontSpec) -> String {
+    format!(
+        "{}|{}|{}",
+        spec.family.to_lowercase(),
+        u8::from(spec.bold),
+        u8::from(spec.italic)
+    )
+}
+
 struct FontSegment {
     start: usize,
     end: usize,
@@ -59,6 +124,7 @@ pub(crate) struct PaintContext<'a, 'b> {
     pub pixmap: &'a mut Pixmap,
     pub resources: &'a RenderResources<'b>,
     pub cache: &'a mut GlyphCache,
+    pub specs: &'a mut FontSpecCache,
     pub budget: &'a mut PageBudget,
     pub base_transform: Transform,
     pub mask: Option<&'a Mask>,
@@ -72,6 +138,7 @@ impl<'a, 'b> PaintContext<'a, 'b> {
             pixmap: self.pixmap,
             resources: self.resources,
             cache: self.cache,
+            specs: self.specs,
             budget: self.budget,
             base_transform: self.base_transform,
             mask: Some(mask),
@@ -101,11 +168,11 @@ fn paint_text_core(
     if run.text.is_empty() {
         return Ok(());
     }
-    let spec = parse_font(&run.font)?;
-    if run.small_caps || spec.small_caps {
+    let parsed = context.specs.font(&run.font)?;
+    if run.small_caps || parsed.spec.small_caps {
         return Err("unsupported text field: smallCaps".to_string());
     }
-    let rect = text_rect(run, spec.size)?;
+    let rect = text_rect(run, parsed.spec.size)?;
     let visual = primitive_visual_transform(
         rect,
         run.rotation_deg.as_ref(),
@@ -114,7 +181,7 @@ fn paint_text_core(
     let transform = context.base_transform.pre_concat(visual);
     let color = color_with_opacity(&run.color, context.opacity)?;
     if let Some(leader) = active_leader(&run.attrs.leader_glyphs) {
-        return paint_leader(context, run, leader, &spec, color, transform);
+        return paint_leader(context, run, leader, &parsed, color, transform);
     }
     context.budget.charge_glyphs(painted_chars(run))?;
     let text = if run.all_caps {
@@ -139,7 +206,8 @@ fn paint_text_core(
         &text,
         number_f32(&run.x)?,
         number_f32(&run.baseline_y)?,
-        &spec,
+        &parsed.spec,
+        &parsed.chain_key,
         run.rtl == Some(true),
         run.attrs.lang.as_deref(),
         letter_spacing,
@@ -311,7 +379,7 @@ fn paint_leader(
     context: &mut PaintContext<'_, '_>,
     run: &TextRunPrimitive,
     leader: &LeaderGlyphMetadata,
-    run_spec: &FontSpec,
+    run_font: &ParsedFont,
     fallback_color: tiny_skia::Color,
     transform: Transform,
 ) -> Result<(), String> {
@@ -345,7 +413,7 @@ fn paint_leader(
         .map(number_f32)
         .transpose()?
         .unwrap_or(number_f32(&run.baseline_y)?);
-    let mut spec = run_spec.clone();
+    let mut spec = run_font.spec.clone();
     if let Some(family) = leader.font.as_deref() {
         spec.family = family.to_string();
     }
@@ -355,6 +423,10 @@ fn paint_leader(
             return Err("leader glyph size must be positive".to_string());
         }
     }
+    let chain_key = match leader.font.as_deref() {
+        Some(_) => chain_key(&spec),
+        None => run_font.chain_key.clone(),
+    };
     let color = leader
         .color
         .as_deref()
@@ -364,39 +436,135 @@ fn paint_leader(
     let mut paint = Paint::default();
     paint.set_color(color);
     paint.anti_alias = true;
-    let direction = leader.rtl == Some(true);
+    let rtl = leader.rtl == Some(true);
+    let direction = if rtl {
+        ShapeDirection::Rtl
+    } else {
+        ShapeDirection::Ltr
+    };
+    let stamp = shape_stamp(
+        context,
+        glyph,
+        &spec,
+        &chain_key,
+        direction,
+        count,
+        leader.font_id,
+    )?;
     for index in 0..count {
-        let visual_index = if direction { count - 1 - index } else { index };
+        let visual_index = if rtl { count - 1 - index } else { index };
         let origin = x + visual_index as f32 * advance;
-        if let Some(raw) = leader.font_id {
-            paint_single_font_text(
-                context,
-                glyph,
-                FontId::from_u32(raw),
-                spec.size,
-                origin,
-                baseline,
-                direction,
-                None,
-                &[],
-                &paint,
-                transform,
-            )?;
-        } else {
-            paint_resolved_text(
-                context,
-                glyph,
-                origin,
-                baseline,
-                &spec,
-                direction,
-                None,
-                0.0,
-                0.0,
-                &[],
-                color,
-                transform,
-            )?;
+        paint_shaped_stamp(context, &stamp, origin, baseline, &paint, transform)?;
+    }
+    Ok(())
+}
+
+/// One shaped leader text, ready to be stamped at every repeat position.
+struct ShapedStamp {
+    size: f32,
+    segments: Vec<ShapedSegment>,
+}
+
+struct ShapedSegment {
+    font: FontId,
+    glyphs: Vec<ShapedGlyph>,
+}
+
+/// Shapes the leader text once in the order its glyphs are painted, charging
+/// what every repeat will paint. Shaping never depends on the pen origin, so
+/// one pass covers every repeat.
+#[allow(clippy::too_many_arguments)]
+fn shape_stamp(
+    context: &mut PaintContext<'_, '_>,
+    glyph: &str,
+    spec: &FontSpec,
+    key: &str,
+    direction: ShapeDirection,
+    count: usize,
+    font_id: Option<u32>,
+) -> Result<ShapedStamp, String> {
+    let mut segments = Vec::new();
+    let mut excess = 0u64;
+    if let Some(raw) = font_id {
+        let font = FontId::from_u32(raw);
+        let glyphs = shape_segment(context, glyph, font, spec.size, direction)?;
+        excess = (glyphs.len() as u64).saturating_sub(glyph.chars().count() as u64);
+        segments.push(ShapedSegment { font, glyphs });
+    } else {
+        let chain = context
+            .resources
+            .font_chains
+            .get(key)
+            .ok_or_else(|| format!("missing font chain for `{key}`"))?;
+        if chain.is_empty() {
+            return Err(format!("font chain `{key}` is empty"));
+        }
+        for segment in font_segments(context.resources.fonts, chain, glyph)? {
+            let text = &glyph[segment.start..segment.end];
+            let glyphs = shape_segment(context, text, segment.font, spec.size, direction)?;
+            excess = excess
+                .saturating_add((glyphs.len() as u64).saturating_sub(text.chars().count() as u64));
+            segments.push(ShapedSegment {
+                font: segment.font,
+                glyphs,
+            });
+        }
+        if matches!(direction, ShapeDirection::Rtl) {
+            segments.reverse();
+        }
+    }
+    context
+        .budget
+        .charge_glyphs(excess.saturating_mul(count as u64))?;
+    Ok(ShapedStamp {
+        size: spec.size,
+        segments,
+    })
+}
+
+fn shape_segment(
+    context: &PaintContext<'_, '_>,
+    text: &str,
+    font: FontId,
+    size: f32,
+    direction: ShapeDirection,
+) -> Result<Vec<ShapedGlyph>, String> {
+    shape_with_properties(
+        context.resources.fonts,
+        font,
+        text,
+        size,
+        &[],
+        direction,
+        None,
+    )
+    .map_err(|error| error.to_string())
+}
+
+/// Replays one shaping at a stamp origin, painting exactly what a fresh shape
+/// at that origin would.
+fn paint_shaped_stamp(
+    context: &mut PaintContext<'_, '_>,
+    stamp: &ShapedStamp,
+    origin: f32,
+    baseline: f32,
+    paint: &Paint<'_>,
+    transform: Transform,
+) -> Result<(), String> {
+    let mut pen = origin;
+    for segment in &stamp.segments {
+        for glyph in &segment.glyphs {
+            let placed = PlacedGlyph {
+                id: glyph.glyph_id,
+                x: f64::from(pen + glyph.x_offset),
+                y: f64::from(baseline - glyph.y_offset),
+                cluster: glyph.cluster,
+                advance: f64::from(glyph.x_advance),
+                logical_order: None,
+                bidi_level: None,
+            };
+            paint_placed_glyph(context, segment.font, &placed, stamp.size, paint, transform)?;
+            pen += glyph.x_advance;
         }
     }
     Ok(())
@@ -409,6 +577,7 @@ fn paint_resolved_text(
     x: f32,
     baseline: f32,
     spec: &FontSpec,
+    key: &str,
     rtl: bool,
     language: Option<&str>,
     letter_spacing: f32,
@@ -417,16 +586,10 @@ fn paint_resolved_text(
     color: tiny_skia::Color,
     transform: Transform,
 ) -> Result<(), String> {
-    let key = format!(
-        "{}|{}|{}",
-        spec.family.to_lowercase(),
-        u8::from(spec.bold),
-        u8::from(spec.italic)
-    );
     let chain = context
         .resources
         .font_chains
-        .get(&key)
+        .get(key)
         .ok_or_else(|| format!("missing font chain for `{key}`"))?;
     if chain.is_empty() {
         return Err(format!("font chain `{key}` is empty"));
@@ -497,53 +660,6 @@ fn paint_resolved_text(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn paint_single_font_text(
-    context: &mut PaintContext<'_, '_>,
-    text: &str,
-    font: FontId,
-    size: f32,
-    x: f32,
-    baseline: f32,
-    rtl: bool,
-    language: Option<&str>,
-    features: &[ShapeFeature],
-    paint: &Paint<'_>,
-    transform: Transform,
-) -> Result<(), String> {
-    let direction = if rtl {
-        ShapeDirection::Rtl
-    } else {
-        ShapeDirection::Ltr
-    };
-    let glyphs = shape_with_properties(
-        context.resources.fonts,
-        font,
-        text,
-        size,
-        features,
-        direction,
-        language,
-    )
-    .map_err(|error| error.to_string())?;
-    charge_shaped_excess(context, text, glyphs.len())?;
-    let mut pen = x;
-    for glyph in glyphs {
-        let placed = PlacedGlyph {
-            id: glyph.glyph_id,
-            x: f64::from(pen + glyph.x_offset),
-            y: f64::from(baseline - glyph.y_offset),
-            cluster: glyph.cluster,
-            advance: f64::from(glyph.x_advance),
-            logical_order: None,
-            bidi_level: None,
-        };
-        paint_placed_glyph(context, font, &placed, size, paint, transform)?;
-        pen += glyph.x_advance;
-    }
-    Ok(())
-}
-
 /// Shaping can place more glyphs than the text had characters. The caller
 /// charged the characters before the shaper ran, so only the excess is left.
 fn charge_shaped_excess(
@@ -594,22 +710,33 @@ fn cached_glyph<'a>(
     font: FontId,
     glyph_id: u32,
 ) -> Result<&'a CachedGlyph, String> {
+    match cache.store {
+        Some(bound) if bound != fonts.id() => {
+            return Err("glyph cache is bound to another font store".to_string());
+        }
+        None => cache.store = Some(fonts.id()),
+        _ => {}
+    }
     let key = (font.to_u32(), glyph_id);
-    match cache.entries.entry(key) {
-        Entry::Occupied(entry) => Ok(entry.into_mut()),
-        Entry::Vacant(entry) => {
-            let id = u16::try_from(glyph_id)
-                .map_err(|_| format!("glyph id {glyph_id} exceeds the font outline range"))?;
-            let outline = fonts
-                .outline_glyph(font, id)
-                .map_err(|error| error.to_string())?;
-            let path = outline_path(&outline.cmds)?;
-            Ok(entry.insert(CachedGlyph {
+    if !cache.entries.contains_key(&key) {
+        let id = u16::try_from(glyph_id)
+            .map_err(|_| format!("glyph id {glyph_id} exceeds the font outline range"))?;
+        let outline = fonts
+            .outline_glyph(font, id)
+            .map_err(|error| error.to_string())?;
+        let path = outline_path(&outline.cmds)?;
+        cache.remember(
+            key,
+            CachedGlyph {
                 path,
                 upem: f32::from(outline.upem),
-            }))
-        }
+            },
+        );
     }
+    Ok(cache
+        .entries
+        .get(&key)
+        .expect("a just-inserted or occupied key is present"))
 }
 
 fn outline_path(commands: &[PathCmd]) -> Result<Option<Path>, String> {
@@ -778,6 +905,8 @@ fn f64_to_f32(value: f64, field: &str) -> Result<f32, String> {
 mod tests {
     use super::*;
 
+    const CARLITO: &[u8] = include_bytes!("../tests/assets/Carlito-Regular.ttf");
+
     #[test]
     fn parses_layout_font_shorthands() {
         let regular = parse_font("400 16px Liberation Sans, sans-serif").unwrap();
@@ -793,5 +922,91 @@ mod tests {
         assert!(styled.bold);
         assert!(styled.italic);
         assert!(styled.small_caps);
+    }
+
+    #[test]
+    fn spec_cache_reuses_one_parse_per_raw_string() {
+        let mut cache = FontSpecCache::default();
+        let first = cache
+            .font("400 16px Liberation Sans, sans-serif")
+            .expect("parse");
+        let second = cache
+            .font("400 16px Liberation Sans, sans-serif")
+            .expect("parse");
+        assert!(Rc::ptr_eq(&first, &second));
+        assert_eq!(first.spec.family, "Liberation Sans");
+        assert_eq!(first.chain_key, "liberation sans|0|0");
+        assert_eq!(cache.entries.len(), 1);
+
+        let bold = cache
+            .font("700 16px Liberation Sans, sans-serif")
+            .expect("parse");
+        assert!(!Rc::ptr_eq(&bold, &first));
+        assert!(bold.spec.bold && !bold.spec.italic);
+        assert_ne!(bold.chain_key, first.chain_key);
+
+        let italic = cache
+            .font("italic 16px Liberation Sans, sans-serif")
+            .expect("parse");
+        assert!(italic.spec.italic && !italic.spec.bold);
+        assert_ne!(italic.chain_key, bold.chain_key);
+        assert_eq!(cache.entries.len(), 3);
+
+        assert!(cache.font("16 Liberation Sans").is_err());
+        assert!(cache.font("px").is_err());
+        assert_eq!(cache.entries.len(), 3);
+    }
+
+    #[test]
+    fn the_glyph_cache_evicts_its_oldest_entries_past_the_cap() {
+        let mut cache = GlyphCache::default();
+        for index in 0..MAX_CACHED_GLYPH_OUTLINES as u32 + 2 {
+            cache.remember(
+                (index, 0),
+                CachedGlyph {
+                    path: None,
+                    upem: 1000.0,
+                },
+            );
+        }
+        assert_eq!(cache.entries.len(), MAX_CACHED_GLYPH_OUTLINES);
+        assert_eq!(cache.order.len(), MAX_CACHED_GLYPH_OUTLINES);
+        assert!(!cache.entries.contains_key(&(0, 0)));
+        assert!(cache.entries.contains_key(&(2, 0)));
+        assert!(
+            cache
+                .entries
+                .contains_key(&(MAX_CACHED_GLYPH_OUTLINES as u32 + 1, 0))
+        );
+    }
+
+    /// Distinct outlines past the cap evict earlier ones; a render that asks
+    /// for an evicted outline gets a fresh extraction, not a stale or missing
+    /// path.
+    #[test]
+    fn an_evicted_glyph_outline_is_extracted_again_on_demand() {
+        let mut fonts = FontStore::new();
+        let mut ids = Vec::new();
+        for _ in 0..4 {
+            ids.push(fonts.register(CARLITO.to_vec()).expect("font"));
+        }
+        let mut cache = GlyphCache::default();
+        let mut inserted = 0usize;
+        for id in &ids {
+            for gid in 0..u16::MAX {
+                if cached_glyph(&mut cache, &fonts, *id, u32::from(gid)).is_err() {
+                    break;
+                }
+                inserted += 1;
+            }
+        }
+        assert!(inserted > MAX_CACHED_GLYPH_OUTLINES);
+        assert_eq!(cache.entries.len(), MAX_CACHED_GLYPH_OUTLINES);
+        assert!(!cache.entries.contains_key(&(ids[0].to_u32(), 0)));
+        let refilled =
+            cached_glyph(&mut cache, &fonts, ids[0], 0).expect("re-extract after eviction");
+        let upem = fonts.metrics(ids[0]).expect("metrics").units_per_em;
+        assert_eq!(refilled.upem, f32::from(upem));
+        assert!(cache.entries.contains_key(&(ids[0].to_u32(), 0)));
     }
 }

--- a/crates/docx-raster/src/lib.rs
+++ b/crates/docx-raster/src/lib.rs
@@ -167,9 +167,8 @@ pub fn render_page(
 }
 
 /// Renders one display-list page into a caller-owned glyph cache, so a
-/// multi-page export reuses the outlines the cache still holds instead of
-/// extracting them again. The cache is bounded, so a page that needs more
-/// outlines than it retains re-extracts the ones it evicted.
+/// multi-page export reuses the outlines it still holds. The cache is bounded:
+/// an export past its cap re-extracts what it evicted.
 pub fn render_page_cached(
     display_list: &DisplayList,
     page_ordinal: usize,

--- a/crates/docx-raster/src/lib.rs
+++ b/crates/docx-raster/src/lib.rs
@@ -166,8 +166,10 @@ pub fn render_page(
     )
 }
 
-/// Renders one display-list page into a caller-owned glyph cache, so
-/// multi-page exports extract every glyph outline once.
+/// Renders one display-list page into a caller-owned glyph cache, so a
+/// multi-page export reuses the outlines the cache still holds instead of
+/// extracting them again. The cache is bounded, so a page that needs more
+/// outlines than it retains re-extracts the ones it evicted.
 pub fn render_page_cached(
     display_list: &DisplayList,
     page_ordinal: usize,

--- a/crates/docx-raster/src/lib.rs
+++ b/crates/docx-raster/src/lib.rs
@@ -5,7 +5,7 @@ compile_error!("betteroffice-docx-raster is server-side only");
 
 mod font;
 
-pub use font::measure_text;
+pub use font::{GlyphCache, measure_text};
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -26,7 +26,7 @@ use tiny_skia::{
     RadialGradient, Rect, SpreadMode, Stroke, StrokeDash, Transform,
 };
 
-use font::{GlyphCache, PaintContext};
+use font::{FontSpecCache, PaintContext};
 
 /// Layout font chains keyed as `"<family lowercase>|<bold>|<italic>"`.
 pub type FontChains = HashMap<String, Vec<FontId>>;
@@ -151,10 +151,28 @@ pub fn render_png(
 }
 
 /// Renders one display-list page, reporting the image references it skipped.
+/// Each call starts from a fresh glyph cache; pass a shared one to
+/// [`render_page_cached`] when rendering many pages of one export.
 pub fn render_page(
     display_list: &DisplayList,
     page_ordinal: usize,
     resources: &RenderResources<'_>,
+) -> Result<RenderedPage, String> {
+    render_page_cached(
+        display_list,
+        page_ordinal,
+        resources,
+        &mut GlyphCache::default(),
+    )
+}
+
+/// Renders one display-list page into a caller-owned glyph cache, so
+/// multi-page exports extract every glyph outline once.
+pub fn render_page_cached(
+    display_list: &DisplayList,
+    page_ordinal: usize,
+    resources: &RenderResources<'_>,
+    glyphs: &mut GlyphCache,
 ) -> Result<RenderedPage, String> {
     let page = display_list
         .pages
@@ -165,7 +183,7 @@ pub fn render_page(
     validate_page_surface(width, height)?;
     let mut pixmap = Pixmap::new(width, height).ok_or_else(|| "invalid pixmap size".to_string())?;
     pixmap.fill(Color::WHITE);
-    let mut renderer = Renderer::new(width, height);
+    let mut renderer = Renderer::new(width, height, glyphs);
     renderer.paint_page(&mut pixmap, page, resources)?;
     Ok(RenderedPage {
         bytes: encode_png(pixmap, width, height)?,
@@ -347,7 +365,8 @@ fn mask_bytes(width: u32, height: u32) -> u64 {
 /// Everything one page render accumulates: the caches that keep repeated work
 /// from repeating, and the budget that bounds the work left over.
 struct Scratch<'k> {
-    glyphs: GlyphCache,
+    glyphs: &'k mut GlyphCache,
+    specs: FontSpecCache,
     images: ImageCache<'k>,
     masks: MaskCache,
     budget: PageBudget,
@@ -359,11 +378,12 @@ struct Renderer<'k> {
 }
 
 impl<'k> Renderer<'k> {
-    fn new(width: u32, height: u32) -> Self {
+    fn new(width: u32, height: u32, glyphs: &'k mut GlyphCache) -> Self {
         Self {
             clips: ClipSurface::default(),
             scratch: Scratch {
-                glyphs: GlyphCache::default(),
+                glyphs,
+                specs: FontSpecCache::default(),
                 images: ImageCache::default(),
                 masks: MaskCache::new(width, height),
                 budget: PageBudget::new(width, height),
@@ -470,7 +490,8 @@ fn paint_primitive_core<'k>(
             let mut context = PaintContext {
                 pixmap,
                 resources,
-                cache: &mut scratch.glyphs,
+                cache: &mut *scratch.glyphs,
+                specs: &mut scratch.specs,
                 budget: &mut scratch.budget,
                 base_transform: transform,
                 mask,
@@ -484,7 +505,8 @@ fn paint_primitive_core<'k>(
             let mut context = PaintContext {
                 pixmap,
                 resources,
-                cache: &mut scratch.glyphs,
+                cache: &mut *scratch.glyphs,
+                specs: &mut scratch.specs,
                 budget: &mut scratch.budget,
                 base_transform: transform,
                 mask,
@@ -2602,7 +2624,8 @@ mod tests {
     #[test]
     fn a_clip_surface_shrinks_back_to_the_clip_it_serves() {
         let mut pixmap = Pixmap::new(800, 1120).expect("page");
-        let mut renderer = Renderer::new(800, 1120);
+        let mut glyphs = GlyphCache::default();
+        let mut renderer = Renderer::new(800, 1120, &mut glyphs);
         let mut surface = ClipSurface::default();
         for rect in [clip(0.0, 0.0, 800.0, 1120.0), clip(8.0, 8.0, 64.0, 16.0)] {
             surface
@@ -2622,7 +2645,8 @@ mod tests {
     #[test]
     fn a_resized_clip_surface_is_charged_once_at_its_high_water_mark() {
         let mut pixmap = Pixmap::new(400, 560).expect("page");
-        let mut renderer = Renderer::new(400, 560);
+        let mut glyphs = GlyphCache::default();
+        let mut renderer = Renderer::new(400, 560, &mut glyphs);
         let mut surface = ClipSurface::default();
         for index in 0..32 {
             let rect = if index % 2 == 0 {

--- a/crates/docx-raster/tests/budgets.rs
+++ b/crates/docx-raster/tests/budgets.rs
@@ -457,6 +457,37 @@ fn an_oversized_text_run_is_refused_before_the_shaper_allocates() {
     );
 }
 
+/// A `font` shorthand is a display-list string of any length, and a page may
+/// carry a distinct one per run. Parsing each one once must not mean holding a
+/// copy of every raw string for the length of the page.
+#[test]
+fn a_page_of_distinct_font_shorthands_does_not_retain_them() {
+    let (fonts, chains) = carlito();
+    let images = ImageMap::new();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    let primitives: Vec<Value> = (0..512)
+        .map(|index| {
+            json!({
+                "kind": "text",
+                "text": "x",
+                "x": 1,
+                "baselineY": 6,
+                "width": 4,
+                "font": format!("400 {}12px Carlito, sans-serif", " ".repeat(16_384 + index)),
+                "color": "#000000",
+                "leaderGlyphs": {"glyph": ".", "count": 1, "advance": 0}
+            })
+        })
+        .collect();
+    let scene = list(8.0, 8.0, primitives);
+    let (result, allocated) = allocated_by(|| render_png(&scene, 0, &resources));
+    result.expect("render");
+    assert!(
+        allocated < MIB,
+        "a page of distinct shorthands allocated {allocated} bytes keeping them"
+    );
+}
+
 /// A leader repeats its glyph `count` times, and the glyph is a display-list
 /// string of any length. The charge is the product, not the count: 1:1 shaping
 /// leaves no excess for the shaped-glyph charge to recover.

--- a/crates/docx-raster/tests/contracts.rs
+++ b/crates/docx-raster/tests/contracts.rs
@@ -4,13 +4,14 @@ use std::io::{Cursor, Write};
 
 use docx_layout::display_list::DisplayList;
 use docx_raster::{
-    FontChains, ImageMap, ImageScope, MAX_IMAGE_PIXELS, MAX_PAGE_IMAGE_PIXELS, RenderResources,
-    render_page, render_png, scoped_image_key,
+    FontChains, GlyphCache, ImageMap, ImageScope, MAX_IMAGE_PIXELS, MAX_PAGE_IMAGE_PIXELS,
+    RenderResources, render_page, render_page_cached, render_png, scoped_image_key,
 };
 use ooxml_text::{FontStore, shape};
 use serde_json::{Value, json};
 
 const FONT: &[u8] = include_bytes!("assets/Carlito-Regular.ttf");
+const LIBERATION: &[u8] = include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
 
 fn list(width: f64, height: f64, primitives: Vec<Value>) -> DisplayList {
     serde_json::from_value(json!({
@@ -26,6 +27,113 @@ fn list(width: f64, height: f64, primitives: Vec<Value>) -> DisplayList {
 
 fn empty_resources() -> (FontStore, FontChains, ImageMap) {
     (FontStore::new(), FontChains::new(), ImageMap::new())
+}
+
+/// A chain whose first face lacks Hebrew, so text mixing Latin and Hebrew
+/// shapes into one segment per font.
+fn fallback_resources() -> (FontStore, FontChains, ImageMap) {
+    let mut fonts = FontStore::new();
+    let carlito = fonts.register(FONT.to_vec()).expect("carlito");
+    let liberation = fonts.register(LIBERATION.to_vec()).expect("liberation");
+    assert!(!fonts.covers(carlito, '\u{05d0}').expect("coverage"));
+    assert!(fonts.covers(liberation, '\u{05d0}').expect("coverage"));
+    let chains = FontChains::from([("carlito|0|0".to_string(), vec![carlito, liberation])]);
+    (fonts, chains, ImageMap::new())
+}
+
+fn carlito_resources() -> (FontStore, FontChains, ImageMap) {
+    let mut fonts = FontStore::new();
+    let id = fonts.register(FONT.to_vec()).expect("font");
+    let chains = FontChains::from([("carlito|0|0".to_string(), vec![id])]);
+    (fonts, chains, ImageMap::new())
+}
+
+fn leader_scene(rtl: bool, glyph: &str) -> DisplayList {
+    list(
+        160.0,
+        48.0,
+        vec![json!({
+            "kind": "text",
+            "text": "Tab",
+            "x": 10,
+            "baselineY": 34,
+            "width": 130,
+            "font": "400 24px Carlito, sans-serif",
+            "color": "#000000",
+            "leaderGlyphs": {"glyph": glyph, "count": 3, "advance": 10, "rtl": rtl}
+        })],
+    )
+}
+
+fn single_glyph_scene() -> DisplayList {
+    list(
+        60.0,
+        24.0,
+        vec![json!({
+            "kind": "text",
+            "text": "A",
+            "x": 4,
+            "baselineY": 16,
+            "width": 20,
+            "font": "400 12px Carlito, sans-serif",
+            "color": "#000000"
+        })],
+    )
+}
+
+fn leader_extent(resources: &RenderResources<'_>, rtl: bool, glyph: &str) -> f64 {
+    let png = render_png(&leader_scene(rtl, glyph), 0, resources).expect("leader render");
+    let bounds = ink_bounds(&png).expect("leader ink");
+    f64::from(bounds.1 - bounds.0)
+}
+
+/// A leader whose text splits across fallback fonts has to advance the pen
+/// through every segment; resetting it at each segment overprints them.
+#[test]
+fn a_multi_segment_leader_advances_across_fallback_segments() {
+    let (fonts, chains, images) = fallback_resources();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    let single = leader_extent(&resources, false, "A");
+    let mixed = leader_extent(&resources, false, "A\u{05d0}");
+    let grew = mixed - single;
+    assert!(
+        grew > 3.0,
+        "the fallback segment must extend the leader past the first segment's ink, grew {grew}"
+    );
+}
+
+/// The same, reading right-to-left: the segments still lay out sequentially
+/// rather than stacking on the stamp origin.
+#[test]
+fn an_rtl_multi_segment_leader_advances_across_fallback_segments() {
+    let (fonts, chains, images) = fallback_resources();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    let single = leader_extent(&resources, true, "A");
+    let mixed = leader_extent(&resources, true, "A\u{05d0}");
+    let grew = mixed - single;
+    assert!(
+        grew > 3.0,
+        "the fallback segment must extend the leader past the first segment's ink, grew {grew}"
+    );
+}
+
+/// Glyph ids are store-local, so a cache filled by one store must never feed
+/// renders of another: it is bound to the store that filled it.
+#[test]
+fn a_glyph_cache_is_bound_to_the_store_that_filled_it() {
+    let mut cache = GlyphCache::default();
+    {
+        let (fonts, chains, images) = carlito_resources();
+        let resources = RenderResources::new(&fonts, &chains, &images);
+        render_page_cached(&single_glyph_scene(), 0, &resources, &mut cache)
+            .expect("render into an unbound cache");
+    }
+    let (fonts, chains, images) = carlito_resources();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    assert_eq!(
+        render_page_cached(&single_glyph_scene(), 0, &resources, &mut cache).unwrap_err(),
+        "glyph cache is bound to another font store"
+    );
 }
 
 #[test]
@@ -346,6 +454,39 @@ fn a_tab_leader_paints_from_a_bare_family_name() {
     );
     let png = render_png(&list, 0, &resources).expect("a bare leader family must render");
     assert_eq!(&png[..8], b"\x89PNG\r\n\x1a\n");
+}
+
+/// A cache shared across pages has to paint exactly what a fresh cache paints:
+/// the second page reuses the outlines the first one extracted.
+#[test]
+fn a_shared_glyph_cache_renders_every_page_identically() {
+    let mut fonts = FontStore::new();
+    let font = fonts.register(FONT.to_vec()).expect("font");
+    let chains = FontChains::from([("carlito|0|0".to_string(), vec![font])]);
+    let images = ImageMap::new();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    let run = json!({
+        "kind": "text",
+        "text": "Page glyph",
+        "x": 4,
+        "baselineY": 26,
+        "width": 60,
+        "font": "400 16px Carlito, sans-serif",
+        "color": "#000000"
+    });
+    let list: DisplayList = serde_json::from_value(json!({
+        "pages": [
+            {"pageIndex": 0, "width": 120.0, "height": 40.0, "primitives": [run.clone()]},
+            {"pageIndex": 1, "width": 120.0, "height": 40.0, "primitives": [run]}
+        ]
+    }))
+    .expect("display list");
+    let mut cache = GlyphCache::default();
+    for page in 0..2 {
+        let shared = render_page_cached(&list, page, &resources, &mut cache).expect("shared");
+        let fresh = render_page(&list, page, &resources).expect("fresh");
+        assert_eq!(shared.bytes, fresh.bytes);
+    }
 }
 
 /// PNG headers declaring a bomb-sized surface, with an IDAT too short to

--- a/crates/docx-raster/tests/contracts.rs
+++ b/crates/docx-raster/tests/contracts.rs
@@ -81,6 +81,23 @@ fn single_glyph_scene() -> DisplayList {
     )
 }
 
+/// A glyph id past the outline range, so the page fails before the cache holds
+/// anything.
+fn missing_glyph_scene() -> DisplayList {
+    list(
+        60.0,
+        24.0,
+        vec![json!({
+            "kind": "glyphRun",
+            "fontId": 0,
+            "size": 12,
+            "color": "#000000",
+            "text": "A",
+            "glyphs": [{"id": 65_536, "x": 4, "y": 16, "cluster": 0, "advance": 8}]
+        })],
+    )
+}
+
 fn leader_extent(resources: &RenderResources<'_>, rtl: bool, glyph: &str) -> f64 {
     let png = render_png(&leader_scene(rtl, glyph), 0, resources).expect("leader render");
     let bounds = ink_bounds(&png).expect("leader ink");
@@ -134,6 +151,25 @@ fn a_glyph_cache_is_bound_to_the_store_that_filled_it() {
         render_page_cached(&single_glyph_scene(), 0, &resources, &mut cache).unwrap_err(),
         "glyph cache is bound to another font store"
     );
+}
+
+/// A page that fails before it caches anything leaves the cache unbound: only
+/// an outline the cache actually holds can tie it to the store it came from.
+#[test]
+fn a_failed_page_leaves_a_glyph_cache_free_to_bind_elsewhere() {
+    let mut cache = GlyphCache::default();
+    {
+        let (fonts, chains, images) = carlito_resources();
+        let resources = RenderResources::new(&fonts, &chains, &images);
+        assert_eq!(
+            render_page_cached(&missing_glyph_scene(), 0, &resources, &mut cache).unwrap_err(),
+            "glyph id 65536 exceeds the font outline range"
+        );
+    }
+    let (fonts, chains, images) = carlito_resources();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    render_page_cached(&single_glyph_scene(), 0, &resources, &mut cache)
+        .expect("render into a cache no failed page bound");
 }
 
 #[test]

--- a/crates/docx-raster/tests/contracts.rs
+++ b/crates/docx-raster/tests/contracts.rs
@@ -81,6 +81,22 @@ fn single_glyph_scene() -> DisplayList {
     )
 }
 
+/// One glyph id, painted from whichever face the run names.
+fn glyph_id_scene(font_id: u32, glyph_id: u32) -> DisplayList {
+    list(
+        60.0,
+        24.0,
+        vec![json!({
+            "kind": "glyphRun",
+            "fontId": font_id,
+            "size": 18,
+            "color": "#000000",
+            "text": "A",
+            "glyphs": [{"id": glyph_id, "x": 6, "y": 19, "cluster": 0, "advance": 12}]
+        })],
+    )
+}
+
 /// A glyph id past the outline range, so the page fails before the cache holds
 /// anything.
 fn missing_glyph_scene() -> DisplayList {
@@ -150,6 +166,41 @@ fn a_glyph_cache_is_bound_to_the_store_that_filled_it() {
     assert_eq!(
         render_page_cached(&single_glyph_scene(), 0, &resources, &mut cache).unwrap_err(),
         "glyph cache is bound to another font store"
+    );
+}
+
+/// Glyph ids are face-local, so a cache spanning pages has to key on the face
+/// too. The same id from a second face must paint that face's outline, not the
+/// one an earlier page cached.
+#[test]
+fn a_shared_cache_keeps_one_glyph_id_apart_per_face() {
+    let mut fonts = FontStore::new();
+    let carlito = fonts.register(FONT.to_vec()).expect("carlito");
+    let liberation = fonts.register(LIBERATION.to_vec()).expect("liberation");
+    let chains = FontChains::new();
+    let images = ImageMap::new();
+    let resources = RenderResources::new(&fonts, &chains, &images);
+    let first = glyph_id_scene(carlito.to_u32(), 36);
+    let second = glyph_id_scene(liberation.to_u32(), 36);
+    let fresh_first = render_page(&first, 0, &resources).expect("first").bytes;
+    let fresh_second = render_page(&second, 0, &resources).expect("second").bytes;
+    assert_ne!(
+        fresh_first, fresh_second,
+        "the fixture faces must draw glyph 36 differently"
+    );
+
+    let mut cache = GlyphCache::default();
+    assert_eq!(
+        render_page_cached(&first, 0, &resources, &mut cache)
+            .expect("shared first")
+            .bytes,
+        fresh_first
+    );
+    assert_eq!(
+        render_page_cached(&second, 0, &resources, &mut cache)
+            .expect("shared second")
+            .bytes,
+        fresh_second
     );
 }
 

--- a/crates/ooxml-text/src/font_store.rs
+++ b/crates/ooxml-text/src/font_store.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use skrifa::raw::TableProvider;
 use skrifa::raw::tables::os2::SelectionFlags;
@@ -208,15 +209,34 @@ struct FontEntry {
 /// Registry of fonts, keyed by [`FontId`], parsed from raw bytes.
 ///
 /// The store owns the byte buffers borrowed by shaping and outline extraction.
-#[derive(Default)]
 pub struct FontStore {
+    id: u64,
     fonts: Vec<FontEntry>,
     shape_cache: RefCell<ShapeCache>,
 }
 
+static NEXT_FONT_STORE_ID: AtomicU64 = AtomicU64::new(0);
+
+impl Default for FontStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FontStore {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            id: NEXT_FONT_STORE_ID.fetch_add(1, Ordering::Relaxed),
+            fonts: Vec::new(),
+            shape_cache: RefCell::default(),
+        }
+    }
+
+    /// Identity unique to this store within the process. [`FontId`]s are
+    /// store-local indexes, so anything keyed by them (glyph caches) binds to
+    /// this value instead of silently reusing another store's outlines.
+    pub fn id(&self) -> u64 {
+        self.id
     }
 
     /// Parse and register a font from raw bytes, returning its handle.


### PR DESCRIPTION
TL;DR:

Repro file:
`crates/docx-raster/tests/budgets.rs::a_page_of_distinct_font_shorthands_does_not_retain_them` — 512 distinct 16 KiB `font` shorthands on one page.

Summary:
- one `GlyphCache` shared across every page of a document export (bound to its `FontStore`, FIFO-capped at 8192 outlines) instead of re-extracting outlines per page
- CSS font shorthand parsed once per distinct string instead of per text run, with the parse cache bounded at 256 entries / 64 KiB of copied key bytes so an untrusted display list cannot make a page retain its own font strings
- leader dots shaped once and stamped at N positions instead of reshaped per repeat; pixels and the accept/reject budget boundary are unchanged, though the charge sequence on partial exhaustion is not
- a glyph cache binds to a font store only once it holds one of that store's outlines, so a page that fails before caching anything leaves it free to bind elsewhere

Test plan:
- [x] `cargo test -p betteroffice-docx-raster` and `cargo test -p betteroffice-docx --features raster` green incl. PNG goldens (the facade's render tests are `#![cfg(feature = "raster")]` and run zero tests without the feature)
- [x] 21 rendered pages byte-identical to `origin/main`: leaders (LTR/RTL, single- and multi-font fallback, family/size/`fontId`/colour overrides), header and footnote scoped media sharing one `rId`, the same family at three sizes and two weights, positioned glyph runs, and a 16-page/10,400-outline eviction stress rendered twice
- [x] multi-page export measured before/after: 20 pages x 2,000 distinct outlines allocates 613.1 MB -> 438.6 MB (-28.5%) and 1.69 s -> 1.56 s CPU; 30 pages of Latin prose is within noise
