### PR TITLE
fix(redact): catch external targets missing TargetMode

### DIFF
--- a/.changeset/redact-external-links.md
+++ b/.changeset/redact-external-links.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Redact scheme-bearing relationship targets missing TargetMode.

--- a/.changeset/redact-external-links.md
+++ b/.changeset/redact-external-links.md
@@ -2,4 +2,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Redact scheme-bearing relationship targets missing TargetMode.
+Redact relationship targets that point outside the package when TargetMode is missing, and declare the mode on the rewritten relationship.

--- a/.changeset/redact-external-links.md
+++ b/.changeset/redact-external-links.md
@@ -2,4 +2,4 @@
 "@betteroffice/rust-crates": patch
 ---
 
-Redact relationship targets that point outside the package when TargetMode is missing, and declare the mode on the rewritten relationship.
+Redact relationship targets that carry a URI scheme, are protocol-relative or name a UNC share even when TargetMode is missing or oddly spelled, and declare the mode on the rewritten relationship.

--- a/crates/ooxml-redact/src/lib.rs
+++ b/crates/ooxml-redact/src/lib.rs
@@ -90,12 +90,20 @@ pub fn redact_with_report(
         format: detected,
         ..RedactionReport::default()
     };
+    let names = parts
+        .iter()
+        .map(|(path, _)| path.trim_start_matches('/').to_ascii_lowercase())
+        .collect();
     for (path, data) in &mut parts {
         let lower = path.to_ascii_lowercase();
         if media::is_replaceable_part(&lower) {
             *data = replace_media(path, data, &mut report)?;
         } else if is_xml_part(&lower) {
-            *data = redact_xml(detected, path, data, &mut report)?;
+            let part = xml::Part {
+                path,
+                names: &names,
+            };
+            *data = redact_xml(detected, &part, data, &mut report)?;
         } else if is_sensitive_binary(&lower) {
             data.clear();
             report.binary_parts += 1;

--- a/crates/ooxml-redact/src/lib.rs
+++ b/crates/ooxml-redact/src/lib.rs
@@ -90,20 +90,12 @@ pub fn redact_with_report(
         format: detected,
         ..RedactionReport::default()
     };
-    let names = parts
-        .iter()
-        .map(|(path, _)| path.trim_start_matches('/').to_ascii_lowercase())
-        .collect();
     for (path, data) in &mut parts {
         let lower = path.to_ascii_lowercase();
         if media::is_replaceable_part(&lower) {
             *data = replace_media(path, data, &mut report)?;
         } else if is_xml_part(&lower) {
-            let part = xml::Part {
-                path,
-                names: &names,
-            };
-            *data = redact_xml(detected, &part, data, &mut report)?;
+            *data = redact_xml(detected, path, data, &mut report)?;
         } else if is_sensitive_binary(&lower) {
             data.clear();
             report.binary_parts += 1;

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -563,6 +563,57 @@ fn lowercase_target_mode_attribute_is_written_back_canonically() {
 }
 
 #[test]
+fn a_case_variant_target_does_not_externalize_the_real_one() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml" target="mailto:jane@example.com"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Pptx,
+        "ppt/_rels/presentation.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(r#"Target="slides/slide1.xml""#));
+    assert!(!text.contains("TargetMode"));
+    assert_eq!(report.attributes, 0);
+}
+
+#[test]
+fn repeated_target_mode_spellings_collapse_to_one_attribute() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://secret.example/x" TargetMode="External" targetmode="external"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert_eq!(text.matches("TargetMode").count(), 1);
+    assert!(!text.contains("secret.example"));
+    let mut again = RedactionReport::default();
+    xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        text.as_bytes(),
+        &mut again,
+    )
+    .unwrap();
+}
+
+#[test]
 fn internal_target_mode_keeps_the_producer_spelling() {
     let rels = concat!(
         r#"<?xml version="1.0"?>"#,

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -548,6 +548,42 @@ fn padded_target_mode_still_marks_relationship_external() {
 }
 
 #[test]
+fn lowercase_target_mode_attribute_is_written_back_canonically() {
+    let source = pptx_fixture_with_slide_relationship(
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://PPTX_SECRET_HOST/x" targetmode="external"/>"#,
+    );
+    let (output, _) = redact_with_report(&source, Format::Pptx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    let rels =
+        String::from_utf8_lossy(part(&parts, "ppt/slides/_rels/slide1.xml.rels")).into_owned();
+    assert!(rels.contains(r#"TargetMode="External""#));
+    assert!(!rels.contains("targetmode"));
+    assert!(!rels.contains("PPTX_SECRET_HOST"));
+    pptx_parse::parse_pptx(&output).unwrap();
+}
+
+#[test]
+fn internal_target_mode_keeps_the_producer_spelling() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png" targetmode="internal"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(r#"targetmode="internal""#));
+    assert_eq!(report.attributes, 0);
+}
+
+#[test]
 fn inferred_external_relationship_declares_target_mode() {
     let source = pptx_fixture_with_slide_relationship(
         r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="tel:+49PPTX_SECRET_PHONE"/>"#,
@@ -643,11 +679,12 @@ fn foreign_attributes_do_not_drive_relationship_mode() {
 }
 
 #[test]
-fn relationship_markup_outside_a_rels_part_is_untouched() {
+fn target_inspection_is_limited_to_rels_parts() {
     let body = concat!(
         r#"<?xml version="1.0"?>"#,
         r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:q="urn:qa">"#,
         r#"<q:Relationship Target="tel:+49123456789"/>"#,
+        r#"<q:Relationship Target="https://secret.example/x" TargetMode="External"/>"#,
         r#"</w:document>"#,
     );
     let mut report = RedactionReport::default();
@@ -660,7 +697,9 @@ fn relationship_markup_outside_a_rels_part_is_untouched() {
     .unwrap();
     let text = String::from_utf8(output).unwrap();
     assert!(text.contains(r#"Target="tel:+49123456789""#));
-    assert!(!text.contains("TargetMode"));
+    assert!(!text.contains("secret.example"));
+    assert_eq!(text.matches("TargetMode").count(), 1);
+    assert_eq!(report.attributes, 1);
 }
 
 fn pptx_fixture_with_slide_relationship(relationship: &str) -> Vec<u8> {

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -479,6 +479,119 @@ fn uri_in_fragment_keeps_relationship_internal() {
 }
 
 #[test]
+fn unc_relationship_targets_redacted_without_target_mode() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="\\fileserver01\finance\q3.xlsx"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="\\?\UNC\fileserver02\finance\q4.xlsx"/>"#,
+        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="\word\media\image1.png"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert_eq!(text.matches(r#"Target="https://example.com""#).count(), 2);
+    assert!(!text.contains("fileserver01"));
+    assert!(!text.contains("fileserver02"));
+    assert!(text.contains(r#"Target="\word\media\image1.png""#));
+    assert_eq!(report.attributes, 2);
+}
+
+#[test]
+fn parent_escaping_targets_redacted_without_target_mode() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="../../../Users/rachel/book.xlsx"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>"#,
+        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image2.png"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(!text.contains("rachel"));
+    assert!(text.contains(r#"Target="../media/image1.png""#));
+    assert!(text.contains(r#"Target="media/image2.png""#));
+    assert_eq!(report.attributes, 1);
+}
+
+#[test]
+fn padded_target_mode_still_marks_relationship_external() {
+    let source = pptx_fixture_with_slide_relationship(
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="PPTX_SECRET_SHARE/finance/q1.xlsx" TargetMode=" External "/>"#,
+    );
+    let (output, _) = redact_with_report(&source, Format::Pptx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    let rels =
+        String::from_utf8_lossy(part(&parts, "ppt/slides/_rels/slide1.xml.rels")).into_owned();
+    assert!(rels.contains(r#"Target="https://example.com""#));
+    assert!(rels.contains(r#"TargetMode="External""#));
+    assert!(!rels.contains("PPTX_SECRET_SHARE"));
+    pptx_parse::parse_pptx(&output).unwrap();
+}
+
+#[test]
+fn inferred_external_relationship_declares_target_mode() {
+    let source = pptx_fixture_with_slide_relationship(
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="tel:+49PPTX_SECRET_PHONE"/>"#,
+    );
+    pptx_parse::parse_pptx(&source).unwrap();
+
+    let (output, _) = redact_with_report(&source, Format::Pptx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    let rels =
+        String::from_utf8_lossy(part(&parts, "ppt/slides/_rels/slide1.xml.rels")).into_owned();
+    assert!(rels.contains(r#"Target="https://example.com""#));
+    assert!(rels.contains(r#"TargetMode="External""#));
+    assert!(
+        parts
+            .iter()
+            .all(|(_, bytes)| !String::from_utf8_lossy(bytes).contains("PPTX_SECRET_PHONE")),
+        "secret survived: PPTX_SECRET_PHONE"
+    );
+    pptx_parse::parse_pptx(&output).unwrap();
+}
+
+#[test]
+fn declared_target_mode_is_not_duplicated() {
+    let source = pptx_fixture_with_slide_relationship(
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://secret.example/pptx" TargetMode="External"/>"#,
+    );
+    let (output, _) = redact_with_report(&source, Format::Pptx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    let rels =
+        String::from_utf8_lossy(part(&parts, "ppt/slides/_rels/slide1.xml.rels")).into_owned();
+    assert_eq!(rels.matches("TargetMode").count(), 1);
+    pptx_parse::parse_pptx(&output).unwrap();
+}
+
+fn pptx_fixture_with_slide_relationship(relationship: &str) -> Vec<u8> {
+    let mut parts = ooxml_opc::unzip_parts(&pptx_fixture()).unwrap();
+    for (path, data) in &mut parts {
+        if path == "ppt/slides/_rels/slide1.xml.rels" {
+            *data = xml(&format!(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{relationship}</Relationships>"#
+            ));
+        }
+    }
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+#[test]
 fn media_placeholder_keeps_each_format() {
     for (format, ext) in [
         (ImageFormat::Gif, "gif"),

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -396,6 +396,89 @@ fn empty_shared_string_cell_does_not_leak_next_value() {
 }
 
 #[test]
+fn scheme_bearing_relationship_targets_redacted_without_target_mode() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://secret.example/docx" TargetMode="External"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/a"/>"#,
+        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="file:///C:/Users/jane/x.xlsx"/>"#,
+        r#"<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="file:///\\server\share\x.xlsx"/>"#,
+        r#"<Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(r#"Target="https://example.com""#));
+    assert!(!text.contains("secret.example"));
+    assert!(!text.contains(r"\server\share"));
+    assert!(!text.contains("/Users/jane"));
+    assert!(text.contains(r#"Target="media/image1.png""#));
+    assert_eq!(report.attributes, 4);
+}
+
+#[test]
+fn rfc3986_scheme_targets_redacted_without_target_mode() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="tel:+49123456789"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="MAILTO:jane@example.com"/>"#,
+        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="myapp://x"/>"#,
+        r#"<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="../fonts/x.ttf"/>"#,
+        r#"<Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="media/image:1.png"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert_eq!(text.matches(r#"Target="https://example.com""#).count(), 3);
+    assert!(!text.contains("tel:"));
+    assert!(!text.contains("jane@example.com"));
+    assert!(!text.contains("myapp:"));
+    assert!(text.contains(r#"Target="../fonts/x.ttf""#));
+    assert!(text.contains(r#"Target="media/image:1.png""#));
+    assert_eq!(report.attributes, 3);
+}
+
+#[test]
+fn uri_in_fragment_keeps_relationship_internal() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="worksheet.xml#ref=https://example.com/x"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/x"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        "word/_rels/document.xml.rels",
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(r#"Target="worksheet.xml#ref=https://example.com/x""#));
+    assert!(!text.contains(r#"Target="https://example.com/x""#));
+    assert!(text.contains(r#"Target="https://example.com""#));
+    assert_eq!(report.attributes, 1);
+}
+
+#[test]
 fn media_placeholder_keeps_each_format() {
     for (format, ext) in [
         (ImageFormat::Gif, "gif"),

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -1,5 +1,6 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
+use std::sync::OnceLock;
 
 use docx_parse::{S9ParseOptions, parse_docx_s9_wire};
 use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb};
@@ -105,6 +106,14 @@ fn assert_fixture_properties(source: &[u8], output: &[u8], secrets: &[&str], med
         (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE)
     );
     assert_eq!(image::guess_format(after_image).unwrap(), ImageFormat::Png);
+}
+
+fn test_part(path: &str) -> xml::Part<'_> {
+    static NAMES: OnceLock<BTreeSet<String>> = OnceLock::new();
+    xml::Part {
+        path,
+        names: NAMES.get_or_init(BTreeSet::new),
+    }
 }
 
 fn part_names(parts: &[(String, Vec<u8>)]) -> Vec<&str> {
@@ -383,7 +392,7 @@ fn empty_shared_string_cell_does_not_leak_next_value() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Xlsx,
-        "xl/worksheets/sheet1.xml",
+        &test_part("xl/worksheets/sheet1.xml"),
         sheet.as_bytes(),
         &mut report,
     )
@@ -410,7 +419,7 @@ fn scheme_bearing_relationship_targets_redacted_without_target_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        "word/_rels/document.xml.rels",
+        &test_part("word/_rels/document.xml.rels"),
         rels.as_bytes(),
         &mut report,
     )
@@ -439,7 +448,7 @@ fn rfc3986_scheme_targets_redacted_without_target_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        "word/_rels/document.xml.rels",
+        &test_part("word/_rels/document.xml.rels"),
         rels.as_bytes(),
         &mut report,
     )
@@ -466,7 +475,7 @@ fn uri_in_fragment_keeps_relationship_internal() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        "word/_rels/document.xml.rels",
+        &test_part("word/_rels/document.xml.rels"),
         rels.as_bytes(),
         &mut report,
     )
@@ -491,7 +500,7 @@ fn unc_relationship_targets_redacted_without_target_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        "word/_rels/document.xml.rels",
+        &test_part("word/_rels/document.xml.rels"),
         rels.as_bytes(),
         &mut report,
     )
@@ -517,7 +526,7 @@ fn parent_escaping_targets_redacted_without_target_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        "word/_rels/document.xml.rels",
+        &test_part("word/_rels/document.xml.rels"),
         rels.as_bytes(),
         &mut report,
     )
@@ -579,13 +588,102 @@ fn declared_target_mode_is_not_duplicated() {
     pptx_parse::parse_pptx(&output).unwrap();
 }
 
+#[test]
+fn declared_internal_mode_is_corrected_when_the_target_is_external() {
+    let source = pptx_fixture_with_slide_relationship(
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="tel:+49PPTX_SECRET_PHONE" TargetMode="Internal"/>"#,
+    );
+    pptx_parse::parse_pptx(&source).unwrap();
+
+    let (output, _) = redact_with_report(&source, Format::Pptx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    let rels =
+        String::from_utf8_lossy(part(&parts, "ppt/slides/_rels/slide1.xml.rels")).into_owned();
+    assert!(rels.contains(r#"Target="https://example.com""#));
+    assert!(rels.contains(r#"TargetMode="External""#));
+    assert!(!rels.contains("PPTX_SECRET_PHONE"));
+    pptx_parse::parse_pptx(&output).unwrap();
+}
+
+#[test]
+fn parent_segments_resolving_to_a_package_part_stay_internal() {
+    let target = "../../xl/XLSX_LOOPBACK_SEGMENT/../worksheets/sheet1.xml";
+    let source = fixture_with_part(
+        xlsx_fixture(),
+        "xl/_rels/workbook.xml.rels",
+        xml(&format!(
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="{target}"/></Relationships>"#
+        )),
+    );
+    let (output, _) = redact_with_report(&source, Format::Xlsx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    let rels = String::from_utf8_lossy(part(&parts, "xl/_rels/workbook.xml.rels")).into_owned();
+    assert!(rels.contains(&format!(r#"Target="{target}""#)));
+    assert!(!rels.contains("TargetMode"));
+    xlsx_parse::parse_workbook(&parts).unwrap();
+}
+
+#[test]
+fn foreign_attributes_do_not_drive_relationship_mode() {
+    let rels = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships" xmlns:q="urn:qa">"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml" q:Target="https://foreign.example/x"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml" q:TargetMode="External"/>"#,
+        r#"</Relationships>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        &test_part("word/_rels/document.xml.rels"),
+        rels.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(r#"Target="footnotes.xml""#));
+    assert!(text.contains(r#"Target="endnotes.xml""#));
+    assert!(text.contains(r#"q:TargetMode="External""#));
+    assert!(!text.contains(r#" TargetMode="External""#));
+    assert_eq!(report.attributes, 0);
+}
+
+#[test]
+fn relationship_markup_outside_a_rels_part_is_untouched() {
+    let body = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:q="urn:qa">"#,
+        r#"<q:Relationship Target="tel:+49123456789"/>"#,
+        r#"</w:document>"#,
+    );
+    let mut report = RedactionReport::default();
+    let output = xml::redact_xml(
+        Format::Docx,
+        &test_part("word/document.xml"),
+        body.as_bytes(),
+        &mut report,
+    )
+    .unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(r#"Target="tel:+49123456789""#));
+    assert!(!text.contains("TargetMode"));
+}
+
 fn pptx_fixture_with_slide_relationship(relationship: &str) -> Vec<u8> {
-    let mut parts = ooxml_opc::unzip_parts(&pptx_fixture()).unwrap();
-    for (path, data) in &mut parts {
-        if path == "ppt/slides/_rels/slide1.xml.rels" {
-            *data = xml(&format!(
-                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{relationship}</Relationships>"#
-            ));
+    fixture_with_part(
+        pptx_fixture(),
+        "ppt/slides/_rels/slide1.xml.rels",
+        xml(&format!(
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{relationship}</Relationships>"#
+        )),
+    )
+}
+
+fn fixture_with_part(source: Vec<u8>, path: &str, data: Vec<u8>) -> Vec<u8> {
+    let mut parts = ooxml_opc::unzip_parts(&source).unwrap();
+    for (candidate, bytes) in &mut parts {
+        if candidate == path {
+            *bytes = data.clone();
         }
     }
     ooxml_opc::rezip_parts(&parts).unwrap()

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -1,6 +1,5 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::io::Cursor;
-use std::sync::OnceLock;
 
 use docx_parse::{S9ParseOptions, parse_docx_s9_wire};
 use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb};
@@ -106,14 +105,6 @@ fn assert_fixture_properties(source: &[u8], output: &[u8], secrets: &[&str], med
         (media::PLACEHOLDER_SIZE, media::PLACEHOLDER_SIZE)
     );
     assert_eq!(image::guess_format(after_image).unwrap(), ImageFormat::Png);
-}
-
-fn test_part(path: &str) -> xml::Part<'_> {
-    static NAMES: OnceLock<BTreeSet<String>> = OnceLock::new();
-    xml::Part {
-        path,
-        names: NAMES.get_or_init(BTreeSet::new),
-    }
 }
 
 fn part_names(parts: &[(String, Vec<u8>)]) -> Vec<&str> {
@@ -392,7 +383,7 @@ fn empty_shared_string_cell_does_not_leak_next_value() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Xlsx,
-        &test_part("xl/worksheets/sheet1.xml"),
+        "xl/worksheets/sheet1.xml",
         sheet.as_bytes(),
         &mut report,
     )
@@ -419,7 +410,7 @@ fn scheme_bearing_relationship_targets_redacted_without_target_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/_rels/document.xml.rels"),
+        "word/_rels/document.xml.rels",
         rels.as_bytes(),
         &mut report,
     )
@@ -448,7 +439,7 @@ fn rfc3986_scheme_targets_redacted_without_target_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/_rels/document.xml.rels"),
+        "word/_rels/document.xml.rels",
         rels.as_bytes(),
         &mut report,
     )
@@ -475,7 +466,7 @@ fn uri_in_fragment_keeps_relationship_internal() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/_rels/document.xml.rels"),
+        "word/_rels/document.xml.rels",
         rels.as_bytes(),
         &mut report,
     )
@@ -488,54 +479,57 @@ fn uri_in_fragment_keeps_relationship_internal() {
 }
 
 #[test]
-fn unc_relationship_targets_redacted_without_target_mode() {
+fn unc_and_protocol_relative_targets_redacted_without_target_mode() {
     let rels = concat!(
         r#"<?xml version="1.0"?>"#,
         r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
         r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="\\fileserver01\finance\q3.xlsx"/>"#,
         r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="\\?\UNC\fileserver02\finance\q4.xlsx"/>"#,
-        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="\word\media\image1.png"/>"#,
+        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="//fileserver03.example/finance/q1.xlsx"/>"#,
+        r#"<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="\word\media\image1.png"/>"#,
         r#"</Relationships>"#,
     );
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/_rels/document.xml.rels"),
+        "word/_rels/document.xml.rels",
         rels.as_bytes(),
         &mut report,
     )
     .unwrap();
     let text = String::from_utf8(output).unwrap();
-    assert_eq!(text.matches(r#"Target="https://example.com""#).count(), 2);
+    assert_eq!(text.matches(r#"Target="https://example.com""#).count(), 3);
     assert!(!text.contains("fileserver01"));
     assert!(!text.contains("fileserver02"));
+    assert!(!text.contains("fileserver03"));
     assert!(text.contains(r#"Target="\word\media\image1.png""#));
-    assert_eq!(report.attributes, 2);
+    assert_eq!(report.attributes, 3);
 }
 
 #[test]
-fn parent_escaping_targets_redacted_without_target_mode() {
+fn percent_encoded_and_dotted_relative_targets_stay_internal() {
     let rels = concat!(
         r#"<?xml version="1.0"?>"#,
         r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
-        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="../../../Users/rachel/book.xlsx"/>"#,
-        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>"#,
-        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image2.png"/>"#,
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../../word/media/im%7Eage1.png"/>"#,
+        r#"<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../../word/./media/image2.png"/>"#,
+        r#"<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="..\..\word\media\image3.png"/>"#,
         r#"</Relationships>"#,
     );
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/_rels/document.xml.rels"),
+        "word/_rels/document.xml.rels",
         rels.as_bytes(),
         &mut report,
     )
     .unwrap();
     let text = String::from_utf8(output).unwrap();
-    assert!(!text.contains("rachel"));
-    assert!(text.contains(r#"Target="../media/image1.png""#));
-    assert!(text.contains(r#"Target="media/image2.png""#));
-    assert_eq!(report.attributes, 1);
+    assert!(text.contains(r#"Target="../../word/media/im%7Eage1.png""#));
+    assert!(text.contains(r#"Target="../../word/./media/image2.png""#));
+    assert!(text.contains(r#"Target="..\..\word\media\image3.png""#));
+    assert!(!text.contains("TargetMode"));
+    assert_eq!(report.attributes, 0);
 }
 
 #[test]
@@ -606,8 +600,8 @@ fn declared_internal_mode_is_corrected_when_the_target_is_external() {
 }
 
 #[test]
-fn parent_segments_resolving_to_a_package_part_stay_internal() {
-    let target = "../../xl/XLSX_LOOPBACK_SEGMENT/../worksheets/sheet1.xml";
+fn relative_target_with_parent_segments_stays_internal() {
+    let target = "../../xl/nested/../worksheets/sheet1.xml";
     let source = fixture_with_part(
         xlsx_fixture(),
         "xl/_rels/workbook.xml.rels",
@@ -635,7 +629,7 @@ fn foreign_attributes_do_not_drive_relationship_mode() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/_rels/document.xml.rels"),
+        "word/_rels/document.xml.rels",
         rels.as_bytes(),
         &mut report,
     )
@@ -659,7 +653,7 @@ fn relationship_markup_outside_a_rels_part_is_untouched() {
     let mut report = RedactionReport::default();
     let output = xml::redact_xml(
         Format::Docx,
-        &test_part("word/document.xml"),
+        "word/document.xml",
         body.as_bytes(),
         &mut report,
     )

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -139,8 +139,11 @@ fn rewrite_start(
         let local = attribute_local(&key);
         if relationship && is_unqualified(&key) && local.eq_ignore_ascii_case("TargetMode") {
             wrote_target_mode = true;
-            let mode = if external { "External" } else { value.as_str() };
-            output.push_attribute((key.as_str(), mode));
+            if external {
+                output.push_attribute(("TargetMode", "External"));
+            } else {
+                output.push_attribute((key.as_str(), value.as_str()));
+            }
             continue;
         }
         let replacement =
@@ -165,7 +168,7 @@ fn rewrite_start(
             *cell_type = Some(value);
         }
     }
-    if external && !wrote_target_mode {
+    if relationship && external && !wrote_target_mode {
         output.push_attribute(("TargetMode", "External"));
     }
     Ok(output)
@@ -372,23 +375,23 @@ fn attribute_local(name: &str) -> &str {
     name.rsplit_once(':').map_or(name, |(_, local)| local)
 }
 
-/// Whether the element is a package relationship, and whether it points outside
-/// the package. Only unqualified OPC attributes take part in the decision.
+/// Whether the element is a relationship in a package relationship part, and
+/// whether it points outside the package. Only unqualified OPC attributes take
+/// part in the decision, and a target is inspected only inside a `.rels` part.
 fn relationship_mode(path: &str, element: &str, attributes: &[(String, String)]) -> (bool, bool) {
-    if !element.eq_ignore_ascii_case("Relationship")
-        || !path.to_ascii_lowercase().ends_with(".rels")
-    {
+    if !element.eq_ignore_ascii_case("Relationship") {
         return (false, false);
     }
+    let package_part = path.to_ascii_lowercase().ends_with(".rels");
     let external = attributes.iter().any(|(key, value)| {
         if !is_unqualified(key) {
             return false;
         }
         let local = attribute_local(key);
         local.eq_ignore_ascii_case("TargetMode") && value.trim().eq_ignore_ascii_case("External")
-            || local.eq_ignore_ascii_case("Target") && external_target(value)
+            || package_part && local.eq_ignore_ascii_case("Target") && external_target(value)
     });
-    (true, external)
+    (package_part, external)
 }
 
 fn is_unqualified(key: &str) -> bool {

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -130,8 +130,9 @@ fn rewrite_start(
 
     let external = element.eq_ignore_ascii_case("Relationship")
         && attributes.iter().any(|(key, value)| {
-            attribute_local(key).eq_ignore_ascii_case("TargetMode")
-                && value.eq_ignore_ascii_case("External")
+            let local = attribute_local(key);
+            local.eq_ignore_ascii_case("TargetMode") && value.eq_ignore_ascii_case("External")
+                || local.eq_ignore_ascii_case("Target") && external_target(value)
         });
     if format == Format::Xlsx && element == "c" {
         *cell_type = None;
@@ -363,6 +364,23 @@ fn local_name(name: &[u8]) -> String {
 
 fn attribute_local(name: &str) -> &str {
     name.rsplit_once(':').map_or(name, |(_, local)| local)
+}
+
+/// True for relationship targets pointing outside the package.
+fn external_target(target: &str) -> bool {
+    let lower = target.trim().to_ascii_lowercase();
+    lower.starts_with("//")
+        || lower
+            .split_once(':')
+            .is_some_and(|(scheme, _)| is_uri_scheme(scheme))
+}
+
+fn is_uri_scheme(scheme: &str) -> bool {
+    let mut chars = scheme.chars();
+    if !matches!(chars.next(), Some(first) if first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.'))
 }
 
 fn xml_error(path: &str, error: impl fmt::Display) -> RedactError {

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -138,12 +138,12 @@ fn rewrite_start(
     for (key, value) in attributes {
         let local = attribute_local(&key);
         if relationship && is_unqualified(&key) && local.eq_ignore_ascii_case("TargetMode") {
-            wrote_target_mode = true;
-            if external {
-                output.push_attribute(("TargetMode", "External"));
-            } else {
+            if !external {
                 output.push_attribute((key.as_str(), value.as_str()));
+            } else if !wrote_target_mode {
+                output.push_attribute(("TargetMode", "External"));
             }
+            wrote_target_mode = true;
             continue;
         }
         let replacement =
@@ -377,7 +377,8 @@ fn attribute_local(name: &str) -> &str {
 
 /// Whether the element is a relationship in a package relationship part, and
 /// whether it points outside the package. Only unqualified OPC attributes take
-/// part in the decision, and a target is inspected only inside a `.rels` part.
+/// part in the decision; a target shape is read only from the exact-case
+/// `Target` a `.rels` part's consumers resolve.
 fn relationship_mode(path: &str, element: &str, attributes: &[(String, String)]) -> (bool, bool) {
     if !element.eq_ignore_ascii_case("Relationship") {
         return (false, false);
@@ -389,7 +390,7 @@ fn relationship_mode(path: &str, element: &str, attributes: &[(String, String)])
         }
         let local = attribute_local(key);
         local.eq_ignore_ascii_case("TargetMode") && value.trim().eq_ignore_ascii_case("External")
-            || package_part && local.eq_ignore_ascii_case("Target") && external_target(value)
+            || package_part && local == "Target" && external_target(value)
     });
     (package_part, external)
 }

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -128,12 +128,7 @@ fn rewrite_start(
         attributes.push((key, value));
     }
 
-    let external = element.eq_ignore_ascii_case("Relationship")
-        && attributes.iter().any(|(key, value)| {
-            let local = attribute_local(key);
-            local.eq_ignore_ascii_case("TargetMode") && value.eq_ignore_ascii_case("External")
-                || local.eq_ignore_ascii_case("Target") && external_target(value)
-        });
+    let (external, declare_external) = relationship_mode(path, element, &attributes);
     if format == Format::Xlsx && element == "c" {
         *cell_type = None;
     }
@@ -141,6 +136,11 @@ fn rewrite_start(
     output.clear_attributes();
     for (key, value) in attributes {
         let local = attribute_local(&key);
+        if local.eq_ignore_ascii_case("TargetMode") && value.trim().eq_ignore_ascii_case("External")
+        {
+            output.push_attribute((key.as_str(), "External"));
+            continue;
+        }
         let replacement = if external && local.eq_ignore_ascii_case("Target") {
             Some("https://example.com".to_owned())
         } else if !key.starts_with("xmlns")
@@ -161,6 +161,9 @@ fn rewrite_start(
         if format == Format::Xlsx && element == "c" && local == "t" {
             *cell_type = Some(value);
         }
+    }
+    if declare_external {
+        output.push_attribute(("TargetMode", "External"));
     }
     Ok(output)
 }
@@ -366,13 +369,37 @@ fn attribute_local(name: &str) -> &str {
     name.rsplit_once(':').map_or(name, |(_, local)| local)
 }
 
+/// Whether a relationship points outside the package, and whether `TargetMode`
+/// has to be synthesized so the rewritten target is not read back as an internal
+/// part reference.
+fn relationship_mode(path: &str, element: &str, attributes: &[(String, String)]) -> (bool, bool) {
+    if !element.eq_ignore_ascii_case("Relationship") {
+        return (false, false);
+    }
+    let mut declared = false;
+    let mut external = false;
+    let mut inferred = false;
+    for (key, value) in attributes {
+        let local = attribute_local(key);
+        if local.eq_ignore_ascii_case("TargetMode") {
+            declared = true;
+            external |= value.trim().eq_ignore_ascii_case("External");
+        } else if local.eq_ignore_ascii_case("Target") && external_target(path, value) {
+            inferred = true;
+        }
+    }
+    (external || inferred, inferred && !declared)
+}
+
 /// True for relationship targets pointing outside the package.
-fn external_target(target: &str) -> bool {
+fn external_target(path: &str, target: &str) -> bool {
     let lower = target.trim().to_ascii_lowercase();
     lower.starts_with("//")
+        || lower.starts_with(r"\\")
         || lower
             .split_once(':')
             .is_some_and(|(scheme, _)| is_uri_scheme(scheme))
+        || escapes_package(path, &lower)
 }
 
 fn is_uri_scheme(scheme: &str) -> bool {
@@ -381,6 +408,30 @@ fn is_uri_scheme(scheme: &str) -> bool {
         return false;
     }
     chars.all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.'))
+}
+
+/// True when a relative target climbs above the package root, which no internal
+/// part reference can do.
+fn escapes_package(path: &str, target: &str) -> bool {
+    let target = target.split(['?', '#']).next().unwrap_or_default();
+    if target.starts_with('/') || target.starts_with('\\') {
+        return false;
+    }
+    let mut depth = path
+        .replace('\\', "/")
+        .rsplit_once("/_rels/")
+        .map_or(0, |(directory, _)| {
+            directory.split('/').filter(|part| !part.is_empty()).count()
+        });
+    for segment in target.replace('\\', "/").split('/') {
+        match segment {
+            "" | "." => {}
+            ".." if depth == 0 => return true,
+            ".." => depth -= 1,
+            _ => depth += 1,
+        }
+    }
+    false
 }
 
 fn xml_error(path: &str, error: impl fmt::Display) -> RedactError {

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -1,24 +1,14 @@
-use std::collections::BTreeSet;
-
 use quick_xml::events::{BytesCData, BytesStart, BytesText, Event};
 use quick_xml::{Reader, Writer, XmlVersion};
 
 use crate::{Format, RedactError, RedactionReport};
 
-/// The part being rewritten, plus the package's part names so a relationship
-/// target can be checked against what the package actually contains.
-pub(crate) struct Part<'a> {
-    pub path: &'a str,
-    pub names: &'a BTreeSet<String>,
-}
-
 pub(crate) fn redact_xml(
     format: Format,
-    part: &Part<'_>,
+    path: &str,
     bytes: &[u8],
     report: &mut RedactionReport,
 ) -> Result<Vec<u8>, RedactError> {
-    let path = part.path;
     let mut reader = Reader::from_reader(bytes);
     reader.config_mut().trim_text(false);
     let mut writer = Writer::new(Vec::with_capacity(bytes.len()));
@@ -33,7 +23,7 @@ pub(crate) fn redact_xml(
             Event::Start(start) => {
                 let local = local_name(start.name().local_name().as_ref());
                 let rewritten =
-                    rewrite_start(format, part, &reader, start, &local, report, &mut cell_type)?;
+                    rewrite_start(format, path, &reader, start, &local, report, &mut cell_type)?;
                 stack.push(local);
                 writer
                     .write_event(Event::Start(rewritten))
@@ -42,7 +32,7 @@ pub(crate) fn redact_xml(
             Event::Empty(start) => {
                 let local = local_name(start.name().local_name().as_ref());
                 let rewritten =
-                    rewrite_start(format, part, &reader, start, &local, report, &mut cell_type)?;
+                    rewrite_start(format, path, &reader, start, &local, report, &mut cell_type)?;
                 writer
                     .write_event(Event::Empty(rewritten))
                     .map_err(|error| xml_error(path, error))?;
@@ -120,14 +110,13 @@ pub(crate) fn redact_xml(
 
 fn rewrite_start(
     format: Format,
-    part: &Part<'_>,
+    path: &str,
     reader: &Reader<&[u8]>,
     start: BytesStart<'_>,
     element: &str,
     report: &mut RedactionReport,
     cell_type: &mut Option<String>,
 ) -> Result<BytesStart<'static>, RedactError> {
-    let path = part.path;
     let mut attributes = Vec::new();
     for attribute in start.attributes() {
         let attribute = attribute.map_err(|error| xml_error(path, error))?;
@@ -139,7 +128,7 @@ fn rewrite_start(
         attributes.push((key, value));
     }
 
-    let (relationship, external) = relationship_mode(part, element, &attributes);
+    let (relationship, external) = relationship_mode(path, element, &attributes);
     let mut wrote_target_mode = false;
     if format == Format::Xlsx && element == "c" {
         *cell_type = None;
@@ -385,13 +374,9 @@ fn attribute_local(name: &str) -> &str {
 
 /// Whether the element is a package relationship, and whether it points outside
 /// the package. Only unqualified OPC attributes take part in the decision.
-fn relationship_mode(
-    part: &Part<'_>,
-    element: &str,
-    attributes: &[(String, String)],
-) -> (bool, bool) {
+fn relationship_mode(path: &str, element: &str, attributes: &[(String, String)]) -> (bool, bool) {
     if !element.eq_ignore_ascii_case("Relationship")
-        || !part.path.to_ascii_lowercase().ends_with(".rels")
+        || !path.to_ascii_lowercase().ends_with(".rels")
     {
         return (false, false);
     }
@@ -401,7 +386,7 @@ fn relationship_mode(
         }
         let local = attribute_local(key);
         local.eq_ignore_ascii_case("TargetMode") && value.trim().eq_ignore_ascii_case("External")
-            || local.eq_ignore_ascii_case("Target") && external_target(part, value)
+            || local.eq_ignore_ascii_case("Target") && external_target(value)
     });
     (true, external)
 }
@@ -411,14 +396,13 @@ fn is_unqualified(key: &str) -> bool {
 }
 
 /// True for relationship targets pointing outside the package.
-fn external_target(part: &Part<'_>, target: &str) -> bool {
+fn external_target(target: &str) -> bool {
     let lower = target.trim().to_ascii_lowercase();
     lower.starts_with("//")
         || lower.starts_with(r"\\")
         || lower
             .split_once(':')
             .is_some_and(|(scheme, _)| is_uri_scheme(scheme))
-        || escapes_package(part, &lower)
 }
 
 fn is_uri_scheme(scheme: &str) -> bool {
@@ -427,35 +411,6 @@ fn is_uri_scheme(scheme: &str) -> bool {
         return false;
     }
     chars.all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.'))
-}
-
-/// True when a relative target climbs above the package root and the clamped
-/// path names no part, which is how a filesystem path appears in a defective
-/// relationship.
-fn escapes_package(part: &Part<'_>, target: &str) -> bool {
-    let target = target.split(['?', '#']).next().unwrap_or_default();
-    if target.starts_with('/') || target.starts_with('\\') {
-        return false;
-    }
-    let source = part.path.replace('\\', "/");
-    let base = source
-        .rsplit_once("/_rels/")
-        .map_or("", |(directory, _)| directory);
-    let normalized = target.replace('\\', "/");
-    let mut segments: Vec<&str> = base.split('/').filter(|part| !part.is_empty()).collect();
-    let mut climbed = false;
-    for segment in normalized.split('/') {
-        match segment {
-            "" | "." => {}
-            ".." if segments.pop().is_none() => climbed = true,
-            ".." => {}
-            other => segments.push(other),
-        }
-    }
-    climbed
-        && !part
-            .names
-            .contains(&segments.join("/").to_ascii_lowercase())
 }
 
 fn xml_error(path: &str, error: impl fmt::Display) -> RedactError {

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -1,14 +1,24 @@
+use std::collections::BTreeSet;
+
 use quick_xml::events::{BytesCData, BytesStart, BytesText, Event};
 use quick_xml::{Reader, Writer, XmlVersion};
 
 use crate::{Format, RedactError, RedactionReport};
 
+/// The part being rewritten, plus the package's part names so a relationship
+/// target can be checked against what the package actually contains.
+pub(crate) struct Part<'a> {
+    pub path: &'a str,
+    pub names: &'a BTreeSet<String>,
+}
+
 pub(crate) fn redact_xml(
     format: Format,
-    path: &str,
+    part: &Part<'_>,
     bytes: &[u8],
     report: &mut RedactionReport,
 ) -> Result<Vec<u8>, RedactError> {
+    let path = part.path;
     let mut reader = Reader::from_reader(bytes);
     reader.config_mut().trim_text(false);
     let mut writer = Writer::new(Vec::with_capacity(bytes.len()));
@@ -23,7 +33,7 @@ pub(crate) fn redact_xml(
             Event::Start(start) => {
                 let local = local_name(start.name().local_name().as_ref());
                 let rewritten =
-                    rewrite_start(format, path, &reader, start, &local, report, &mut cell_type)?;
+                    rewrite_start(format, part, &reader, start, &local, report, &mut cell_type)?;
                 stack.push(local);
                 writer
                     .write_event(Event::Start(rewritten))
@@ -32,7 +42,7 @@ pub(crate) fn redact_xml(
             Event::Empty(start) => {
                 let local = local_name(start.name().local_name().as_ref());
                 let rewritten =
-                    rewrite_start(format, path, &reader, start, &local, report, &mut cell_type)?;
+                    rewrite_start(format, part, &reader, start, &local, report, &mut cell_type)?;
                 writer
                     .write_event(Event::Empty(rewritten))
                     .map_err(|error| xml_error(path, error))?;
@@ -110,13 +120,14 @@ pub(crate) fn redact_xml(
 
 fn rewrite_start(
     format: Format,
-    path: &str,
+    part: &Part<'_>,
     reader: &Reader<&[u8]>,
     start: BytesStart<'_>,
     element: &str,
     report: &mut RedactionReport,
     cell_type: &mut Option<String>,
 ) -> Result<BytesStart<'static>, RedactError> {
+    let path = part.path;
     let mut attributes = Vec::new();
     for attribute in start.attributes() {
         let attribute = attribute.map_err(|error| xml_error(path, error))?;
@@ -128,7 +139,8 @@ fn rewrite_start(
         attributes.push((key, value));
     }
 
-    let (external, declare_external) = relationship_mode(path, element, &attributes);
+    let (relationship, external) = relationship_mode(part, element, &attributes);
+    let mut wrote_target_mode = false;
     if format == Format::Xlsx && element == "c" {
         *cell_type = None;
     }
@@ -136,20 +148,22 @@ fn rewrite_start(
     output.clear_attributes();
     for (key, value) in attributes {
         let local = attribute_local(&key);
-        if local.eq_ignore_ascii_case("TargetMode") && value.trim().eq_ignore_ascii_case("External")
-        {
-            output.push_attribute((key.as_str(), "External"));
+        if relationship && is_unqualified(&key) && local.eq_ignore_ascii_case("TargetMode") {
+            wrote_target_mode = true;
+            let mode = if external { "External" } else { value.as_str() };
+            output.push_attribute((key.as_str(), mode));
             continue;
         }
-        let replacement = if external && local.eq_ignore_ascii_case("Target") {
-            Some("https://example.com".to_owned())
-        } else if !key.starts_with("xmlns")
-            && sensitive_attribute(format, path, element, local, &value)
-        {
-            Some(placeholder(&value))
-        } else {
-            None
-        };
+        let replacement =
+            if external && is_unqualified(&key) && local.eq_ignore_ascii_case("Target") {
+                Some("https://example.com".to_owned())
+            } else if !key.starts_with("xmlns")
+                && sensitive_attribute(format, path, element, local, &value)
+            {
+                Some(placeholder(&value))
+            } else {
+                None
+            };
         if let Some(replacement) = replacement {
             if replacement != value {
                 report.attributes += 1;
@@ -162,7 +176,7 @@ fn rewrite_start(
             *cell_type = Some(value);
         }
     }
-    if declare_external {
+    if external && !wrote_target_mode {
         output.push_attribute(("TargetMode", "External"));
     }
     Ok(output)
@@ -369,37 +383,42 @@ fn attribute_local(name: &str) -> &str {
     name.rsplit_once(':').map_or(name, |(_, local)| local)
 }
 
-/// Whether a relationship points outside the package, and whether `TargetMode`
-/// has to be synthesized so the rewritten target is not read back as an internal
-/// part reference.
-fn relationship_mode(path: &str, element: &str, attributes: &[(String, String)]) -> (bool, bool) {
-    if !element.eq_ignore_ascii_case("Relationship") {
+/// Whether the element is a package relationship, and whether it points outside
+/// the package. Only unqualified OPC attributes take part in the decision.
+fn relationship_mode(
+    part: &Part<'_>,
+    element: &str,
+    attributes: &[(String, String)],
+) -> (bool, bool) {
+    if !element.eq_ignore_ascii_case("Relationship")
+        || !part.path.to_ascii_lowercase().ends_with(".rels")
+    {
         return (false, false);
     }
-    let mut declared = false;
-    let mut external = false;
-    let mut inferred = false;
-    for (key, value) in attributes {
-        let local = attribute_local(key);
-        if local.eq_ignore_ascii_case("TargetMode") {
-            declared = true;
-            external |= value.trim().eq_ignore_ascii_case("External");
-        } else if local.eq_ignore_ascii_case("Target") && external_target(path, value) {
-            inferred = true;
+    let external = attributes.iter().any(|(key, value)| {
+        if !is_unqualified(key) {
+            return false;
         }
-    }
-    (external || inferred, inferred && !declared)
+        let local = attribute_local(key);
+        local.eq_ignore_ascii_case("TargetMode") && value.trim().eq_ignore_ascii_case("External")
+            || local.eq_ignore_ascii_case("Target") && external_target(part, value)
+    });
+    (true, external)
+}
+
+fn is_unqualified(key: &str) -> bool {
+    !key.contains(':')
 }
 
 /// True for relationship targets pointing outside the package.
-fn external_target(path: &str, target: &str) -> bool {
+fn external_target(part: &Part<'_>, target: &str) -> bool {
     let lower = target.trim().to_ascii_lowercase();
     lower.starts_with("//")
         || lower.starts_with(r"\\")
         || lower
             .split_once(':')
             .is_some_and(|(scheme, _)| is_uri_scheme(scheme))
-        || escapes_package(path, &lower)
+        || escapes_package(part, &lower)
 }
 
 fn is_uri_scheme(scheme: &str) -> bool {
@@ -410,28 +429,33 @@ fn is_uri_scheme(scheme: &str) -> bool {
     chars.all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.'))
 }
 
-/// True when a relative target climbs above the package root, which no internal
-/// part reference can do.
-fn escapes_package(path: &str, target: &str) -> bool {
+/// True when a relative target climbs above the package root and the clamped
+/// path names no part, which is how a filesystem path appears in a defective
+/// relationship.
+fn escapes_package(part: &Part<'_>, target: &str) -> bool {
     let target = target.split(['?', '#']).next().unwrap_or_default();
     if target.starts_with('/') || target.starts_with('\\') {
         return false;
     }
-    let mut depth = path
-        .replace('\\', "/")
+    let source = part.path.replace('\\', "/");
+    let base = source
         .rsplit_once("/_rels/")
-        .map_or(0, |(directory, _)| {
-            directory.split('/').filter(|part| !part.is_empty()).count()
-        });
-    for segment in target.replace('\\', "/").split('/') {
+        .map_or("", |(directory, _)| directory);
+    let normalized = target.replace('\\', "/");
+    let mut segments: Vec<&str> = base.split('/').filter(|part| !part.is_empty()).collect();
+    let mut climbed = false;
+    for segment in normalized.split('/') {
         match segment {
             "" | "." => {}
-            ".." if depth == 0 => return true,
-            ".." => depth -= 1,
-            _ => depth += 1,
+            ".." if segments.pop().is_none() => climbed = true,
+            ".." => {}
+            other => segments.push(other),
         }
     }
-    false
+    climbed
+        && !part
+            .names
+            .contains(&segments.join("/").to_ascii_lowercase())
 }
 
 fn xml_error(path: &str, error: impl fmt::Display) -> RedactError {


### PR DESCRIPTION
TL;DR:


Summary:
- a relationship target is treated as external when `TargetMode=External` (whitespace- and case-tolerant), or when the target carries an RFC 3986 scheme, is protocol-relative (`//host/share`), or names a UNC share (`\\host\share`, `\\?\UNC\...`)
- a relationship the target proves external always ends up with `TargetMode="External"` — synthesized when absent, normalized when the producer spelled it oddly, corrected when the producer declared `Internal` — so the placeholder target and the declared mode never disagree and the redacted package still parses
- relationship handling applies only to `.rels` parts and to unqualified OPC attributes, so foreign namespaced attributes and `Relationship`-shaped markup in ordinary parts are left alone
- fragments and queries containing URIs (`part.xml#ref=https://...`), package-root targets (`/word/media/x.png`) and relative targets stay internal and byte-identical
- targets that climb above the package root are unchanged from today's behaviour; classifying them safely needs canonical OPC part-name resolution, tracked in #245

Test plan:
- [ ] `cargo test -p betteroffice-redact` green
- [ ] `cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` green
- [ ] redact a package with a no-`TargetMode` UNC hyperlink and confirm the host does not survive in the output zip
- [ ] confirm a redacted package still loads through `docx-parse` / `xlsx-parse` / `pptx-parse`
- [ ] confirm an internal relationship that resolves to a real part is preserved byte-for-byte, including percent-encoded, `./` and backslash spellings
