### PR TITLE
fix(redact): cover pivot caches, threaded comments and metadata

### DIFF
--- a/.changeset/redact-scrub-coverage.md
+++ b/.changeset/redact-scrub-coverage.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": patch
+---
+
+Scrub pivot caches, threaded comments, connections and document metadata.

--- a/crates/ooxml-redact/src/lib.rs
+++ b/crates/ooxml-redact/src/lib.rs
@@ -1,12 +1,18 @@
 mod media;
 mod xml;
 
+use std::collections::hash_map::RandomState;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::hash::BuildHasher;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use quick_xml::Reader;
+use quick_xml::events::Event;
 use thiserror::Error;
 
 use crate::media::replace_media;
-use crate::xml::redact_xml;
+use crate::xml::{RunState, redact_xml};
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Format {
@@ -90,12 +96,26 @@ pub fn redact_with_report(
         format: detected,
         ..RedactionReport::default()
     };
+    let content_types = PackageContentTypes::parse(&parts);
+    let mut mappings = IdMappings {
+        salt: Some(run_salt()),
+        ..IdMappings::default()
+    };
     for (path, data) in &mut parts {
         let lower = path.to_ascii_lowercase();
         if media::is_replaceable_part(&lower) {
             *data = replace_media(path, data, &mut report)?;
-        } else if is_xml_part(&lower) {
-            *data = redact_xml(detected, path, data, &mut report)?;
+            continue;
+        }
+        let content_type = content_types.resolve(&lower);
+        let classified_xml =
+            is_xml_part(&lower) || content_type.as_deref().is_some_and(is_xml_content_type);
+        if classified_xml {
+            let mut state = RunState {
+                report: &mut report,
+                mappings: &mut mappings,
+            };
+            *data = redact_xml(detected, path, content_type.as_deref(), data, &mut state)?;
         } else if is_sensitive_binary(&lower) {
             data.clear();
             report.binary_parts += 1;
@@ -104,6 +124,189 @@ pub fn redact_with_report(
 
     let output = ooxml_opc::rezip_parts(&parts).map_err(RedactError::Container)?;
     Ok((output, report))
+}
+
+fn is_xml_content_type(content_type: &str) -> bool {
+    content_type.ends_with("+xml") || content_type.ends_with("/xml")
+}
+
+/// Per-run entropy so FNV-derived pseudonyms cannot be dictionary-tested
+/// across documents produced by separate redaction runs.
+fn run_salt() -> u64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos() as u64);
+    let random = RandomState::new().hash_one(nanos);
+    let address = &nanos as *const u64 as usize as u64;
+    nanos ^ random ^ address
+}
+
+pub(crate) fn stable_hash(value: &str) -> u32 {
+    let mut hash: u32 = 0x811C_9DC5;
+    for byte in value.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
+}
+
+#[derive(Default)]
+pub(crate) struct IdMappings {
+    salt: Option<u64>,
+    hex_ids: HashMap<String, String>,
+    ref_names: HashMap<String, String>,
+    guids: HashMap<String, String>,
+    taken: HashSet<String>,
+}
+
+impl IdMappings {
+    pub(crate) fn hex_id(&mut self, original: &str) -> String {
+        Self::assign(&mut self.hex_ids, &mut self.taken, original, self.salt)
+    }
+
+    pub(crate) fn ref_name(&mut self, original: &str) -> String {
+        format!(
+            "r{}",
+            Self::assign(&mut self.ref_names, &mut self.taken, original, self.salt)
+        )
+    }
+
+    pub(crate) fn guid(&mut self, original: &str) -> String {
+        if let Some(assigned) = self.guids.get(original) {
+            return assigned.clone();
+        }
+        let mut candidate = format_guid(&self.guid_digest(original));
+        let mut salt: u32 = 0;
+        while self.taken.contains(&candidate) {
+            salt += 1;
+            candidate = format_guid(&self.guid_digest(&format!("{original}|{salt}")));
+        }
+        self.taken.insert(candidate.clone());
+        self.guids.insert(original.to_owned(), candidate.clone());
+        candidate
+    }
+
+    fn digest(salt: Option<u64>, input: &str) -> u32 {
+        match salt {
+            Some(salt) => stable_hash(&format!("{salt:016x}{input}")),
+            None => stable_hash(input),
+        }
+    }
+
+    fn assign(
+        map: &mut HashMap<String, String>,
+        taken: &mut HashSet<String>,
+        original: &str,
+        salt: Option<u64>,
+    ) -> String {
+        if let Some(assigned) = map.get(original) {
+            return assigned.clone();
+        }
+        let mut candidate = format!("{:08X}", Self::digest(salt, original));
+        let mut bump: u32 = 0;
+        while taken.contains(&candidate) {
+            bump += 1;
+            candidate = format!("{:08X}", Self::digest(salt, &format!("{original}|{bump}")));
+        }
+        taken.insert(candidate.clone());
+        map.insert(original.to_owned(), candidate.clone());
+        candidate
+    }
+
+    fn guid_digest(&self, input: &str) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        for (index, chunk) in bytes.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            chunk.copy_from_slice(
+                &Self::digest(self.salt, &format!("{input}@{index}")).to_be_bytes(),
+            );
+        }
+        bytes
+    }
+}
+
+fn format_guid(bytes: &[u8; 16]) -> String {
+    let mut shaped = *bytes;
+    shaped[6] = (shaped[6] & 0x0F) | 0x40;
+    shaped[8] = (shaped[8] & 0x3F) | 0x80;
+    let hex: String = shaped.iter().map(|byte| format!("{byte:02X}")).collect();
+    format!(
+        "{{{}-{}-{}-{}-{}}}",
+        &hex[..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..]
+    )
+}
+
+/// Content types declared by `[Content_Types].xml`, via `Override` (per part)
+/// and `Default` (per extension). Only XML content types resolve.
+#[derive(Default)]
+struct PackageContentTypes {
+    overrides: HashMap<String, String>,
+    defaults: HashMap<String, String>,
+}
+
+impl PackageContentTypes {
+    fn parse(parts: &[(String, Vec<u8>)]) -> Self {
+        let Some((_, bytes)) = parts
+            .iter()
+            .find(|(path, _)| path.eq_ignore_ascii_case("[Content_Types].xml"))
+        else {
+            return Self::default();
+        };
+        let mut reader = Reader::from_reader(bytes.as_slice());
+        let mut declarations = Self::default();
+        loop {
+            match reader.read_event() {
+                Ok(Event::Start(start)) | Ok(Event::Empty(start))
+                    if matches!(start.name().local_name().as_ref(), b"Override" | b"Default") =>
+                {
+                    let mut key = None;
+                    let mut content_type = None;
+                    for attribute in start.attributes().flatten() {
+                        let name = String::from_utf8_lossy(attribute.key.local_name().as_ref())
+                            .to_lowercase();
+                        match name.as_str() {
+                            "partname" | "extension" => {
+                                key = Some(String::from_utf8_lossy(&attribute.value).into_owned());
+                            }
+                            "contenttype" => {
+                                content_type =
+                                    Some(String::from_utf8_lossy(&attribute.value).into_owned());
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let Some((key, content_type)) = key.zip(content_type) {
+                        let lower = content_type.to_ascii_lowercase();
+                        if start.name().local_name().as_ref() == b"Override" {
+                            declarations
+                                .overrides
+                                .insert(key.trim_start_matches('/').to_ascii_lowercase(), lower);
+                        } else if !key.is_empty() {
+                            declarations
+                                .defaults
+                                .insert(key.to_ascii_lowercase(), lower);
+                        }
+                    }
+                }
+                Ok(Event::Eof) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+        declarations
+    }
+
+    fn resolve(&self, path_lower: &str) -> Option<String> {
+        let content_type = self.overrides.get(path_lower).cloned().or_else(|| {
+            let extension = path_lower
+                .rsplit_once('.')
+                .map(|(_, extension)| extension)?;
+            self.defaults.get(extension).cloned()
+        })?;
+        is_xml_content_type(&content_type).then_some(content_type)
+    }
 }
 
 fn detect_parts(parts: &[(String, Vec<u8>)]) -> Result<Format, RedactError> {

--- a/crates/ooxml-redact/src/tests.rs
+++ b/crates/ooxml-redact/src/tests.rs
@@ -15,6 +15,10 @@ const DOCX_SECRETS: &[&str] = &[
     "DOCX_SECRET_TITLE",
     "DOCX_SECRET_COMPANY",
     "https://secret.example/docx",
+    "DOCX_SECRET_IDENTIFIER",
+    "DOCX_SECRET_LANGUAGE",
+    "DOCX_SECRET_VERSION",
+    "DOCX_SECRET_CONTENT_TYPE",
 ];
 const XLSX_SECRETS: &[&str] = &[
     "XLSX_SECRET_TEXT",
@@ -214,7 +218,7 @@ fn docx_fixture() -> Vec<u8> {
         (
             "docProps/core.xml",
             xml(
-                r#"<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>DOCX_SECRET_TITLE</dc:title><dc:creator>DOCX_SECRET_AUTHOR</dc:creator></cp:coreProperties>"#,
+                r#"<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>DOCX_SECRET_TITLE</dc:title><dc:creator>DOCX_SECRET_AUTHOR</dc:creator><dc:identifier>DOCX_SECRET_IDENTIFIER</dc:identifier><dc:language>DOCX_SECRET_LANGUAGE</dc:language><cp:version>DOCX_SECRET_VERSION</cp:version><cp:contentType>DOCX_SECRET_CONTENT_TYPE</cp:contentType></cp:coreProperties>"#,
             ),
         ),
         (
@@ -366,6 +370,1300 @@ fn pptx_fixture() -> Vec<u8> {
 }
 
 #[test]
+fn pivot_cache_values_are_scrubbed() {
+    let definition = r##"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheFields count="5"><cacheField name="Customer"><sharedItems count="1"><s v="PIVOT_CACHE_SECRET"/></sharedItems></cacheField><cacheField name="Amount"><sharedItems containsString="0" containsNumber="1" count="1"><n v="89.45"/></sharedItems></cacheField><cacheField name="Active"><sharedItems containsSemiMixedTypes="0" containsString="0" containsNumber="1" containsInteger="1" count="1"><b v="1"/></sharedItems></cacheField><cacheField name="Ordered"><sharedItems containsNonDate="0" containsDate="1" containsString="0" count="1"><d v="2024-05-06T07:08:09Z"/></sharedItems></cacheField><cacheField name="Ratio"><sharedItems count="1"><e v="#DIV/0!"/></sharedItems></cacheField></cacheFields></pivotCacheDefinition>"##;
+    let records = r##"<pivotCacheRecords xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1"><r><x v="0"/><n v="12.5"/><b v="1"/><d v="2024-05-06T07:08:09Z"/><e v="#DIV/0!"/><s v="PIVOT_RECORD_SECRET"/></r></pivotCacheRecords>"##;
+    let definition_out = scrub(
+        Format::Xlsx,
+        "xl/pivotCache/pivotCacheDefinition1.xml",
+        definition.as_bytes(),
+    );
+    let records_out = scrub(
+        Format::Xlsx,
+        "xl/pivotCache/pivotCacheRecords1.xml",
+        records.as_bytes(),
+    );
+    assert!(!definition_out.contains("PIVOT_CACHE_SECRET"));
+    assert!(!records_out.contains("PIVOT_RECORD_SECRET"));
+    for leaked in ["89.45", "2024-05-06", "#DIV/0!"] {
+        assert!(
+            !definition_out.contains(leaked) && !records_out.contains(leaked),
+            "{leaked} survived"
+        );
+    }
+    assert!(definition_out.contains(r#"<s v="xxxxxxxxxxxxxxxxxx"/>"#));
+    assert!(records_out.contains(r#"<s v="xxxxxxxxxxxxxxxxxxx"/>"#));
+    for typed in [
+        r#"<n v="0"/>"#,
+        r#"<b v="0"/>"#,
+        r#"<d v="1970-01-01T00:00:00Z"/>"#,
+        r##"<e v="#N/A"/>"##,
+    ] {
+        assert!(definition_out.contains(typed), "{typed} missing");
+        assert!(records_out.contains(typed), "{typed} missing");
+    }
+    assert!(records_out.contains(r#"<x v="0"/>"#), "index was rewritten");
+    assert_eq!(definition_out.matches("count=\"1\"").count(), 5);
+}
+
+#[test]
+fn threaded_comment_text_and_person_identity_are_scrubbed() {
+    let comments = r#"<threadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><threadedComment ref="A1" dT="2024-01-01T00:00:00Z" id="{11111111-1111-1111-1111-111111111111}" personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"><text>THREAD_SECRET_TEXT</text></threadedComment><threadedComment ref="A2" dT="2024-01-02T00:00:00Z" id="{44444444-4444-4444-4444-444444444444}" parentId="{11111111-1111-1111-1111-111111111111}" personId="{22222222-2222-2222-2222-222222222222}"><mentions><mention personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" mentionpersonId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" mentionId="{66666666-6666-6666-6666-666666666666}" displayName="MENTION_NAME_SECRET"/></mentions><text>REPLY_SECRET_TEXT</text></threadedComment><extLst><ext uri="{D4E1A1F8-D4E1-A1F8-0000-400080000001}"><tcExt count="3"><checksum>1234567890</checksum></tcExt></ext></extLst></threadedComments>"#;
+    let persons = r#"<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><person id="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" displayName="PERSON_SECRET_NAME" userId="USER_SECRET_ID" providerId="PROVIDER_SECRET_ID"/><person id="{22222222-2222-2222-2222-222222222222}" displayName="PERSON_TWO_NAME" userId="USER_TWO_ID" providerId="PROVIDER_TWO_ID"/></personList>"#;
+    let comments_out = scrub(
+        Format::Xlsx,
+        "xl/threadedComments/threadedComment1.xml",
+        comments.as_bytes(),
+    );
+    let persons_out = scrub(Format::Xlsx, "xl/persons/person.xml", persons.as_bytes());
+    for secret in [
+        "THREAD_SECRET_TEXT",
+        "REPLY_SECRET_TEXT",
+        "2024-01-01",
+        "MENTION_NAME_SECRET",
+        "PERSON_SECRET_NAME",
+        "PERSON_TWO_NAME",
+        "USER_SECRET_ID",
+        "USER_TWO_ID",
+        "PROVIDER_SECRET_ID",
+        "PROVIDER_TWO_ID",
+        "{11111111-1111-1111-1111-111111111111}",
+        "{44444444-4444-4444-4444-444444444444}",
+        "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}",
+        "{22222222-2222-2222-2222-222222222222}",
+        "{66666666-6666-6666-6666-666666666666}",
+        "1234567890",
+    ] {
+        assert!(
+            !comments_out.contains(secret) && !persons_out.contains(secret),
+            "{secret} survived"
+        );
+    }
+    assert!(
+        comments_out.contains("<checksum>0</checksum>"),
+        "checksum element text must be neutralized: {comments_out}"
+    );
+    assert!(comments_out.contains("ref=\"A1\""));
+    assert_xsd_date_time(&attribute_value(&comments_out, "dT").unwrap());
+
+    let comment_ids = tag_attribute_values(&comments_out, "threadedComment", "id");
+    let parent_ids = tag_attribute_values(&comments_out, "threadedComment", "parentId");
+    let comment_person_ids = tag_attribute_values(&comments_out, "threadedComment", "personId");
+    let mention_ids = tag_attribute_values(&comments_out, "mention", "mentionId");
+    let mention_person_ids = tag_attribute_values(&comments_out, "mention", "personId");
+    let mention_mention_ids = tag_attribute_values(&comments_out, "mention", "mentionpersonId");
+    let person_ids = tag_attribute_values(&persons_out, "person", "id");
+    for value in comment_ids
+        .iter()
+        .chain(parent_ids.iter())
+        .chain(comment_person_ids.iter())
+        .chain(mention_ids.iter())
+        .chain(mention_person_ids.iter())
+        .chain(mention_mention_ids.iter())
+        .chain(person_ids.iter())
+    {
+        assert_guid(value);
+    }
+    assert_eq!(
+        parent_ids[0], comment_ids[0],
+        "reply parentId must track parent threadedComment id"
+    );
+    assert_eq!(
+        mention_mention_ids[0], comment_person_ids[0],
+        "mention@mentionpersonId must track the mentioned threadedComment@personId"
+    );
+    assert_eq!(
+        mention_person_ids[0], person_ids[0],
+        "mention@personId must track person@id"
+    );
+}
+
+#[test]
+fn threaded_comment_person_identity_maps_consistently_across_parts() {
+    let comments = r#"<threadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><threadedComment ref="A1" dT="2024-01-01T00:00:00Z" personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"><text>THREAD_SECRET_TEXT</text></threadedComment></threadedComments>"#;
+    let persons = r#"<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><person id="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" displayName="PERSON_SECRET_NAME" userId="USER_SECRET_ID" providerId="PROVIDER_SECRET_ID"/></personList>"#;
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    let comments_out = scrub_shared(
+        Format::Xlsx,
+        "xl/threadedComments/threadedComment1.xml",
+        comments.as_bytes(),
+        &mut RunState {
+            report: &mut report,
+            mappings: &mut mappings,
+        },
+    );
+    let persons_out = scrub_shared(
+        Format::Xlsx,
+        "xl/persons/person.xml",
+        persons.as_bytes(),
+        &mut RunState {
+            report: &mut report,
+            mappings: &mut mappings,
+        },
+    );
+    assert!(!comments_out.contains("{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"));
+    let comment_person_id = attribute_value(&comments_out, "personId").unwrap();
+    let person_id = attribute_value(&persons_out, "id").unwrap();
+    assert_guid(&comment_person_id);
+    assert_guid(&person_id);
+    assert_eq!(
+        comment_person_id, person_id,
+        "matching originals must share one placeholder across parts"
+    );
+}
+
+#[test]
+fn database_connection_strings_are_scrubbed() {
+    let connections = r#"<connections xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><connection id="1" name="db" type="101" keepAlive="1" odcFile="ODC_FILE_PATH_SECRET" sourceFile="SOURCE_FILE_PATH_SECRET"><dbPr connection="CONNECTION_STRING_SECRET" command="COMMAND_TEXT_SECRET" serverCommand="SERVER_COMMAND_SECRET"/><olapPr sendLocale="1" localConnection="OLAP_CONNECTION_SECRET"/><webPr htmlTables="1" url="WEB_QUERY_URL_SECRET"/></connection><parameters count="5"><parameter name="Region" string="PARAMETER_VALUE_SECRET"/><parameter name="Limit" double="99.5"/><parameter name="Enabled" boolean="1"/><parameter name="Hint" prompt="PROMPT_TEXT_SECRET"/><parameter name="Anchor" cell="CELL_REF_SECRET"/></parameters></connections>"#;
+    let output = scrub(Format::Xlsx, "xl/connections.xml", connections.as_bytes());
+    for secret in [
+        "CONNECTION_STRING_SECRET",
+        "COMMAND_TEXT_SECRET",
+        "SERVER_COMMAND_SECRET",
+        "OLAP_CONNECTION_SECRET",
+        "WEB_QUERY_URL_SECRET",
+        "PARAMETER_VALUE_SECRET",
+        "ODC_FILE_PATH_SECRET",
+        "SOURCE_FILE_PATH_SECRET",
+        "PROMPT_TEXT_SECRET",
+        "CELL_REF_SECRET",
+        "99.5",
+    ] {
+        assert!(!output.contains(secret), "{secret} survived");
+    }
+    for preserved in ["keepAlive=\"1\"", "sendLocale=\"1\"", "htmlTables=\"1\""] {
+        assert!(output.contains(preserved), "{preserved} was rewritten");
+    }
+    let names = tag_attribute_values(&output, "parameter", "name");
+    assert_eq!(names.len(), 5);
+    let connection_name = tag_attribute(&output, "connection ", "name").unwrap();
+    assert_ref_name(&connection_name);
+    for value in &names {
+        assert_ref_name(value);
+    }
+    let mut unique = names.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), names.len(), "distinct originals diverged");
+    let strings = tag_attribute_values(&output, "parameter", "string");
+    assert_eq!(strings.len(), 1);
+    assert!(
+        strings[0].bytes().all(|byte| byte == b'x'),
+        "{}",
+        strings[0]
+    );
+    for attribute in ["prompt", "cell"] {
+        let values = tag_attribute_values(&output, "parameter", attribute);
+        assert_eq!(values.len(), 1, "{attribute}");
+        assert!(values[0].bytes().all(|byte| byte == b'x'), "{}", values[0]);
+    }
+    for attribute in ["double", "boolean"] {
+        let values = tag_attribute_values(&output, "parameter", attribute);
+        assert_eq!(values, vec!["0".to_owned()], "{attribute}");
+    }
+}
+
+#[test]
+fn pivot_cache_refresh_metadata_is_scrubbed() {
+    let definition = r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" invalid="1" refreshOnLoad="1" refreshedBy="REFRESHED_BY_SECRET" refreshedDate="45418.297222222226" refreshedDateIso="2024-05-06T07:08:09Z" createdVersion="1" refreshedVersion="1" recordCount="1"><cacheSource type="worksheet"><worksheetSource ref="A1:C4" sheet="Data"/></cacheSource></pivotCacheDefinition>"#;
+    let output = scrub(
+        Format::Xlsx,
+        "xl/pivotCache/pivotCacheDefinition1.xml",
+        definition.as_bytes(),
+    );
+    assert!(!output.contains("REFRESHED_BY_SECRET"));
+    assert!(output.contains(r#"refreshedBy="xxxxxxxxxxxxxxxxxxx""#));
+    assert!(!output.contains("2024-05-06"));
+    assert!(!output.contains("45418.297222222226"));
+    assert_eq!(
+        attribute_value(&output, "refreshedDate").as_deref(),
+        Some("45000")
+    );
+    assert_eq!(
+        attribute_value(&output, "refreshedDateIso").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert!(output.contains(r#"recordCount="1""#));
+}
+
+#[test]
+fn pivot_cache_definition_names_and_sources_are_scrubbed() {
+    let definition = r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" refreshedDate="45418.297222222226"><cacheSource type="worksheet"><worksheetSource ref="A1:C4" sheet="SHEET_NAME_SECRET" name="RANGE_NAME_SECRET"/></cacheSource><cacheFields count="1"><cacheField name="FIELD_NAME_SECRET" caption="FIELD_CAPTION_SECRET" propertyName="PROPERTY_NAME_SECRET" formula="FIELD_FORMULA_SECRET" numFmtId="0"><sharedItems count="1"><s v="PIVOT_CACHE_SECRET"/></sharedItems></cacheField></cacheFields><calculatedItems count="1"><calculatedItem index="0"><formula>CALC_ITEM_FORMULA_SECRET</formula></calculatedItem></calculatedItems></pivotCacheDefinition>"#;
+    let slicer_cache = r#"<slicerCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" name="CACHE_NAME_OK" sourceName="FIELD_NAME_SECRET"/>"#;
+    let output = scrub(
+        Format::Xlsx,
+        "xl/pivotCache/pivotCacheDefinition1.xml",
+        definition.as_bytes(),
+    );
+    for secret in [
+        "45418.297222222226",
+        "SHEET_NAME_SECRET",
+        "RANGE_NAME_SECRET",
+        "FIELD_NAME_SECRET",
+        "FIELD_CAPTION_SECRET",
+        "PROPERTY_NAME_SECRET",
+        "FIELD_FORMULA_SECRET",
+        "CALC_ITEM_FORMULA_SECRET",
+    ] {
+        assert!(!output.contains(secret), "{secret} survived");
+    }
+    assert_eq!(
+        attribute_value(&output, "refreshedDate").as_deref(),
+        Some("45000")
+    );
+    assert!(output.contains("<formula>0</formula>"), "{output}");
+    let field_name = tag_attribute(&output, "cacheField ", "name").unwrap();
+    let field_caption = tag_attribute(&output, "cacheField ", "caption").unwrap();
+    assert_ref_name(&field_name);
+    assert_ref_name(&field_caption);
+    let property_name = attribute_value(&output, "propertyName").unwrap();
+    assert_eq!(
+        property_name,
+        "x".repeat("PROPERTY_NAME_SECRET".len()),
+        "cacheField@propertyName must mask like other pivot labels"
+    );
+    for (tag, attribute) in [("worksheetSource", "sheet"), ("worksheetSource", "name")] {
+        let value = tag_attribute_values(&output, tag, attribute).remove(0);
+        assert!(
+            !value.is_empty() && value.bytes().all(|byte| byte == b'x'),
+            "{attribute}={value} is not a masked name"
+        );
+    }
+    let worksheet_sheet = tag_attribute(&output, "worksheetSource ", "sheet").unwrap();
+    let expected_mask = "x".repeat("SHEET_NAME_SECRET".len());
+    assert_eq!(
+        worksheet_sheet, expected_mask,
+        "sheet must mask like sheet@name"
+    );
+    let cache_out = scrub(
+        Format::Xlsx,
+        "xl/slicerCaches/slicerCache1.xml",
+        slicer_cache.as_bytes(),
+    );
+    assert_eq!(
+        attribute_value(&cache_out, "sourceName").unwrap(),
+        field_name,
+        "slicer sourceName must track cacheField@name"
+    );
+}
+
+#[test]
+fn pivot_table_item_names_are_scrubbed() {
+    let pivot_table = r#"<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" name="PivotTable1" dataCaption="DATA_CAPTION_SECRET" rowHeaderCaption="ROW_HEADER_CAPTION_SECRET" cacheId="0"><pivotFields count="1"><pivotField axis="axisRow" showAll="0" name="PIVOT_FIELD_NAME_SECRET" subtotalCaption="SUBTOTAL_CAPTION_SECRET"><items count="2"><item x="0"/><item n="MEMBER_LABEL_SECRET"/></items></pivotField></pivotFields><rowFields count="1"><field x="0"/></rowFields><dataFields count="1"><dataField name="DATA_FIELD_NAME_SECRET" fld="0" baseField="0" baseItem="0"/></dataFields></pivotTableDefinition>"#;
+    let slicer_cache = r#"<slicerCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" name="CACHE_NAME_SECRET" sourceName="MEMBER_LABEL_SECRET"><pivotTables count="1"><pivotTable tabId="1" name="PivotTable1"/></pivotTables></slicerCacheDefinition>"#;
+    let table_out = scrub(
+        Format::Xlsx,
+        "xl/pivotTables/pivotTable1.xml",
+        pivot_table.as_bytes(),
+    );
+    let cache_out = scrub(
+        Format::Xlsx,
+        "xl/slicerCaches/slicerCache1.xml",
+        slicer_cache.as_bytes(),
+    );
+    for secret in [
+        "MEMBER_LABEL_SECRET",
+        "PIVOT_FIELD_NAME_SECRET",
+        "SUBTOTAL_CAPTION_SECRET",
+        "DATA_CAPTION_SECRET",
+        "ROW_HEADER_CAPTION_SECRET",
+        "DATA_FIELD_NAME_SECRET",
+    ] {
+        assert!(!table_out.contains(secret), "{secret} survived");
+    }
+    let item_names = tag_attribute_values(&table_out, "item", "n");
+    assert_eq!(item_names.len(), 1);
+    assert_ref_name(&item_names[0]);
+    let source_name = attribute_value(&cache_out, "sourceName").unwrap();
+    assert_ref_name(&source_name);
+    assert_eq!(
+        item_names[0], source_name,
+        "equal originals must share one RefName placeholder"
+    );
+    let pivot_field_name = tag_attribute(&table_out, "pivotField ", "name").unwrap();
+    let pivot_field_subtotal = tag_attribute(&table_out, "pivotField ", "subtotalCaption").unwrap();
+    assert_eq!(
+        pivot_field_name,
+        "x".repeat("PIVOT_FIELD_NAME_SECRET".len()),
+        "pivotField@name must mask like other pivot labels"
+    );
+    assert_eq!(
+        pivot_field_subtotal,
+        "x".repeat("SUBTOTAL_CAPTION_SECRET".len()),
+        "pivotField@subtotalCaption must mask like other pivot labels"
+    );
+    for (attribute, secret) in [
+        ("dataCaption", "DATA_CAPTION_SECRET"),
+        ("rowHeaderCaption", "ROW_HEADER_CAPTION_SECRET"),
+    ] {
+        let value = attribute_value(&table_out, attribute).unwrap();
+        assert_eq!(
+            value,
+            "x".repeat(secret.len()),
+            "{attribute} must mask like other pivot labels"
+        );
+    }
+    let data_field_name = tag_attribute(&table_out, "dataField ", "name").unwrap();
+    assert_eq!(
+        data_field_name,
+        "x".repeat("DATA_FIELD_NAME_SECRET".len()),
+        "dataField@name must mask like other pivot labels"
+    );
+    let definition_name = tag_attribute(&table_out, "pivotTableDefinition ", "name").unwrap();
+    let cached_table_name = tag_attribute(&cache_out, "pivotTable ", "name").unwrap();
+    assert_ref_name(&definition_name);
+    assert_eq!(
+        definition_name, cached_table_name,
+        "slicerCache pivotTable@name must track pivotTableDefinition@name"
+    );
+    assert_ne!(
+        definition_name,
+        attribute_value(&cache_out, "name").unwrap()
+    );
+}
+
+#[test]
+fn chart_pivot_source_compound_names_use_ref_mappings() {
+    let chart_xml = |name: &str| {
+        format!(
+            r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:pivotSource><c:name>{name}</c:name><c:fmtId val="0"/></c:pivotSource><c:chart><c:plotArea/></c:chart></c:chartSpace>"#
+        )
+    };
+    let pivot_table = r#"<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" name="CHART_TABLE_SOURCE" cacheId="0"/>"#;
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    let mut state = RunState {
+        report: &mut report,
+        mappings: &mut mappings,
+    };
+    let bracketed_out = scrub_shared(
+        Format::Xlsx,
+        "xl/charts/chart1.xml",
+        chart_xml("[CHART_BOOK_SOURCE]CHART_SHEET_SOURCE!CHART_TABLE_SOURCE").as_bytes(),
+        &mut state,
+    );
+    let plain_out = scrub_shared(
+        Format::Xlsx,
+        "xl/charts/chart2.xml",
+        chart_xml("CHART_SHEET_SOURCE!CHART_TABLE_SOURCE").as_bytes(),
+        &mut state,
+    );
+    let table_out = scrub_shared(
+        Format::Xlsx,
+        "xl/pivotTables/pivotTable1.xml",
+        pivot_table.as_bytes(),
+        &mut state,
+    );
+    for output in [&bracketed_out, &plain_out] {
+        for secret in ["CHART_SHEET_SOURCE", "CHART_TABLE_SOURCE"] {
+            assert!(!output.contains(secret), "{secret} survived");
+        }
+    }
+    let definition_name = attribute_value(&table_out, "name").unwrap();
+    assert_ref_name(&definition_name);
+    let bracketed_mapped = between(&bracketed_out, "<c:name>", "</c:name>").unwrap();
+    let book_segment = between(bracketed_mapped, "[", "]").unwrap();
+    assert_eq!(
+        book_segment, "CHART_BOOK_SOURCE",
+        "bracketed workbook filename must stay verbatim"
+    );
+    let plain_mapped = between(&plain_out, "<c:name>", "</c:name>").unwrap();
+    let bracketed_segments = &bracketed_mapped[book_segment.len() + 2..];
+    let plain_split = plain_mapped.split_once('!').unwrap();
+    for (sheet_segment, table_segment) in [bracketed_segments.split_once('!').unwrap(), plain_split]
+    {
+        assert_eq!(
+            sheet_segment,
+            "x".repeat("CHART_SHEET_SOURCE".len()),
+            "chart sheet segment must mask like workbook sheet@name"
+        );
+        assert_ref_name(table_segment);
+        assert_ne!(sheet_segment, table_segment);
+        assert_eq!(
+            table_segment, definition_name,
+            "pivotSource table segment must track pivotTableDefinition@name"
+        );
+    }
+}
+
+#[test]
+fn pivot_cache_extras_are_scrubbed() {
+    let definition = r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheSource type="consolidate"><ranges count="1"><rangeSet ref="A1:C4" sheet="RANGESET_SHEET_SECRET" name="RANGESET_RANGE_NAME_SECRET"/></ranges></cacheSource><cacheHierarchies count="1"><cacheHierarchy caption="HIERARCHY_CAPTION_SECRET" uniqueName="[PRODUCTS].[ALL_PRODUCTS_MEMBERS_SECRET]" dimensionUniqueName="[PRODUCTS_DIMENSION_UNIQUE_SECRET]" allCaption="HIERARCHY_ALL_CAPTION_SECRET" allUniqueName="[PRODUCTS].[ALL_UNIQUE_NAME_SECRET]" defaultMemberUniqueName="[PRODUCTS].[DEFAULT_MEMBER_UNIQUE_SECRET]" displayFolder="DISPLAY_FOLDER_SECRET"/></cacheHierarchies><cacheFields count="1"><cacheField name="EXTRA_FIELD_SECRET" numFmtId="0"/></cacheFields></pivotCacheDefinition>"#;
+    let pivot_table = r#"<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" name="PivotTable9" cacheId="0"><pageFields count="1"><pageField fld="0" hier="-1" name="PAGE_FIELD_NAME_SECRET" cap="PAGE_FIELD_CAPTION_SECRET"/><pageItem name="PivotTable9"/></pageFields></pivotTableDefinition>"#;
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    let mut state = RunState {
+        report: &mut report,
+        mappings: &mut mappings,
+    };
+    let definition_out = scrub_shared(
+        Format::Xlsx,
+        "xl/pivotCache/pivotCacheDefinition1.xml",
+        definition.as_bytes(),
+        &mut state,
+    );
+    let table_out = scrub_shared(
+        Format::Xlsx,
+        "xl/pivotTables/pivotTable1.xml",
+        pivot_table.as_bytes(),
+        &mut state,
+    );
+    for secret in [
+        "RANGESET_SHEET_SECRET",
+        "RANGESET_RANGE_NAME_SECRET",
+        "HIERARCHY_CAPTION_SECRET",
+        "ALL_PRODUCTS_MEMBERS_SECRET",
+        "PRODUCTS_DIMENSION_UNIQUE_SECRET",
+        "HIERARCHY_ALL_CAPTION_SECRET",
+        "ALL_UNIQUE_NAME_SECRET",
+        "DEFAULT_MEMBER_UNIQUE_SECRET",
+        "DISPLAY_FOLDER_SECRET",
+        "EXTRA_FIELD_SECRET",
+        "PAGE_FIELD_NAME_SECRET",
+        "PAGE_FIELD_CAPTION_SECRET",
+    ] {
+        assert!(
+            !definition_out.contains(secret) && !table_out.contains(secret),
+            "{secret} survived"
+        );
+    }
+    let range_sheet = tag_attribute(&definition_out, "rangeSet ", "sheet").unwrap();
+    let range_name = tag_attribute_values(&definition_out, "rangeSet", "name").remove(0);
+    assert_eq!(
+        range_sheet,
+        "x".repeat("RANGESET_SHEET_SECRET".len()),
+        "rangeSet@sheet must mask like worksheetSource@sheet"
+    );
+    assert_eq!(
+        range_name,
+        "x".repeat("RANGESET_RANGE_NAME_SECRET".len()),
+        "rangeSet@name must mask like worksheetSource@name"
+    );
+    let hierarchy_caption = attribute_value(&definition_out, "caption").unwrap();
+    assert_eq!(
+        hierarchy_caption,
+        "x".repeat("HIERARCHY_CAPTION_SECRET".len())
+    );
+    let unique_name = attribute_value(&definition_out, "uniqueName").unwrap();
+    assert_eq!(
+        unique_name.len(),
+        "[PRODUCTS].[ALL_PRODUCTS_MEMBERS_SECRET]".len()
+    );
+    assert!(unique_name.bytes().all(|byte| byte == b'x'));
+    let dimension_unique_name = attribute_value(&definition_out, "dimensionUniqueName").unwrap();
+    assert_eq!(
+        dimension_unique_name.len(),
+        "[PRODUCTS_DIMENSION_UNIQUE_SECRET]".len()
+    );
+    assert!(dimension_unique_name.bytes().all(|byte| byte == b'x'));
+    for (attribute, secret) in [
+        ("allCaption", "HIERARCHY_ALL_CAPTION_SECRET"),
+        ("allUniqueName", "[PRODUCTS].[ALL_UNIQUE_NAME_SECRET]"),
+        (
+            "defaultMemberUniqueName",
+            "[PRODUCTS].[DEFAULT_MEMBER_UNIQUE_SECRET]",
+        ),
+        ("displayFolder", "DISPLAY_FOLDER_SECRET"),
+    ] {
+        let value = attribute_values(&definition_out, attribute).remove(0);
+        assert_eq!(
+            value,
+            "x".repeat(secret.len()),
+            "{attribute} must mask like other hierarchy names"
+        );
+    }
+    let page_field_name = tag_attribute(&table_out, "pageField ", "name").unwrap();
+    let page_field_cap = tag_attribute(&table_out, "pageField ", "cap").unwrap();
+    assert_eq!(
+        page_field_name,
+        "x".repeat("PAGE_FIELD_NAME_SECRET".len()),
+        "pageField@name must mask like worksheetSource masks"
+    );
+    assert_eq!(
+        page_field_cap,
+        "x".repeat("PAGE_FIELD_CAPTION_SECRET".len()),
+        "pageField@cap must mask like worksheetSource masks"
+    );
+    let page_item = tag_attribute(&table_out, "pageItem ", "name").unwrap();
+    let definition_name = tag_attribute(&table_out, "pivotTableDefinition ", "name").unwrap();
+    assert_ref_name(&page_item);
+    assert_eq!(
+        page_item, definition_name,
+        "pageItem@name must track pivotTableDefinition@name"
+    );
+}
+
+#[test]
+fn pseudonym_placeholders_vary_between_runs() {
+    let source = package(vec![
+        (
+            "[Content_Types].xml",
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "word/document.xml",
+            xml(
+                r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p w:rsidR="00AA11BB" w:rsidP="00CC22DD"><w:r><w:t>x</w:t></w:r></w:p><w:sectPr w:rsidR="00AA11BB"/></w:body></w:document>"#,
+            ),
+        ),
+    ]);
+    let extract_rsid = |bytes: &[u8]| {
+        let parts = ooxml_opc::unzip_parts(bytes).unwrap();
+        let document = part_string(&parts, "word/document.xml");
+        attribute_values(&document, "rsidR")
+    };
+    let first_rsids = extract_rsid(&redact(&source, Format::Docx).unwrap());
+    let second_rsids = extract_rsid(&redact(&source, Format::Docx).unwrap());
+    assert_eq!(first_rsids.len(), 2);
+    assert_eq!(
+        first_rsids[0], first_rsids[1],
+        "within a run, equal originals must stay equal"
+    );
+    assert_eight_hex(&first_rsids[0]);
+    assert_eight_hex(&second_rsids[0]);
+    assert_ne!(
+        first_rsids[0], second_rsids[0],
+        "FNV-derived pseudonyms must be unlinkable across runs"
+    );
+}
+
+#[test]
+fn document_protection_and_merge_sources_are_scrubbed() {
+    let settings = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:documentProtection w:hash="HASH_SECRET" w:salt="SALT_SECRET" w:hashValue="HASH_VALUE_SECRET" w:saltValue="SALT_VALUE_SECRET" w:cryptSpinCount="100000"/><w:writeProtection w:hash="WRITE_HASH_SECRET" w:salt="WRITE_SALT_SECRET" w:hashValue="WRITE_HASH_VALUE_SECRET" w:saltValue="WRITE_SALT_VALUE_SECRET"/><w:mailMerge><w:headerSource r:id="rId2"/><w:dataSource r:id="rId1"/><w:query w:val="QUERY_SECRET"/><w:mailSubject w:val="MAIL_SUBJECT_SECRET"/><w:addressFieldName w:val="ADDRESS_FIELD_SECRET"/><w:odso><w:udl w:val="UDL_SECRET"/><w:table w:val="MERGE_TABLE_SECRET"/></w:odso></w:mailMerge></w:settings>"#;
+    let output = scrub(Format::Docx, "word/settings.xml", settings.as_bytes());
+    for secret in [
+        "HASH_SECRET",
+        "SALT_SECRET",
+        "HASH_VALUE_SECRET",
+        "SALT_VALUE_SECRET",
+        "WRITE_HASH_SECRET",
+        "WRITE_SALT_SECRET",
+        "WRITE_HASH_VALUE_SECRET",
+        "WRITE_SALT_VALUE_SECRET",
+        "QUERY_SECRET",
+        "MAIL_SUBJECT_SECRET",
+        "ADDRESS_FIELD_SECRET",
+        "UDL_SECRET",
+        "MERGE_TABLE_SECRET",
+    ] {
+        assert!(!output.contains(secret), "{secret} survived");
+    }
+    assert!(output.contains(r#"w:cryptSpinCount="100000""#));
+    assert!(!output.contains("dataSource=\""));
+    assert!(output.contains("<w:headerSource r:id=\"rId2\"/><w:dataSource r:id=\"rId1\"/>"));
+    let query_val = attribute_value(&output, "val").unwrap();
+    assert_eq!(query_val, "xxxxxxxxxxxx");
+}
+
+#[test]
+fn rsid_attributes_are_scrubbed() {
+    let document = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p w:rsidR="00AA11BB" w:rsidP="00CC22DD" w:rsidRDefault="00AA11BB"><w:r><w:t>hi</w:t></w:r></w:p><w:sectPr w:rsidR="00AA11BB"/></w:body></w:document>"#;
+    let output = scrub(Format::Docx, "word/document.xml", document.as_bytes());
+    assert!(!output.contains("00AA11BB"));
+    assert!(!output.contains("00CC22DD"));
+    let rsid_r = attribute_values(&output, "rsidR");
+    assert_eq!(rsid_r.len(), 2);
+    for value in &rsid_r {
+        assert_eight_hex(value);
+    }
+    assert_eq!(rsid_r[0], rsid_r[1], "equal originals must stay equal");
+    let rsid_default = attribute_value(&output, "rsidRDefault").unwrap();
+    assert_eight_hex(&rsid_default);
+    assert_eq!(rsid_default, rsid_r[0]);
+    let rsid_p = attribute_value(&output, "rsidP").unwrap();
+    assert_eight_hex(&rsid_p);
+    assert_ne!(rsid_p, rsid_r[0]);
+}
+
+#[test]
+fn revision_timestamps_are_scrubbed() {
+    let document = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:ins w:id="1" w:author="DOCX_SECRET_AUTHOR" w:date="2024-03-04T09:00:00Z" w:dateUtc="2024-03-04T09:00:00Z"><w:r><w:t>x</w:t></w:r></w:ins><w:del w:id="2" w:author="DOCX_DEL_AUTHOR" w:date="2024-03-04T09:30:00Z"><w:r><w:delText>y</w:delText></w:r></w:del><w:cellIns w:id="5" w:author="CELL_AUTHOR_SECRET" w:date="2024-05-05T05:05:05Z"/><w:cellDel w:id="6" w:author="CELL_AUTHOR_SECRET" w:dateUtc="2024-05-05T05:05:05Z"/><w:cellMerge w:id="7" w:author="CELL_AUTHOR_SECRET" w:date="2024-05-05T05:05:05Z"/><w:customXmlInsRangeStart w:id="8" w:author="XML_AUTHOR_SECRET" w:date="2024-07-07T07:07:07Z"/><w:customXmlDelRangeStart w:id="9" w:author="XML_AUTHOR_SECRET" w:dateUtc="2024-07-07T07:07:07Z"/><w:customXmlMoveRangeEnd w:id="10" w:author="XML_AUTHOR_SECRET" w:date="2024-07-07T07:07:07Z"/></w:body></w:document>"#;
+    let output = scrub(Format::Docx, "word/document.xml", document.as_bytes());
+    assert!(!output.contains("2024-03-04"));
+    assert!(!output.contains("2024-05-05"));
+    assert!(!output.contains("2024-07-07"));
+    for author_secret in [
+        "DOCX_SECRET_AUTHOR",
+        "DOCX_DEL_AUTHOR",
+        "CELL_AUTHOR_SECRET",
+        "XML_AUTHOR_SECRET",
+    ] {
+        assert!(!output.contains(author_secret), "{author_secret} survived");
+    }
+    for element in [
+        "cellIns",
+        "cellDel",
+        "cellMerge",
+        "customXmlInsRangeStart",
+        "customXmlDelRangeStart",
+        "customXmlMoveRangeEnd",
+    ] {
+        assert!(output.contains(element), "{element} was dropped");
+    }
+    let date = attribute_value(&output, "date").unwrap();
+    assert_xsd_date_time(&date);
+    let date_utc = attribute_value(&output, "dateUtc").unwrap();
+    assert_xsd_date_time(&date_utc);
+    assert_eq!(date, date_utc);
+}
+
+#[test]
+fn pptx_section_names_are_scrubbed() {
+    let presentation = r#"<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main"><p:sldIdLst><p:sldId id="256"/></p:sldIdLst><p:extLst><p:ext uri="{521415D9-36F7-43E2-AB2F-B90AF26B5E84}"><p14:sectionLst><p14:section name="PROJECT_SECTION_SECRET" id="{33333333-3333-3333-3333-333333333333}"><p14:sldIdLst><p14:sldId id="256"/></p14:sldIdLst></p14:section></p14:sectionLst></p:ext></p:extLst></p:presentation>"#;
+    let output = scrub(
+        Format::Pptx,
+        "ppt/presentation.xml",
+        presentation.as_bytes(),
+    );
+    assert!(!output.contains("PROJECT_SECTION_SECRET"));
+    assert!(output.contains("<p14:section name=\"xxxxxxxxxxxxxxxxxxxxxx\""));
+}
+
+#[test]
+fn slicer_metadata_is_scrubbed() {
+    let slicers = r#"<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"><slicer name="SLICER_CACHE_NAME_SECRET" caption="SOURCE_FIELD_SECRET" cache="SLICER_CACHE_NAME_SECRET" rowHeight="241300"/></slicers>"#;
+    let cache = r#"<slicerCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" name="SLICER_CACHE_NAME_SECRET" sourceName="SOURCE_FIELD_SECRET"/>"#;
+    let slicers_out = scrub(Format::Xlsx, "xl/slicers/slicer1.xml", slicers.as_bytes());
+    let cache_out = scrub(
+        Format::Xlsx,
+        "xl/slicerCaches/slicerCache1.xml",
+        cache.as_bytes(),
+    );
+    for secret in ["SLICER_CACHE_NAME_SECRET", "SOURCE_FIELD_SECRET"] {
+        assert!(
+            !slicers_out.contains(secret) && !cache_out.contains(secret),
+            "{secret} survived"
+        );
+    }
+    assert!(slicers_out.contains("rowHeight=\"241300\""));
+    let slicer_name = attribute_value(&slicers_out, "name").unwrap();
+    let slicer_cache = attribute_value(&slicers_out, "cache").unwrap();
+    let cache_name = attribute_value(&cache_out, "name").unwrap();
+    assert_eq!(slicer_name, cache_name);
+    assert_eq!(
+        slicer_cache, cache_name,
+        "slicer@cache must track slicerCacheDefinition@name"
+    );
+    assert_ref_name(&cache_name);
+    let caption = attribute_value(&slicers_out, "caption").unwrap();
+    let source_name = attribute_value(&cache_out, "sourceName").unwrap();
+    assert_eq!(
+        caption, source_name,
+        "equal originals must yield equal placeholders"
+    );
+    assert_ref_name(&caption);
+    assert_ne!(cache_name, caption);
+}
+
+#[test]
+fn drawing_slicer_names_track_the_slicer_view() {
+    let drawing = r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:sle="http://schemas.microsoft.com/office/drawing/2010/slicer" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"><xdr:twoCellAnchor><xdr:graphicFrame macro=""><xdr:nvGraphicFramePr><xdr:cNvPr id="2" name="SLICER_SHAPE_NAME_SECRET"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr><xdr:graphic><a:graphicData uri="http://schemas.microsoft.com/office/drawing/2010/slicer"><sle:slicer name="SLICER_CACHE_NAME_SECRET"/></a:graphicData></xdr:graphic></xdr:graphicFrame></xdr:twoCellAnchor><xdr:twoCellAnchor><xdr:graphicFrame macro=""><xdr:nvGraphicFramePr><xdr:cNvPr id="3" name="SECOND_SLICER_SHAPE_SECRET"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr><xdr:graphic><a:graphicData uri="http://schemas.microsoft.com/office/drawing/2010/slicer"><x14:slicer name="SLICER_CACHE_NAME_SECRET"/></a:graphicData></xdr:graphic></xdr:graphicFrame></xdr:twoCellAnchor></xdr:wsDr>"#;
+    let slicers = r#"<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"><slicer name="SLICER_CACHE_NAME_SECRET" caption="CAPTION_SECRET" cache="SLICER_CACHE_NAME_SECRET" rowHeight="241300"/></slicers>"#;
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    let mut state = RunState {
+        report: &mut report,
+        mappings: &mut mappings,
+    };
+    let drawing_out = scrub_shared(
+        Format::Xlsx,
+        "xl/drawings/slicerDrawing1.xml",
+        drawing.as_bytes(),
+        &mut state,
+    );
+    let slicers_out = scrub_shared(
+        Format::Xlsx,
+        "xl/slicers/slicer1.xml",
+        slicers.as_bytes(),
+        &mut state,
+    );
+    for secret in [
+        "SLICER_CACHE_NAME_SECRET",
+        "SLICER_SHAPE_NAME_SECRET",
+        "SECOND_SLICER_SHAPE_SECRET",
+    ] {
+        assert!(
+            !drawing_out.contains(secret) && !slicers_out.contains(secret),
+            "{secret} survived"
+        );
+    }
+    let view_name = tag_attribute(&slicers_out, "slicer ", "name").unwrap();
+    let cache_ref = tag_attribute(&slicers_out, "slicer ", "cache").unwrap();
+    assert_eq!(view_name, cache_ref);
+    for tag in ["sle:slicer", "x14:slicer"] {
+        let drawing_name = tag_attribute(&drawing_out, &format!("{tag} "), "name").unwrap();
+        assert_ref_name(&drawing_name);
+        assert_eq!(
+            drawing_name, view_name,
+            "{tag}@name must track the slicer-view name"
+        );
+    }
+}
+
+#[test]
+fn legacy_comment_uids_map_to_threaded_comment_ids() {
+    let comments = r#"<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><authors><author>tc={CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}</author><author>LEGACY_AUTHOR_SECRET</author></authors><commentList><comment ref="A1" authorId="0" shapeId="0" uid="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}"><r><t>LEGACY_COMMENT_SECRET</t></r></comment></commentList></comments>"#;
+    let threaded = r#"<threadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><threadedComment ref="A1" id="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}" dT="2024-05-06T07:08:09Z" personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"><text>THREAD_SECRET_TEXT</text></threadedComment></threadedComments>"#;
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    let comments_out = scrub_shared(
+        Format::Xlsx,
+        "xl/comments1.xml",
+        comments.as_bytes(),
+        &mut RunState {
+            report: &mut report,
+            mappings: &mut mappings,
+        },
+    );
+    let threaded_out = scrub_shared(
+        Format::Xlsx,
+        "xl/threadedComments/threadedComment1.xml",
+        threaded.as_bytes(),
+        &mut RunState {
+            report: &mut report,
+            mappings: &mut mappings,
+        },
+    );
+    for secret in [
+        "LEGACY_AUTHOR_SECRET",
+        "LEGACY_COMMENT_SECRET",
+        "{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}",
+    ] {
+        assert!(
+            !comments_out.contains(secret) && !threaded_out.contains(secret),
+            "{secret} survived"
+        );
+    }
+    let legacy_uid = tag_attribute_values(&comments_out, "comment", "uid").remove(0);
+    let thread_id = tag_attribute_values(&threaded_out, "threadedComment", "id").remove(0);
+    assert_guid(&legacy_uid);
+    assert_eq!(
+        legacy_uid, thread_id,
+        "equal original uid and threadedComment id must share one placeholder"
+    );
+    let author_text = between(&comments_out, "<author>", "</author>").unwrap();
+    assert_eq!(
+        author_text,
+        format!("tc={legacy_uid}"),
+        "author text tc={{guid}} must remap the same guid as comment@uid"
+    );
+    assert!(
+        comments_out.contains(&format!(
+            "<author>{}</author>",
+            "x".repeat("LEGACY_AUTHOR_SECRET".len())
+        )),
+        "non-threaded authors keep the plain mask: {comments_out}"
+    );
+    assert!(comments_out.contains("ref=\"A1\""));
+}
+
+#[test]
+fn word_comment_timestamps_are_scrubbed() {
+    let comments = r#"<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="0" w:author="JANE" w:date="2024-08-08T09:10:11Z"><w:p><w:r><t xml:space="preserve">LEGACY_TEXT</t></w:r></w:p></w:comment></w:comments>"#;
+    let extended = r#"<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="11111111" w15:dateUtc="2024-08-08T09:30:11Z" w15:done="0"/></w15:commentsEx>"#;
+    let extensible = r#"<w16ce:commentsExtensible xmlns:w16ce="http://schemas.microsoft.com/office/word/2018/wordml/cex"><w16ce:commentExtensible w16ce:durableId="22222222" w16ce:dateUtc="2024-08-08T09:40:11Z"/></w16ce:commentsExtensible>"#;
+    let comments_out = scrub(Format::Docx, "word/comments.xml", comments.as_bytes());
+    let extended_out = scrub(
+        Format::Docx,
+        "word/commentsExtended.xml",
+        extended.as_bytes(),
+    );
+    let extensible_out = scrub(
+        Format::Docx,
+        "word/commentsExtensible.xml",
+        extensible.as_bytes(),
+    );
+    for output in [&comments_out, &extended_out, &extensible_out] {
+        assert!(!output.contains("2024-08-08"), "{output}");
+    }
+    assert_eq!(
+        attribute_value(&comments_out, "date").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    for output in [&extended_out, &extensible_out] {
+        assert_eq!(
+            attribute_value(output, "dateUtc").as_deref(),
+            Some("1970-01-01T00:00:00Z")
+        );
+    }
+    assert!(extensible_out.contains(r#"durableId="22222222""#));
+    assert!(extended_out.contains(r#"done="0""#));
+}
+
+#[test]
+fn relocated_core_properties_are_scrubbed_by_content_type() {
+    let source = package(vec![
+        (
+            "[Content_Types].xml",
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="corepkg" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/><Default Extension="apppkg" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/><Default Extension="custpkg" ContentType="application/vnd.openxmlformats-officedocument.custom-properties+xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "xl/workbook.xml",
+            xml(
+                r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheets/></workbook>"#,
+            ),
+        ),
+        (
+            "meta/core.corepkg",
+            xml(
+                r#"<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"><dc:title>RELOCATED_CORE_TITLE_SECRET</dc:title><dc:creator>RELOCATED_CORE_AUTHOR</dc:creator><dcterms:created>2024-05-06T07:08:09Z</dcterms:created><cp:revision>77</cp:revision><dc:identifier>RELOCATED_CORE_IDENTIFIER</dc:identifier><dc:language>RELOCATED_CORE_LANGUAGE</dc:language><cp:version>RELOCATED_CORE_VERSION</cp:version><cp:contentType>RELOCATED_CORE_CONTENT_TYPE</cp:contentType></cp:coreProperties>"#,
+            ),
+        ),
+        (
+            "meta/app.apppkg",
+            xml(
+                r#"<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"><Company>RELOCATED_APP_COMPANY</Company><AppVersion>16.0301</AppVersion></Properties>"#,
+            ),
+        ),
+        (
+            "meta/custom.custpkg",
+            xml(
+                r#"<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"><property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2" name="RELOCATED_CUSTOM_NAME" linkTarget="RELOCATED_LINK_TARGET_SECRET"><vt:lpwstr>RELOCATED_CUSTOM_VALUE</vt:lpwstr></property></Properties>"#,
+            ),
+        ),
+    ]);
+    let output = redact(&source, Format::Xlsx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    assert_no_secrets(
+        &parts,
+        &[
+            "RELOCATED_CORE_TITLE_SECRET",
+            "RELOCATED_CORE_AUTHOR",
+            "2024-05-06",
+            "77",
+            "RELOCATED_CORE_IDENTIFIER",
+            "RELOCATED_CORE_LANGUAGE",
+            "RELOCATED_CORE_VERSION",
+            "RELOCATED_CORE_CONTENT_TYPE",
+            "RELOCATED_APP_COMPANY",
+            "16.0301",
+            "RELOCATED_CUSTOM_NAME",
+            "RELOCATED_LINK_TARGET_SECRET",
+            "RELOCATED_CUSTOM_VALUE",
+        ],
+    );
+    let core = part_string(&parts, "meta/core.corepkg");
+    assert_eq!(
+        between(&core, "<cp:revision>", "</cp:revision>"),
+        Some("88"),
+        "numeric revision must keep its numeric shape"
+    );
+    let title_text = between(&core, "<dc:title>", "</dc:title>").unwrap();
+    assert_eq!(title_text, "x".repeat("RELOCATED_CORE_TITLE_SECRET".len()));
+    for (tag, secret) in [
+        ("<dc:identifier>", "RELOCATED_CORE_IDENTIFIER"),
+        ("<dc:language>", "RELOCATED_CORE_LANGUAGE"),
+        ("<cp:version>", "RELOCATED_CORE_VERSION"),
+        ("<cp:contentType>", "RELOCATED_CORE_CONTENT_TYPE"),
+    ] {
+        let closing = tag.replace('<', "</");
+        let text = between(&core, tag, &closing).unwrap();
+        assert_eq!(text, "x".repeat(secret.len()), "{tag} must be masked");
+    }
+    let app = part_string(&parts, "meta/app.apppkg");
+    let company = between(&app, "<Company>", "</Company>").unwrap();
+    assert_eq!(company, "x".repeat("RELOCATED_APP_COMPANY".len()));
+    let custom = part_string(&parts, "meta/custom.custpkg");
+    let property_name = attribute_value(&custom, "name").unwrap();
+    assert_eq!(property_name, "x".repeat("RELOCATED_CUSTOM_NAME".len()));
+    let link_target = attribute_value(&custom, "linkTarget").unwrap();
+    assert_eq!(
+        link_target,
+        "x".repeat("RELOCATED_LINK_TARGET_SECRET".len()),
+        "custom property linkTarget must be masked"
+    );
+}
+
+#[test]
+fn content_type_overrides_classify_unusual_extensions() {
+    let source = package(vec![
+        (
+            "[Content_Types].xml",
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/custom/cache.pvt" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "xl/workbook.xml",
+            xml(
+                r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheets/></workbook>"#,
+            ),
+        ),
+        (
+            "custom/cache.pvt",
+            xml(
+                r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" refreshedBy="REFRESHED_BY_SECRET"><cacheFields count="1"><cacheField name="FIELD_NAME_SECRET" numFmtId="0"><sharedItems count="1"><s v="PIVOT_CACHE_SECRET"/></sharedItems></cacheField></cacheFields></pivotCacheDefinition>"#,
+            ),
+        ),
+        (
+            "custom/data.xyz",
+            xml(r#"<unknown xmlns="urn:example">UNCLASSIFIED_PART_SECRET</unknown>"#),
+        ),
+    ]);
+    let output = redact(&source, Format::Xlsx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    assert_no_secrets(
+        &parts,
+        &[
+            "PIVOT_CACHE_SECRET",
+            "REFRESHED_BY_SECRET",
+            "FIELD_NAME_SECRET",
+        ],
+    );
+    let cache = part_string(&parts, "custom/cache.pvt");
+    let unclassified = part_string(&parts, "custom/data.xyz");
+    assert!(
+        unclassified.contains("UNCLASSIFIED_PART_SECRET"),
+        "parts without an xml classification must pass through untouched"
+    );
+    assert!(cache.contains(r#"refreshedBy="xxxxxxxxxxxxxxxxxxx""#));
+    assert!(cache.contains(r#"<s v="xxxxxxxxxxxxxxxxxx"/>"#));
+}
+
+#[test]
+fn content_type_routing_applies_semantic_rules() {
+    let source = package(vec![
+        (
+            "[Content_Types].xml",
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/blobs/plot.data" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/><Override PartName="/blobs/link.data" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.connections+xml"/><Override PartName="/blobs/folk.data" ContentType="application/vnd.ms-excel.person+xml"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "xl/workbook.xml",
+            xml(
+                r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheets/></workbook>"#,
+            ),
+        ),
+        (
+            "blobs/plot.data",
+            xml(
+                r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:pivotSource><c:name>[Book1]CHART_SHEET_SECRET!CHART_TABLE_SECRET</c:name></c:pivotSource><c:chart><c:plotArea><c:ser><c:tx><c:strRef><c:f>CHART_SHEET_SECRET!$A$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>CHART_LABEL_SECRET</c:v></c:pt></c:strCache></c:strRef></c:tx></c:ser></c:plotArea></c:chart></c:chartSpace>"#,
+            ),
+        ),
+        (
+            "blobs/link.data",
+            xml(
+                r#"<connections xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><connection id="1" name="db" type="101" keepAlive="1" odcFile="ODC_FILE_PATH_SECRET"><dbPr connection="CONNECTION_STRING_SECRET"/><webPr htmlTables="1" url="WEB_QUERY_URL_SECRET"/></connection><parameters count="1"><parameter name="Region" string="PARAMETER_VALUE_SECRET"/></parameters></connections>"#,
+            ),
+        ),
+        (
+            "blobs/folk.data",
+            xml(
+                r#"<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><person id="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" displayName="PERSON_SECRET_NAME" userId="USER_SECRET_ID" providerId="PROVIDER_SECRET_ID"/></personList>"#,
+            ),
+        ),
+    ]);
+    let output = redact(&source, Format::Xlsx).unwrap();
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    assert_no_secrets(
+        &parts,
+        &[
+            "CHART_SHEET_SECRET",
+            "CHART_TABLE_SECRET",
+            "CHART_LABEL_SECRET",
+            "CONNECTION_STRING_SECRET",
+            "WEB_QUERY_URL_SECRET",
+            "PARAMETER_VALUE_SECRET",
+            "ODC_FILE_PATH_SECRET",
+            "PERSON_SECRET_NAME",
+            "USER_SECRET_ID",
+            "PROVIDER_SECRET_ID",
+            "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}",
+        ],
+    );
+    let chart = part_string(&parts, "blobs/plot.data");
+    let pivot_source = between(&chart, "<c:name>", "</c:name>").unwrap();
+    assert!(
+        pivot_source.starts_with("[Book1]"),
+        "bracketed workbook filename must stay verbatim: {pivot_source}"
+    );
+    let (sheet_segment, table_segment) = pivot_source["[Book1]".len()..].split_once('!').unwrap();
+    assert_eq!(
+        sheet_segment,
+        "x".repeat("CHART_SHEET_SECRET".len()),
+        "content-type-routed chart must rewrite the sheet segment"
+    );
+    assert_ref_name(table_segment);
+    let cached_label = between(&chart, "<c:v>", "</c:v>").unwrap();
+    assert_eq!(
+        cached_label,
+        "x".repeat("CHART_LABEL_SECRET".len()),
+        "content-type-routed chart must scrub cached labels"
+    );
+    let connections = part_string(&parts, "blobs/link.data");
+    let connection_name = tag_attribute(&connections, "connection ", "name").unwrap();
+    assert_ref_name(&connection_name);
+    let parameter_name = tag_attribute_values(&connections, "parameter", "name").remove(0);
+    assert_ref_name(&parameter_name);
+    assert!(connections.contains(r#"keepAlive="1""#));
+    let person = part_string(&parts, "blobs/folk.data");
+    let person_id = tag_attribute(&person, "person ", "id").unwrap();
+    assert_guid(&person_id);
+    assert_eq!(
+        tag_attribute(&person, "person ", "displayName").unwrap(),
+        "x".repeat("PERSON_SECRET_NAME".len())
+    );
+}
+
+#[test]
+fn connection_identity_and_web_query_extras_are_scrubbed() {
+    let connections = r#"<connections xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><connection id="1" name="db" type="101" keepAlive="1" description="CONNECTION_DESCRIPTION_SECRET" singleSignOnId="SSO_ID_SECRET"><dbPr connection="CONNECTION_STRING_SECRET"/><webPr htmlTables="1" url="WEB_QUERY_URL_SECRET" post="WEB_POST_SECRET" editPage="EDIT_PAGE_SECRET"><tables count="1"><s v="TABLE_NAME_SECRET"/></tables></webPr><textPr prompt="1" codePage="437" sourceFile="TEXT_SOURCE_FILE_SECRET"/></connection></connections>"#;
+    let output = scrub(Format::Xlsx, "xl/connections.xml", connections.as_bytes());
+    for secret in [
+        "CONNECTION_DESCRIPTION_SECRET",
+        "SSO_ID_SECRET",
+        "WEB_POST_SECRET",
+        "EDIT_PAGE_SECRET",
+        "WEB_QUERY_URL_SECRET",
+        "TABLE_NAME_SECRET",
+        "TEXT_SOURCE_FILE_SECRET",
+    ] {
+        assert!(!output.contains(secret), "{secret} survived");
+    }
+    for preserved in ["keepAlive=\"1\"", "prompt=\"1\"", "codePage=\"437\""] {
+        assert!(output.contains(preserved), "{preserved} was rewritten");
+    }
+    let connection_name = tag_attribute(&output, "connection ", "name").unwrap();
+    assert_ref_name(&connection_name);
+}
+
+#[test]
+fn tracked_moves_and_rsid_elements_are_scrubbed() {
+    let document = r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p w:rsidR="00AA11BB"><w:moveFromRangeStart w:id="3" w:author="MOVE_AUTHOR_SECRET" w:date="2024-04-05T10:00:00Z"/><w:moveFrom w:id="1" w:author="MOVE_AUTHOR_SECRET" w:date="2024-04-05T10:00:00Z"><w:r><w:t>old</w:t></w:r></w:moveFrom><w:moveToRangeStart w:id="4" w:author="MOVE_AUTHOR_SECRET" w:dateUtc="2024-04-05T10:30:00Z"/><w:moveTo w:id="2" w:author="MOVE_AUTHOR_SECRET" w:date="2024-04-05T10:00:00Z"><w:r><w:t>new</w:t></w:r></w:moveTo><w:moveFromRangeEnd w:id="3"/><w:moveToRangeEnd w:id="4"/></w:p><w:sectPr w:rsidR="00AA11BB"/></w:body></w:document>"#;
+    let settings = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:rsids><w:rsidRoot w:val="00AA11BB"/><w:rsid w:val="00CC22DD"/></w:rsids></w:settings>"#;
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    let mut state = RunState {
+        report: &mut report,
+        mappings: &mut mappings,
+    };
+    let document_out = scrub_shared(
+        Format::Docx,
+        "word/document.xml",
+        document.as_bytes(),
+        &mut state,
+    );
+    let settings_out = scrub_shared(
+        Format::Docx,
+        "word/settings.xml",
+        settings.as_bytes(),
+        &mut state,
+    );
+    assert!(!document_out.contains("2024-04-05"));
+    assert!(!document_out.contains("MOVE_AUTHOR_SECRET"));
+    for element in [
+        "moveFromRangeStart",
+        "moveFrom",
+        "moveToRangeStart",
+        "moveTo",
+        "moveFromRangeEnd",
+        "moveToRangeEnd",
+    ] {
+        assert!(document_out.contains(element), "{element} was dropped");
+    }
+    assert_eq!(
+        attribute_value(&document_out, "date").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        attribute_value(&document_out, "dateUtc").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    let rsid_root = tag_attribute(&settings_out, "w:rsidRoot ", "val").unwrap();
+    let rsid_val = tag_attribute(&settings_out, "w:rsid ", "val").unwrap();
+    let rsid_r = attribute_values(&document_out, "rsidR")[0].clone();
+    assert_eight_hex(&rsid_root);
+    assert_eight_hex(&rsid_val);
+    assert_ne!(rsid_root, rsid_val);
+    assert_eq!(
+        rsid_root, rsid_r,
+        "rsidRoot@val must map like rsid attributes across parts"
+    );
+}
+
+#[test]
+fn colliding_originals_get_distinct_placeholders() {
+    assert_eq!(super::stable_hash("1aa9"), super::stable_hash("25054"));
+    let definition = r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cacheFields count="2"><cacheField name="1aa9" numFmtId="0"/><cacheField name="25054" numFmtId="0"/></cacheFields></pivotCacheDefinition>"#;
+    let settings = r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:rsids><w:rsid w:val="1aa9"/><w:rsid w:val="25054"/></w:rsids></w:settings>"#;
+    let cache_out = scrub(
+        Format::Xlsx,
+        "xl/pivotCache/pivotCacheDefinition1.xml",
+        definition.as_bytes(),
+    );
+    let names = attribute_values(&cache_out, "name");
+    assert_eq!(names.len(), 2);
+    assert_ne!(
+        names[0], names[1],
+        "FNV-32 collisions must not merge distinct names"
+    );
+    assert_eq!(names[0], "r0BCDD871");
+    for value in &names {
+        assert_ref_name(value);
+    }
+    let settings_out = scrub(Format::Docx, "word/settings.xml", settings.as_bytes());
+    let values = attribute_values(&settings_out, "val");
+    assert_eq!(values.len(), 2);
+    assert_ne!(values[0], values[1]);
+    assert_eq!(values[0], "0BCDD871");
+    for value in &values {
+        assert_eight_hex(value);
+    }
+}
+
+fn attribute_values(markup: &str, attribute: &str) -> Vec<String> {
+    let pattern = format!("{attribute}=\"");
+    let mut values = Vec::new();
+    let mut cursor = 0;
+    while let Some(offset) = markup[cursor..].find(&pattern) {
+        let start = cursor + offset + pattern.len();
+        let Some(end) = markup[start..].find('"') else {
+            break;
+        };
+        values.push(markup[start..start + end].to_owned());
+        cursor = start + end + 1;
+    }
+    values
+}
+
+fn attribute_value(markup: &str, attribute: &str) -> Option<String> {
+    attribute_values(markup, attribute).into_iter().next()
+}
+
+fn tag_attribute(markup: &str, tag: &str, attribute: &str) -> Option<String> {
+    let marker = format!("<{tag}");
+    let offset = markup.find(&marker)?;
+    let rest = &markup[offset..];
+    let end = rest.find('>')?;
+    attribute_value(&rest[..end], attribute)
+}
+
+fn between<'a>(markup: &'a str, start: &str, end: &str) -> Option<&'a str> {
+    let offset = markup.find(start)? + start.len();
+    let rest = &markup[offset..];
+    let stop = rest.find(end)?;
+    Some(&rest[..stop])
+}
+
+fn tag_attribute_values(markup: &str, tag: &str, attribute: &str) -> Vec<String> {
+    let mut reader = Reader::from_str(markup);
+    reader.config_mut().trim_text(false);
+    let mut values = Vec::new();
+    loop {
+        match reader.read_event().unwrap() {
+            Event::Start(start) | Event::Empty(start) => {
+                if start.name().local_name().as_ref() == tag.as_bytes() {
+                    for attr in start.attributes().flatten() {
+                        if attr.key.local_name().as_ref() == attribute.as_bytes() {
+                            values.push(String::from_utf8_lossy(&attr.value).into_owned());
+                        }
+                    }
+                }
+            }
+            Event::Eof => return values,
+            _ => {}
+        }
+    }
+}
+
+fn assert_eight_hex(value: &str) {
+    assert_eq!(value.len(), 8, "{value}");
+    assert!(
+        value.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "{value}"
+    );
+}
+
+fn assert_ref_name(value: &str) {
+    assert!(value.starts_with('r'), "{value}");
+    assert_eight_hex(&value[1..]);
+}
+
+fn assert_guid(value: &str) {
+    let body = value
+        .strip_prefix('{')
+        .and_then(|rest| rest.strip_suffix('}'))
+        .unwrap_or_else(|| panic!("guid must be braced: {value}"));
+    let groups: Vec<&str> = body.split('-').collect();
+    assert_eq!(groups.len(), 5, "{value}");
+    for (group, expected) in groups.iter().zip([8usize, 4, 4, 4, 12]) {
+        assert_eq!(group.len(), expected, "{value}");
+        assert!(
+            group
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'A'..=b'F')),
+            "{value} must be uppercase hex"
+        );
+    }
+    assert_eq!(groups[2].chars().next(), Some('4'), "{value} not UUIDv4");
+    assert!(
+        matches!(groups[3].chars().next(), Some('8' | '9' | 'A' | 'B')),
+        "{value} has invalid UUID variant"
+    );
+}
+
+fn assert_xsd_date_time(value: &str) {
+    let pattern = "0000-00-00T00:00:00Z";
+    assert_eq!(value.len(), pattern.len(), "{value}");
+    for (actual, expected) in value.chars().zip(pattern.chars()) {
+        if expected == '0' {
+            assert!(actual.is_ascii_digit(), "{value}");
+        } else {
+            assert_eq!(actual, expected, "{value}");
+        }
+    }
+}
+
+fn scrub(format: Format, path: &str, bytes: &[u8]) -> String {
+    let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
+    scrub_shared(
+        format,
+        path,
+        bytes,
+        &mut RunState {
+            report: &mut report,
+            mappings: &mut mappings,
+        },
+    )
+}
+
+fn scrub_shared(format: Format, path: &str, bytes: &[u8], state: &mut RunState<'_>) -> String {
+    let output = xml::redact_xml(format, path, None, bytes, state).unwrap();
+    String::from_utf8(output).unwrap()
+}
+
+#[test]
 fn empty_shared_string_cell_does_not_leak_next_value() {
     // Greptile #68: a self-closing <c t="s"/> has no End event, so its cell
     // type must not bleed into the following untyped numeric cell's value.
@@ -378,11 +1676,16 @@ fn empty_shared_string_cell_does_not_leak_next_value() {
         r#"</row></sheetData></worksheet>"#,
     );
     let mut report = RedactionReport::default();
+    let mut mappings = IdMappings::default();
     let output = xml::redact_xml(
         Format::Xlsx,
         "xl/worksheets/sheet1.xml",
+        None,
         sheet.as_bytes(),
-        &mut report,
+        &mut RunState {
+            report: &mut report,
+            mappings: &mut mappings,
+        },
     )
     .unwrap();
     let text = String::from_utf8(output).unwrap();
@@ -422,4 +1725,491 @@ fn media_rejects_unencodable_formats() {
     let mut report = RedactionReport::default();
     let error = media::replace_media("word/media/image1.emf", b"not an image", &mut report);
     assert!(matches!(error, Err(RedactError::Image { .. })));
+}
+
+const INTEGRATION_XLSX_SECRETS: &[&str] = &[
+    "PIVOT_SHEET_SECRET",
+    "SOURCE_RANGE_NAME_SECRET",
+    "REFRESHED_BY_SECRET",
+    "45418.297222222226",
+    "PIVOT_CACHE_SECRET",
+    "CUSTOMER_FIELD_SECRET",
+    "FIELD_CAPTION_SECRET",
+    "FIELD_FORMULA_SECRET",
+    "CALC_ITEM_FORMULA_SECRET",
+    "MEMBER_LABEL_SECRET",
+    "SLICER_CACHE_NAME_SECRET",
+    "CONNECTION_DESCRIPTION_SECRET",
+    "SSO_ID_SECRET",
+    "ODC_FILE_PATH_SECRET",
+    "SOURCE_FILE_PATH_SECRET",
+    "CONNECTION_STRING_SECRET",
+    "COMMAND_TEXT_SECRET",
+    "WEB_QUERY_URL_SECRET",
+    "WEB_POST_SECRET",
+    "EDIT_PAGE_SECRET",
+    "TABLE_NAME_SECRET",
+    "TEXT_SOURCE_FILE_SECRET",
+    "THREAD_SECRET_TEXT",
+    "REPLY_THREAD_SECRET",
+    "TCS2_THREAD_SECRET",
+    "https://secret.example/tcs2",
+    "CACHE_LABEL_SECRET",
+    "CATEGORY_CACHE_SECRET",
+    "PERSON_SECRET_NAME",
+    "PERSON_TWO_SECRET",
+    "USER_SECRET_ID",
+    "USER_TWO_SECRET",
+    "PROVIDER_SECRET_ID",
+    "{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}",
+    "{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}",
+    "{DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD}",
+    "{EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE}",
+    "{66666666-6666-6666-6666-666666666666}",
+    "2024-05-06",
+    "PivotTable1",
+    "LEGACY_COMMENT_SECRET",
+    "SLICER_SHAPE_SECRET",
+];
+
+const INTEGRATION_DOCX_SECRETS: &[&str] = &[
+    "MOVE_AUTHOR_SECRET",
+    "OLD_MOVE_SECRET",
+    "NEW_MOVE_SECRET",
+    "{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}",
+    "{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}",
+    "{77777777-7777-7777-7777-777777777777}",
+    "{88888888-8888-8888-8888-888888888888}",
+    "{99999999-9999-9999-9999-999999999999}",
+    "WORD_USER_SECRET",
+    "WORD_THREAD_SECRET",
+    "WORD_REPLY_SECRET",
+    "JANE_DOE",
+    "WORD_LEGACY_COMMENT_SECRET",
+    "00AA11BB",
+    "00CC22DD",
+    "2024-04-05",
+    "2024-06-07",
+    "2024-08-08",
+];
+
+#[test]
+fn package_redaction_is_secret_free_and_referentially_consistent() {
+    assert_integration_xlsx();
+    assert_integration_docx();
+}
+
+fn assert_no_secrets(parts: &[(String, Vec<u8>)], secrets: &[&str]) {
+    for (path, bytes) in parts {
+        let text = String::from_utf8_lossy(bytes);
+        for secret in secrets {
+            assert!(!text.contains(secret), "secret {secret} survived in {path}");
+        }
+    }
+}
+
+fn assert_integration_xlsx() {
+    let source = package(vec![
+        (
+            "[Content_Types].xml",
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="tcsx" ContentType="application/vnd.ms-excel.threadedcomments+xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/pivotCache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/><Override PartName="/xl/pivotTables/pivotTable1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"/><Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/><Override PartName="/xl/connections.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.connections+xml"/><Override PartName="/xl/slicerCaches/slicerCache1.xml" ContentType="application/vnd.ms-excel.slicercache+xml"/><Override PartName="/xl/slicers/slicer1.xml" ContentType="application/vnd.ms-excel.slicer+xml"/><Override PartName="/xl/drawings/slicerDrawing1.xml" ContentType="application/vnd.ms-excel.slicerdrawing+xml"/><Override PartName="/xl/threadedComments/threadedComment1.xml" ContentType="application/vnd.ms-excel.threadedcomments+xml"/><Override PartName="/xl/persons/person.xml" ContentType="application/vnd.ms-excel.person+xml"/><Override PartName="/xl/comments1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "xl/workbook.xml",
+            xml(
+                r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="PIVOT_SHEET_SECRET" sheetId="1" r:id="rId1"/></sheets><pivotCaches><pivotCache cacheId="0" r:id="rId4"/></pivotCaches></workbook>"#,
+            ),
+        ),
+        (
+            "xl/_rels/workbook.xml.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" Target="pivotCache/pivotCacheDefinition1.xml"/><Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/connections" Target="connections.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "xl/worksheets/sheet1.xml",
+            xml(
+                r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData></worksheet>"#,
+            ),
+        ),
+        (
+            "xl/pivotCache/pivotCacheDefinition1.xml",
+            xml(
+                r#"<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" invalid="1" refreshOnLoad="1" refreshedBy="REFRESHED_BY_SECRET" refreshedDate="45418.297222222226" refreshedDateIso="2024-05-06T07:08:09Z" recordCount="1"><cacheSource type="worksheet"><worksheetSource ref="A1:C4" sheet="PIVOT_SHEET_SECRET" name="SOURCE_RANGE_NAME_SECRET"/></cacheSource><cacheFields count="1"><cacheField name="CUSTOMER_FIELD_SECRET" caption="FIELD_CAPTION_SECRET" formula="FIELD_FORMULA_SECRET" numFmtId="0"><sharedItems count="1"><s v="PIVOT_CACHE_SECRET"/></sharedItems></cacheField></cacheFields><calculatedItems count="1"><calculatedItem index="0"><formula>CALC_ITEM_FORMULA_SECRET</formula></calculatedItem></calculatedItems></pivotCacheDefinition>"#,
+            ),
+        ),
+        (
+            "xl/pivotTables/pivotTable1.xml",
+            xml(
+                r#"<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" name="PivotTable1" cacheId="0"><pivotFields count="1"><pivotField axis="axisRow" showAll="0"><items count="2"><item x="0"/><item n="MEMBER_LABEL_SECRET"/></items></pivotField></pivotFields><rowFields count="1"><field x="0"/></rowFields></pivotTableDefinition>"#,
+            ),
+        ),
+        (
+            "xl/charts/chart1.xml",
+            xml(
+                r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:pivotSource><c:name>[Book1]PIVOT_SHEET_SECRET!PivotTable1</c:name><c:fmtId val="0"/></c:pivotSource><c:chart><c:plotArea><c:barChart><c:ser><c:tx><c:strRef><c:f>PIVOT_SHEET_SECRET!$A$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>CACHE_LABEL_SECRET</c:v></c:pt></c:strCache></c:strRef></c:tx><c:cat><c:strRef><c:f>PIVOT_SHEET_SECRET!$B$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>CATEGORY_CACHE_SECRET</c:v></c:pt></c:strCache></c:strRef></c:cat><c:val><c:numRef><c:f>PIVOT_SHEET_SECRET!$C$1</c:f><c:numCache><c:formatCode>General</c:formatCode><c:ptCount val="1"/><c:pt idx="0"><c:v>42.5</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#,
+            ),
+        ),
+        (
+            "xl/slicerCaches/slicerCache1.xml",
+            xml(
+                r#"<slicerCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" name="SLICER_CACHE_NAME_SECRET" sourceName="CUSTOMER_FIELD_SECRET"><pivotTables count="1"><pivotTable tabId="1" name="PivotTable1"/></pivotTables></slicerCacheDefinition>"#,
+            ),
+        ),
+        (
+            "xl/drawings/slicerDrawing1.xml",
+            xml(
+                r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:sle="http://schemas.microsoft.com/office/drawing/2010/slicer"><xdr:twoCellAnchor><xdr:graphicFrame macro=""><xdr:nvGraphicFramePr><xdr:cNvPr id="2" name="SLICER_SHAPE_SECRET"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr><xdr:graphic><a:graphicData uri="http://schemas.microsoft.com/office/drawing/2010/slicer"><sle:slicer name="SLICER_CACHE_NAME_SECRET"/></a:graphicData></xdr:graphic></xdr:graphicFrame></xdr:twoCellAnchor></xdr:wsDr>"#,
+            ),
+        ),
+        (
+            "xl/slicers/slicer1.xml",
+            xml(
+                r#"<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"><slicer name="SLICER_CACHE_NAME_SECRET" caption="CUSTOMER_FIELD_SECRET" cache="SLICER_CACHE_NAME_SECRET" rowHeight="241300"/></slicers>"#,
+            ),
+        ),
+        (
+            "xl/connections.xml",
+            xml(
+                r#"<connections xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><connection id="1" name="db" type="101" keepAlive="1" description="CONNECTION_DESCRIPTION_SECRET" singleSignOnId="SSO_ID_SECRET" odcFile="ODC_FILE_PATH_SECRET" sourceFile="SOURCE_FILE_PATH_SECRET"><dbPr connection="CONNECTION_STRING_SECRET" command="COMMAND_TEXT_SECRET"/><webPr htmlTables="1" url="WEB_QUERY_URL_SECRET" post="WEB_POST_SECRET" editPage="EDIT_PAGE_SECRET"><tables count="1"><s v="TABLE_NAME_SECRET"/></tables></webPr><textPr prompt="1" codePage="437" sourceFile="TEXT_SOURCE_FILE_SECRET"/></connection></connections>"#,
+            ),
+        ),
+        (
+            "xl/threadedComments/threadedComment1.xml",
+            xml(
+                r#"<threadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><threadedComment ref="A1" id="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}" dT="2024-05-06T07:08:09Z" personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"><text>THREAD_SECRET_TEXT</text></threadedComment><threadedComment ref="A2" id="{DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD}" parentId="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}" dT="2024-05-06T07:09:09Z" personId="{EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE}"><mentions><mention personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" mentionpersonId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" mentionId="{66666666-6666-6666-6666-666666666666}" displayName="PERSON_SECRET_NAME"/></mentions><text>REPLY_THREAD_SECRET</text></threadedComment></threadedComments>"#,
+            ),
+        ),
+        (
+            "xl/threadedComments/threadedComments2.tcsx",
+            xml(
+                r#"<threadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><threadedComment ref="D4" id="{88888888-8888-8888-8888-888888888888}" dT="2024-05-06T07:12:13Z" personId="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}"><text>TCS2_THREAD_SECRET</text></threadedComment><extLst><ext uri="{D4E1A1F8-D4E1-A1F8-0000-400080000001}"><tcExt count="3"><checksum>42424242</checksum><hyperlink url="https://secret.example/tcs2"/><junk>TCS2_RAW_SURVIVOR</junk></tcExt></ext></extLst></threadedComments>"#,
+            ),
+        ),
+        (
+            "xl/comments1.xml",
+            xml(
+                r#"<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><authors><author>tc={CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}</author><author>XLSX_SECRET_AUTHOR</author></authors><commentList><comment ref="A1" authorId="0" shapeId="0" uid="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}"><r><t>LEGACY_COMMENT_SECRET</t></r></comment></commentList></comments>"#,
+            ),
+        ),
+        (
+            "xl/persons/person.xml",
+            xml(
+                r#"<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><person id="{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}" displayName="PERSON_SECRET_NAME" userId="USER_SECRET_ID" providerId="PROVIDER_SECRET_ID"/><person id="{EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE}" displayName="PERSON_TWO_SECRET" userId="USER_TWO_SECRET" providerId="PROVIDER_TWO_ID"/></personList>"#,
+            ),
+        ),
+    ]);
+    let (output, report) = redact_with_report(&source, Format::Auto).unwrap();
+    assert_eq!(report.format, Format::Xlsx);
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    assert_no_secrets(&parts, INTEGRATION_XLSX_SECRETS);
+
+    let slicers = part_string(&parts, "xl/slicers/slicer1.xml");
+    let slicer_cache = part_string(&parts, "xl/slicerCaches/slicerCache1.xml");
+    let slicer_drawing = part_string(&parts, "xl/drawings/slicerDrawing1.xml");
+    let cache_definition = part_string(&parts, "xl/pivotCache/pivotCacheDefinition1.xml");
+    let pivot_table = part_string(&parts, "xl/pivotTables/pivotTable1.xml");
+    let workbook = part_string(&parts, "xl/workbook.xml");
+    let comments = part_string(&parts, "xl/threadedComments/threadedComment1.xml");
+    let legacy_comments = part_string(&parts, "xl/comments1.xml");
+    let persons = part_string(&parts, "xl/persons/person.xml");
+
+    let slicer_name = attribute_value(&slicers, "name").unwrap();
+    let slicer_cache_ref = attribute_value(&slicers, "cache").unwrap();
+    let cache_name = attribute_value(&slicer_cache, "name").unwrap();
+    assert_eq!(slicer_name, slicer_cache_ref);
+    assert_eq!(
+        slicer_cache_ref, cache_name,
+        "slicer@cache must track slicerCacheDefinition@name"
+    );
+    let drawing_name = tag_attribute(&slicer_drawing, "sle:slicer ", "name").unwrap();
+    assert_ref_name(&drawing_name);
+    assert_eq!(
+        drawing_name, slicer_name,
+        "drawing slicer@name must track the slicer-view name"
+    );
+    let caption = attribute_value(&slicers, "caption").unwrap();
+    let source_name = attribute_value(&slicer_cache, "sourceName").unwrap();
+    let field_name = tag_attribute(&cache_definition, "cacheField ", "name").unwrap();
+    assert_eq!(caption, source_name);
+    assert_eq!(
+        source_name, field_name,
+        "slicer sourceName must track cacheField@name"
+    );
+
+    let definition_name = tag_attribute(&pivot_table, "pivotTableDefinition ", "name").unwrap();
+    let cached_table_name = tag_attribute(&slicer_cache, "pivotTable ", "name").unwrap();
+    assert_ref_name(&definition_name);
+    assert_eq!(
+        definition_name, cached_table_name,
+        "slicerCache pivotTable@name must track pivotTableDefinition@name"
+    );
+
+    let chart = part_string(&parts, "xl/charts/chart1.xml");
+    let pivot_source = between(&chart, "<c:name>", "</c:name>").unwrap();
+    let book_segment = between(pivot_source, "[", "]").unwrap();
+    assert_eq!(
+        book_segment, "Book1",
+        "bracketed workbook filename must stay verbatim"
+    );
+    let sheet_name = tag_attribute(&workbook, "sheet ", "name").unwrap();
+    let (chart_sheet_segment, chart_table_segment) = pivot_source[book_segment.len() + 2..]
+        .split_once('!')
+        .unwrap();
+    assert_eq!(
+        chart_sheet_segment, sheet_name,
+        "chart sheet segment must track the redacted workbook sheet@name"
+    );
+    assert_ref_name(chart_table_segment);
+    assert_ne!(chart_sheet_segment, chart_table_segment);
+    assert_eq!(
+        chart_table_segment, definition_name,
+        "chart pivotSource table segment must track pivotTableDefinition@name"
+    );
+    assert!(!chart.contains("CACHE_LABEL_SECRET") && !chart.contains("$A$1"));
+
+    let legacy_uid = tag_attribute_values(&legacy_comments, "comment", "uid").remove(0);
+    let thread_ids = tag_attribute_values(&comments, "threadedComment", "id");
+    assert_guid(&legacy_uid);
+    assert_eq!(
+        legacy_uid, thread_ids[0],
+        "legacy comment@uid must track the threadedComment id it links to"
+    );
+    let author_text = between(&legacy_comments, "<author>", "</author>").unwrap();
+    assert_eq!(
+        author_text,
+        format!("tc={legacy_uid}"),
+        "xl/comments author text tc={{guid}} must reuse the comment@uid mapping"
+    );
+
+    let comment_person_id = attribute_value(&comments, "personId").unwrap();
+    let person_id = attribute_value(&persons, "id").unwrap();
+    assert_guid(&comment_person_id);
+    assert_guid(&person_id);
+    assert_eq!(
+        comment_person_id, person_id,
+        "personId must stay consistent across persons and threadedComments"
+    );
+    let parent_ids = tag_attribute_values(&comments, "threadedComment", "parentId");
+    let comment_person_ids = tag_attribute_values(&comments, "threadedComment", "personId");
+    let mention_ids = tag_attribute_values(&comments, "mention", "mentionId");
+    let mention_mention_ids = tag_attribute_values(&comments, "mention", "mentionpersonId");
+    let person_ids = tag_attribute_values(&persons, "person", "id");
+    for value in thread_ids
+        .iter()
+        .chain(parent_ids.iter())
+        .chain(comment_person_ids.iter())
+        .chain(mention_ids.iter())
+        .chain(mention_mention_ids.iter())
+        .chain(person_ids.iter())
+    {
+        assert_guid(value);
+    }
+    assert_eq!(
+        parent_ids[0], thread_ids[0],
+        "reply parentId must track parent threadedComment id"
+    );
+    assert_eq!(
+        mention_mention_ids[0], comment_person_ids[0],
+        "mention@mentionpersonId must track the mentioned threadedComment@personId"
+    );
+
+    let tcs2 = part_string(&parts, "xl/threadedComments/threadedComments2.tcsx");
+    assert!(
+        !tcs2.contains("TCS2_THREAD_SECRET"),
+        "threadedcomment body text must be scrubbed"
+    );
+    assert!(
+        tcs2.contains("<checksum>0</checksum>"),
+        "checksum element text must be neutralized: {tcs2}"
+    );
+    assert!(tcs2.contains(r#"count="3""#));
+    assert_eq!(
+        attribute_value(&tcs2, "dT").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    let tcs2_url = tag_attribute(&tcs2, "hyperlink ", "url").unwrap();
+    assert_eq!(
+        tcs2_url,
+        "x".repeat("https://secret.example/tcs2".len()),
+        "hyperlink@url must be masked"
+    );
+    assert_eq!(tag_attribute_values(&tcs2, "hyperlink", "url").len(), 1);
+    assert!(
+        tcs2.contains("<junk>TCS2_RAW_SURVIVOR</junk>"),
+        "text outside comment bodies must pass through untouched: {tcs2}"
+    );
+
+    let worksheet_sheet = tag_attribute(&cache_definition, "worksheetSource ", "sheet").unwrap();
+    assert_eq!(
+        worksheet_sheet, sheet_name,
+        "worksheetSource@sheet must equal the redacted workbook sheet name"
+    );
+    let worksheet_source_name =
+        tag_attribute_values(&cache_definition, "worksheetSource", "name").remove(0);
+    assert!(
+        !worksheet_source_name.is_empty() && worksheet_source_name.bytes().all(|byte| byte == b'x'),
+        "worksheetSource@name is not a masked name: {worksheet_source_name}"
+    );
+    assert_eq!(
+        attribute_value(&cache_definition, "refreshedDate").as_deref(),
+        Some("45000")
+    );
+    assert_eq!(
+        attribute_value(&cache_definition, "refreshedDateIso").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert!(cache_definition.contains("<formula>0</formula>"));
+}
+
+fn assert_integration_docx() {
+    let source = package(vec![
+        (
+            "[Content_Types].xml",
+            xml(
+                r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/comments.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml"/><Override PartName="/word/commentsExtended.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml"/><Override PartName="/word/commentsExtensible.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtensible+xml"/><Override PartName="/word/people.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.people+xml"/><Override PartName="/word/threadedComments/threadedComment1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.threadedComments+xml"/></Types>"#,
+            ),
+        ),
+        (
+            "_rels/.rels",
+            xml(
+                r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+            ),
+        ),
+        (
+            "word/document.xml",
+            xml(
+                r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p w:rsidR="00AA11BB" w:rsidRDefault="00AA11BB"><w:moveFromRangeStart w:id="3" w:author="MOVE_AUTHOR_SECRET" w:date="2024-04-05T10:00:00Z"/><w:moveFrom w:id="1" w:author="MOVE_AUTHOR_SECRET" w:date="2024-04-05T10:00:00Z"><w:r><w:t>OLD_MOVE_SECRET</w:t></w:r></w:moveFrom><w:moveTo w:id="2" w:author="MOVE_AUTHOR_SECRET" w:date="2024-04-05T10:00:00Z"><w:r><w:t>NEW_MOVE_SECRET</w:t></w:r></w:moveTo><w:moveFromRangeEnd w:id="3"/><w:moveToRangeStart w:id="4" w:author="MOVE_AUTHOR_SECRET" w:dateUtc="2024-04-05T10:30:00Z"/><w:moveToRangeEnd w:id="4"/></w:p><w:sectPr w:rsidR="00AA11BB"/></w:body></w:document>"#,
+            ),
+        ),
+        (
+            "word/settings.xml",
+            xml(
+                r#"<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:zoom w:percent="100"/><w:rsids><w:rsidRoot w:val="00AA11BB"/><w:rsid w:val="00CC22DD"/></w:rsids></w:settings>"#,
+            ),
+        ),
+        (
+            "word/people.xml",
+            xml(
+                r#"<w15:persons xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml/person"><w15:person w15:author="JANE_DOE"><w15:presenceInfo w15:userId="WORD_USER_SECRET" w15:providerId="None"/></w15:person></w15:persons>"#,
+            ),
+        ),
+        (
+            "word/comments.xml",
+            xml(
+                r#"<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w:comment w:id="0" w:author="JANE_DOE" w:date="2024-08-08T09:10:11Z" w15:paraId="11111111" w15:textId="22222222"><w:p><w:r><w:t>WORD_LEGACY_COMMENT_SECRET</w:t></w:r></w:p></w:comment></w:comments>"#,
+            ),
+        ),
+        (
+            "word/commentsExtended.xml",
+            xml(
+                r#"<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="11111111" w15:dateUtc="2024-08-08T09:30:11Z" w15:done="0"/></w15:commentsEx>"#,
+            ),
+        ),
+        (
+            "word/commentsExtensible.xml",
+            xml(
+                r#"<w16ce:commentsExtensible xmlns:w16ce="http://schemas.microsoft.com/office/word/2018/wordml/cex"><w16ce:commentExtensible w16ce:durableId="33333333" w16ce:dateUtc="2024-08-08T09:40:11Z"/></w16ce:commentsExtensible>"#,
+            ),
+        ),
+        (
+            "word/threadedComments/threadedComment1.xml",
+            xml(
+                r#"<wtp:threadedComments xmlns:wtp="http://schemas.microsoft.com/office/word/2018/wordprocessing/threadedComments"><wtp:threadedComment wtp:id="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}" wtp:date="2024-06-07T11:12:13Z" wtp:personId="{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}"><wtp:text>WORD_THREAD_SECRET</wtp:text></wtp:threadedComment><wtp:threadedComment wtp:id="{77777777-7777-7777-7777-777777777777}" wtp:parentId="{CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC}" wtp:date="2024-06-07T11:14:15Z" wtp:personId="{88888888-8888-8888-8888-888888888888}"><wtp:mentions><wtp:mention wtp:personId="{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}" wtp:mentionpersonId="{BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB}" wtp:mentionId="{99999999-9999-9999-9999-999999999999}" wtp:userId="WORD_USER_SECRET"/></wtp:mentions><wtp:text>WORD_REPLY_SECRET</wtp:text></wtp:threadedComment></wtp:threadedComments>"#,
+            ),
+        ),
+    ]);
+    let (output, report) = redact_with_report(&source, Format::Docx).unwrap();
+    assert_eq!(report.format, Format::Docx);
+    let parts = ooxml_opc::unzip_parts(&output).unwrap();
+    assert_no_secrets(&parts, INTEGRATION_DOCX_SECRETS);
+
+    let document = part_string(&parts, "word/document.xml");
+    let settings = part_string(&parts, "word/settings.xml");
+    let people = part_string(&parts, "word/people.xml");
+    let legacy_comments = part_string(&parts, "word/comments.xml");
+    let comments_extended = part_string(&parts, "word/commentsExtended.xml");
+    let comments_extensible = part_string(&parts, "word/commentsExtensible.xml");
+    let comments = part_string(&parts, "word/threadedComments/threadedComment1.xml");
+
+    let person_author = tag_attribute(&people, "w15:person ", "author").unwrap();
+    let comment_author = tag_attribute(&legacy_comments, "w:comment ", "author").unwrap();
+    assert_eq!(
+        person_author, comment_author,
+        "person@author must mask exactly like annotation authors"
+    );
+    assert_eq!(person_author, "xxxxxxxx", "authors must be masked strings");
+
+    for output in [
+        &legacy_comments,
+        &comments_extended,
+        &comments_extensible,
+        &comments,
+    ] {
+        assert!(!output.contains("2024-08-08") && !output.contains("2024-06-07"));
+    }
+    assert_eq!(
+        attribute_value(&legacy_comments, "date").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        attribute_value(&comments_extended, "dateUtc").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        attribute_value(&comments_extensible, "dateUtc").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+
+    let comment_person_id = attribute_value(&comments, "personId").unwrap();
+    assert_guid(&comment_person_id);
+    let comment_ids = tag_attribute_values(&comments, "threadedComment", "id");
+    let parent_ids = tag_attribute_values(&comments, "threadedComment", "parentId");
+    let mention_ids = tag_attribute_values(&comments, "mention", "mentionId");
+    let mention_mention_ids = tag_attribute_values(&comments, "mention", "mentionpersonId");
+    for value in comment_ids
+        .iter()
+        .chain(parent_ids.iter())
+        .chain(mention_ids.iter())
+        .chain(mention_mention_ids.iter())
+    {
+        assert_guid(value);
+    }
+    assert_eq!(
+        parent_ids[0], comment_ids[0],
+        "reply parentId must track parent threadedComment id"
+    );
+    assert_eq!(
+        mention_mention_ids[0], comment_person_id,
+        "mention@mentionpersonId must track the mentioned threadedComment@personId"
+    );
+
+    let rsid_root = tag_attribute(&settings, "w:rsidRoot ", "val").unwrap();
+    let rsid_r = attribute_values(&document, "rsidR")[0].clone();
+    assert_eight_hex(&rsid_root);
+    assert_eq!(
+        rsid_root, rsid_r,
+        "rsidRoot@val must map like rsid attributes across parts"
+    );
+
+    assert_eq!(
+        attribute_value(&document, "date").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert_eq!(
+        attribute_value(&comments, "date").as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+}
+
+fn part_string(parts: &[(String, Vec<u8>)], path: &str) -> String {
+    String::from_utf8(part(parts, path).to_vec()).unwrap()
 }

--- a/crates/ooxml-redact/src/xml.rs
+++ b/crates/ooxml-redact/src/xml.rs
@@ -1,14 +1,60 @@
 use quick_xml::events::{BytesCData, BytesStart, BytesText, Event};
 use quick_xml::{Reader, Writer, XmlVersion};
 
-use crate::{Format, RedactError, RedactionReport};
+use crate::{Format, IdMappings, RedactError, RedactionReport};
+
+const DATE_PLACEHOLDER: &str = "1970-01-01T00:00:00Z";
+
+pub(crate) struct RunState<'a> {
+    pub(crate) report: &'a mut RedactionReport,
+    pub(crate) mappings: &'a mut IdMappings,
+}
+
+struct ScrubContext<'a> {
+    format: Format,
+    path: &'a str,
+    content_type: Option<&'a str>,
+}
+
+impl ScrubContext<'_> {
+    fn classifies(&self, needle: &str) -> bool {
+        self.path.contains(needle) || self.content_type.is_some_and(|ct| ct.contains(needle))
+    }
+
+    fn is_chart(&self) -> bool {
+        self.classifies("/charts/") || self.content_type.is_some_and(|ct| ct.contains("chart+xml"))
+    }
+
+    fn is_connections(&self) -> bool {
+        self.path == "xl/connections.xml"
+            || self
+                .content_type
+                .is_some_and(|ct| ct.contains("connections+xml"))
+    }
+
+    fn is_person_part(&self) -> bool {
+        self.classifies("/persons/")
+            || self.classifies("/people")
+            || self
+                .content_type
+                .is_some_and(|ct| ct.contains("person+xml") || ct.contains("people+xml"))
+    }
+}
 
 pub(crate) fn redact_xml(
     format: Format,
     path: &str,
+    content_type: Option<&str>,
     bytes: &[u8],
-    report: &mut RedactionReport,
+    state: &mut RunState<'_>,
 ) -> Result<Vec<u8>, RedactError> {
+    let path_lower = path.to_ascii_lowercase();
+    let content_type_lower = content_type.map(|value| value.to_ascii_lowercase());
+    let context = ScrubContext {
+        format,
+        path: &path_lower,
+        content_type: content_type_lower.as_deref(),
+    };
     let mut reader = Reader::from_reader(bytes);
     reader.config_mut().trim_text(false);
     let mut writer = Writer::new(Vec::with_capacity(bytes.len()));
@@ -22,8 +68,15 @@ pub(crate) fn redact_xml(
         match event {
             Event::Start(start) => {
                 let local = local_name(start.name().local_name().as_ref());
-                let rewritten =
-                    rewrite_start(format, path, &reader, start, &local, report, &mut cell_type)?;
+                let rewritten = rewrite_start(
+                    &context,
+                    path,
+                    &reader,
+                    start,
+                    &local,
+                    state,
+                    &mut cell_type,
+                )?;
                 stack.push(local);
                 writer
                     .write_event(Event::Start(rewritten))
@@ -31,8 +84,15 @@ pub(crate) fn redact_xml(
             }
             Event::Empty(start) => {
                 let local = local_name(start.name().local_name().as_ref());
-                let rewritten =
-                    rewrite_start(format, path, &reader, start, &local, report, &mut cell_type)?;
+                let rewritten = rewrite_start(
+                    &context,
+                    path,
+                    &reader,
+                    start,
+                    &local,
+                    state,
+                    &mut cell_type,
+                )?;
                 writer
                     .write_event(Event::Empty(rewritten))
                     .map_err(|error| xml_error(path, error))?;
@@ -47,12 +107,12 @@ pub(crate) fn redact_xml(
                     .map_err(|error| xml_error(path, error))?;
             }
             Event::Text(text) => {
-                if let Some(kind) = replacement_kind(format, path, &stack, cell_type.as_deref()) {
+                if let Some(kind) = replacement_kind(&context, &stack, cell_type.as_deref()) {
                     let decoded = text.decode().map_err(|error| xml_error(path, error))?;
                     let unescaped = quick_xml::escape::unescape(&decoded)
                         .map_err(|error| xml_error(path, error))?;
-                    let replacement = replace_text(&unescaped, kind, &stack);
-                    charge_text(report, &unescaped);
+                    let replacement = replace_text(&unescaped, kind, state.mappings);
+                    charge_text(state.report, &unescaped);
                     writer
                         .write_event(Event::Text(BytesText::new(&replacement)))
                         .map_err(|error| xml_error(path, error))?;
@@ -63,10 +123,10 @@ pub(crate) fn redact_xml(
                 }
             }
             Event::CData(text) => {
-                if let Some(kind) = replacement_kind(format, path, &stack, cell_type.as_deref()) {
+                if let Some(kind) = replacement_kind(&context, &stack, cell_type.as_deref()) {
                     let decoded = text.decode().map_err(|error| xml_error(path, error))?;
-                    let replacement = replace_text(&decoded, kind, &stack);
-                    charge_text(report, &decoded);
+                    let replacement = replace_text(&decoded, kind, state.mappings);
+                    charge_text(state.report, &decoded);
                     writer
                         .write_event(Event::CData(BytesCData::new(&replacement)))
                         .map_err(|error| xml_error(path, error))?;
@@ -77,9 +137,9 @@ pub(crate) fn redact_xml(
                 }
             }
             Event::GeneralRef(reference) => {
-                if replacement_kind(format, path, &stack, cell_type.as_deref()).is_some() {
-                    report.text_nodes += 1;
-                    report.characters += 1;
+                if replacement_kind(&context, &stack, cell_type.as_deref()).is_some() {
+                    state.report.text_nodes += 1;
+                    state.report.characters += 1;
                     writer
                         .write_event(Event::Text(BytesText::new("x")))
                         .map_err(|error| xml_error(path, error))?;
@@ -90,7 +150,7 @@ pub(crate) fn redact_xml(
                 }
             }
             Event::Comment(_) | Event::PI(_) => {
-                report.xml_comments += 1;
+                state.report.xml_comments += 1;
             }
             Event::DocType(_) => {
                 return Err(RedactError::Xml {
@@ -109,12 +169,12 @@ pub(crate) fn redact_xml(
 }
 
 fn rewrite_start(
-    format: Format,
+    context: &ScrubContext<'_>,
     path: &str,
     reader: &Reader<&[u8]>,
     start: BytesStart<'_>,
     element: &str,
-    report: &mut RedactionReport,
+    state: &mut RunState<'_>,
     cell_type: &mut Option<String>,
 ) -> Result<BytesStart<'static>, RedactError> {
     let mut attributes = Vec::new();
@@ -133,7 +193,7 @@ fn rewrite_start(
             attribute_local(key).eq_ignore_ascii_case("TargetMode")
                 && value.eq_ignore_ascii_case("External")
         });
-    if format == Format::Xlsx && element == "c" {
+    if context.format == Format::Xlsx && element == "c" {
         *cell_type = None;
     }
     let mut output = start.into_owned();
@@ -142,22 +202,21 @@ fn rewrite_start(
         let local = attribute_local(&key);
         let replacement = if external && local.eq_ignore_ascii_case("Target") {
             Some("https://example.com".to_owned())
-        } else if !key.starts_with("xmlns")
-            && sensitive_attribute(format, path, element, local, &value)
-        {
-            Some(placeholder(&value))
+        } else if !key.starts_with("xmlns") {
+            attribute_scrub(context, element, local, &value)
+                .map(|scrub| apply_attribute_scrub(scrub, &value, state.mappings))
         } else {
             None
         };
         if let Some(replacement) = replacement {
             if replacement != value {
-                report.attributes += 1;
+                state.report.attributes += 1;
             }
             output.push_attribute((key.as_str(), replacement.as_str()));
         } else {
             output.push_attribute((key.as_str(), value.as_str()));
         }
-        if format == Format::Xlsx && element == "c" && local == "t" {
+        if context.format == Format::Xlsx && element == "c" && local == "t" {
             *cell_type = Some(value);
         }
     }
@@ -172,55 +231,104 @@ enum Replacement {
     Date,
     Boolean,
     Error,
+    CompoundRefName,
+    Checksum,
+    LegacyAuthor,
+}
+
+#[derive(Clone, Copy)]
+enum AttributeScrub {
+    Mask,
+    HexId,
+    RefName,
+    Guid,
+    Fixed(&'static str),
+}
+
+fn apply_attribute_scrub(scrub: AttributeScrub, value: &str, mappings: &mut IdMappings) -> String {
+    match scrub {
+        AttributeScrub::Mask => placeholder(value),
+        AttributeScrub::HexId => mappings.hex_id(value),
+        AttributeScrub::RefName => mappings.ref_name(value),
+        AttributeScrub::Guid => mappings.guid(value),
+        AttributeScrub::Fixed(literal) => literal.to_owned(),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MetadataSection {
+    Core,
+    App,
+    Custom,
+}
+
+fn metadata_section(context: &ScrubContext<'_>) -> Option<MetadataSection> {
+    let content_type = context.content_type;
+    if context.path == "docprops/core.xml"
+        || content_type.is_some_and(|ct| ct.contains("core-properties"))
+    {
+        Some(MetadataSection::Core)
+    } else if context.path == "docprops/app.xml"
+        || content_type.is_some_and(|ct| ct.contains("extended-properties"))
+    {
+        Some(MetadataSection::App)
+    } else if context.path == "docprops/custom.xml"
+        || content_type
+            .is_some_and(|ct| ct.contains("custom-properties") || ct.contains("customproperties"))
+    {
+        Some(MetadataSection::Custom)
+    } else {
+        None
+    }
 }
 
 fn replacement_kind(
-    format: Format,
-    path: &str,
+    context: &ScrubContext<'_>,
     stack: &[String],
     cell_type: Option<&str>,
 ) -> Option<Replacement> {
     let element = stack.last().map(String::as_str)?;
-    let lower = path.to_ascii_lowercase();
-    if lower == "docprops/core.xml" {
-        return match element {
-            "created" | "modified" | "lastPrinted" => Some(Replacement::Date),
-            "revision" => Some(Replacement::Number),
-            "title" | "subject" | "creator" | "keywords" | "description" | "lastModifiedBy"
-            | "category" | "contentStatus" => Some(Replacement::Text),
-            _ => None,
+    if let Some(section) = metadata_section(context) {
+        return match section {
+            MetadataSection::Core => match element {
+                "created" | "modified" | "lastPrinted" => Some(Replacement::Date),
+                "revision" => Some(Replacement::Number),
+                "title" | "subject" | "creator" | "keywords" | "description" | "lastModifiedBy"
+                | "category" | "contentStatus" | "identifier" | "language" | "version"
+                | "contentType" => Some(Replacement::Text),
+                _ => None,
+            },
+            MetadataSection::App => matches!(
+                element,
+                "Application"
+                    | "AppVersion"
+                    | "Company"
+                    | "Manager"
+                    | "Template"
+                    | "HyperlinkBase"
+                    | "lpstr"
+                    | "lpwstr"
+                    | "bstr"
+            )
+            .then_some(Replacement::Text),
+            MetadataSection::Custom => match element {
+                "i1" | "i2" | "i4" | "i8" | "int" | "uint" | "ui1" | "ui2" | "ui4" | "ui8"
+                | "r4" | "r8" | "decimal" => Some(Replacement::Number),
+                "bool" => Some(Replacement::Boolean),
+                "date" | "filetime" => Some(Replacement::Date),
+                _ => Some(Replacement::Text),
+            },
         };
     }
-    if lower == "docprops/app.xml" {
-        return matches!(
-            element,
-            "Application"
-                | "AppVersion"
-                | "Company"
-                | "Manager"
-                | "Template"
-                | "HyperlinkBase"
-                | "lpstr"
-                | "lpwstr"
-                | "bstr"
-        )
-        .then_some(Replacement::Text);
-    }
-    if lower == "docprops/custom.xml" {
-        return match element {
-            "i1" | "i2" | "i4" | "i8" | "int" | "uint" | "ui1" | "ui2" | "ui4" | "ui8" | "r4"
-            | "r8" | "decimal" => Some(Replacement::Number),
-            "bool" => Some(Replacement::Boolean),
-            "date" | "filetime" => Some(Replacement::Date),
-            _ => Some(Replacement::Text),
-        };
-    }
-    if lower.starts_with("customxml/") && !lower.contains("itemprops") {
+    if context.path.starts_with("customxml/") && !context.path.contains("itemprops") {
         return Some(Replacement::Text);
     }
-    if lower.contains("/charts/") {
+    if context.is_chart() {
         return match element {
             "f" => Some(Replacement::Formula),
+            "name" if stack.iter().any(|name| name == "pivotSource") => {
+                Some(Replacement::CompoundRefName)
+            }
             "v" if stack.iter().any(|name| name == "strCache" || name == "tx") => {
                 Some(Replacement::Text)
             }
@@ -229,8 +337,25 @@ fn replacement_kind(
             _ => None,
         };
     }
+    if context.classifies("pivotcacherecords") {
+        return Some(Replacement::Text);
+    }
+    if context.classifies("threadedcomment") {
+        return match element {
+            "text" => Some(Replacement::Text),
+            "checksum" => Some(Replacement::Checksum),
+            _ => None,
+        };
+    }
+    if context.path == "word/settings.xml" {
+        return matches!(
+            element,
+            "table" | "query" | "connectString" | "addressFieldName" | "mailSubject" | "udl"
+        )
+        .then_some(Replacement::Text);
+    }
 
-    match format {
+    match context.format {
         Format::Docx => matches!(element, "t" | "delText" | "instrText" | "delInstrText")
             .then_some(if matches!(element, "instrText" | "delInstrText") {
                 Replacement::Formula
@@ -239,9 +364,10 @@ fn replacement_kind(
             }),
         Format::Pptx => matches!(element, "t" | "text").then_some(Replacement::Text),
         Format::Xlsx => match element {
+            "author" if context.path.starts_with("xl/comments") => Some(Replacement::LegacyAuthor),
             "t" | "author" | "oddHeader" | "oddFooter" | "evenHeader" | "evenFooter"
             | "firstHeader" | "firstFooter" => Some(Replacement::Text),
-            "f" | "formula1" | "formula2" | "definedName" => Some(Replacement::Formula),
+            "f" | "formula1" | "formula2" | "definedName" | "formula" => Some(Replacement::Formula),
             "v" if cell_type == Some("s") => None,
             "v" if matches!(cell_type, Some("str" | "inlineStr")) => Some(Replacement::Text),
             "v" if cell_type == Some("e") => Some(Replacement::Error),
@@ -252,7 +378,7 @@ fn replacement_kind(
     }
 }
 
-fn replace_text(text: &str, kind: Replacement, _stack: &[String]) -> String {
+fn replace_text(text: &str, kind: Replacement, mappings: &mut IdMappings) -> String {
     if text.trim().is_empty() {
         return text.to_owned();
     }
@@ -260,59 +386,329 @@ fn replace_text(text: &str, kind: Replacement, _stack: &[String]) -> String {
         Replacement::Text => placeholder(text),
         Replacement::Number => numeric_placeholder(text),
         Replacement::Formula => "0".to_owned(),
-        Replacement::Date => "1970-01-01T00:00:00Z".to_owned(),
+        Replacement::Date => DATE_PLACEHOLDER.to_owned(),
         Replacement::Boolean => "false".to_owned(),
         Replacement::Error => "#N/A".to_owned(),
+        Replacement::Checksum => "0".to_owned(),
+        Replacement::CompoundRefName => compound_ref_name(text, mappings),
+        Replacement::LegacyAuthor => match text.strip_prefix("tc=") {
+            Some(guid) => format!("tc={}", mappings.guid(guid)),
+            None => placeholder(text),
+        },
     }
 }
 
-fn sensitive_attribute(
-    format: Format,
-    path: &str,
+fn compound_ref_name(text: &str, mappings: &mut IdMappings) -> String {
+    let mut rest = text;
+    let mut rebuilt = String::new();
+    if let Some(inner) = rest.strip_prefix('[')
+        && let Some((book, tail)) = inner.split_once(']')
+    {
+        rebuilt.push('[');
+        rebuilt.push_str(book);
+        rebuilt.push(']');
+        rest = tail;
+    }
+    match rest.rsplit_once('!') {
+        Some((sheet, table)) => {
+            rebuilt.push_str(&placeholder(sheet));
+            rebuilt.push('!');
+            rebuilt.push_str(&mappings.ref_name(table));
+        }
+        None => rebuilt.push_str(&mappings.ref_name(rest)),
+    }
+    rebuilt
+}
+
+fn attribute_scrub(
+    context: &ScrubContext<'_>,
     element: &str,
     attribute: &str,
     value: &str,
-) -> bool {
-    let lower = path.to_ascii_lowercase();
-    if lower == "docprops/custom.xml" && attribute == "name" {
-        return true;
+) -> Option<AttributeScrub> {
+    let format = context.format;
+    if metadata_section(context) == Some(MetadataSection::Custom)
+        && matches!(attribute, "name" | "linkTarget")
+    {
+        return Some(AttributeScrub::Mask);
     }
-    if lower.starts_with("customxml/") && !lower.contains("itemprops") {
-        return !matches!(attribute, "id" | "Id");
+    if context.path.starts_with("customxml/")
+        && !context.path.contains("itemprops")
+        && !matches!(attribute, "id" | "Id")
+    {
+        return Some(AttributeScrub::Mask);
     }
     if matches!(element, "docPr" | "cNvPr") && matches!(attribute, "name" | "descr" | "title") {
-        return true;
+        return Some(AttributeScrub::Mask);
     }
     if element == "textpath" && attribute == "string" {
-        return true;
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("pivotcache") && attribute == "refreshedBy" {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("pivotcache") && attribute == "refreshedDateIso" {
+        return Some(AttributeScrub::Fixed(DATE_PLACEHOLDER));
+    }
+    if context.classifies("pivotcache") && attribute == "refreshedDate" {
+        return Some(AttributeScrub::Fixed("45000"));
+    }
+    if context.classifies("pivotcache")
+        && element == "rangeSet"
+        && matches!(attribute, "sheet" | "name")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("pivotcache")
+        && element == "worksheetSource"
+        && matches!(attribute, "name" | "sheet")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("pivotcache")
+        && element == "cacheHierarchy"
+        && matches!(
+            attribute,
+            "caption"
+                | "uniqueName"
+                | "dimensionUniqueName"
+                | "allCaption"
+                | "allUniqueName"
+                | "defaultMemberUniqueName"
+                | "displayFolder"
+        )
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if (context.classifies("pivotcache") || context.classifies("pivottable"))
+        && element == "pageField"
+        && matches!(attribute, "name" | "cap")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if (context.classifies("pivotcache") || context.classifies("pivottable"))
+        && element == "pageItem"
+        && attribute == "name"
+    {
+        return Some(AttributeScrub::RefName);
+    }
+    if context.classifies("pivotcache") && element == "cacheField" {
+        return match attribute {
+            "name" | "caption" => Some(AttributeScrub::RefName),
+            "propertyName" | "formula" => Some(AttributeScrub::Mask),
+            _ => None,
+        };
+    }
+    if context.classifies("pivotcache") && attribute == "v" {
+        return match element {
+            "x" => None,
+            "n" | "b" => Some(AttributeScrub::Fixed("0")),
+            "d" => Some(AttributeScrub::Fixed(DATE_PLACEHOLDER)),
+            "e" => Some(AttributeScrub::Fixed("#N/A")),
+            _ => Some(AttributeScrub::Mask),
+        };
+    }
+    if context.classifies("pivottable")
+        && matches!(element, "item" | "pivotItem")
+        && attribute == "n"
+    {
+        return Some(AttributeScrub::RefName);
+    }
+    if context.classifies("pivottable") && element.eq_ignore_ascii_case("pivotTableDefinition") {
+        if attribute == "name" {
+            return Some(AttributeScrub::RefName);
+        }
+        if attribute.to_ascii_lowercase().contains("caption") {
+            return Some(AttributeScrub::Mask);
+        }
+    }
+    if context.classifies("pivottable")
+        && element.eq_ignore_ascii_case("pivotField")
+        && matches!(attribute, "name" | "subtotalCaption")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("pivottable")
+        && element.eq_ignore_ascii_case("dataField")
+        && attribute == "name"
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("slicer")
+        && matches!(attribute, "name" | "cache" | "sourceName" | "caption")
+    {
+        return Some(AttributeScrub::RefName);
+    }
+    if context.path.starts_with("word/comments")
+        && (attribute.eq_ignore_ascii_case("dateUtc")
+            || (element.eq_ignore_ascii_case("comment") && attribute.eq_ignore_ascii_case("date")))
+    {
+        return Some(AttributeScrub::Fixed(DATE_PLACEHOLDER));
+    }
+    if context.path.starts_with("xl/comments")
+        && element.eq_ignore_ascii_case("comment")
+        && attribute.eq_ignore_ascii_case("uid")
+    {
+        return Some(AttributeScrub::Guid);
+    }
+    if context.classifies("threadedcomment")
+        && (attribute.eq_ignore_ascii_case("dt") || matches!(attribute, "date" | "dateUtc"))
+    {
+        return Some(AttributeScrub::Fixed(DATE_PLACEHOLDER));
+    }
+    if context.classifies("threadedcomment") && element == "hyperlink" && attribute == "url" {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.classifies("threadedcomment") || context.is_person_part() {
+        if matches!(
+            attribute,
+            "userId" | "displayName" | "providerId" | "initials"
+        ) {
+            return Some(AttributeScrub::Mask);
+        }
+        let identity_attribute = attribute.eq_ignore_ascii_case("personId")
+            || (element.eq_ignore_ascii_case("person") && attribute.eq_ignore_ascii_case("id"))
+            || (element.eq_ignore_ascii_case("threadedComment")
+                && matches!(attribute, "id" | "parentId"))
+            || (element.eq_ignore_ascii_case("mention")
+                && matches!(attribute, "mentionpersonId" | "mentionId"));
+        if identity_attribute {
+            return Some(AttributeScrub::Guid);
+        }
+    }
+    if context.is_connections() {
+        if element == "connection" && attribute == "name" {
+            return Some(AttributeScrub::RefName);
+        }
+        if element == "parameter" {
+            return match attribute {
+                "name" => Some(AttributeScrub::RefName),
+                "string" | "prompt" | "cell" => Some(AttributeScrub::Mask),
+                "double" | "integer" | "boolean" => Some(AttributeScrub::Fixed("0")),
+                _ => None,
+            };
+        }
+        if matches!(
+            (element, attribute),
+            ("dbPr", "connection" | "command" | "serverCommand")
+                | ("olapPr", "localConnection")
+                | ("webPr", "url" | "post" | "editPage")
+                | (
+                    "connection",
+                    "odcFile" | "sourceFile" | "singleSignOnId" | "description"
+                )
+                | ("textPr", "sourceFile")
+                | ("s", "v")
+        ) {
+            return Some(AttributeScrub::Mask);
+        }
+    }
+    if context.path == "word/settings.xml"
+        && matches!(
+            element,
+            "table" | "query" | "connectString" | "addressFieldName" | "mailSubject" | "udl"
+        )
+        && attribute == "val"
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if context.path == "word/styles.xml" && element == "name" && attribute == "val" {
+        return Some(AttributeScrub::Mask);
     }
     match format {
-        Format::Docx => {
-            matches!(attribute, "author" | "initials")
-                || element == "fldSimple" && attribute == "instr"
-                || element == "hyperlink" && matches!(attribute, "tooltip" | "tgtFrame")
-                || matches!(element, "alias" | "tag" | "docVar")
-                    && matches!(attribute, "name" | "val")
-                || lower == "word/styles.xml" && element == "name" && attribute == "val"
-        }
-        Format::Xlsx => {
-            element == "sheet" && attribute == "name"
-                || element == "definedName" && attribute == "name" && !value.starts_with("_xlnm.")
-                || matches!(element, "table" | "tableColumn")
-                    && matches!(attribute, "name" | "displayName")
-                || element == "dataValidation"
-                    && matches!(attribute, "prompt" | "promptTitle" | "error" | "errorTitle")
-                || element == "hyperlink" && matches!(attribute, "display" | "tooltip" | "location")
-                || element == "filter" && attribute == "val"
-        }
-        Format::Pptx => {
-            element == "cSld" && attribute == "name"
-                || element == "cmAuthor" && matches!(attribute, "name" | "initials")
-                || element == "tag" && matches!(attribute, "name" | "val")
-                || element == "custShow" && attribute == "name"
-        }
-        Format::Auto => false,
+        Format::Docx => docx_attribute_scrub(element, attribute),
+        Format::Xlsx => xlsx_attribute_scrub(element, attribute, value),
+        Format::Pptx => pptx_attribute_scrub(element, attribute),
+        Format::Auto => None,
     }
+}
+
+fn docx_attribute_scrub(element: &str, attribute: &str) -> Option<AttributeScrub> {
+    let lower_element = element.to_ascii_lowercase();
+    if matches!(attribute, "author" | "initials") {
+        return Some(AttributeScrub::Mask);
+    }
+    if attribute.to_ascii_lowercase().starts_with("rsid") {
+        return Some(AttributeScrub::HexId);
+    }
+    if (lower_element == "rsid" || lower_element == "rsidroot")
+        && attribute.eq_ignore_ascii_case("val")
+    {
+        return Some(AttributeScrub::HexId);
+    }
+    if (matches!(element, "ins" | "del")
+        || lower_element.ends_with("change")
+        || lower_element.starts_with("move")
+        || matches!(
+            lower_element.as_str(),
+            "cellins"
+                | "celldel"
+                | "cellmerge"
+                | "customxmlins"
+                | "customxmldel"
+                | "customxmlmove"
+                | "customxmlinsrangestart"
+                | "customxmldelrangestart"
+                | "customxmlmoverangestart"
+                | "customxmlinsrangeend"
+                | "customxmldelrangeend"
+                | "customxmlmoverangeend"
+        ))
+        && matches!(attribute, "date" | "dateUtc")
+    {
+        return Some(AttributeScrub::Fixed(DATE_PLACEHOLDER));
+    }
+    if matches!(element, "documentProtection" | "writeProtection")
+        && matches!(attribute, "hash" | "salt" | "hashValue" | "saltValue")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if element == "fldSimple" && attribute == "instr" {
+        return Some(AttributeScrub::Mask);
+    }
+    if element == "hyperlink" && matches!(attribute, "tooltip" | "tgtFrame") {
+        return Some(AttributeScrub::Mask);
+    }
+    if matches!(element, "alias" | "tag" | "docVar") && matches!(attribute, "name" | "val") {
+        return Some(AttributeScrub::Mask);
+    }
+    None
+}
+
+fn xlsx_attribute_scrub(element: &str, attribute: &str, value: &str) -> Option<AttributeScrub> {
+    if element == "sheet" && attribute == "name" {
+        return Some(AttributeScrub::Mask);
+    }
+    if element == "definedName" && attribute == "name" && !value.starts_with("_xlnm.") {
+        return Some(AttributeScrub::Mask);
+    }
+    if matches!(element, "table" | "tableColumn") && matches!(attribute, "name" | "displayName") {
+        return Some(AttributeScrub::Mask);
+    }
+    if element == "dataValidation"
+        && matches!(attribute, "prompt" | "promptTitle" | "error" | "errorTitle")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    if element == "hyperlink" && matches!(attribute, "display" | "tooltip" | "location") {
+        return Some(AttributeScrub::Mask);
+    }
+    if element == "filter" && attribute == "val" {
+        return Some(AttributeScrub::Mask);
+    }
+    None
+}
+
+fn pptx_attribute_scrub(element: &str, attribute: &str) -> Option<AttributeScrub> {
+    if (element == "cSld" && attribute == "name")
+        || (element == "cmAuthor" && matches!(attribute, "name" | "initials"))
+        || (element == "tag" && matches!(attribute, "name" | "val"))
+        || (element == "custShow" && attribute == "name")
+        || (element == "section" && attribute == "name")
+    {
+        return Some(AttributeScrub::Mask);
+    }
+    None
 }
 
 fn placeholder(text: &str) -> String {


### PR DESCRIPTION
TL;DR:

Summary:
- scrub pivot-cache and pivot-table metadata end to end: shared items (type-valid placeholders per xsd type), cache fields, calculated items, page/range sets, hierarchy captions, worksheet sources, refresh metadata
- cover threaded comments + legacy comments consistently: person ids as schema-valid braced GUIDs with cross-part referential equality, `tc={uid}` author linkage, mention identifiers, extension checksums neutralized
- cover connections (dbPr/webPr/olapPr/parameters), slicer/drawing name chains, DOCX mail-merge children, modern password verifiers, rsids (schema-valid 8-hex), revision dates across all tracked-change elements
- placeholders are type-valid (hex/dateTime/GUID/double), reference-consistent via a per-run bijective salted mapping, and collision-free in O(1)
- parts are classified by content type as well as path, so relocated or unusually named XML parts still get scrubbed

Known follow-ups (long tail, intentionally deferred):
- a few deep pivot-cache attributes (calculatedItem@formula attr form, sharedItems min/max bounds, rangePr) and custom-property typed variants (vt:cy/clsid/i1 overflow) still pass through; tracked for a follow-up PR
- pseudonym digest is salted FNV — adequate against casual dictionary attacks, not a keyed PRF; revisit if redacted docs face targeted adversaries

Test plan:
- [ ] `cargo test -p betteroffice-redact` green (33 tests incl. package-level integration)
- [ ] redact real-world xlsx with pivot table + slicers + threaded comments; open in Excel without repair prompts
- [ ] redact docx with tracked changes + people store; verify authors/dates gone and file opens clean