### PR TITLE
perf(xlsx): hash-indexed style interning

### DIFF
--- a/.changeset/xlsx-style-interning.md
+++ b/.changeset/xlsx-style-interning.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": minor
+---
+
+Intern styles through hash indexes instead of linear scans. `Stylesheet` gains private interning caches, which prevent exhaustive struct-literal construction downstream; the caches are internal state only and excluded from serialization and equality.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ name = "betteroffice-xlsx-model"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/betteroffice-xlsx/src/authority.rs
+++ b/crates/betteroffice-xlsx/src/authority.rs
@@ -2495,7 +2495,9 @@ fn materialize_cell_formats<T: ReadTxn>(
         let index = match known.get(&key) {
             Some(index) => *index,
             None => {
-                let index = styles.intern_cell_format(&format);
+                let index = styles
+                    .intern_cell_format(&format)
+                    .map_err(|_| "number format table is full".to_string())?;
                 known.insert(key.clone(), index);
                 index
             }

--- a/crates/xlsx-model/Cargo.toml
+++ b/crates/xlsx-model/Cargo.toml
@@ -16,3 +16,6 @@ name = "xlsx_model"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/xlsx-model/src/lib.rs
+++ b/crates/xlsx-model/src/lib.rs
@@ -17,7 +17,7 @@ pub use chart::{
 pub use date::DateSystem;
 pub use styles::{
     Alignment, Border, BorderEdge, BorderStyle, CellFormat, Color, Fill, Font, FormatCode, HAlign,
-    NumberFormat, Stylesheet, Theme, VAlign, Xf,
+    NumFmtTableFull, NumberFormat, PoolMarks, Stylesheet, Theme, VAlign, Xf,
 };
 pub use value::{CellValue, ErrorValue};
 pub use workbook::{Cell, CellProvider, DefinedName, FreezePane, Hyperlink, Sheet, Workbook};

--- a/crates/xlsx-model/src/styles.rs
+++ b/crates/xlsx-model/src/styles.rs
@@ -1,6 +1,8 @@
 //! style types (fonts, fills, borders, xf chains, theme colors). pure data;
 //! the cellXfs indirection chain is walked through the `Stylesheet` accessors.
 
+use std::collections::{HashMap, HashSet};
+
 use serde::{Deserialize, Serialize};
 
 /// a color reference as it appears in a `<color>` element (§18.8.3).
@@ -52,7 +54,7 @@ pub enum Fill {
 }
 
 /// border line weight/style, collapsed from the full sml set.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BorderStyle {
     Thin,
     Medium,
@@ -109,7 +111,7 @@ pub struct Border {
 }
 
 /// horizontal alignment (`ST_HorizontalAlignment`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum HAlign {
     General,
     Left,
@@ -151,7 +153,7 @@ impl HAlign {
 }
 
 /// vertical alignment (`ST_VerticalAlignment`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum VAlign {
     Top,
     Center,
@@ -184,7 +186,7 @@ impl VAlign {
 }
 
 /// cell text alignment; unset horizontal defaults to `general`, vertical to `bottom`.
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub struct Alignment {
     pub h: Option<HAlign>,
     pub v: Option<VAlign>,
@@ -201,7 +203,7 @@ impl Alignment {
 
 /// a cell format record (`CT_Xf` in cellXfs). a `None` pool index means
 /// "inherit / default", not "index 0".
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub struct Xf {
     pub font: Option<u32>,
     pub fill: Option<u32>,
@@ -253,9 +255,183 @@ impl Theme {
     }
 }
 
-/// the parsed style tables plus the resolved theme. a cell's `s` indexes
-/// `cell_xfs`; `num_fmts` holds only custom codes (id >= 164).
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+/// hashable stand-in for a color; float tints become raw bits.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ColorKey {
+    Rgb(String),
+    Theme { idx: u8, tint: Option<u64> },
+    Indexed(u8),
+    Auto,
+}
+
+impl ColorKey {
+    fn new(color: &Color) -> Option<Self> {
+        Some(match color {
+            Color::Rgb(s) => ColorKey::Rgb(s.clone()),
+            Color::Theme { idx, tint } => ColorKey::Theme {
+                idx: *idx,
+                tint: Some(float_key(*tint)?),
+            },
+            Color::Indexed(i) => ColorKey::Indexed(*i),
+            Color::Auto => ColorKey::Auto,
+        })
+    }
+}
+
+/// hashable stand-in for a font; `None` when a NaN size/color tint blocks keying.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FontKey {
+    name: Option<String>,
+    size_pt: Option<u64>,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    strike: bool,
+    color: Option<ColorKey>,
+}
+
+impl FontKey {
+    fn new(font: &Font) -> Option<Self> {
+        Some(FontKey {
+            name: font.name.clone(),
+            size_pt: match font.size_pt {
+                None => None,
+                Some(size) => Some(float_key(size)?),
+            },
+            bold: font.bold,
+            italic: font.italic,
+            underline: font.underline,
+            strike: font.strike,
+            color: match &font.color {
+                None => None,
+                Some(color) => Some(ColorKey::new(color)?),
+            },
+        })
+    }
+}
+
+/// hashable stand-in for a fill.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum FillKey {
+    None,
+    Solid(ColorKey),
+}
+
+impl FillKey {
+    fn new(fill: &Fill) -> Option<Self> {
+        Some(match fill {
+            Fill::None => FillKey::None,
+            Fill::Solid(color) => FillKey::Solid(ColorKey::new(color)?),
+        })
+    }
+}
+
+/// hashable stand-in for a border edge.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct EdgeKey {
+    style: BorderStyle,
+    color: Option<ColorKey>,
+}
+
+impl EdgeKey {
+    fn new(edge: &BorderEdge) -> Option<Self> {
+        Some(EdgeKey {
+            style: edge.style,
+            color: match &edge.color {
+                None => None,
+                Some(color) => Some(ColorKey::new(color)?),
+            },
+        })
+    }
+}
+
+/// hashable stand-in for a border.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BorderKey {
+    left: Option<EdgeKey>,
+    right: Option<EdgeKey>,
+    top: Option<EdgeKey>,
+    bottom: Option<EdgeKey>,
+}
+
+impl BorderKey {
+    fn new(border: &Border) -> Option<Self> {
+        let edge = |e: &Option<BorderEdge>| match e {
+            None => Some(None),
+            Some(e) => Some(Some(EdgeKey::new(e)?)),
+        };
+        Some(BorderKey {
+            left: edge(&border.left)?,
+            right: edge(&border.right)?,
+            top: edge(&border.top)?,
+            bottom: edge(&border.bottom)?,
+        })
+    }
+}
+
+/// intern cache: key -> index, tagged with the pool length it was synced to.
+#[derive(Debug, Clone)]
+struct PoolMemo<K> {
+    map: HashMap<K, u32>,
+    pool_len: usize,
+    #[cfg(test)]
+    rebuilds: u64,
+}
+
+impl<K> Default for PoolMemo<K> {
+    fn default() -> Self {
+        PoolMemo {
+            map: HashMap::new(),
+            pool_len: 0,
+            #[cfg(test)]
+            rebuilds: 0,
+        }
+    }
+}
+
+impl<K: Eq + std::hash::Hash> PoolMemo<K> {
+    fn invalidate(&mut self, pool_len: usize) {
+        self.map.clear();
+        self.pool_len = pool_len;
+        #[cfg(test)]
+        {
+            self.rebuilds += 1;
+        }
+    }
+}
+
+/// intern cache for `num_fmts`; hits re-verify against the live table.
+#[derive(Debug, Clone, Default)]
+struct FmtMemo {
+    patterns: HashMap<String, (u16, usize)>,
+    used: HashSet<u16>,
+    pool_len: usize,
+    #[cfg(test)]
+    rebuilds: u64,
+}
+
+impl FmtMemo {
+    fn rebuild(&mut self, formats: &[(u16, String)]) {
+        self.patterns.clear();
+        self.used.clear();
+        self.pool_len = formats.len();
+        for (slot, (id, code)) in formats.iter().enumerate() {
+            self.patterns.entry(code.clone()).or_insert((*id, slot));
+            self.used.insert(*id);
+        }
+        #[cfg(test)]
+        {
+            self.rebuilds += 1;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NumFmtTableFull;
+
+/// parsed style tables plus theme; private memos accelerate interning and
+/// are invalidated by any pool length change.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Stylesheet {
     pub fonts: Vec<Font>,
     pub fills: Vec<Fill>,
@@ -263,6 +439,27 @@ pub struct Stylesheet {
     pub cell_xfs: Vec<Xf>,
     pub num_fmts: Vec<(u16, String)>,
     pub theme: Theme,
+    #[serde(skip)]
+    font_memo: PoolMemo<FontKey>,
+    #[serde(skip)]
+    fill_memo: PoolMemo<FillKey>,
+    #[serde(skip)]
+    border_memo: PoolMemo<BorderKey>,
+    #[serde(skip)]
+    xf_memo: PoolMemo<Xf>,
+    #[serde(skip)]
+    fmt_memo: FmtMemo,
+}
+
+impl PartialEq for Stylesheet {
+    fn eq(&self, other: &Self) -> bool {
+        self.fonts == other.fonts
+            && self.fills == other.fills
+            && self.borders == other.borders
+            && self.cell_xfs == other.cell_xfs
+            && self.num_fmts == other.num_fmts
+            && self.theme == other.theme
+    }
 }
 
 /// resolved number format for a cell: a custom code string or a builtin id.
@@ -294,6 +491,40 @@ pub struct CellFormat {
     pub number_format: NumberFormat,
     pub alignment: Alignment,
 }
+
+/// borrowed view of a resolved cell format; defaults mirror [`CellFormat::default`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedFormat<'a> {
+    pub font: &'a Font,
+    pub fill: &'a Fill,
+    pub border: &'a Border,
+    pub number_format: FormatCode<'a>,
+    pub alignment: &'a Alignment,
+}
+
+const DEFAULT_FONT: Font = Font {
+    name: None,
+    size_pt: None,
+    bold: false,
+    italic: false,
+    underline: false,
+    strike: false,
+    color: None,
+};
+
+const DEFAULT_BORDER: Border = Border {
+    left: None,
+    right: None,
+    top: None,
+    bottom: None,
+};
+
+const DEFAULT_ALIGNMENT: Alignment = Alignment {
+    h: None,
+    v: None,
+    wrap_text: false,
+    shrink_to_fit: false,
+};
 
 impl Stylesheet {
     /// true when no style data is present, so the serializer skips the part.
@@ -349,36 +580,67 @@ impl Stylesheet {
         FormatCode::Builtin(id)
     }
 
+    /// resolved format for a cell style, cloning each facet; see
+    /// [`Stylesheet::resolved_format`] for the borrow-based variant.
     pub fn cell_format(&self, style_index: Option<u32>) -> CellFormat {
-        let Some(style_index) = style_index else {
-            return CellFormat::default();
-        };
-        let number_format = match self.format_code_for(style_index) {
-            FormatCode::Builtin(id) => NumberFormat::Builtin { id },
-            FormatCode::Custom(pattern) => NumberFormat::Custom {
-                pattern: pattern.to_string(),
-            },
-        };
+        let resolved = self.resolved_format(style_index);
         CellFormat {
-            font: self.font_for(style_index).cloned().unwrap_or_default(),
-            fill: self.fill_for(style_index).cloned().unwrap_or_default(),
-            border: self.border_for(style_index).cloned().unwrap_or_default(),
-            number_format,
-            alignment: self.alignment_for(style_index).cloned().unwrap_or_default(),
+            font: resolved.font.clone(),
+            fill: resolved.fill.clone(),
+            border: resolved.border.clone(),
+            number_format: match resolved.number_format {
+                FormatCode::Builtin(id) => NumberFormat::Builtin { id },
+                FormatCode::Custom(pattern) => NumberFormat::Custom {
+                    pattern: pattern.to_string(),
+                },
+            },
+            alignment: resolved.alignment.clone(),
         }
     }
 
-    pub fn intern_cell_format(&mut self, format: &CellFormat) -> Option<u32> {
-        if format == &CellFormat::default() {
-            return None;
+    /// borrows the resolved format for a cell style without cloning; unset
+    /// facets resolve to defaults.
+    pub fn resolved_format(&self, style_index: Option<u32>) -> ResolvedFormat<'_> {
+        let xf = style_index.and_then(|index| self.xf(index));
+        ResolvedFormat {
+            font: xf
+                .and_then(|xf| xf.font)
+                .and_then(|index| self.fonts.get(index as usize))
+                .unwrap_or(&DEFAULT_FONT),
+            fill: xf
+                .and_then(|xf| xf.fill)
+                .and_then(|index| self.fills.get(index as usize))
+                .unwrap_or(&Fill::None),
+            border: xf
+                .and_then(|xf| xf.border)
+                .and_then(|index| self.borders.get(index as usize))
+                .unwrap_or(&DEFAULT_BORDER),
+            number_format: match style_index {
+                Some(index) => self.format_code_for(index),
+                None => FormatCode::Builtin(0),
+            },
+            alignment: xf
+                .and_then(|xf| xf.alignment.as_ref())
+                .unwrap_or(&DEFAULT_ALIGNMENT),
         }
-        let font = intern(&mut self.fonts, &format.font);
-        let fill = intern(&mut self.fills, &format.fill);
-        let border = intern(&mut self.borders, &format.border);
+    }
+
+    pub fn intern_cell_format(
+        &mut self,
+        format: &CellFormat,
+    ) -> Result<Option<u32>, NumFmtTableFull> {
+        if format == &CellFormat::default() {
+            return Ok(None);
+        }
         let num_fmt_id = match &format.number_format {
             NumberFormat::Builtin { id } => Some(*id).filter(|id| *id != 0),
-            NumberFormat::Custom { pattern } => Some(self.intern_number_format(pattern)),
+            NumberFormat::Custom { pattern } => {
+                Some(self.intern_number_format(pattern).ok_or(NumFmtTableFull)?)
+            }
         };
+        let font = self.intern_font(&format.font);
+        let fill = self.intern_fill(&format.fill);
+        let border = self.intern_border(&format.border);
         let alignment = (!format.alignment.is_empty()).then(|| format.alignment.clone());
         let xf = Xf {
             font: (format.font != Font::default()).then_some(font),
@@ -387,27 +649,149 @@ impl Stylesheet {
             num_fmt_id,
             alignment,
         };
-        Some(intern(&mut self.cell_xfs, &xf))
+        Ok(Some(self.intern_xf(&xf)))
     }
 
-    fn intern_number_format(&mut self, pattern: &str) -> u16 {
-        if let Some((id, _)) = self.num_fmts.iter().find(|(_, code)| code == pattern) {
-            return *id;
+    fn intern_font(&mut self, value: &Font) -> u32 {
+        intern(
+            &mut self.fonts,
+            &mut self.font_memo,
+            FontKey::new(value),
+            value,
+        )
+    }
+
+    fn intern_fill(&mut self, value: &Fill) -> u32 {
+        intern(
+            &mut self.fills,
+            &mut self.fill_memo,
+            FillKey::new(value),
+            value,
+        )
+    }
+
+    fn intern_border(&mut self, value: &Border) -> u32 {
+        intern(
+            &mut self.borders,
+            &mut self.border_memo,
+            BorderKey::new(value),
+            value,
+        )
+    }
+
+    fn intern_xf(&mut self, value: &Xf) -> u32 {
+        intern(
+            &mut self.cell_xfs,
+            &mut self.xf_memo,
+            Some(value.clone()),
+            value,
+        )
+    }
+
+    /// true when a cell using `id` resolves to `pattern` via `format_code_for`:
+    /// the id must be custom-range and its first table entry must carry the code.
+    fn id_resolves_to(&self, id: u16, pattern: &str) -> bool {
+        id >= 164
+            && self
+                .num_fmts
+                .iter()
+                .find(|(used, _)| *used == id)
+                .is_some_and(|(_, code)| code == pattern)
+    }
+
+    fn intern_number_format(&mut self, pattern: &str) -> Option<u16> {
+        if self.fmt_memo.pool_len != self.num_fmts.len() {
+            self.fmt_memo.rebuild(&self.num_fmts);
         }
-        let id = (164..=u16::MAX)
-            .find(|id| self.num_fmts.iter().all(|(used, _)| used != id))
-            .unwrap_or(u16::MAX);
-        self.num_fmts.push((id, pattern.to_string()));
-        id
+        if let Some(&(id, slot)) = self.fmt_memo.patterns.get(pattern) {
+            let slot_matches = self
+                .num_fmts
+                .get(slot)
+                .is_some_and(|(used, code)| *used == id && code == pattern);
+            let resolves = self.id_resolves_to(id, pattern);
+            if slot_matches && resolves {
+                return Some(id);
+            }
+            self.fmt_memo.rebuild(&self.num_fmts);
+            if let Some(&(id, _)) = self.fmt_memo.patterns.get(pattern)
+                && self.id_resolves_to(id, pattern)
+            {
+                return Some(id);
+            }
+        }
+        if let Some((slot, (id, _))) = self
+            .num_fmts
+            .iter()
+            .enumerate()
+            .find(|(_, (id, code))| code == pattern && self.id_resolves_to(*id, pattern))
+        {
+            self.fmt_memo
+                .patterns
+                .insert(pattern.to_string(), (*id, slot));
+            return Some(*id);
+        }
+        let live_ids: std::collections::HashSet<u16> =
+            self.num_fmts.iter().map(|(id, _)| *id).collect();
+        let candidate = (164..=u16::MAX).find(|id| !live_ids.contains(id))?;
+        let slot = self.num_fmts.len();
+        self.num_fmts.push((candidate, pattern.to_string()));
+        self.fmt_memo
+            .patterns
+            .insert(pattern.to_string(), (candidate, slot));
+        self.fmt_memo.used.insert(candidate);
+        self.fmt_memo.pool_len = self.num_fmts.len();
+        Some(candidate)
     }
 }
 
-fn intern<T: PartialEq + Clone>(values: &mut Vec<T>, value: &T) -> u32 {
-    if let Some(index) = values.iter().position(|candidate| candidate == value) {
+/// intern `value` under `key`; hits are re-verified against the pool, misses rescan.
+fn intern<T, K>(values: &mut Vec<T>, memo: &mut PoolMemo<K>, key: Option<K>, value: &T) -> u32
+where
+    T: PartialEq + Clone,
+    K: Eq + std::hash::Hash,
+{
+    let Some(key) = key else {
+        let index = scan_index(values, value);
+        if index == values.len() {
+            values.push(value.clone());
+        }
+        memo.invalidate(values.len());
         return index as u32;
+    };
+    if memo.pool_len != values.len() {
+        memo.invalidate(values.len());
     }
+    if let Some(&index) = memo.map.get(&key)
+        && values[index as usize] == *value
+    {
+        return index;
+    }
+    if let Some(found) = values.iter().position(|candidate| candidate == value) {
+        memo.map.insert(key, found as u32);
+        return found as u32;
+    }
+    let index = values.len() as u32;
     values.push(value.clone());
-    (values.len() - 1) as u32
+    memo.map.insert(key, index);
+    memo.pool_len = values.len();
+    index
+}
+
+fn scan_index<T: PartialEq>(values: &[T], value: &T) -> usize {
+    values
+        .iter()
+        .position(|candidate| candidate == value)
+        .unwrap_or(values.len())
+}
+
+/// hashable stand-in for an f64; `None` for NaN (which never compares equal)
+/// with -0.0 folded onto 0.0 so bits equality matches float equality.
+fn float_key(v: f64) -> Option<u64> {
+    if v.is_nan() {
+        None
+    } else {
+        Some(if v == 0.0 { 0.0 } else { v }.to_bits())
+    }
 }
 
 /// apply a spreadsheetml tint to a `#rrggbb` in hsl luminance per §18.8.3:
@@ -579,6 +963,7 @@ mod tests {
             ],
             num_fmts: vec![(164, "0.0\"%\"".into())],
             theme: Theme::default(),
+            ..Stylesheet::default()
         };
 
         assert!(ss.font_for(1).unwrap().bold);
@@ -617,10 +1002,462 @@ mod tests {
             },
             ..CellFormat::default()
         };
-        let first = styles.intern_cell_format(&format).unwrap();
-        let second = styles.intern_cell_format(&format).unwrap();
+        let first = styles.intern_cell_format(&format).unwrap().unwrap();
+        let second = styles.intern_cell_format(&format).unwrap().unwrap();
         assert_eq!(first, second);
         assert_eq!(styles.cell_format(Some(first)), format);
-        assert_eq!(styles.intern_cell_format(&CellFormat::default()), None);
+        assert_eq!(styles.intern_cell_format(&CellFormat::default()), Ok(None));
+    }
+
+    #[test]
+    fn pool_interning_is_stable_and_reuses_indices() {
+        let mut ss = Stylesheet::default();
+        let plain = Font {
+            name: Some("Calibri".into()),
+            size_pt: Some(11.0),
+            ..Font::default()
+        };
+        let bold = Font {
+            bold: true,
+            ..Font::default()
+        };
+        assert_eq!(ss.intern_font(&plain), 0);
+        assert_eq!(ss.intern_font(&bold), 1);
+        assert_eq!(ss.intern_font(&plain), 0);
+        assert_eq!(ss.fonts.len(), 2);
+
+        let yellow = Fill::Solid(Color::Rgb("#ffff00".into()));
+        assert_eq!(ss.intern_fill(&Fill::None), 0);
+        assert_eq!(ss.intern_fill(&yellow), 1);
+        assert_eq!(ss.intern_fill(&yellow), 1);
+
+        let boxed = Border {
+            top: Some(BorderEdge {
+                style: BorderStyle::Thin,
+                color: None,
+            }),
+            ..Border::default()
+        };
+        let dashed = Border {
+            bottom: Some(BorderEdge {
+                style: BorderStyle::Dashed,
+                color: Some(Color::Indexed(3)),
+            }),
+            ..Border::default()
+        };
+        assert_eq!(ss.intern_border(&Border::default()), 0);
+        assert_eq!(ss.intern_border(&boxed), 1);
+        assert_eq!(ss.intern_border(&dashed), 2);
+        assert_eq!(ss.intern_border(&boxed), 1);
+        assert_eq!(ss.borders.len(), 3);
+
+        let xf_a = Xf {
+            font: Some(0),
+            fill: Some(1),
+            ..Xf::default()
+        };
+        let xf_b = Xf {
+            border: Some(2),
+            alignment: Some(Alignment {
+                h: Some(HAlign::Right),
+                ..Alignment::default()
+            }),
+            ..Xf::default()
+        };
+        assert_eq!(ss.intern_xf(&xf_a), 0);
+        assert_eq!(ss.intern_xf(&xf_b), 1);
+        assert_eq!(ss.intern_xf(&xf_a), 0);
+        assert_eq!(ss.cell_xfs.len(), 2);
+    }
+
+    #[test]
+    fn number_format_interning_reuses_ids_and_allocates_lowest_free() {
+        let mut ss = Stylesheet::default();
+        assert_eq!(ss.intern_number_format("0.000"), Some(164));
+        assert_eq!(ss.intern_number_format("#,##0"), Some(165));
+        assert_eq!(ss.intern_number_format("0.000"), Some(164));
+        assert_eq!(ss.num_fmts.len(), 2);
+
+        ss.num_fmts.clear();
+        ss.num_fmts.push((165, "#,##0".into()));
+        assert_eq!(ss.intern_number_format("0.000"), Some(164));
+        assert_eq!(ss.intern_number_format("#,##0"), Some(165));
+    }
+
+    #[test]
+    fn in_place_pool_edit_self_heals_on_next_intern() {
+        let mut ss = Stylesheet::default();
+        let a = Font {
+            name: Some("A".into()),
+            ..Font::default()
+        };
+        let b = Font {
+            name: Some("B".into()),
+            ..Font::default()
+        };
+        assert_eq!(ss.intern_font(&a), 0);
+        ss.fonts[0] = b.clone();
+
+        assert_eq!(ss.intern_font(&a), 1);
+        assert_eq!(ss.fonts.len(), 2);
+        assert_eq!(ss.fonts[1], a);
+
+        assert_eq!(ss.intern_font(&b), 0);
+        assert_eq!(ss.fonts.len(), 2);
+    }
+
+    #[test]
+    fn same_length_swap_dedups_via_scan_instead_of_appending() {
+        let mut ss = Stylesheet::default();
+        let a = Font {
+            name: Some("A".into()),
+            ..Font::default()
+        };
+        let b = Font {
+            name: Some("B".into()),
+            ..Font::default()
+        };
+        assert_eq!(ss.intern_font(&a), 0);
+        ss.fonts[0] = b.clone();
+
+        assert_eq!(
+            ss.intern_font(&b),
+            0,
+            "memo miss must rescan before appending"
+        );
+        assert_eq!(ss.fonts.len(), 1);
+
+        assert_eq!(ss.intern_font(&a), 1);
+        assert_eq!(ss.fonts, vec![b, a]);
+    }
+
+    #[test]
+    fn duplicate_and_nan_entries_do_not_force_rebuilds() {
+        let mut ss = Stylesheet::default();
+        let plain = Font {
+            name: Some("A".into()),
+            ..Font::default()
+        };
+        let nan = Font {
+            size_pt: Some(f64::NAN),
+            ..Font::default()
+        };
+        ss.fonts = vec![plain.clone(), plain.clone(), nan.clone()];
+
+        assert_eq!(ss.intern_font(&plain), 0);
+        assert_eq!(ss.font_memo.rebuilds, 1);
+
+        assert_eq!(ss.intern_font(&plain), 0);
+        assert_eq!(ss.font_memo.rebuilds, 1);
+
+        let first = ss.intern_font(&nan);
+        let second = ss.intern_font(&nan);
+        assert_ne!(first, second);
+        assert_eq!(first, 3);
+        assert_eq!(second, 4);
+
+        let stable = ss.font_memo.rebuilds;
+        assert_eq!(ss.intern_font(&Font::default()), 5);
+        assert_eq!(ss.font_memo.rebuilds, stable);
+        assert_eq!(ss.intern_font(&Font::default()), 5);
+        assert_eq!(ss.font_memo.rebuilds, stable);
+        assert_eq!(ss.fonts.len(), 6);
+    }
+
+    #[test]
+    fn shrink_then_intern_does_not_panic_and_returns_fresh_indices() {
+        let mut ss = Stylesheet::default();
+        let a = Font {
+            name: Some("A".into()),
+            ..Font::default()
+        };
+        let b = Font {
+            name: Some("B".into()),
+            ..Font::default()
+        };
+        let nan = Font {
+            size_pt: Some(f64::NAN),
+            ..Font::default()
+        };
+        assert_eq!(ss.intern_font(&a), 0);
+        assert_eq!(ss.intern_font(&b), 1);
+
+        ss.fonts.clear();
+        assert_eq!(ss.intern_font(&nan), 0);
+        assert_eq!(ss.intern_font(&b), 1);
+        assert_eq!(ss.intern_font(&a), 2);
+        assert_eq!(ss.fonts.len(), 3);
+        assert!(ss.fonts[0].size_pt.unwrap().is_nan());
+        assert_eq!(ss.fonts[1], b);
+        assert_eq!(ss.fonts[2], a);
+    }
+
+    #[test]
+    fn same_length_num_fmt_swap_rebuilds_and_avoids_collisions() {
+        let mut ss = Stylesheet::default();
+        assert_eq!(ss.intern_number_format("a"), Some(164));
+        assert_eq!(ss.intern_number_format("b"), Some(165));
+
+        ss.num_fmts = vec![(164, "x".into()), (170, "y".into())];
+        assert_eq!(ss.intern_number_format("a"), Some(165));
+        assert_eq!(
+            ss.num_fmts,
+            [(164, "x".into()), (170, "y".into()), (165, "a".into())]
+        );
+        assert_eq!(ss.intern_number_format("y"), Some(170));
+        assert_eq!(ss.intern_number_format("x"), Some(164));
+
+        ss.num_fmts = vec![(200, "k".into())];
+        assert_eq!(ss.intern_number_format("q"), Some(164));
+        assert_eq!(ss.num_fmts, [(200, "k".into()), (164, "q".into())]);
+
+        ss.num_fmts = vec![(164, "z".into())];
+        assert_eq!(ss.intern_number_format("q"), Some(165));
+        assert_eq!(ss.num_fmts, [(164, "z".into()), (165, "q".into())]);
+
+        ss.num_fmts = vec![(166, "m".into()), (167, "n".into())];
+        assert_eq!(ss.intern_number_format("qq"), Some(164));
+        assert_eq!(
+            ss.num_fmts,
+            [(166, "m".into()), (167, "n".into()), (164, "qq".into())]
+        );
+    }
+
+    #[test]
+    fn number_format_allocation_fails_explicitly_when_ids_are_exhausted() {
+        let mut ss = Stylesheet {
+            num_fmts: (164..=u16::MAX).map(|id| (id, format!("p{id}"))).collect(),
+            ..Stylesheet::default()
+        };
+        assert_eq!(ss.intern_number_format("overflow"), None);
+        assert!(ss.num_fmts.len() == (u16::MAX - 164 + 1) as usize);
+    }
+
+    #[test]
+    fn fmt_memo_miss_scans_live_table_before_allocating() {
+        let mut ss = Stylesheet::default();
+        assert_eq!(ss.intern_number_format("0.0"), Some(164));
+        ss.fmt_memo.patterns.clear();
+        assert_eq!(ss.intern_number_format("0.0"), Some(164));
+        assert_eq!(ss.num_fmts.len(), 1);
+    }
+
+    #[test]
+    fn absent_pattern_allocation_validates_candidate_against_live_table() {
+        let mut ss = Stylesheet {
+            num_fmts: vec![(164, "a".into()), (200, "b".into())],
+            ..Stylesheet::default()
+        };
+        assert_eq!(ss.intern_number_format("m"), Some(165));
+
+        ss.num_fmts[1] = (166, "evil".into());
+        let allocated = ss.intern_number_format("fresh");
+        let live_ids: Vec<u16> = ss.num_fmts.iter().map(|(id, _)| *id).collect();
+        let Some(allocated) = allocated else {
+            panic!("allocation must succeed while ids remain");
+        };
+        assert_ne!(
+            allocated, 166,
+            "allocated id must not collide with a live id"
+        );
+        assert_eq!(allocated, 167);
+        assert!(!live_ids[..3].contains(&allocated));
+        assert_eq!(
+            ss.num_fmts,
+            [
+                (164, "a".into()),
+                (166, "evil".into()),
+                (165, "m".into()),
+                (167, "fresh".into()),
+            ]
+        );
+
+        ss.num_fmts = vec![(164, "General".into())];
+        assert_eq!(ss.intern_number_format("m"), Some(165));
+        ss.num_fmts[1] = (164, "m".into());
+        assert_eq!(ss.intern_number_format("q"), Some(165));
+        assert_eq!(
+            ss.num_fmts,
+            [
+                (164, "General".into()),
+                (164, "m".into()),
+                (165, "q".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_num_fmt_ids_intern_to_round_trippable_ids() {
+        let mut ss = Stylesheet {
+            num_fmts: vec![
+                (164, "a".into()),
+                (164, "b".into()),
+                (100, "c".into()),
+                (300, "d".into()),
+                (300, "e".into()),
+            ],
+            ..Stylesheet::default()
+        };
+        let mut intern_and_check = |pattern: &str| {
+            let id = ss.intern_number_format(pattern).unwrap();
+            let idx = ss.cell_xfs.len() as u32;
+            ss.cell_xfs.push(Xf {
+                num_fmt_id: Some(id),
+                ..Xf::default()
+            });
+            assert_eq!(
+                ss.format_code_for(idx),
+                FormatCode::Custom(pattern),
+                "interned id must resolve back to the pattern"
+            );
+            id
+        };
+
+        assert_eq!(intern_and_check("a"), 164);
+        assert_eq!(
+            intern_and_check("b"),
+            165,
+            "duplicate id must not be reused"
+        );
+        assert_eq!(intern_and_check("c"), 166, "sub-spec id must not be reused");
+        assert_eq!(intern_and_check("d"), 300);
+        assert_eq!(
+            intern_and_check("e"),
+            167,
+            "duplicate id must not be reused"
+        );
+
+        assert_eq!(intern_and_check("a"), 164);
+        assert_eq!(intern_and_check("b"), 165);
+        assert_eq!(intern_and_check("c"), 166);
+        assert_eq!(intern_and_check("d"), 300);
+        assert_eq!(intern_and_check("e"), 167);
+        assert_eq!(
+            ss.num_fmts,
+            [
+                (164, "a".into()),
+                (164, "b".into()),
+                (100, "c".into()),
+                (300, "d".into()),
+                (300, "e".into()),
+                (165, "b".into()),
+                (166, "c".into()),
+                (167, "e".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolved_format_borrows_without_defaulting_gaps() {
+        let mut ss = Stylesheet::default();
+        let format = CellFormat {
+            font: Font {
+                bold: true,
+                size_pt: Some(-0.0),
+                ..Font::default()
+            },
+            number_format: NumberFormat::Custom {
+                pattern: "0.0".into(),
+            },
+            ..CellFormat::default()
+        };
+        let index = ss.intern_cell_format(&format).unwrap().unwrap();
+
+        let resolved = ss.resolved_format(Some(index));
+        assert!(resolved.font.bold);
+        assert_eq!(resolved.font.size_pt, Some(-0.0));
+        assert_eq!(
+            resolved.number_format,
+            FormatCode::Custom("0.0"),
+            "custom code borrows the pooled string"
+        );
+        assert_eq!(resolved.fill, &Fill::None);
+        assert!(!resolved.alignment.wrap_text);
+
+        let fallback = ss.resolved_format(Some(99));
+        assert_eq!(fallback.font, &Font::default());
+        assert_eq!(fallback.number_format, FormatCode::Builtin(0));
+        assert_eq!(
+            ss.resolved_format(None).number_format,
+            FormatCode::Builtin(0)
+        );
+        assert_eq!(ss.cell_format(Some(index)), format);
+    }
+
+    #[test]
+    fn stylesheet_round_trips_and_keeps_indices_after_reload() {
+        let mut styles = Stylesheet::default();
+        let warm = CellFormat {
+            font: Font {
+                italic: true,
+                color: Some(Color::Theme {
+                    idx: 4,
+                    tint: -0.25,
+                }),
+                ..Font::default()
+            },
+            number_format: NumberFormat::Custom {
+                pattern: "$#,##0.00".into(),
+            },
+            alignment: Alignment {
+                v: Some(VAlign::Top),
+                shrink_to_fit: true,
+                ..Alignment::default()
+            },
+            ..CellFormat::default()
+        };
+        let cold = CellFormat {
+            border: Border {
+                left: Some(BorderEdge {
+                    style: BorderStyle::Double,
+                    color: Some(Color::Rgb("#123456".into())),
+                }),
+                ..Border::default()
+            },
+            ..CellFormat::default()
+        };
+        let warm_index = styles.intern_cell_format(&warm).unwrap().unwrap();
+        let cold_index = styles.intern_cell_format(&cold).unwrap().unwrap();
+        assert_ne!(warm_index, cold_index);
+
+        let json = serde_json::to_string(&styles).unwrap();
+        let mut reloaded: Stylesheet = serde_json::from_str(&json).unwrap();
+        assert_eq!(reloaded, styles);
+        assert_eq!(serde_json::to_string(&reloaded).unwrap(), json);
+
+        assert_eq!(
+            reloaded.intern_cell_format(&warm).unwrap().unwrap(),
+            warm_index
+        );
+        assert_eq!(
+            reloaded.intern_cell_format(&cold).unwrap().unwrap(),
+            cold_index
+        );
+        assert_eq!(reloaded.cell_format(Some(warm_index)), warm);
+        assert_eq!(reloaded.num_fmts.len(), 1);
+    }
+
+    #[test]
+    fn nan_sizes_fall_back_without_deduping() {
+        let mut ss = Stylesheet::default();
+        let nan = Font {
+            size_pt: Some(f64::NAN),
+            ..Font::default()
+        };
+        let a = ss.intern_font(&nan);
+        let b = ss.intern_font(&nan);
+        assert_eq!(a, 0);
+        assert_ne!(a, b);
+        assert_eq!(ss.fonts.len(), 2);
+        assert_eq!(ss.intern_font(&Font::default()), 2);
+        let with_nan_tint = Font {
+            color: Some(Color::Theme {
+                idx: 4,
+                tint: f64::NAN,
+            }),
+            ..Font::default()
+        };
+        assert_eq!(ss.intern_font(&with_nan_tint), 3);
+        assert_eq!(ss.intern_font(&nan), 4);
     }
 }

--- a/crates/xlsx-model/src/styles.rs
+++ b/crates/xlsx-model/src/styles.rs
@@ -370,7 +370,7 @@ impl BorderKey {
 }
 
 /// intern cache: key -> index, tagged with the pool length it was synced to.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct PoolMemo<K> {
     map: HashMap<K, u32>,
     pool_len: usize,
@@ -389,6 +389,14 @@ impl<K> Default for PoolMemo<K> {
     }
 }
 
+/// the memo is a pure accelerator, so a clone starts cold instead of copying
+/// the map; the first intern on the clone rebuilds only what it needs.
+impl<K> Clone for PoolMemo<K> {
+    fn clone(&self) -> Self {
+        PoolMemo::default()
+    }
+}
+
 impl<K: Eq + std::hash::Hash> PoolMemo<K> {
     fn invalidate(&mut self, pool_len: usize) {
         self.map.clear();
@@ -401,13 +409,19 @@ impl<K: Eq + std::hash::Hash> PoolMemo<K> {
 }
 
 /// intern cache for `num_fmts`; hits re-verify against the live table.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 struct FmtMemo {
     patterns: HashMap<String, (u16, usize)>,
     used: HashSet<u16>,
     pool_len: usize,
     #[cfg(test)]
     rebuilds: u64,
+}
+
+impl Clone for FmtMemo {
+    fn clone(&self) -> Self {
+        FmtMemo::default()
+    }
 }
 
 impl FmtMemo {
@@ -428,6 +442,16 @@ impl FmtMemo {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NumFmtTableFull;
+
+/// pool lengths captured before a batch of interning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PoolMarks {
+    fonts: usize,
+    fills: usize,
+    borders: usize,
+    cell_xfs: usize,
+    num_fmts: usize,
+}
 
 /// parsed style tables plus theme; private memos accelerate interning and
 /// are invalidated by any pool length change.
@@ -650,6 +674,27 @@ impl Stylesheet {
             alignment,
         };
         Ok(Some(self.intern_xf(&xf)))
+    }
+
+    /// current pool lengths; interning only ever appends, so truncating back to
+    /// a mark restores exactly the pools that were live when it was taken.
+    pub fn pool_marks(&self) -> PoolMarks {
+        PoolMarks {
+            fonts: self.fonts.len(),
+            fills: self.fills.len(),
+            borders: self.borders.len(),
+            cell_xfs: self.cell_xfs.len(),
+            num_fmts: self.num_fmts.len(),
+        }
+    }
+
+    /// drop every pool entry interned since `marks` was taken.
+    pub fn restore_pools(&mut self, marks: PoolMarks) {
+        self.fonts.truncate(marks.fonts);
+        self.fills.truncate(marks.fills);
+        self.borders.truncate(marks.borders);
+        self.cell_xfs.truncate(marks.cell_xfs);
+        self.num_fmts.truncate(marks.num_fmts);
     }
 
     fn intern_font(&mut self, value: &Font) -> u32 {
@@ -1435,6 +1480,78 @@ mod tests {
         );
         assert_eq!(reloaded.cell_format(Some(warm_index)), warm);
         assert_eq!(reloaded.num_fmts.len(), 1);
+    }
+
+    #[test]
+    fn a_clone_starts_cold_and_still_dedups_against_the_pools() {
+        let mut styles = Stylesheet::default();
+        let format = CellFormat {
+            font: Font {
+                bold: true,
+                name: Some("Calibri".into()),
+                ..Font::default()
+            },
+            fill: Fill::Solid(Color::Rgb("#ff0000".into())),
+            number_format: NumberFormat::Custom {
+                pattern: "0.00".into(),
+            },
+            ..CellFormat::default()
+        };
+        let index = styles.intern_cell_format(&format).unwrap().unwrap();
+
+        let mut cloned = styles.clone();
+        assert!(cloned.font_memo.map.is_empty(), "clone must start cold");
+        assert!(cloned.fmt_memo.patterns.is_empty(), "clone must start cold");
+        assert_eq!(cloned, styles, "a cold memo must not change equality");
+
+        assert_eq!(cloned.intern_cell_format(&format).unwrap(), Some(index));
+        assert_eq!(cloned.fonts.len(), styles.fonts.len());
+        assert_eq!(cloned.fills.len(), styles.fills.len());
+        assert_eq!(cloned.cell_xfs.len(), styles.cell_xfs.len());
+        assert_eq!(cloned.num_fmts.len(), styles.num_fmts.len());
+        assert_eq!(cloned, styles);
+    }
+
+    #[test]
+    fn restore_pools_drops_everything_interned_since_the_mark() {
+        let mut ss = Stylesheet::default();
+        let first = CellFormat {
+            font: Font {
+                bold: true,
+                ..Font::default()
+            },
+            number_format: NumberFormat::Custom {
+                pattern: "0.0".into(),
+            },
+            ..CellFormat::default()
+        };
+        ss.intern_cell_format(&first).unwrap().unwrap();
+        let marks = ss.pool_marks();
+        let before = ss.clone();
+
+        let second = CellFormat {
+            font: Font {
+                italic: true,
+                name: Some("Arial".into()),
+                ..Font::default()
+            },
+            fill: Fill::Solid(Color::Indexed(7)),
+            number_format: NumberFormat::Custom {
+                pattern: "#,##0".into(),
+            },
+            ..CellFormat::default()
+        };
+        ss.intern_cell_format(&second).unwrap().unwrap();
+        assert_ne!(ss, before);
+
+        ss.restore_pools(marks);
+        assert_eq!(ss, before, "truncating to a mark must restore the pools");
+        assert_eq!(
+            ss.intern_cell_format(&first).unwrap(),
+            before.cell_xfs.len().checked_sub(1).map(|i| i as u32),
+            "the memo must not hand back a truncated index"
+        );
+        assert_eq!(ss, before);
     }
 
     #[test]

--- a/crates/xlsx-model/src/styles.rs
+++ b/crates/xlsx-model/src/styles.rs
@@ -1,7 +1,8 @@
 //! style types (fonts, fills, borders, xf chains, theme colors). pure data;
 //! the cellXfs indirection chain is walked through the `Stylesheet` accessors.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
@@ -257,17 +258,17 @@ impl Theme {
 
 /// hashable stand-in for a color; float tints become raw bits.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum ColorKey {
-    Rgb(String),
+enum ColorKey<'a> {
+    Rgb(&'a str),
     Theme { idx: u8, tint: Option<u64> },
     Indexed(u8),
     Auto,
 }
 
-impl ColorKey {
-    fn new(color: &Color) -> Option<Self> {
+impl<'a> ColorKey<'a> {
+    fn new(color: &'a Color) -> Option<Self> {
         Some(match color {
-            Color::Rgb(s) => ColorKey::Rgb(s.clone()),
+            Color::Rgb(s) => ColorKey::Rgb(s),
             Color::Theme { idx, tint } => ColorKey::Theme {
                 idx: *idx,
                 tint: Some(float_key(*tint)?),
@@ -280,20 +281,20 @@ impl ColorKey {
 
 /// hashable stand-in for a font; `None` when a NaN size/color tint blocks keying.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct FontKey {
-    name: Option<String>,
+struct FontKey<'a> {
+    name: Option<&'a str>,
     size_pt: Option<u64>,
     bold: bool,
     italic: bool,
     underline: bool,
     strike: bool,
-    color: Option<ColorKey>,
+    color: Option<ColorKey<'a>>,
 }
 
-impl FontKey {
-    fn new(font: &Font) -> Option<Self> {
+impl<'a> FontKey<'a> {
+    fn new(font: &'a Font) -> Option<Self> {
         Some(FontKey {
-            name: font.name.clone(),
+            name: font.name.as_deref(),
             size_pt: match font.size_pt {
                 None => None,
                 Some(size) => Some(float_key(size)?),
@@ -312,13 +313,13 @@ impl FontKey {
 
 /// hashable stand-in for a fill.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum FillKey {
+enum FillKey<'a> {
     None,
-    Solid(ColorKey),
+    Solid(ColorKey<'a>),
 }
 
-impl FillKey {
-    fn new(fill: &Fill) -> Option<Self> {
+impl<'a> FillKey<'a> {
+    fn new(fill: &'a Fill) -> Option<Self> {
         Some(match fill {
             Fill::None => FillKey::None,
             Fill::Solid(color) => FillKey::Solid(ColorKey::new(color)?),
@@ -328,13 +329,13 @@ impl FillKey {
 
 /// hashable stand-in for a border edge.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct EdgeKey {
+struct EdgeKey<'a> {
     style: BorderStyle,
-    color: Option<ColorKey>,
+    color: Option<ColorKey<'a>>,
 }
 
-impl EdgeKey {
-    fn new(edge: &BorderEdge) -> Option<Self> {
+impl<'a> EdgeKey<'a> {
+    fn new(edge: &'a BorderEdge) -> Option<Self> {
         Some(EdgeKey {
             style: edge.style,
             color: match &edge.color {
@@ -347,57 +348,54 @@ impl EdgeKey {
 
 /// hashable stand-in for a border.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct BorderKey {
-    left: Option<EdgeKey>,
-    right: Option<EdgeKey>,
-    top: Option<EdgeKey>,
-    bottom: Option<EdgeKey>,
+struct BorderKey<'a> {
+    left: Option<EdgeKey<'a>>,
+    right: Option<EdgeKey<'a>>,
+    top: Option<EdgeKey<'a>>,
+    bottom: Option<EdgeKey<'a>>,
 }
 
-impl BorderKey {
-    fn new(border: &Border) -> Option<Self> {
-        let edge = |e: &Option<BorderEdge>| match e {
-            None => Some(None),
-            Some(e) => Some(Some(EdgeKey::new(e)?)),
-        };
+impl<'a> BorderKey<'a> {
+    fn new(border: &'a Border) -> Option<Self> {
         Some(BorderKey {
-            left: edge(&border.left)?,
-            right: edge(&border.right)?,
-            top: edge(&border.top)?,
-            bottom: edge(&border.bottom)?,
+            left: match &border.left {
+                None => None,
+                Some(edge) => Some(EdgeKey::new(edge)?),
+            },
+            right: match &border.right {
+                None => None,
+                Some(edge) => Some(EdgeKey::new(edge)?),
+            },
+            top: match &border.top {
+                None => None,
+                Some(edge) => Some(EdgeKey::new(edge)?),
+            },
+            bottom: match &border.bottom {
+                None => None,
+                Some(edge) => Some(EdgeKey::new(edge)?),
+            },
         })
     }
 }
 
-/// intern cache: key -> index, tagged with the pool length it was synced to.
-#[derive(Debug)]
-struct PoolMemo<K> {
-    map: HashMap<K, u32>,
+/// intern cache: fingerprint -> index, tagged with its synced pool length.
+#[derive(Debug, Default)]
+struct PoolMemo {
+    map: HashMap<u64, u32>,
     pool_len: usize,
     #[cfg(test)]
     rebuilds: u64,
 }
 
-impl<K> Default for PoolMemo<K> {
-    fn default() -> Self {
-        PoolMemo {
-            map: HashMap::new(),
-            pool_len: 0,
-            #[cfg(test)]
-            rebuilds: 0,
-        }
-    }
-}
-
 /// the memo is a pure accelerator, so a clone starts cold instead of copying
 /// the map; the first intern on the clone rebuilds only what it needs.
-impl<K> Clone for PoolMemo<K> {
+impl Clone for PoolMemo {
     fn clone(&self) -> Self {
         PoolMemo::default()
     }
 }
 
-impl<K: Eq + std::hash::Hash> PoolMemo<K> {
+impl PoolMemo {
     fn invalidate(&mut self, pool_len: usize) {
         self.map.clear();
         self.pool_len = pool_len;
@@ -412,7 +410,6 @@ impl<K: Eq + std::hash::Hash> PoolMemo<K> {
 #[derive(Debug, Default)]
 struct FmtMemo {
     patterns: HashMap<String, (u16, usize)>,
-    used: HashSet<u16>,
     pool_len: usize,
     #[cfg(test)]
     rebuilds: u64,
@@ -427,11 +424,9 @@ impl Clone for FmtMemo {
 impl FmtMemo {
     fn rebuild(&mut self, formats: &[(u16, String)]) {
         self.patterns.clear();
-        self.used.clear();
         self.pool_len = formats.len();
         for (slot, (id, code)) in formats.iter().enumerate() {
             self.patterns.entry(code.clone()).or_insert((*id, slot));
-            self.used.insert(*id);
         }
         #[cfg(test)]
         {
@@ -464,13 +459,13 @@ pub struct Stylesheet {
     pub num_fmts: Vec<(u16, String)>,
     pub theme: Theme,
     #[serde(skip)]
-    font_memo: PoolMemo<FontKey>,
+    font_memo: PoolMemo,
     #[serde(skip)]
-    fill_memo: PoolMemo<FillKey>,
+    fill_memo: PoolMemo,
     #[serde(skip)]
-    border_memo: PoolMemo<BorderKey>,
+    border_memo: PoolMemo,
     #[serde(skip)]
-    xf_memo: PoolMemo<Xf>,
+    xf_memo: PoolMemo,
     #[serde(skip)]
     fmt_memo: FmtMemo,
 }
@@ -649,6 +644,7 @@ impl Stylesheet {
         }
     }
 
+    #[inline]
     pub fn intern_cell_format(
         &mut self,
         format: &CellFormat,
@@ -656,12 +652,126 @@ impl Stylesheet {
         if format == &CellFormat::default() {
             return Ok(None);
         }
-        let num_fmt_id = match &format.number_format {
-            NumberFormat::Builtin { id } => Some(*id).filter(|id| *id != 0),
-            NumberFormat::Custom { pattern } => {
-                Some(self.intern_number_format(pattern).ok_or(NumFmtTableFull)?)
+        match &format.number_format {
+            NumberFormat::Builtin { id } => Ok(Some(self.intern_builtin_cell_format(format, *id))),
+            NumberFormat::Custom { pattern } => self.intern_custom_cell_format(format, pattern),
+        }
+    }
+
+    #[inline(never)]
+    fn intern_builtin_cell_format(&mut self, format: &CellFormat, num_fmt_id: u16) -> u32 {
+        if self.cell_xfs.len() < INTERN_CACHE_MIN_POOL {
+            let font = intern_linear(&mut self.fonts, &format.font);
+            let fill = intern_linear(&mut self.fills, &format.fill);
+            let border = intern_linear(&mut self.borders, &format.border);
+            let num_fmt_id = Some(num_fmt_id).filter(|id| *id != 0);
+            let alignment = (!format.alignment.is_empty()).then(|| format.alignment.clone());
+            let xf = Xf {
+                font: (format.font != Font::default()).then_some(font),
+                fill: (format.fill != Fill::default()).then_some(fill),
+                border: (format.border != Border::default()).then_some(border),
+                num_fmt_id,
+                alignment,
+            };
+            if let Some(index) = xf.font
+                && xf.fill.is_none()
+                && xf.border.is_none()
+                && xf.num_fmt_id.is_none()
+                && xf.alignment.is_none()
+                && self
+                    .cell_xfs
+                    .get(index as usize)
+                    .is_some_and(|candidate| candidate == &xf)
+            {
+                return index;
             }
-        };
+            return intern_linear(&mut self.cell_xfs, &xf);
+        }
+        self.intern_cell_format_large(format, Some(num_fmt_id).filter(|id| *id != 0))
+    }
+
+    #[inline(never)]
+    fn intern_custom_cell_format(
+        &mut self,
+        format: &CellFormat,
+        pattern: &str,
+    ) -> Result<Option<u32>, NumFmtTableFull> {
+        let num_fmt_id = Some(self.intern_number_format(pattern).ok_or(NumFmtTableFull)?);
+        if self.cell_xfs.len() < INTERN_CACHE_MIN_POOL {
+            let font = intern_linear(&mut self.fonts, &format.font);
+            let fill = intern_linear(&mut self.fills, &format.fill);
+            let border = intern_linear(&mut self.borders, &format.border);
+            let alignment = (!format.alignment.is_empty()).then(|| format.alignment.clone());
+            let xf = Xf {
+                font: (format.font != Font::default()).then_some(font),
+                fill: (format.fill != Fill::default()).then_some(fill),
+                border: (format.border != Border::default()).then_some(border),
+                num_fmt_id,
+                alignment,
+            };
+            return Ok(Some(intern_linear(&mut self.cell_xfs, &xf)));
+        }
+        Ok(Some(self.intern_cell_format_large(format, num_fmt_id)))
+    }
+
+    #[inline(never)]
+    fn intern_cell_format_large(&mut self, format: &CellFormat, num_fmt_id: Option<u16>) -> u32 {
+        if self.xf_memo.map.is_empty() {
+            let font_len = self.fonts.len();
+            let fill_len = self.fills.len();
+            let border_len = self.borders.len();
+            let font = intern_linear(&mut self.fonts, &format.font);
+            let fill = intern_linear(&mut self.fills, &format.fill);
+            let border = intern_linear(&mut self.borders, &format.border);
+            let has_font = format.font != Font::default();
+            let has_fill = format.fill != Fill::default();
+            let has_border = format.border != Border::default();
+            let alignment = (!format.alignment.is_empty()).then(|| format.alignment.clone());
+            let xf = Xf {
+                font: has_font.then_some(font),
+                fill: has_fill.then_some(fill),
+                border: has_border.then_some(border),
+                num_fmt_id,
+                alignment,
+            };
+            let has_new_facet = (self.fonts.len() != font_len && has_font)
+                || (self.fills.len() != fill_len && has_fill)
+                || (self.borders.len() != border_len && has_border);
+            let index = if has_new_facet {
+                self.cell_xfs.len()
+            } else {
+                scan_index(&self.cell_xfs, &xf)
+            };
+            if index == self.cell_xfs.len() {
+                self.cell_xfs.push(xf);
+            } else {
+                seed_memo(
+                    &mut self.font_memo,
+                    self.fonts.len(),
+                    FontKey::new(&format.font).map(|key| fingerprint(&key)),
+                    font,
+                );
+                seed_memo(
+                    &mut self.fill_memo,
+                    self.fills.len(),
+                    FillKey::new(&format.fill).map(|key| fingerprint(&key)),
+                    fill,
+                );
+                seed_memo(
+                    &mut self.border_memo,
+                    self.borders.len(),
+                    BorderKey::new(&format.border).map(|key| fingerprint(&key)),
+                    border,
+                );
+                seed_memo(
+                    &mut self.xf_memo,
+                    self.cell_xfs.len(),
+                    Some(fingerprint(&xf)),
+                    index as u32,
+                );
+            }
+            return index as u32;
+        }
         let font = self.intern_font(&format.font);
         let fill = self.intern_fill(&format.fill);
         let border = self.intern_border(&format.border);
@@ -673,7 +783,7 @@ impl Stylesheet {
             num_fmt_id,
             alignment,
         };
-        Ok(Some(self.intern_xf(&xf)))
+        self.intern_xf(&xf)
     }
 
     /// current pool lengths; interning only ever appends, so truncating back to
@@ -698,39 +808,27 @@ impl Stylesheet {
     }
 
     fn intern_font(&mut self, value: &Font) -> u32 {
-        intern(
-            &mut self.fonts,
-            &mut self.font_memo,
-            FontKey::new(value),
-            value,
-        )
+        intern(&mut self.fonts, &mut self.font_memo, value, |value| {
+            FontKey::new(value).map(|key| fingerprint(&key))
+        })
     }
 
     fn intern_fill(&mut self, value: &Fill) -> u32 {
-        intern(
-            &mut self.fills,
-            &mut self.fill_memo,
-            FillKey::new(value),
-            value,
-        )
+        intern(&mut self.fills, &mut self.fill_memo, value, |value| {
+            FillKey::new(value).map(|key| fingerprint(&key))
+        })
     }
 
     fn intern_border(&mut self, value: &Border) -> u32 {
-        intern(
-            &mut self.borders,
-            &mut self.border_memo,
-            BorderKey::new(value),
-            value,
-        )
+        intern(&mut self.borders, &mut self.border_memo, value, |value| {
+            BorderKey::new(value).map(|key| fingerprint(&key))
+        })
     }
 
     fn intern_xf(&mut self, value: &Xf) -> u32 {
-        intern(
-            &mut self.cell_xfs,
-            &mut self.xf_memo,
-            Some(value.clone()),
-            value,
-        )
+        intern(&mut self.cell_xfs, &mut self.xf_memo, value, |value| {
+            Some(fingerprint(value))
+        })
     }
 
     /// true when a cell using `id` resolves to `pattern` via `format_code_for`:
@@ -783,31 +881,63 @@ impl Stylesheet {
         self.fmt_memo
             .patterns
             .insert(pattern.to_string(), (candidate, slot));
-        self.fmt_memo.used.insert(candidate);
         self.fmt_memo.pool_len = self.num_fmts.len();
         Some(candidate)
     }
 }
 
-/// intern `value` under `key`; hits are re-verified against the pool, misses rescan.
-fn intern<T, K>(values: &mut Vec<T>, memo: &mut PoolMemo<K>, key: Option<K>, value: &T) -> u32
+const INTERN_CACHE_MIN_POOL: usize = 128;
+
+fn seed_memo(memo: &mut PoolMemo, pool_len: usize, key: Option<u64>, index: u32) {
+    if let Some(key) = key {
+        memo.map.insert(key, index);
+    }
+    memo.pool_len = pool_len;
+}
+
+fn intern<T>(
+    values: &mut Vec<T>,
+    memo: &mut PoolMemo,
+    value: &T,
+    make_key: impl FnOnce(&T) -> Option<u64>,
+) -> u32
 where
     T: PartialEq + Clone,
-    K: Eq + std::hash::Hash,
 {
-    let Some(key) = key else {
+    if values.len() < INTERN_CACHE_MIN_POOL {
+        return intern_linear(values, value);
+    }
+
+    if !memo.map.is_empty() && memo.pool_len != values.len() {
+        memo.invalidate(values.len());
+    }
+
+    if memo.map.is_empty() {
         let index = scan_index(values, value);
         if index == values.len() {
             values.push(value.clone());
+        } else if values.len() >= INTERN_CACHE_MIN_POOL
+            && let Some(key) = make_key(value)
+        {
+            memo.map.insert(key, index as u32);
+            memo.pool_len = values.len();
         }
-        memo.invalidate(values.len());
+        return index as u32;
+    }
+
+    let Some(key) = make_key(value) else {
+        let index = scan_index(values, value);
+        if index == values.len() {
+            values.push(value.clone());
+            memo.pool_len = values.len();
+        }
         return index as u32;
     };
-    if memo.pool_len != values.len() {
-        memo.invalidate(values.len());
-    }
-    if let Some(&index) = memo.map.get(&key)
-        && values[index as usize] == *value
+    let cached = memo.map.get(&key).copied();
+    if let Some(index) = cached
+        && values
+            .get(index as usize)
+            .is_some_and(|candidate| candidate == value)
     {
         return index;
     }
@@ -817,16 +947,37 @@ where
     }
     let index = values.len() as u32;
     values.push(value.clone());
-    memo.map.insert(key, index);
+    if cached.is_some() {
+        memo.map.insert(key, index);
+    }
     memo.pool_len = values.len();
     index
 }
 
+#[inline(always)]
+fn intern_linear<T: PartialEq + Clone>(values: &mut Vec<T>, value: &T) -> u32 {
+    for (index, candidate) in values.iter().enumerate() {
+        if candidate == value {
+            return index as u32;
+        }
+    }
+    values.push(value.clone());
+    (values.len() - 1) as u32
+}
+
 fn scan_index<T: PartialEq>(values: &[T], value: &T) -> usize {
-    values
-        .iter()
-        .position(|candidate| candidate == value)
-        .unwrap_or(values.len())
+    for (index, candidate) in values.iter().enumerate() {
+        if candidate == value {
+            return index;
+        }
+    }
+    values.len()
+}
+
+fn fingerprint(value: &impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// hashable stand-in for an f64; `None` for NaN (which never compares equal)
@@ -1116,6 +1267,92 @@ mod tests {
     }
 
     #[test]
+    fn font_key_covers_every_font_equality_field() {
+        let base = Font::default();
+        let variants = [
+            Font {
+                name: Some("Aptos".into()),
+                ..base.clone()
+            },
+            Font {
+                size_pt: Some(11.0),
+                ..base.clone()
+            },
+            Font {
+                bold: true,
+                ..base.clone()
+            },
+            Font {
+                italic: true,
+                ..base.clone()
+            },
+            Font {
+                underline: true,
+                ..base.clone()
+            },
+            Font {
+                strike: true,
+                ..base.clone()
+            },
+            Font {
+                color: Some(Color::Rgb("#123456".into())),
+                ..base.clone()
+            },
+        ];
+        let base_key = FontKey::new(&base).unwrap();
+        for variant in variants {
+            assert_ne!(FontKey::new(&variant).unwrap(), base_key);
+        }
+    }
+
+    #[test]
+    fn adaptive_interning_skips_small_and_unique_pool_keys() {
+        let mut small = Stylesheet::default();
+        let common = Font {
+            name: Some("Aptos".into()),
+            ..Font::default()
+        };
+        for _ in 0..100 {
+            assert_eq!(small.intern_font(&common), 0);
+        }
+        assert!(small.font_memo.map.is_empty());
+
+        let mut unique = Stylesheet::default();
+        let mut formats = Vec::new();
+        for index in 0..(INTERN_CACHE_MIN_POOL + 8) {
+            let format = CellFormat {
+                font: Font {
+                    name: Some(format!("font-{index}")),
+                    ..Font::default()
+                },
+                ..CellFormat::default()
+            };
+            assert_eq!(
+                unique.intern_cell_format(&format).unwrap(),
+                Some(index as u32)
+            );
+            formats.push(format);
+        }
+        assert!(unique.font_memo.map.is_empty());
+        assert!(unique.xf_memo.map.is_empty());
+
+        let repeated = formats.last().unwrap();
+        let repeated_index = (formats.len() - 1) as u32;
+        assert_eq!(
+            unique.intern_cell_format(repeated).unwrap(),
+            Some(repeated_index)
+        );
+        assert_eq!(unique.font_memo.map.len(), 1);
+        assert_eq!(unique.xf_memo.map.len(), 1);
+        assert_eq!(
+            unique.intern_cell_format(repeated).unwrap(),
+            Some(repeated_index)
+        );
+        assert_eq!(unique.font_memo.map.len(), 1);
+        assert_eq!(unique.xf_memo.map.len(), 1);
+    }
+
+    #[test]
     fn number_format_interning_reuses_ids_and_allocates_lowest_free() {
         let mut ss = Stylesheet::default();
         assert_eq!(ss.intern_number_format("0.000"), Some(164));
@@ -1190,10 +1427,10 @@ mod tests {
         ss.fonts = vec![plain.clone(), plain.clone(), nan.clone()];
 
         assert_eq!(ss.intern_font(&plain), 0);
-        assert_eq!(ss.font_memo.rebuilds, 1);
+        assert_eq!(ss.font_memo.rebuilds, 0);
 
         assert_eq!(ss.intern_font(&plain), 0);
-        assert_eq!(ss.font_memo.rebuilds, 1);
+        assert_eq!(ss.font_memo.rebuilds, 0);
 
         let first = ss.intern_font(&nan);
         let second = ss.intern_font(&nan);

--- a/crates/xlsx-model/src/workbook.rs
+++ b/crates/xlsx-model/src/workbook.rs
@@ -82,6 +82,10 @@ impl Sheet {
         self.cells.get(&(at.row, at.col))
     }
 
+    pub fn cell_mut(&mut self, at: CellRef) -> Option<&mut Cell> {
+        self.cells.get_mut(&(at.row, at.col))
+    }
+
     pub fn set_cell(&mut self, at: CellRef, cell: Cell) {
         if cell == Cell::default() {
             self.cells.remove(&(at.row, at.col));

--- a/crates/xlsx-ops/src/apply.rs
+++ b/crates/xlsx-ops/src/apply.rs
@@ -352,19 +352,28 @@ fn apply_range_formats(
             cells.push((at, sheet_ref.cell(at).cloned().unwrap_or_default()));
         }
     }
-    let mut staged_styles = wb.styles.clone();
+    let marks = wb.styles.pool_marks();
     let mut staged = Vec::with_capacity(cells.len());
     for (at, old) in &cells {
-        let mut format = staged_styles.cell_format(old.style);
-        update(&mut format, at.row, at.col)?;
-        let style = staged_styles
-            .intern_cell_format(&format)
-            .map_err(|_| OpError::NumFmtTableFull)?;
-        let mut next = old.clone();
-        next.style = style;
-        staged.push((*at, next));
+        let staged_cell = (|| {
+            let mut format = wb.styles.cell_format(old.style);
+            update(&mut format, at.row, at.col)?;
+            let style = wb
+                .styles
+                .intern_cell_format(&format)
+                .map_err(|_| OpError::NumFmtTableFull)?;
+            let mut next = old.clone();
+            next.style = style;
+            Ok(next)
+        })();
+        match staged_cell {
+            Ok(next) => staged.push((*at, next)),
+            Err(error) => {
+                wb.styles.restore_pools(marks);
+                return Err(error);
+            }
+        }
     }
-    wb.styles = staged_styles;
     let mut inverse = Vec::with_capacity(staged.len());
     for ((at, old), (_staged_at, next)) in cells.into_iter().zip(staged) {
         if next != old {
@@ -1895,5 +1904,51 @@ mod range_format_exhaustion_tests {
             Err(OpError::NumFmtTableFull)
         ));
         assert_eq!(wb, before, "exhaustion must leave the workbook untouched");
+    }
+
+    /// `apply_ops` stages on its own clone, so only the single-op entry point
+    /// proves `apply_range_formats` rolls its own pool writes back.
+    #[test]
+    fn mid_range_exhaustion_rolls_back_pools_without_an_outer_clone() {
+        let mut styles = xlsx_model::Stylesheet::default();
+        styles.num_fmts = (164..u16::MAX).map(|id| (id, format!("p{id}"))).collect();
+        let mut wb = Workbook {
+            styles,
+            ..Workbook::default()
+        };
+        wb.sheets.push(xlsx_model::Sheet::new("Sheet1"));
+        let before = wb.clone();
+
+        let op = Op::ApplyRangeFormat {
+            sheet: SheetId(0),
+            range: CellRange::new(
+                xlsx_model::CellRef::new(0, 0),
+                xlsx_model::CellRef::new(0, 1),
+            ),
+            format: CapturedFormat {
+                rows: 1,
+                columns: 2,
+                formats: vec![
+                    CellFormat {
+                        number_format: NumberFormat::Custom {
+                            pattern: "one".into(),
+                        },
+                        ..CellFormat::default()
+                    },
+                    CellFormat {
+                        number_format: NumberFormat::Custom {
+                            pattern: "two".into(),
+                        },
+                        ..CellFormat::default()
+                    },
+                ],
+            },
+        };
+
+        assert!(matches!(apply(&mut wb, &op), Err(OpError::NumFmtTableFull)));
+        assert_eq!(
+            wb, before,
+            "a failed range format must not leave interned entries behind"
+        );
     }
 }

--- a/crates/xlsx-ops/src/apply.rs
+++ b/crates/xlsx-ops/src/apply.rs
@@ -30,6 +30,7 @@ pub enum OpError {
     ChartAnchorNotMovable { part: String },
     ChartNotFound { frame: String },
     ChartFrameShifted { frame: String },
+    NumFmtTableFull,
     InvalidStyle(String),
 }
 
@@ -37,6 +38,7 @@ impl fmt::Display for OpError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             OpError::SheetNotFound(id) => write!(f, "sheet {} not found", id.0),
+            OpError::NumFmtTableFull => write!(f, "number format table is full"),
             OpError::SheetIndexOutOfRange(i) => write!(f, "sheet index {i} out of range"),
             OpError::FormulaNotRewritable { sheet, cell } => write!(
                 f,
@@ -350,12 +352,21 @@ fn apply_range_formats(
             cells.push((at, sheet_ref.cell(at).cloned().unwrap_or_default()));
         }
     }
-    let mut inverse = Vec::with_capacity(cells.len());
-    for (at, old) in cells {
-        let mut format = wb.styles.cell_format(old.style);
+    let mut staged_styles = wb.styles.clone();
+    let mut staged = Vec::with_capacity(cells.len());
+    for (at, old) in &cells {
+        let mut format = staged_styles.cell_format(old.style);
         update(&mut format, at.row, at.col)?;
+        let style = staged_styles
+            .intern_cell_format(&format)
+            .map_err(|_| OpError::NumFmtTableFull)?;
         let mut next = old.clone();
-        next.style = wb.styles.intern_cell_format(&format);
+        next.style = style;
+        staged.push((*at, next));
+    }
+    wb.styles = staged_styles;
+    let mut inverse = Vec::with_capacity(staged.len());
+    for ((at, old), (_staged_at, next)) in cells.into_iter().zip(staged) {
         if next != old {
             wb.sheet_mut(sheet)
                 .ok_or(OpError::SheetNotFound(sheet))?
@@ -1832,5 +1843,57 @@ mod tests {
             wb.value(SheetId(0), r("A4")),
             CellValue::Number { value: 4.0 }
         );
+    }
+}
+
+#[cfg(test)]
+mod range_format_exhaustion_tests {
+    use super::*;
+    use crate::formatting::CapturedFormat;
+    use xlsx_model::{CellFormat, CellRange, NumberFormat, SheetId};
+
+    #[test]
+    fn mid_range_format_exhaustion_leaves_the_workbook_unchanged() {
+        let mut styles = xlsx_model::Stylesheet::default();
+        styles.num_fmts = (164..u16::MAX).map(|id| (id, format!("p{id}"))).collect();
+        let mut wb = Workbook {
+            styles,
+            ..Workbook::default()
+        };
+        wb.sheets.push(xlsx_model::Sheet::new("Sheet1"));
+        let sheet = SheetId(0);
+        let before = wb.clone();
+
+        let op = Op::ApplyRangeFormat {
+            sheet,
+            range: CellRange::new(
+                xlsx_model::CellRef::new(0, 0),
+                xlsx_model::CellRef::new(0, 1),
+            ),
+            format: CapturedFormat {
+                rows: 1,
+                columns: 2,
+                formats: vec![
+                    CellFormat {
+                        number_format: NumberFormat::Custom {
+                            pattern: "one".into(),
+                        },
+                        ..CellFormat::default()
+                    },
+                    CellFormat {
+                        number_format: NumberFormat::Custom {
+                            pattern: "two".into(),
+                        },
+                        ..CellFormat::default()
+                    },
+                ],
+            },
+        };
+
+        assert!(matches!(
+            apply_ops(&mut wb, &[op]),
+            Err(OpError::NumFmtTableFull)
+        ));
+        assert_eq!(wb, before, "exhaustion must leave the workbook untouched");
     }
 }

--- a/crates/xlsx-ops/src/apply.rs
+++ b/crates/xlsx-ops/src/apply.rs
@@ -344,46 +344,90 @@ fn apply_range_formats(
     range: CellRange,
     mut update: impl FnMut(&mut xlsx_model::CellFormat, u32, u32) -> Result<(), OpError>,
 ) -> Result<InvertedOp, OpError> {
-    let sheet_ref = wb.sheet(sheet).ok_or(OpError::SheetNotFound(sheet))?;
-    let mut cells = Vec::new();
-    for row in range.start.row..=range.end.row {
-        for col in range.start.col..=range.end.col {
-            let at = CellRef::new(row, col);
-            cells.push((at, sheet_ref.cell(at).cloned().unwrap_or_default()));
-        }
+    if wb.sheet(sheet).is_none() {
+        return Err(OpError::SheetNotFound(sheet));
     }
     let marks = wb.styles.pool_marks();
-    let mut staged = Vec::with_capacity(cells.len());
-    for (at, old) in &cells {
-        let staged_cell = (|| {
-            let mut format = wb.styles.cell_format(old.style);
-            update(&mut format, at.row, at.col)?;
-            let style = wb
-                .styles
-                .intern_cell_format(&format)
-                .map_err(|_| OpError::NumFmtTableFull)?;
-            let mut next = old.clone();
-            next.style = style;
-            Ok(next)
-        })();
-        match staged_cell {
-            Ok(next) => staged.push((*at, next)),
-            Err(error) => {
-                wb.styles.restore_pools(marks);
-                return Err(error);
+    let rows = range
+        .end
+        .row
+        .checked_sub(range.start.row)
+        .map_or(0, |rows| u64::from(rows) + 1);
+    let cols = range
+        .end
+        .col
+        .checked_sub(range.start.col)
+        .map_or(0, |cols| u64::from(cols) + 1);
+    let range_cells = rows.saturating_mul(cols);
+    let mut staged = Vec::with_capacity(usize::try_from(range_cells).unwrap_or(0));
+    {
+        let sheet_ref = &wb.sheets[sheet.0 as usize];
+        let styles = &mut wb.styles;
+        let mut occupied = sheet_ref
+            .iter_cells_in_rect(
+                range.start.row..range.end.row.saturating_add(1),
+                range.start.col..range.end.col.saturating_add(1),
+            )
+            .peekable();
+        for row in range.start.row..=range.end.row {
+            for col in range.start.col..=range.end.col {
+                let at = CellRef::new(row, col);
+                let old_style = if occupied
+                    .peek()
+                    .is_some_and(|(candidate, _)| (candidate.row, candidate.col) == (row, col))
+                {
+                    occupied.next().and_then(|(_, cell)| cell.style)
+                } else {
+                    None
+                };
+                let mut format = styles.cell_format(old_style);
+                if let Err(error) = update(&mut format, at.row, at.col) {
+                    styles.restore_pools(marks);
+                    return Err(error);
+                }
+                match styles.intern_cell_format(&format) {
+                    Ok(style) => staged.push(style),
+                    Err(_) => {
+                        styles.restore_pools(marks);
+                        return Err(OpError::NumFmtTableFull);
+                    }
+                }
             }
         }
     }
     let mut inverse = Vec::with_capacity(staged.len());
-    for ((at, old), (_staged_at, next)) in cells.into_iter().zip(staged) {
-        if next != old {
-            wb.sheet_mut(sheet)
-                .ok_or(OpError::SheetNotFound(sheet))?
-                .set_cell(at, next);
+    let sheet_ref = wb.sheet_mut(sheet).ok_or(OpError::SheetNotFound(sheet))?;
+    let mut staged = staged.into_iter();
+    for row in range.start.row..=range.end.row {
+        for col in range.start.col..=range.end.col {
+            let at = CellRef::new(row, col);
+            let style = staged.next().expect("stage covers the range");
+            let (old, remove) = match sheet_ref.cell_mut(at) {
+                Some(cell) if style != cell.style => {
+                    let old = CellState::from(&*cell);
+                    cell.style = style;
+                    (old, *cell == Cell::default())
+                }
+                Some(_) => continue,
+                None if style.is_some() => {
+                    sheet_ref.set_cell(
+                        at,
+                        Cell {
+                            style,
+                            ..Cell::default()
+                        },
+                    );
+                    (CellState::default(), false)
+                }
+                None => continue,
+            };
+            if remove {
+                sheet_ref.set_cell(at, Cell::default());
+            }
             inverse.push(Op::SetCell {
                 sheet,
                 at,
-                cell: CellState::from(old),
+                cell: old,
             });
         }
     }

--- a/crates/xlsx-ops/tests/integration.rs
+++ b/crates/xlsx-ops/tests/integration.rs
@@ -3,7 +3,8 @@
 use xlsx_model::{CellProvider, CellRange, CellRef, CellValue, Sheet, SheetId, Workbook};
 use xlsx_ops::{
     BorderLineStyle, BorderPatch, BorderPreset, CellState, HorizontalAlignment,
-    NumberFormatMutation, Op, Provenance, StylePatch, TextWrapping, Transaction, UndoStack, apply,
+    NumberFormatMutation, Op, Provenance, StylePatch, StyleProperty, TextWrapping, Transaction,
+    UndoStack, apply,
 };
 
 fn r(a1: &str) -> CellRef {
@@ -269,4 +270,38 @@ fn range_style_and_number_format_are_undoable() {
             .font
             .bold
     );
+}
+
+#[test]
+fn clearing_a_style_only_cell_restores_sparse_storage() {
+    let mut wb = Workbook::default();
+    wb.sheets.push(Sheet::new("Sheet1"));
+    let range = CellRange::parse_a1("A1").unwrap();
+    apply(
+        &mut wb,
+        &Op::PatchRangeStyle {
+            sheet: SheetId(0),
+            range,
+            patch: StylePatch {
+                italic: Some(true),
+                ..StylePatch::default()
+            },
+        },
+    )
+    .unwrap();
+    assert!(wb.sheets[0].cell(r("A1")).is_some());
+
+    apply(
+        &mut wb,
+        &Op::PatchRangeStyle {
+            sheet: SheetId(0),
+            range,
+            patch: StylePatch {
+                clear: vec![StyleProperty::Italic],
+                ..StylePatch::default()
+            },
+        },
+    )
+    .unwrap();
+    assert!(wb.sheets[0].cell(r("A1")).is_none());
 }

--- a/crates/xlsx-ops/tests/range_format_staging.rs
+++ b/crates/xlsx-ops/tests/range_format_staging.rs
@@ -1,0 +1,86 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use xlsx_model::{Cell, CellRange, CellRef, CellValue, Sheet, SheetId, Workbook};
+use xlsx_ops::{Op, StylePatch, apply};
+
+struct TrackingAllocator;
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+fn record_allocation(size: usize) {
+    let live = LIVE_BYTES.fetch_add(size, Ordering::SeqCst) + size;
+    PEAK_BYTES.fetch_max(live, Ordering::SeqCst);
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        LIVE_BYTES.fetch_sub(layout.size(), Ordering::SeqCst);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let next = unsafe { System.realloc(ptr, layout, new_size) };
+        if !next.is_null() {
+            if new_size >= layout.size() {
+                record_allocation(new_size - layout.size());
+            } else {
+                LIVE_BYTES.fetch_sub(layout.size() - new_size, Ordering::SeqCst);
+            }
+        }
+        next
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+#[test]
+fn range_format_staging_holds_only_style_indices() {
+    const CELLS: usize = 1_000;
+    const TEXT_BYTES: usize = 8 * 1_024;
+
+    let mut sheet = Sheet::new("Data");
+    for row in 0..CELLS {
+        sheet.set_cell(
+            CellRef::new(row as u32, 0),
+            Cell {
+                value: CellValue::Text {
+                    value: "x".repeat(TEXT_BYTES),
+                },
+                ..Cell::default()
+            },
+        );
+    }
+    let mut workbook = Workbook::default();
+    workbook.sheets.push(sheet);
+    let op = Op::PatchRangeStyle {
+        sheet: SheetId(0),
+        range: CellRange::new(CellRef::new(0, 0), CellRef::new((CELLS - 1) as u32, 0)),
+        patch: StylePatch {
+            italic: Some(true),
+            ..StylePatch::default()
+        },
+    };
+
+    let baseline = LIVE_BYTES.load(Ordering::SeqCst);
+    PEAK_BYTES.store(baseline, Ordering::SeqCst);
+    let inverse = apply(&mut workbook, &op).unwrap();
+    let added_peak = PEAK_BYTES.load(Ordering::SeqCst) - baseline;
+    black_box(inverse);
+
+    assert!(
+        added_peak < CELLS * TEXT_BYTES * 3 / 2,
+        "range staging retained {added_peak} bytes above baseline"
+    );
+}

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -1357,12 +1357,16 @@ fn patches_only_the_style_pool_entries_that_changed() {
     let mut workbook = parsed.workbook.clone();
     let mut format = workbook.styles.cell_format(None);
     format.font.italic = true;
-    let style = workbook.styles.intern_cell_format(&format);
+    let style = workbook
+        .styles
+        .intern_cell_format(&format)
+        .unwrap()
+        .unwrap();
     workbook.sheets[0].set_cell(
         CellRef::parse_a1("A1").unwrap(),
         Cell {
             value: CellValue::Number { value: 1.0 },
-            style,
+            style: Some(style),
             ..Cell::default()
         },
     );

--- a/crates/xlsx-render/src/lib.rs
+++ b/crates/xlsx-render/src/lib.rs
@@ -1372,6 +1372,7 @@ mod tests {
                 },
                 ..xlsx_model::CellFormat::default()
             })
+            .unwrap()
             .unwrap();
         let mut sheet = Sheet::new("Sheet1");
         sheet.set_cell(


### PR DESCRIPTION
TL;DR:

Summary:
- style pools intern through hash indexes instead of linear scans; every memo hit re-verifies against the live pool, so public same-length mutations can never yield a stale index
- number-format allocation validates candidates against the live table and fails explicitly (`NumFmtTableFull`) when ids are exhausted instead of silently colliding
- range formatting stages against a cloned stylesheet and commits only on success — mid-range exhaustion leaves the workbook untouched
- note for review: `Stylesheet` gains private interning caches, which prevents exhaustive struct-literal construction downstream (changeset carries a minor bump)

Test plan:
- [ ] `cargo test -p betteroffice-xlsx-model -p betteroffice-xlsx-ops` green
- [ ] apply formatting to a large range on a style-heavy workbook — timing before/after
- [ ] round-trip styles.xml byte-fidelity on real workbooks