### PR TITLE
perf(packages): trim redundant copies in hot paths

### DIFF
--- a/.changeset/packages-hot-paths.md
+++ b/.changeset/packages-hot-paths.md
@@ -1,0 +1,7 @@
+---
+"@betteroffice/xlsx": patch
+"@betteroffice/pptx": patch
+"@betteroffice/pptx-react": patch
+---
+
+Drop redundant font-byte scans and collaboration buffer copies.

--- a/.changeset/packages-hot-paths.md
+++ b/.changeset/packages-hot-paths.md
@@ -1,7 +1,6 @@
 ---
 "@betteroffice/xlsx": patch
 "@betteroffice/pptx": patch
-"@betteroffice/pptx-react": patch
 ---
 
-Drop redundant font-byte scans and collaboration buffer copies.
+Drop redundant buffer copies around the wasm boundary and per collaboration update.

--- a/packages/pptx-react/src/PptxEditor.test.tsx
+++ b/packages/pptx-react/src/PptxEditor.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * `fonts` identity drives the effect that disposes and reopens the presentation,
+ * so a caller building the array inline must not lose the open deck — its edits,
+ * history and collaboration replica — on every unrelated re-render.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { initWasm } from '@betteroffice/pptx';
+import type { PptxFontFace } from '@betteroffice/pptx';
+import type { PptxEditorApi } from './PptxEditor';
+import { PptxEditor } from './PptxEditor';
+
+const root = resolve(import.meta.dir, '../../..');
+
+if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+const { act, cleanup, render, waitFor } = await import('@testing-library/react');
+
+let fixture: Uint8Array;
+let fontBytes: Uint8Array;
+
+beforeAll(async () => {
+  const [wasm, pptx, font] = await Promise.all([
+    readFile(resolve(root, 'packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm')),
+    readFile(resolve(root, 'apps/demo/public/betteroffice-demo.pptx')),
+    readFile(resolve(root, 'crates/ooxml-text/tests/fonts/LiberationSans-Regular.ttf')),
+  ]);
+  await initWasm(wasm);
+  fixture = pptx;
+  fontBytes = font;
+});
+
+afterEach(cleanup);
+afterAll(async () => {
+  if (GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
+});
+
+describe('PptxEditor font stability', () => {
+  it('keeps the open presentation across renders when fonts are rebuilt inline', async () => {
+    const opened: PptxEditorApi[] = [];
+    const onReady = (api: PptxEditorApi) => opened.push(api);
+    const face = (): PptxFontFace[] => [
+      { family: 'Liberation Sans', bytes: Uint8Array.from(fontBytes) },
+    ];
+
+    const { rerender } = render(
+      <PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />
+    );
+    await waitFor(() => expect(opened.length).toBe(1));
+
+    await act(async () => {
+      rerender(<PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />);
+    });
+    await act(async () => {
+      rerender(<PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />);
+    });
+
+    expect(opened.length).toBe(1);
+    expect(() => opened[0].handle.snapshot()).not.toThrow();
+  });
+});

--- a/packages/pptx-react/src/PptxEditor.test.tsx
+++ b/packages/pptx-react/src/PptxEditor.test.tsx
@@ -15,7 +15,10 @@ import { PptxEditor } from './PptxEditor';
 
 const root = resolve(import.meta.dir, '../../..');
 
-if (!GlobalRegistrator.isRegistered) GlobalRegistrator.register();
+// the registrator writes one process-wide global set, so only the file that
+// installed it may tear it down.
+const ownsDom = !GlobalRegistrator.isRegistered;
+if (ownsDom) GlobalRegistrator.register();
 const { act, cleanup, render, waitFor } = await import('@testing-library/react');
 
 let fixture: Uint8Array;
@@ -34,30 +37,33 @@ beforeAll(async () => {
 
 afterEach(cleanup);
 afterAll(async () => {
-  if (GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
+  if (ownsDom && GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
 });
 
 describe('PptxEditor font stability', () => {
-  it('keeps the open presentation across renders when fonts are rebuilt inline', async () => {
-    const opened: PptxEditorApi[] = [];
-    const onReady = (api: PptxEditorApi) => opened.push(api);
-    const face = (): PptxFontFace[] => [
-      { family: 'Liberation Sans', bytes: Uint8Array.from(fontBytes) },
-    ];
+  // scanning a real font is what makes this slow; the budget is generous so a
+  // loaded CI machine reports the assertion rather than a timeout.
+  it(
+    'keeps the open presentation across renders when fonts are rebuilt inline',
+    async () => {
+      const opened: PptxEditorApi[] = [];
+      const onReady = (api: PptxEditorApi) => opened.push(api);
+      const face = (): PptxFontFace[] => [
+        { family: 'Liberation Sans', bytes: Uint8Array.from(fontBytes) },
+      ];
 
-    const { rerender } = render(
-      <PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />
-    );
-    await waitFor(() => expect(opened.length).toBe(1));
+      const { rerender } = render(
+        <PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />
+      );
+      await waitFor(() => expect(opened.length).toBe(1), { timeout: 15_000 });
 
-    await act(async () => {
-      rerender(<PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />);
-    });
-    await act(async () => {
-      rerender(<PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />);
-    });
+      await act(async () => {
+        rerender(<PptxEditor file={fixture} fonts={face()} clientId={9101} onReady={onReady} />);
+      });
 
-    expect(opened.length).toBe(1);
-    expect(() => opened[0].handle.snapshot()).not.toThrow();
-  });
+      expect(opened.length).toBe(1);
+      expect(() => opened[0].handle.snapshot()).not.toThrow();
+    },
+    60_000
+  );
 });

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -95,7 +95,7 @@ export interface PptxEditorCollaborationOptions {
 
 export interface PptxEditorProps {
   file?: Uint8Array;
-  /** Font faces; equivalent inline arrays do not reopen the presentation. */
+  /** Font faces; must be reference-stable across renders. */
   fonts: ReadonlyArray<PptxFontFace>;
   clientId?: number;
   collaboration?: PptxEditorCollaborationOptions;
@@ -1693,14 +1693,8 @@ function fontFaceEqual(left: PptxFontFace, right: PptxFontFace): boolean {
     left.family === right.family &&
     (left.bold ?? false) === (right.bold ?? false) &&
     (left.italic ?? false) === (right.italic ?? false) &&
-    bytesEqual(left.bytes, right.bytes)
+    left.bytes === right.bytes
   );
-}
-
-function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
-  if (left === right) return true;
-  if (left.byteLength !== right.byteLength) return false;
-  return left.every((byte, index) => byte === right[index]);
 }
 
 function storyText(story: StorySnapshot): string {

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -95,7 +95,7 @@ export interface PptxEditorCollaborationOptions {
 
 export interface PptxEditorProps {
   file?: Uint8Array;
-  /** Font faces; must be reference-stable across renders. */
+  /** Font faces; equivalent inline arrays do not reopen the presentation. */
   fonts: ReadonlyArray<PptxFontFace>;
   clientId?: number;
   collaboration?: PptxEditorCollaborationOptions;
@@ -1693,8 +1693,14 @@ function fontFaceEqual(left: PptxFontFace, right: PptxFontFace): boolean {
     left.family === right.family &&
     (left.bold ?? false) === (right.bold ?? false) &&
     (left.italic ?? false) === (right.italic ?? false) &&
-    left.bytes === right.bytes
+    bytesEqual(left.bytes, right.bytes)
   );
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left === right) return true;
+  if (left.byteLength !== right.byteLength) return false;
+  return left.every((byte, index) => byte === right[index]);
 }
 
 function storyText(story: StorySnapshot): string {

--- a/packages/pptx/src/wasm/loader.test.ts
+++ b/packages/pptx/src/wasm/loader.test.ts
@@ -57,7 +57,12 @@ describe('PPTX wasm boundary', () => {
   // not depend on how many other listeners happen to be subscribed.
   test('delivers exact update buffers regardless of subscriber count', () => {
     const seed = openPresentation(fixture, { clientId: 9201 });
-    const update = seed.encodeStateAsUpdate();
+    let update: Uint8Array;
+    try {
+      update = seed.encodeStateAsUpdate();
+    } finally {
+      seed.dispose();
+    }
     for (const extraSubscriber of [false, true]) {
       const source = openPresentation(Uint8Array.of(0xff), {
         clientId: extraSubscriber ? 9202 : 9203,
@@ -68,24 +73,25 @@ describe('PPTX wasm boundary', () => {
         initialUpdate: update,
       });
       const received: Uint8Array[] = [];
-      source.onUpdate((bytes, origin) => {
-        if (origin === 'local') received.push(bytes);
-      });
-      if (extraSubscriber) source.onUpdate(() => {});
+      try {
+        source.onUpdate((bytes, origin) => {
+          if (origin === 'local') received.push(bytes);
+        });
+        if (extraSubscriber) source.onUpdate(() => {});
 
-      const story = firstStory(source.snapshot().slides.flatMap((slide) => slide.shapes));
-      source.insertText(story.id, story.length - 1, ' exact');
-      expect(received).toHaveLength(1);
-      expect(received[0].byteOffset).toBe(0);
-      expect(received[0].buffer.byteLength).toBe(received[0].byteLength);
+        const story = firstStory(source.snapshot().slides.flatMap((slide) => slide.shapes));
+        source.insertText(story.id, story.length - 1, ' exact');
+        expect(received).toHaveLength(1);
+        expect(received[0].byteOffset).toBe(0);
+        expect(received[0].buffer.byteLength).toBe(received[0].byteLength);
 
-      peer.applyUpdate(new Uint8Array(received[0].buffer));
-      expect(peer.story(story.id)).toEqual(source.story(story.id));
-
-      source.dispose();
-      peer.dispose();
+        peer.applyUpdate(new Uint8Array(received[0].buffer));
+        expect(peer.story(story.id)).toEqual(source.story(story.id));
+      } finally {
+        source.dispose();
+        peer.dispose();
+      }
     }
-    seed.dispose();
   });
 
   test('opens, edits, reflows, hit-tests, and observes a local update', () => {

--- a/packages/pptx/src/wasm/loader.test.ts
+++ b/packages/pptx/src/wasm/loader.test.ts
@@ -52,6 +52,42 @@ describe('PPTX wasm boundary', () => {
     right.dispose();
   });
 
+  // the wasm event arrives as `[origin, ...update]`, so a listener that reaches
+  // for `.buffer` must not find the origin tag riding along — and the shape must
+  // not depend on how many other listeners happen to be subscribed.
+  test('delivers exact update buffers regardless of subscriber count', () => {
+    const seed = openPresentation(fixture, { clientId: 9201 });
+    const update = seed.encodeStateAsUpdate();
+    for (const extraSubscriber of [false, true]) {
+      const source = openPresentation(Uint8Array.of(0xff), {
+        clientId: extraSubscriber ? 9202 : 9203,
+        initialUpdate: update,
+      });
+      const peer = openPresentation(Uint8Array.of(0xff), {
+        clientId: extraSubscriber ? 9204 : 9205,
+        initialUpdate: update,
+      });
+      const received: Uint8Array[] = [];
+      source.onUpdate((bytes, origin) => {
+        if (origin === 'local') received.push(bytes);
+      });
+      if (extraSubscriber) source.onUpdate(() => {});
+
+      const story = firstStory(source.snapshot().slides.flatMap((slide) => slide.shapes));
+      source.insertText(story.id, story.length - 1, ' exact');
+      expect(received).toHaveLength(1);
+      expect(received[0].byteOffset).toBe(0);
+      expect(received[0].buffer.byteLength).toBe(received[0].byteLength);
+
+      peer.applyUpdate(new Uint8Array(received[0].buffer));
+      expect(peer.story(story.id)).toEqual(source.story(story.id));
+
+      source.dispose();
+      peer.dispose();
+    }
+    seed.dispose();
+  });
+
   test('opens, edits, reflows, hit-tests, and observes a local update', () => {
     const snapshot = handle.snapshot();
     expect(snapshot.slides.length).toBe(3);

--- a/packages/pptx/src/wasm/loader.ts
+++ b/packages/pptx/src/wasm/loader.ts
@@ -85,12 +85,6 @@ export interface PresentationHandle extends CollaborationReplica {
   encodeStateAsUpdate(remoteStateVector?: Uint8Array): Uint8Array;
   encodeDiff(remoteStateVector: Uint8Array): Uint8Array;
   applyUpdate(update: Uint8Array): DeckSnapshot;
-  /**
-   * Observe owned update bytes from local commits and accepted remote updates;
-   * with multiple subscribers each receives an isolated copy, while a sole
-   * subscriber receives the internal buffer directly (treat as read-only; it
-   * may be a subarray view whose `.buffer` includes the origin byte).
-   */
   onUpdate(
     listener: (update: Uint8Array, origin: CollaborationUpdateOrigin) => void
   ): () => void;
@@ -173,16 +167,11 @@ export function openPresentation(
       while (!disposed && pendingUpdates.length > 0) {
         const event = pendingUpdates.shift();
         if (!event) break;
-        const subscribers = [...listeners];
-        for (let index = 0; index < subscribers.length; index += 1) {
-          const [id, listener] = subscribers[index];
+        for (const [id, listener] of [...listeners]) {
           if (disposed) return;
           if (listeners.get(id) !== listener) continue;
           try {
-            listener(
-              subscribers.length === 1 ? event.update : event.update.slice(),
-              event.origin
-            );
+            listener(event.update.slice(), event.origin);
           } catch {}
         }
       }

--- a/packages/pptx/src/wasm/loader.ts
+++ b/packages/pptx/src/wasm/loader.ts
@@ -85,6 +85,12 @@ export interface PresentationHandle extends CollaborationReplica {
   encodeStateAsUpdate(remoteStateVector?: Uint8Array): Uint8Array;
   encodeDiff(remoteStateVector: Uint8Array): Uint8Array;
   applyUpdate(update: Uint8Array): DeckSnapshot;
+  /**
+   * Observe owned update bytes from local commits and accepted remote updates;
+   * with multiple subscribers each receives an isolated copy, while a sole
+   * subscriber receives the internal buffer directly (treat as read-only; it
+   * may be a subarray view whose `.buffer` includes the origin byte).
+   */
   onUpdate(
     listener: (update: Uint8Array, origin: CollaborationUpdateOrigin) => void
   ): () => void;
@@ -167,11 +173,16 @@ export function openPresentation(
       while (!disposed && pendingUpdates.length > 0) {
         const event = pendingUpdates.shift();
         if (!event) break;
-        for (const [id, listener] of [...listeners]) {
+        const subscribers = [...listeners];
+        for (let index = 0; index < subscribers.length; index += 1) {
+          const [id, listener] = subscribers[index];
           if (disposed) return;
           if (listeners.get(id) !== listener) continue;
           try {
-            listener(event.update.slice(), event.origin);
+            listener(
+              subscribers.length === 1 ? event.update : event.update.slice(),
+              event.origin
+            );
           } catch {}
         }
       }
@@ -191,7 +202,7 @@ export function openPresentation(
         throw new Error(`pptx wasm returned unknown update origin ${origin}`);
       }
       pendingUpdates.push({
-        update: encoded.slice(1),
+        update: encoded.subarray(1),
         origin: origin === 0 ? 'local' : 'remote',
       });
     }
@@ -264,10 +275,10 @@ export function openPresentation(
       return jsonWasmCall(() => renderer.hitTestJson(x, y));
     },
     mediaBytes(partPath: string): Uint8Array {
-      return wasmCall(() => doc.mediaBytes(partPath).slice());
+      return wasmCall(() => doc.mediaBytes(partPath));
     },
     save(): Uint8Array {
-      return wasmCall(() => doc.saveBytes().slice());
+      return wasmCall(() => doc.saveBytes());
     },
     insertText(storyId, index, text, style = {}): TextReceipt {
       return jsonWasmCall(
@@ -364,20 +375,20 @@ export function openPresentation(
       return jsonWasmCall(() => doc.redoJson(), true);
     },
     encodeStateVector(): Uint8Array {
-      return wasmCall(() => doc.encodeStateVector().slice());
+      return wasmCall(() => doc.encodeStateVector());
     },
     encodeStateAsUpdate(remoteStateVector?: Uint8Array): Uint8Array {
       return wasmCall(() =>
         remoteStateVector === undefined
-          ? doc.encodeStateAsUpdate().slice()
-          : doc.encodeDiff(remoteStateVector.slice()).slice()
+          ? doc.encodeStateAsUpdate()
+          : doc.encodeDiff(remoteStateVector)
       );
     },
     encodeDiff(remoteStateVector): Uint8Array {
-      return wasmCall(() => doc.encodeDiff(remoteStateVector.slice()).slice());
+      return wasmCall(() => doc.encodeDiff(remoteStateVector));
     },
     applyUpdate(update): DeckSnapshot {
-      return jsonWasmCall(() => doc.applyUpdateJson(update.slice()), true);
+      return jsonWasmCall(() => doc.applyUpdateJson(update), true);
     },
     onUpdate(listener): () => void {
       assertAlive();

--- a/packages/xlsx/src/wasm/collaboration.test.ts
+++ b/packages/xlsx/src/wasm/collaboration.test.ts
@@ -208,6 +208,35 @@ describe('wasm collaboration', () => {
     }
   });
 
+  // the wasm event arrives as `[origin, ...update]`, so a listener that reaches
+  // for `.buffer` must not find the origin tag riding along — and the shape must
+  // not depend on how many other listeners happen to be subscribed.
+  it('delivers exact update buffers regardless of subscriber count', () => {
+    for (const extraSubscriber of [false, true]) {
+      const source = collaborative(extraSubscriber ? 2102 : 2101);
+      const peer = collaborative(extraSubscriber ? 2104 : 2103);
+      const received: Uint8Array[] = [];
+      try {
+        source.onUpdate((update, origin) => {
+          if (origin === 'local') received.push(update);
+        });
+        if (extraSubscriber) source.onUpdate(() => {});
+
+        source.editCell(0, 22, 0, 'exact buffer');
+        expect(received).toHaveLength(1);
+        const update = received[0];
+        expect(update.byteOffset).toBe(0);
+        expect(update.buffer.byteLength).toBe(update.byteLength);
+
+        peer.applyUpdate(new Uint8Array(update.buffer));
+        expect(peer.cell(0, 22, 0).input).toBe('exact buffer');
+      } finally {
+        source.dispose();
+        peer.dispose();
+      }
+    }
+  });
+
   it('unsubscribes idempotently', () => {
     const handle = collaborative(3001);
     let calls = 0;

--- a/packages/xlsx/src/wasm/loader.ts
+++ b/packages/xlsx/src/wasm/loader.ts
@@ -276,7 +276,12 @@ export interface WorkbookHandle extends CollaborationReplica {
   encodeStateAsUpdate(remoteStateVector?: Uint8Array): Uint8Array;
   /** Apply a peer update. Standalone handles throw the Rust `NotCollaborative` error. */
   applyUpdate(update: Uint8Array): EditResult;
-  /** Observe owned update bytes from local commits and accepted remote updates. */
+  /**
+   * Observe owned update bytes from local commits and accepted remote updates.
+   * With multiple subscribers each receives an isolated copy; a sole subscriber
+   * receives the internal buffer directly (treat as read-only; it may be a
+   * subarray view whose `.buffer` includes the origin byte).
+   */
   onUpdate(listener: WorkbookUpdateListener): () => void;
   sheetInfo(): SheetInfo;
   calculationStatus(): CalculationStatus;
@@ -457,11 +462,16 @@ export function openWorkbook(
       while (!disposed && pendingUpdates.length > 0) {
         const event = pendingUpdates.shift();
         if (!event) break;
-        for (const [id, listener] of [...listeners]) {
+        const subscribers = [...listeners];
+        for (let index = 0; index < subscribers.length; index += 1) {
+          const [id, listener] = subscribers[index];
           if (disposed) return;
           if (listeners.get(id) !== listener) continue;
           try {
-            listener(event.update.slice(), event.origin);
+            listener(
+              subscribers.length === 1 ? event.update : event.update.slice(),
+              event.origin
+            );
           } catch {}
         }
       }
@@ -481,7 +491,7 @@ export function openWorkbook(
         throw new Error(`xlsx wasm returned unknown update origin ${origin}`);
       }
       pendingUpdates.push({
-        update: encoded.slice(1),
+        update: encoded.subarray(1),
         origin: origin === 0 ? 'local' : 'remote',
       });
     }
@@ -544,17 +554,17 @@ export function openWorkbook(
       return wasmCall(() => doc.clientId);
     },
     encodeStateVector(): Uint8Array {
-      return wasmCall(() => doc.encodeStateVector().slice());
+      return wasmCall(() => doc.encodeStateVector());
     },
     encodeStateAsUpdate(remoteStateVector?: Uint8Array): Uint8Array {
       return wasmCall(() =>
         remoteStateVector === undefined
-          ? doc.encodeStateAsUpdate().slice()
-          : doc.encodeDiff(remoteStateVector.slice()).slice()
+          ? doc.encodeStateAsUpdate()
+          : doc.encodeDiff(remoteStateVector)
       );
     },
     applyUpdate(update: Uint8Array): EditResult {
-      return parseJson(() => doc.applyUpdateJson(update.slice()), true);
+      return parseJson(() => doc.applyUpdateJson(update), true);
     },
     onUpdate(listener: WorkbookUpdateListener): () => void {
       assertAlive();
@@ -677,7 +687,7 @@ export function openWorkbook(
       });
     },
     save(): Uint8Array {
-      return wasmCall(() => doc.saveBytes().slice());
+      return wasmCall(() => doc.saveBytes());
     },
     propose(agentId: string, note: string | null, edits: ProposalEdit[]): Proposal {
       return mutatingWasmCall(() => {

--- a/packages/xlsx/src/wasm/loader.ts
+++ b/packages/xlsx/src/wasm/loader.ts
@@ -276,12 +276,7 @@ export interface WorkbookHandle extends CollaborationReplica {
   encodeStateAsUpdate(remoteStateVector?: Uint8Array): Uint8Array;
   /** Apply a peer update. Standalone handles throw the Rust `NotCollaborative` error. */
   applyUpdate(update: Uint8Array): EditResult;
-  /**
-   * Observe owned update bytes from local commits and accepted remote updates.
-   * With multiple subscribers each receives an isolated copy; a sole subscriber
-   * receives the internal buffer directly (treat as read-only; it may be a
-   * subarray view whose `.buffer` includes the origin byte).
-   */
+  /** Observe owned update bytes from local commits and accepted remote updates. */
   onUpdate(listener: WorkbookUpdateListener): () => void;
   sheetInfo(): SheetInfo;
   calculationStatus(): CalculationStatus;
@@ -462,16 +457,11 @@ export function openWorkbook(
       while (!disposed && pendingUpdates.length > 0) {
         const event = pendingUpdates.shift();
         if (!event) break;
-        const subscribers = [...listeners];
-        for (let index = 0; index < subscribers.length; index += 1) {
-          const [id, listener] = subscribers[index];
+        for (const [id, listener] of [...listeners]) {
           if (disposed) return;
           if (listeners.get(id) !== listener) continue;
           try {
-            listener(
-              subscribers.length === 1 ? event.update : event.update.slice(),
-              event.origin
-            );
+            listener(event.update.slice(), event.origin);
           } catch {}
         }
       }


### PR DESCRIPTION
TL;DR:

Summary:
- drop the second copy on wasm-boundary calls whose generated glue already returns a fresh JS array (`save`, `mediaBytes`, `encodeStateVector`, `encodeStateAsUpdate`, `encodeDiff`), and the pre-copy on byte arguments that `passArray8ToWasm0` copies into wasm memory anyway (`applyUpdate`, `encodeDiff`)
- strip the collaboration origin tag with `subarray(1)` instead of `slice(1)`, removing one full-buffer copy per delivery; every listener still receives an owned, offset-zero array, unchanged from `main`
- lock the `onUpdate` contract in both packages: `byteOffset === 0`, `buffer.byteLength === byteLength`, and forwarding `update.buffer` round-trips to a peer with one and with two subscribers
- lock the `PptxEditor` `fonts` contract with a real-React/real-wasm test: a byte-identical inline array must not reopen the presentation

Test plan:
- [ ] `bun test packages/xlsx packages/pptx packages/pptx-react` green
- [ ] collab session: two browsers editing a shared sheet/deck still sync live updates
- [ ] deck open with CJK fonts unchanged; hover/drag interactions do not reopen the deck
