### PR TITLE
fix(redact): bound media placeholders and blank legacy metafiles

### DIFF
--- a/.changeset/redact-media-bounds.md
+++ b/.changeset/redact-media-bounds.md
@@ -2,4 +2,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Emit fixed-size media placeholders and stub out legacy metafiles instead of failing.
+Media placeholders are now a fixed 64x64 blank image instead of matching the source dimensions, and WMF/EMF parts become blank metafile stubs instead of failing the whole redaction.

--- a/.changeset/redact-media-bounds.md
+++ b/.changeset/redact-media-bounds.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Emit fixed-size media placeholders and stub out legacy metafiles instead of failing.

--- a/crates/ooxml-redact/src/media.rs
+++ b/crates/ooxml-redact/src/media.rs
@@ -4,7 +4,7 @@ use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb};
 
 use crate::{RedactError, RedactionReport};
 
-const MAX_PLACEHOLDER_PIXELS: u64 = 64 * 1024 * 1024;
+pub(crate) const PLACEHOLDER_SIZE: u32 = 64;
 
 pub(crate) fn is_replaceable_part(path: &str) -> bool {
     let extension = path.rsplit_once('.').map(|(_, extension)| extension);
@@ -15,10 +15,9 @@ pub(crate) fn is_replaceable_part(path: &str) -> bool {
         || path.ends_with("/thumbnail")
 }
 
-/// Redact a media part, encoding the placeholder in the part's OWN format so the
-/// `[Content_Types].xml` declaration stays consistent. Formats that cannot be
-/// faithfully re-encoded (vector metafiles, non-image embeds) fail rather than
-/// emit format-mismatched bytes.
+/// Redact a media part by emitting a fixed-size blank placeholder in the
+/// part's OWN format so `[Content_Types].xml` declarations stay consistent.
+/// WMF/EMF parts become minimal valid blank metafile stubs.
 pub(crate) fn replace_media(
     path: &str,
     bytes: &[u8],
@@ -27,16 +26,18 @@ pub(crate) fn replace_media(
     let lower = path.to_ascii_lowercase();
     let extension = lower.rsplit_once('.').map(|(_, ext)| ext);
     let result = match extension {
-        Some("png") => solid_image(path, bytes, ImageFormat::Png)?,
-        Some("jpg" | "jpeg") => solid_image(path, bytes, ImageFormat::Jpeg)?,
-        Some("gif") => solid_image(path, bytes, ImageFormat::Gif)?,
-        Some("bmp") => solid_image(path, bytes, ImageFormat::Bmp)?,
-        Some("tif" | "tiff") => solid_image(path, bytes, ImageFormat::Tiff)?,
+        Some("png") => solid_placeholder(path, ImageFormat::Png)?,
+        Some("jpg" | "jpeg") => solid_placeholder(path, ImageFormat::Jpeg)?,
+        Some("gif") => solid_placeholder(path, ImageFormat::Gif)?,
+        Some("bmp") => solid_placeholder(path, ImageFormat::Bmp)?,
+        Some("tif" | "tiff") => solid_placeholder(path, ImageFormat::Tiff)?,
         Some("svg") => {
             br##"<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1" fill="#aaa"/></svg>"##.to_vec()
         }
+        Some("emf") => emf_stub(),
+        Some("wmf") => wmf_stub(),
         _ => match image::guess_format(bytes).ok().filter(is_encodable) {
-            Some(format) => solid_image(path, bytes, format)?,
+            Some(format) => solid_placeholder(path, format)?,
             None => {
                 return Err(RedactError::Image {
                     part: path.to_owned(),
@@ -60,24 +61,12 @@ fn is_encodable(format: &ImageFormat) -> bool {
     )
 }
 
-fn solid_image(path: &str, bytes: &[u8], format: ImageFormat) -> Result<Vec<u8>, RedactError> {
-    let reader = image::ImageReader::with_format(Cursor::new(bytes), format);
-    let (width, height) = reader
-        .into_dimensions()
-        .map_err(|error| RedactError::Image {
-            part: path.to_owned(),
-            message: error.to_string(),
-        })?;
-    let pixels = u64::from(width) * u64::from(height);
-    if pixels > MAX_PLACEHOLDER_PIXELS {
-        return Err(RedactError::Image {
-            part: path.to_owned(),
-            message: format!("{width}x{height} exceeds placeholder pixel limit"),
-        });
-    }
-
-    let image =
-        DynamicImage::ImageRgb8(ImageBuffer::from_pixel(width, height, Rgb([170, 170, 170])));
+fn solid_placeholder(path: &str, format: ImageFormat) -> Result<Vec<u8>, RedactError> {
+    let image = DynamicImage::ImageRgb8(ImageBuffer::from_pixel(
+        PLACEHOLDER_SIZE,
+        PLACEHOLDER_SIZE,
+        Rgb([170, 170, 170]),
+    ));
     let mut output = Cursor::new(Vec::new());
     image
         .write_to(&mut output, format)
@@ -86,4 +75,65 @@ fn solid_image(path: &str, bytes: &[u8], format: ImageFormat) -> Result<Vec<u8>,
             message: error.to_string(),
         })?;
     Ok(output.into_inner())
+}
+
+fn emf_stub() -> Vec<u8> {
+    let mut out = Vec::with_capacity(108);
+    out.extend_from_slice(&1u32.to_le_bytes()); // iType = EMR_HEADER
+    out.extend_from_slice(&88u32.to_le_bytes()); // nSize
+    out.extend_from_slice(&[0; 16]); // rclBounds
+    out.extend_from_slice(&0u32.to_le_bytes()); // rclFrame left/top
+    out.extend_from_slice(&0u32.to_le_bytes());
+    out.extend_from_slice(&50_800u32.to_le_bytes()); // rclFrame right/bottom, 0.01 mm
+    out.extend_from_slice(&28_575u32.to_le_bytes());
+    out.extend_from_slice(&0x464D4520u32.to_le_bytes()); // " EMF"
+    out.extend_from_slice(&0x00010000u32.to_le_bytes()); // version 1.0
+    out.extend_from_slice(&108u32.to_le_bytes()); // nBytes
+    out.extend_from_slice(&2u32.to_le_bytes()); // nRecords
+    out.extend_from_slice(&0u16.to_le_bytes()); // nHandles
+    out.extend_from_slice(&0u16.to_le_bytes()); // reserved
+    out.extend_from_slice(&0u32.to_le_bytes()); // nDescription
+    out.extend_from_slice(&0u32.to_le_bytes()); // offDescription
+    out.extend_from_slice(&0u32.to_le_bytes()); // nPalEntries
+    out.extend_from_slice(&1920i32.to_le_bytes()); // szlDevice px
+    out.extend_from_slice(&1080i32.to_le_bytes());
+    out.extend_from_slice(&508i32.to_le_bytes()); // szlMillimeters
+    out.extend_from_slice(&285i32.to_le_bytes());
+    out.extend_from_slice(&14u32.to_le_bytes()); // iType = EMR_EOF
+    out.extend_from_slice(&20u32.to_le_bytes()); // nSize
+    out.extend_from_slice(&0u32.to_le_bytes()); // nPalEntries
+    out.extend_from_slice(&16u32.to_le_bytes()); // offPalEntries, no palette
+    out.extend_from_slice(&20u32.to_le_bytes()); // nSizeLast duplicates nSize
+    debug_assert_eq!(out.len(), 108);
+    out
+}
+
+fn wmf_stub() -> Vec<u8> {
+    let mut out = Vec::with_capacity(46);
+    out.extend_from_slice(&0x9AC6CDD7u32.to_le_bytes()); // placeable key
+    out.extend_from_slice(&0u16.to_le_bytes()); // hmf
+    out.extend_from_slice(&0u16.to_le_bytes()); // bbox left
+    out.extend_from_slice(&0u16.to_le_bytes()); // bbox top
+    out.extend_from_slice(&2000u16.to_le_bytes()); // bbox right
+    out.extend_from_slice(&2000u16.to_le_bytes()); // bbox bottom
+    out.extend_from_slice(&1440u16.to_le_bytes()); // inch (twips)
+    out.extend_from_slice(&[0; 4]); // reserved
+    let checksum = out
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .fold(0u16, |acc, chunk| acc ^ u16::from_le_bytes(*chunk));
+    out.extend_from_slice(&checksum.to_le_bytes());
+    out.extend_from_slice(&1u16.to_le_bytes()); // mtType = memory
+    out.extend_from_slice(&9u16.to_le_bytes()); // mtHeaderSize words
+    out.extend_from_slice(&0x0300u16.to_le_bytes()); // version 3.0
+    out.extend_from_slice(&12u32.to_le_bytes()); // mtSize words, excludes placeable header
+    out.extend_from_slice(&0u16.to_le_bytes()); // mtNoObjects
+    out.extend_from_slice(&3u32.to_le_bytes()); // mtMaxRecord
+    out.extend_from_slice(&0u16.to_le_bytes()); // mtNoParameters
+    out.extend_from_slice(&3u16.to_le_bytes()); // META_EOF size
+    out.extend_from_slice(&0u16.to_le_bytes()); // META_EOF function
+    out.extend_from_slice(&0u16.to_le_bytes()); // META_EOF param
+    debug_assert_eq!(out.len(), 46);
+    out
 }

--- a/crates/ooxml-redact/src/media.rs
+++ b/crates/ooxml-redact/src/media.rs
@@ -90,7 +90,7 @@ fn emf_stub() -> Vec<u8> {
     out.extend_from_slice(&0x00010000u32.to_le_bytes()); // version 1.0
     out.extend_from_slice(&108u32.to_le_bytes()); // nBytes
     out.extend_from_slice(&2u32.to_le_bytes()); // nRecords
-    out.extend_from_slice(&0u16.to_le_bytes()); // nHandles
+    out.extend_from_slice(&1u16.to_le_bytes()); // nHandles, GDI reserves index 0
     out.extend_from_slice(&0u16.to_le_bytes()); // reserved
     out.extend_from_slice(&0u32.to_le_bytes()); // nDescription
     out.extend_from_slice(&0u32.to_le_bytes()); // offDescription
@@ -131,9 +131,8 @@ fn wmf_stub() -> Vec<u8> {
     out.extend_from_slice(&0u16.to_le_bytes()); // mtNoObjects
     out.extend_from_slice(&3u32.to_le_bytes()); // mtMaxRecord
     out.extend_from_slice(&0u16.to_le_bytes()); // mtNoParameters
-    out.extend_from_slice(&3u16.to_le_bytes()); // META_EOF size
-    out.extend_from_slice(&0u16.to_le_bytes()); // META_EOF function
-    out.extend_from_slice(&0u16.to_le_bytes()); // META_EOF param
+    out.extend_from_slice(&3u32.to_le_bytes()); // META_EOF RecordSize words
+    out.extend_from_slice(&0u16.to_le_bytes()); // META_EOF RecordFunction
     debug_assert_eq!(out.len(), 46);
     out
 }

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -64,12 +64,15 @@ fn redacts_pptx_without_changing_structure() {
 }
 
 #[test]
-fn preserves_jpeg_dimensions_and_format() {
+fn jpeg_placeholder_is_fixed_size() {
     let source = placeholder_image(ImageFormat::Jpeg);
     let mut report = RedactionReport::default();
     let output = media::replace_media("word/media/photo.jpeg", &source, &mut report).unwrap();
     assert_ne!(source, output);
-    assert_eq!(image_dimensions(&source), image_dimensions(&output));
+    assert_eq!(
+        image_dimensions(&output),
+        (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE)
+    );
     assert_eq!(image::guess_format(&output).unwrap(), ImageFormat::Jpeg);
 }
 
@@ -98,8 +101,8 @@ fn assert_fixture_properties(source: &[u8], output: &[u8], secrets: &[&str], med
     let after_image = part(&after, media_path);
     assert_ne!(before_image, after_image);
     assert_eq!(
-        image_dimensions(before_image),
-        image_dimensions(after_image)
+        image_dimensions(after_image),
+        (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE)
     );
     assert_eq!(image::guess_format(after_image).unwrap(), ImageFormat::Png);
 }
@@ -410,16 +413,155 @@ fn media_placeholder_keeps_each_format() {
             "{ext} format changed"
         );
         assert_eq!(
-            image_dimensions(&source),
             image_dimensions(&output),
+            (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE),
             "{ext} dims changed"
         );
     }
 }
 
 #[test]
-fn media_rejects_unencodable_formats() {
+fn rejects_unknown_extension_media() {
     let mut report = RedactionReport::default();
-    let error = media::replace_media("word/media/image1.emf", b"not an image", &mut report);
+    let error = media::replace_media("word/media/blob.dat", b"not an image", &mut report);
     assert!(matches!(error, Err(RedactError::Image { .. })));
+}
+
+#[test]
+fn replaces_wmf_with_valid_stub() {
+    let mut report = RedactionReport::default();
+    let output = media::replace_media(
+        "docProps/thumbnail.wmf",
+        b"\xd7\xcd\xc6\x9a metafile",
+        &mut report,
+    )
+    .unwrap();
+    assert_eq!(report.media_parts, 1);
+
+    assert_eq!(&output[..4], &0x9AC6_CDD7u32.to_le_bytes());
+    let checksum = output[..20]
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .fold(0u16, |acc, chunk| acc ^ u16::from_le_bytes(*chunk));
+    assert_eq!(le_u16(&output, 20), checksum);
+    assert_eq!(le_u16(&output, 10), 2000);
+    assert_eq!(le_u16(&output, 12), 2000);
+    assert_eq!(le_u16(&output, 14), 1440);
+
+    let content = &output[22..];
+    assert_eq!(le_u16(content, 0), 1);
+    assert_eq!(le_u16(content, 2), 9);
+    assert_eq!(le_u16(content, 4), 0x0300);
+    let mt_size = le_u32(content, 6) as usize;
+    assert_eq!(mt_size * 2, content.len());
+    assert_eq!(le_u32(content, 12), 3);
+
+    let eof = &content[18..];
+    assert_eq!(le_u16(eof, 0), 3);
+    assert_eq!(le_u16(eof, 2), 0);
+    assert_eq!(le_u16(eof, 4), 0);
+    assert_eq!(eof.len(), 6);
+}
+
+#[test]
+fn replaces_emf_with_valid_stub() {
+    let mut report = RedactionReport::default();
+    let output = media::replace_media("word/media/image1.emf", b"not an emf", &mut report).unwrap();
+    assert_eq!(report.media_parts, 1);
+
+    assert_eq!(le_u32(&output, 0), 1);
+    assert_eq!(le_u32(&output, 4), 88);
+    assert_eq!(le_u32(&output, 40), 0x464D_4520);
+    assert_eq!(le_u32(&output, 44), 0x0001_0000);
+    assert_eq!(le_u32(&output, 48) as usize, output.len());
+    assert_eq!(le_u32(&output, 52), 2);
+
+    let eof = &output[88..];
+    assert_eq!(eof.len(), 20);
+    assert_eq!(le_u32(eof, 0), 14);
+    assert_eq!(le_u32(eof, 4), 20);
+    assert_eq!(le_u32(eof, 8), 0);
+    assert_eq!(le_u32(eof, 12), 16);
+    assert_eq!(le_u32(eof, 16), 20);
+}
+
+fn le_u16(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap())
+}
+
+fn le_u32(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+}
+
+#[test]
+fn oversized_declared_dimensions_emit_fixed_placeholder() {
+    let mut hostile = placeholder_png();
+    hostile.truncate(40);
+    hostile[16..20].copy_from_slice(&8000u32.to_be_bytes());
+    hostile[20..24].copy_from_slice(&8000u32.to_be_bytes());
+    let mut report = RedactionReport::default();
+    let output = media::replace_media("word/media/huge.png", &hostile, &mut report).unwrap();
+    assert_eq!(
+        image_dimensions(&output),
+        (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE)
+    );
+    assert!(output.len() < 1024);
+}
+
+#[test]
+fn hostile_package_media_budget_is_bounded() {
+    let mut hostile = placeholder_png();
+    hostile.truncate(40);
+    hostile[16..20].copy_from_slice(&8000u32.to_be_bytes());
+    hostile[20..24].copy_from_slice(&8000u32.to_be_bytes());
+
+    let mut parts: Vec<(String, Vec<u8>)> = vec![
+        (
+            "[Content_Types].xml".to_owned(),
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Default Extension="wmf" ContentType="image/x-wmf"/><Default Extension="emf" ContentType="image/x-emf"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels".to_owned(),
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "word/document.xml".to_owned(),
+            xml(
+                r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p/></w:body></w:document>"#,
+            ),
+        ),
+        ("docProps/thumbnail.wmf".to_owned(), b"metafile".to_vec()),
+        ("ppt/media/pic.emf".to_owned(), b"metafile".to_vec()),
+    ];
+    for index in 0..32 {
+        parts.push((format!("word/media/hostile{index}.png"), hostile.clone()));
+    }
+    let packaged: Vec<(&str, Vec<u8>)> = parts
+        .iter()
+        .map(|(path, bytes)| (path.as_str(), bytes.clone()))
+        .collect();
+    let source = package(packaged);
+
+    let (output, report) = redact_with_report(&source, Format::Auto).unwrap();
+    assert_eq!(report.media_parts, 34);
+    let after = ooxml_opc::unzip_parts(&output).unwrap();
+    let mut media_total = 0;
+    for (path, bytes) in &after {
+        if !path.contains("/media/") && !path.ends_with("thumbnail.wmf") {
+            continue;
+        }
+        if path.ends_with(".png") {
+            assert_eq!(
+                image_dimensions(bytes),
+                (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE)
+            );
+        }
+        media_total += bytes.len();
+    }
+    assert!(media_total < 256 * 1024);
 }

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -439,12 +439,7 @@ fn replaces_wmf_with_valid_stub() {
     assert_eq!(report.media_parts, 1);
 
     assert_eq!(&output[..4], &0x9AC6_CDD7u32.to_le_bytes());
-    let checksum = output[..20]
-        .as_chunks::<2>()
-        .0
-        .iter()
-        .fold(0u16, |acc, chunk| acc ^ u16::from_le_bytes(*chunk));
-    assert_eq!(le_u16(&output, 20), checksum);
+    assert_eq!(le_u16(&output, 20), 0x52B1);
     assert_eq!(le_u16(&output, 10), 2000);
     assert_eq!(le_u16(&output, 12), 2000);
     assert_eq!(le_u16(&output, 14), 1440);
@@ -458,8 +453,7 @@ fn replaces_wmf_with_valid_stub() {
     assert_eq!(le_u32(content, 12), 3);
 
     let eof = &content[18..];
-    assert_eq!(le_u16(eof, 0), 3);
-    assert_eq!(le_u16(eof, 2), 0);
+    assert_eq!(le_u32(eof, 0), 3);
     assert_eq!(le_u16(eof, 4), 0);
     assert_eq!(eof.len(), 6);
 }
@@ -476,6 +470,7 @@ fn replaces_emf_with_valid_stub() {
     assert_eq!(le_u32(&output, 44), 0x0001_0000);
     assert_eq!(le_u32(&output, 48) as usize, output.len());
     assert_eq!(le_u32(&output, 52), 2);
+    assert_eq!(le_u16(&output, 56), 1);
 
     let eof = &output[88..];
     assert_eq!(eof.len(), 20);
@@ -494,12 +489,35 @@ fn le_u32(bytes: &[u8], offset: usize) -> u32 {
     u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
 }
 
+/// PNG whose IHDR declares `width` x `height` with a matching chunk CRC, so a
+/// dimension-preserving encoder really would allocate that many pixels.
+fn png_declaring(width: u32, height: u32) -> Vec<u8> {
+    let mut out = placeholder_png();
+    out[16..20].copy_from_slice(&width.to_be_bytes());
+    out[20..24].copy_from_slice(&height.to_be_bytes());
+    let crc = png_crc(&out[12..29]);
+    out[29..33].copy_from_slice(&crc.to_be_bytes());
+    out
+}
+
+fn png_crc(bytes: &[u8]) -> u32 {
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            crc = if crc & 1 == 0 {
+                crc >> 1
+            } else {
+                (crc >> 1) ^ 0xEDB8_8320
+            };
+        }
+    }
+    !crc
+}
+
 #[test]
 fn oversized_declared_dimensions_emit_fixed_placeholder() {
-    let mut hostile = placeholder_png();
-    hostile.truncate(40);
-    hostile[16..20].copy_from_slice(&8000u32.to_be_bytes());
-    hostile[20..24].copy_from_slice(&8000u32.to_be_bytes());
+    let hostile = png_declaring(8000, 8000);
     let mut report = RedactionReport::default();
     let output = media::replace_media("word/media/huge.png", &hostile, &mut report).unwrap();
     assert_eq!(
@@ -509,18 +527,12 @@ fn oversized_declared_dimensions_emit_fixed_placeholder() {
     assert!(output.len() < 1024);
 }
 
-#[test]
-fn hostile_package_media_budget_is_bounded() {
-    let mut hostile = placeholder_png();
-    hostile.truncate(40);
-    hostile[16..20].copy_from_slice(&8000u32.to_be_bytes());
-    hostile[20..24].copy_from_slice(&8000u32.to_be_bytes());
-
+fn media_package(media: &[(String, Vec<u8>)]) -> Vec<u8> {
     let mut parts: Vec<(String, Vec<u8>)> = vec![
         (
             "[Content_Types].xml".to_owned(),
             xml(
-                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Default Extension="wmf" ContentType="image/x-wmf"/><Default Extension="emf" ContentType="image/x-emf"/></Types>"#,
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Default Extension="jpg" ContentType="image/jpeg"/><Default Extension="gif" ContentType="image/gif"/><Default Extension="bmp" ContentType="image/bmp"/><Default Extension="tiff" ContentType="image/tiff"/><Default Extension="svg" ContentType="image/svg+xml"/><Default Extension="wmf" ContentType="image/x-wmf"/><Default Extension="emf" ContentType="image/x-emf"/></Types>"#,
             ),
         ),
         (
@@ -535,20 +547,24 @@ fn hostile_package_media_budget_is_bounded() {
                 r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p/></w:body></w:document>"#,
             ),
         ),
+    ];
+    parts.extend(media.iter().cloned());
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+#[test]
+fn hostile_package_media_budget_is_bounded() {
+    let hostile = png_declaring(8000, 8000);
+    let mut media: Vec<(String, Vec<u8>)> = vec![
         ("docProps/thumbnail.wmf".to_owned(), b"metafile".to_vec()),
         ("ppt/media/pic.emf".to_owned(), b"metafile".to_vec()),
     ];
     for index in 0..32 {
-        parts.push((format!("word/media/hostile{index}.png"), hostile.clone()));
+        media.push((format!("word/media/hostile{index}.png"), hostile.clone()));
     }
-    let packaged: Vec<(&str, Vec<u8>)> = parts
-        .iter()
-        .map(|(path, bytes)| (path.as_str(), bytes.clone()))
-        .collect();
-    let source = package(packaged);
 
-    let (output, report) = redact_with_report(&source, Format::Auto).unwrap();
-    assert_eq!(report.media_parts, 34);
+    let (output, report) = redact_with_report(&media_package(&media), Format::Auto).unwrap();
+    assert_eq!(report.media_parts, media.len());
     let after = ooxml_opc::unzip_parts(&output).unwrap();
     let mut media_total = 0;
     for (path, bytes) in &after {
@@ -564,4 +580,121 @@ fn hostile_package_media_budget_is_bounded() {
         media_total += bytes.len();
     }
     assert!(media_total < 256 * 1024);
+}
+
+const MEDIA_MARKER: &str = "MEDIA_SOURCE_MARKER";
+
+/// Every replaceable media shape. `mask` is XORed over each wrapped payload and
+/// its marker run, so two masks share no wrapped byte; mask 0 leaves the marker
+/// and the source images verbatim. `mask` also picks the sniffable PNGs' width
+/// and pixels, and those two encodings still share their signature, framing,
+/// IEND tail and some IDAT bytes.
+fn marked_media(mask: u8) -> Vec<(String, Vec<u8>)> {
+    let wrap = |bytes: &[u8]| {
+        let mut out = vec![mask; 8];
+        out.extend(MEDIA_MARKER.bytes().map(|byte| byte ^ mask));
+        out.extend(bytes.iter().map(|byte| byte ^ mask));
+        out.extend(MEDIA_MARKER.bytes().map(|byte| byte ^ mask));
+        out.extend_from_slice(&[mask; 8]);
+        out
+    };
+    let mut encoded = Cursor::new(Vec::new());
+    DynamicImage::ImageRgb8(ImageBuffer::from_pixel(
+        3 + u32::from(mask % 2),
+        2,
+        Rgb([mask, mask, mask]),
+    ))
+    .write_to(&mut encoded, ImageFormat::Png)
+    .unwrap();
+    let sniffable = encoded.into_inner();
+    vec![
+        ("word/media/image1.png".to_owned(), wrap(&placeholder_png())),
+        (
+            "word/media/photo.jpg".to_owned(),
+            wrap(&placeholder_image(ImageFormat::Jpeg)),
+        ),
+        (
+            "word/media/anim.gif".to_owned(),
+            wrap(&placeholder_image(ImageFormat::Gif)),
+        ),
+        (
+            "word/media/raster.bmp".to_owned(),
+            wrap(&placeholder_image(ImageFormat::Bmp)),
+        ),
+        (
+            "word/media/scan.tiff".to_owned(),
+            wrap(&placeholder_image(ImageFormat::Tiff)),
+        ),
+        (
+            "word/media/vector.svg".to_owned(),
+            wrap(
+                format!(
+                    r#"<svg xmlns="http://www.w3.org/2000/svg"><desc>{MEDIA_MARKER}</desc></svg>"#
+                )
+                .as_bytes(),
+            ),
+        ),
+        (
+            "word/media/legacy.wmf".to_owned(),
+            wrap(&[0xd7, 0xcd, 0xc6, 0x9a]),
+        ),
+        (
+            "word/media/legacy.emf".to_owned(),
+            wrap(&[0x01, 0x00, 0x00, 0x00]),
+        ),
+        (
+            "docProps/thumbnail.wmf".to_owned(),
+            wrap(&[0xd7, 0xcd, 0xc6, 0x9a]),
+        ),
+        (
+            "word/media/MixedCase.PNG".to_owned(),
+            wrap(&placeholder_png()),
+        ),
+        ("word/media/sniffed".to_owned(), sniffable.clone()),
+        ("docProps/thumbnail".to_owned(), sniffable),
+        (
+            "word/media/mislabelled.png".to_owned(),
+            wrap(&placeholder_image(ImageFormat::Jpeg)),
+        ),
+        (
+            "word/media/mislabelled.emf".to_owned(),
+            wrap(&placeholder_png()),
+        ),
+        (
+            "word/media/oversized.png".to_owned(),
+            wrap(&png_declaring(8000, 8000)),
+        ),
+        ("word/media/empty.png".to_owned(), Vec::new()),
+        ("word/media/empty.wmf".to_owned(), Vec::new()),
+    ]
+}
+
+#[test]
+fn media_replacement_never_copies_source_bytes() {
+    let first = marked_media(0);
+    let second = marked_media(0x5f);
+    for ((path, wrapped), (_, other)) in first.iter().zip(&second) {
+        if matches!(path.as_str(), "word/media/sniffed" | "docProps/thumbnail") {
+            continue;
+        }
+        assert!(
+            wrapped.iter().zip(other).all(|(one, two)| one != two),
+            "fixtures share a byte in {path}, so a copy of it would go unnoticed"
+        );
+    }
+
+    let (output, report) = redact_with_report(&media_package(&first), Format::Auto).unwrap();
+    assert_eq!(report.media_parts, first.len());
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    for (path, bytes) in &parts {
+        assert!(
+            !bytes
+                .windows(MEDIA_MARKER.len())
+                .any(|window| window == MEDIA_MARKER.as_bytes()),
+            "source bytes survived in {path}"
+        );
+    }
+
+    let (other, _) = redact_with_report(&media_package(&second), Format::Auto).unwrap();
+    assert_eq!(parts, ooxml_opc::unzip_parts(&other).unwrap());
 }


### PR DESCRIPTION
TL;DR:

Summary:
- media placeholders are a fixed 64x64 blank image regardless of the declared dimensions; the input bytes are never decoded, so the 192MB-per-part allocation path is gone
- WMF/EMF parts become minimal valid blank metafile stubs (placeable-header WMF with correct mtSize and checksum; EMR_HEADER + EMR_EOF EMF with nHandles = 1) instead of failing the whole redaction
- unknown extensions still fail closed; total media output stays bounded per package
- `media_replacement_never_copies_source_bytes` redacts every media shape twice with payloads that share no byte at any offset, and asserts the two outputs are byte-identical and marker-free, so a copy of even one source byte fails the suite; the fixture asserts its own no-shared-byte property up front so it cannot silently rot
- oversized-dimension fixtures carry a matching IHDR CRC, so they reach the allocation path the bound removes instead of being rejected earlier on a CRC error
- placeholders no longer carry the source dimensions, which VML without explicit width/height reads intrinsically; the changeset states this

Test plan:
- [x] `cargo test -p betteroffice-redact` green
- [x] redact a document containing a legacy thumbnail.wmf end-to-end
- [x] hostile oversized-dimension image no longer balloons memory