### PR TITLE
perf(python-pptx): release the gil in hot paths

### DIFF
--- a/.changeset/python-pptx-gil.md
+++ b/.changeset/python-pptx-gil.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/python-pptx": patch
+---
+
+Release the GIL during python-pptx open, render, save and update application.

--- a/.changeset/python-pptx-gil.md
+++ b/.changeset/python-pptx-gil.md
@@ -2,4 +2,4 @@
 "@betteroffice/python-pptx": patch
 ---
 
-Release the GIL during python-pptx open, render, save and update application.
+Release the GIL during python-pptx open, render, save, font registration and update application, without copying the input bytes to do it.

--- a/bindings/python-pptx/README.md
+++ b/bindings/python-pptx/README.md
@@ -288,9 +288,9 @@ its own; the deck must also become garbage on its owning thread. Open, use, and
 drop each deck inside one thread, and break any cycle holding it before that
 thread finishes.
 
-Engine calls hold the GIL for their duration, unlike `betteroffice-xlsx`. Only
-the file I/O releases it: `open_path`'s read, and the writes in `save_path`,
-`Media.write` and `DisplayList.write`.
+The heavy operations release the GIL while they run — `open`, `open_path`,
+`render_slide`, `save`, `save_path`, `register_font`, and `apply_update` — as do
+the file writes in `Media.write` and `DisplayList.write`.
 
 ## Status
 

--- a/bindings/python-pptx/src/lib.rs
+++ b/bindings/python-pptx/src/lib.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use pyo3::create_exception;
 use pyo3::exceptions::{PyException, PyIndexError, PyKeyError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyInt};
 use python_common::{generated_client_id, map_io_error};
 
@@ -930,6 +931,13 @@ fn join_text<'a>(parts: impl Iterator<Item = &'a str>) -> String {
         .join("\n")
 }
 
+/// Holds the argument's own reference so its bytes stay readable and immutable
+/// for as long as the caller keeps the result, `detach` included. Nothing is
+/// copied: `bytes` is already immutable, and pyo3 only ever binds one here.
+fn borrow_bytes(data: &Bound<'_, PyBytes>) -> PyBackedBytes {
+    PyBackedBytes::from(data.clone())
+}
+
 /// Moves a deck or a borrow of one across `detach`, which demands `Send`.
 ///
 /// # Safety
@@ -937,9 +945,14 @@ fn join_text<'a>(parts: impl Iterator<Item = &'a str>) -> String {
 /// The core type is `!Send` (`RefCell`s plus stored undo callbacks), but
 /// `PyPresentation` is `unsendable`, so any access from another thread panics
 /// inside pyo3 before reaching it, and `detach` keeps running on this thread.
+///
+/// Each deck shape is named on its own below: a blanket `impl<T>` would also
+/// hand `Send` to a `Bound` or a `Py<T>`, which pyo3 exists to keep out.
 struct DetachedDeck<T>(T);
 
-unsafe impl<T> Send for DetachedDeck<T> {}
+unsafe impl Send for DetachedDeck<CorePresentation> {}
+unsafe impl Send for DetachedDeck<&'_ CorePresentation> {}
+unsafe impl Send for DetachedDeck<&'_ mut CorePresentation> {}
 
 #[pyclass(module = "betteroffice_pptx", name = "Presentation", unsendable)]
 pub struct PyPresentation {
@@ -1059,18 +1072,17 @@ impl PyPresentation {
 
     fn open_bytes_inner(
         py: Python<'_>,
-        data: Vec<u8>,
-        limits: Option<&Bound<'_, PyDict>>,
+        data: &[u8],
+        limits: ParseLimits,
         client_id: Option<u64>,
     ) -> PyResult<Self> {
-        let limits = parse_limits(limits)?;
         let opened = py
             .detach(move || {
                 let opened = match client_id {
                     Some(client_id) => {
-                        CorePresentation::open_collaborative_with_limits(&data, client_id, &limits)
+                        CorePresentation::open_collaborative_with_limits(data, client_id, &limits)
                     }
-                    None => CorePresentation::open_with_limits(&data, &limits),
+                    None => CorePresentation::open_with_limits(data, &limits),
                 };
                 opened.map(DetachedDeck)
             })
@@ -1078,14 +1090,17 @@ impl PyPresentation {
         Ok(Self::wrap(opened.0, client_id.is_some()))
     }
 
-    /// Copies first: a borrow of a Python buffer cannot cross `detach`.
+    /// The limits are parsed before anything touches the input, so a rejected
+    /// argument costs nothing whatever it was handed.
     fn open_bytes(
         py: Python<'_>,
-        data: &[u8],
+        data: &Bound<'_, PyBytes>,
         limits: Option<&Bound<'_, PyDict>>,
         client_id: Option<u64>,
     ) -> PyResult<Self> {
-        Self::open_bytes_inner(py, data.to_vec(), limits, client_id)
+        let limits = parse_limits(limits)?;
+        let data = borrow_bytes(data);
+        Self::open_bytes_inner(py, &data, limits, client_id)
     }
 }
 
@@ -1093,7 +1108,11 @@ impl PyPresentation {
 impl PyPresentation {
     #[staticmethod]
     #[pyo3(signature = (data, *, limits = None))]
-    fn open(py: Python<'_>, data: &[u8], limits: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+    fn open(
+        py: Python<'_>,
+        data: &Bound<'_, PyBytes>,
+        limits: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
         Self::open_bytes(py, data, limits, None)
     }
 
@@ -1107,7 +1126,7 @@ impl PyPresentation {
         let data = py
             .detach(|| fs::read(&path))
             .map_err(|error| map_io_error(&error, &path))?;
-        Self::open_bytes_inner(py, data, limits, None)
+        Self::open_bytes_inner(py, &data, parse_limits(limits)?, None)
     }
 
     /// Open a replica with a generated ID unless `client_id` is supplied.
@@ -1115,7 +1134,7 @@ impl PyPresentation {
     #[pyo3(signature = (data, *, client_id = None, limits = None))]
     fn open_collaborative(
         py: Python<'_>,
-        data: &[u8],
+        data: &Bound<'_, PyBytes>,
         client_id: Option<u64>,
         limits: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
@@ -1505,24 +1524,26 @@ impl PyPresentation {
         Ok(PyTextEdit::from_core(receipt))
     }
 
-    /// Registers a face for layout, copied first since borrows of Python
-    /// objects cannot cross `detach`. Nothing is embedded in the wheel, so
-    /// text only measures against families registered here.
+    /// Register a face for layout. Nothing is embedded in the wheel, so text
+    /// only measures against families registered here. The face itself is not
+    /// copied, so the engine's own size and count limits still reject one
+    /// before it costs anything.
     #[pyo3(signature = (family, data, *, bold = false, italic = false))]
     fn register_font(
         &mut self,
         py: Python<'_>,
         family: &str,
-        data: &[u8],
+        data: &Bound<'_, PyBytes>,
         bold: bool,
         italic: bool,
     ) -> PyResult<u32> {
         let family = family.to_owned();
-        let data = data.to_vec();
+        let owned = borrow_bytes(data);
+        let data: &[u8] = &owned;
         let deck = DetachedDeck(&mut self.presentation);
         py.detach(move || {
             let deck = deck;
-            deck.0.register_font(&family, bold, italic, &data)
+            deck.0.register_font(&family, bold, italic, data)
         })
         .map_err(map_error)
     }
@@ -1588,20 +1609,21 @@ impl PyPresentation {
         Ok(PyBytes::new(py, &update))
     }
 
-    fn apply_update(&self, py: Python<'_>, update: &[u8]) -> PyResult<PyDeck> {
+    fn apply_update(&self, py: Python<'_>, update: &Bound<'_, PyBytes>) -> PyResult<PyDeck> {
         self.require_collaborative()?;
-        if update.len() > MAX_COLLABORATION_BYTES {
+        let owned = borrow_bytes(update);
+        if owned.len() > MAX_COLLABORATION_BYTES {
             return Err(InvalidUpdateError::new_err(format!(
                 "collaboration payload is {} bytes, exceeds the {MAX_COLLABORATION_BYTES}-byte limit",
-                update.len()
+                owned.len()
             )));
         }
-        let update = update.to_vec();
+        let update: &[u8] = &owned;
         let deck = DetachedDeck(&self.presentation);
         let snapshot = py
             .detach(move || {
                 let deck = deck;
-                deck.0.apply_update_v1(&update)
+                deck.0.apply_update_v1(update)
             })
             .map_err(map_error)?;
         self.edited.set(true);

--- a/bindings/python-pptx/src/lib.rs
+++ b/bindings/python-pptx/src/lib.rs
@@ -930,6 +930,17 @@ fn join_text<'a>(parts: impl Iterator<Item = &'a str>) -> String {
         .join("\n")
 }
 
+/// Moves a deck or a borrow of one across `detach`, which demands `Send`.
+///
+/// # Safety
+///
+/// The core type is `!Send` (`RefCell`s plus stored undo callbacks), but
+/// `PyPresentation` is `unsendable`, so any access from another thread panics
+/// inside pyo3 before reaching it, and `detach` keeps running on this thread.
+struct DetachedDeck<T>(T);
+
+unsafe impl<T> Send for DetachedDeck<T> {}
+
 #[pyclass(module = "betteroffice_pptx", name = "Presentation", unsendable)]
 pub struct PyPresentation {
     presentation: CorePresentation,
@@ -1037,24 +1048,44 @@ impl PyPresentation {
         ))
     }
 
-    fn saved_bytes(&self) -> PyResult<Vec<u8>> {
-        self.presentation.save().map_err(map_error)
+    fn saved_bytes(&self, py: Python<'_>) -> PyResult<Vec<u8>> {
+        let deck = DetachedDeck(&self.presentation);
+        py.detach(move || {
+            let deck = deck;
+            deck.0.save()
+        })
+        .map_err(map_error)
     }
 
-    fn open_bytes(
-        data: &[u8],
+    fn open_bytes_inner(
+        py: Python<'_>,
+        data: Vec<u8>,
         limits: Option<&Bound<'_, PyDict>>,
         client_id: Option<u64>,
     ) -> PyResult<Self> {
         let limits = parse_limits(limits)?;
-        match client_id {
-            Some(client_id) => {
-                CorePresentation::open_collaborative_with_limits(data, client_id, &limits)
-            }
-            None => CorePresentation::open_with_limits(data, &limits),
-        }
-        .map(|presentation| Self::wrap(presentation, client_id.is_some()))
-        .map_err(map_error)
+        let opened = py
+            .detach(move || {
+                let opened = match client_id {
+                    Some(client_id) => {
+                        CorePresentation::open_collaborative_with_limits(&data, client_id, &limits)
+                    }
+                    None => CorePresentation::open_with_limits(&data, &limits),
+                };
+                opened.map(DetachedDeck)
+            })
+            .map_err(map_error)?;
+        Ok(Self::wrap(opened.0, client_id.is_some()))
+    }
+
+    /// Copies first: a borrow of a Python buffer cannot cross `detach`.
+    fn open_bytes(
+        py: Python<'_>,
+        data: &[u8],
+        limits: Option<&Bound<'_, PyDict>>,
+        client_id: Option<u64>,
+    ) -> PyResult<Self> {
+        Self::open_bytes_inner(py, data.to_vec(), limits, client_id)
     }
 }
 
@@ -1062,8 +1093,8 @@ impl PyPresentation {
 impl PyPresentation {
     #[staticmethod]
     #[pyo3(signature = (data, *, limits = None))]
-    fn open(data: &[u8], limits: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
-        Self::open_bytes(data, limits, None)
+    fn open(py: Python<'_>, data: &[u8], limits: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
+        Self::open_bytes(py, data, limits, None)
     }
 
     #[staticmethod]
@@ -1076,13 +1107,14 @@ impl PyPresentation {
         let data = py
             .detach(|| fs::read(&path))
             .map_err(|error| map_io_error(&error, &path))?;
-        Self::open_bytes(&data, limits, None)
+        Self::open_bytes_inner(py, data, limits, None)
     }
 
     /// Open a replica with a generated ID unless `client_id` is supplied.
     #[staticmethod]
     #[pyo3(signature = (data, *, client_id = None, limits = None))]
     fn open_collaborative(
+        py: Python<'_>,
         data: &[u8],
         client_id: Option<u64>,
         limits: Option<&Bound<'_, PyDict>>,
@@ -1092,7 +1124,7 @@ impl PyPresentation {
             Some(client_id) => client_id,
             None => generated_client_id(MAX_COLLABORATION_CLIENT_ID)?.max(1),
         };
-        Self::open_bytes(data, limits, Some(client_id))
+        Self::open_bytes(py, data, limits, Some(client_id))
     }
 
     #[getter]
@@ -1473,42 +1505,61 @@ impl PyPresentation {
         Ok(PyTextEdit::from_core(receipt))
     }
 
-    /// Register a face for layout. Nothing is embedded in the wheel, so text
-    /// only measures against families registered here.
+    /// Registers a face for layout, copied first since borrows of Python
+    /// objects cannot cross `detach`. Nothing is embedded in the wheel, so
+    /// text only measures against families registered here.
     #[pyo3(signature = (family, data, *, bold = false, italic = false))]
     fn register_font(
         &mut self,
+        py: Python<'_>,
         family: &str,
         data: &[u8],
         bold: bool,
         italic: bool,
     ) -> PyResult<u32> {
-        self.presentation
-            .register_font(family, bold, italic, data)
-            .map_err(map_error)
+        let family = family.to_owned();
+        let data = data.to_vec();
+        let deck = DetachedDeck(&mut self.presentation);
+        py.detach(move || {
+            let deck = deck;
+            deck.0.register_font(&family, bold, italic, &data)
+        })
+        .map_err(map_error)
     }
 
-    fn render_slide(&self, slide: &Bound<'_, PyAny>) -> PyResult<PyDisplayList> {
+    fn render_slide(&self, py: Python<'_>, slide: &Bound<'_, PyAny>) -> PyResult<PyDisplayList> {
         let index = self.resolve_slide_index(slide)?;
-        let rendered = self.presentation.render_slide(index).map_err(map_error)?;
-        let payload = serde_json::to_string(&rendered.display_list)
-            .map_err(|error| RenderError::new_err(error.to_string()))?;
-        Ok(PyDisplayList {
-            payload,
-            width: rendered.display_list.width,
-            height: rendered.display_list.height,
-            contract_version: rendered.display_list.contract_version,
-            primitives: rendered.display_list.primitives.len(),
+        let deck = DetachedDeck(&self.presentation);
+        enum Failure {
+            Engine(CoreError),
+            Json(serde_json::Error),
+        }
+
+        py.detach(move || {
+            let deck = deck;
+            let rendered = deck.0.render_slide(index).map_err(Failure::Engine)?;
+            let payload = serde_json::to_string(&rendered.display_list).map_err(Failure::Json)?;
+            Ok(PyDisplayList {
+                payload,
+                width: rendered.display_list.width,
+                height: rendered.display_list.height,
+                contract_version: rendered.display_list.contract_version,
+                primitives: rendered.display_list.primitives.len(),
+            })
+        })
+        .map_err(|failure| match failure {
+            Failure::Engine(error) => map_error(error),
+            Failure::Json(error) => RenderError::new_err(error.to_string()),
         })
     }
 
     fn save<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = self.saved_bytes()?;
+        let bytes = self.saved_bytes(py)?;
         Ok(PyBytes::new(py, &bytes))
     }
 
     fn save_path(&self, py: Python<'_>, path: PathBuf) -> PyResult<()> {
-        let bytes = self.saved_bytes()?;
+        let bytes = self.saved_bytes(py)?;
         py.detach(|| fs::write(&path, bytes))
             .map_err(|error| map_io_error(&error, &path))
     }
@@ -1537,7 +1588,7 @@ impl PyPresentation {
         Ok(PyBytes::new(py, &update))
     }
 
-    fn apply_update(&self, update: &[u8]) -> PyResult<PyDeck> {
+    fn apply_update(&self, py: Python<'_>, update: &[u8]) -> PyResult<PyDeck> {
         self.require_collaborative()?;
         if update.len() > MAX_COLLABORATION_BYTES {
             return Err(InvalidUpdateError::new_err(format!(
@@ -1545,9 +1596,13 @@ impl PyPresentation {
                 update.len()
             )));
         }
-        let snapshot = self
-            .presentation
-            .apply_update_v1(update)
+        let update = update.to_vec();
+        let deck = DetachedDeck(&self.presentation);
+        let snapshot = py
+            .detach(move || {
+                let deck = deck;
+                deck.0.apply_update_v1(&update)
+            })
             .map_err(map_error)?;
         self.edited.set(true);
         Ok(PyDeck::from_core(&snapshot))

--- a/bindings/python-pptx/tests/conftest.py
+++ b/bindings/python-pptx/tests/conftest.py
@@ -33,14 +33,6 @@ def font_bytes() -> bytes:
 
 
 @pytest.fixture(scope="session")
-def font_path() -> Path:
-    path = FONTS / "LiberationSans-Regular.ttf"
-    if not path.exists():
-        pytest.skip(f"fixture missing: {path}")
-    return path
-
-
-@pytest.fixture(scope="session")
 def heavy_font_path() -> Path:
     if not HEAVY_FONT.exists():
         pytest.skip(f"fixture missing: {HEAVY_FONT}")

--- a/bindings/python-pptx/tests/conftest.py
+++ b/bindings/python-pptx/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = ROOT / "apps" / "demo" / "public"
 FONTS = ROOT / "crates" / "ooxml-text" / "tests" / "fonts"
+HEAVY_FONT = ROOT / "packages" / "fonts-cjk" / "assets" / "NotoSerifSC-Regular.otf"
 
 
 def _read(path: Path) -> bytes:
@@ -29,3 +30,18 @@ def sample_bytes(sample_path: Path) -> bytes:
 @pytest.fixture(scope="session")
 def font_bytes() -> bytes:
     return _read(FONTS / "LiberationSans-Regular.ttf")
+
+
+@pytest.fixture(scope="session")
+def font_path() -> Path:
+    path = FONTS / "LiberationSans-Regular.ttf"
+    if not path.exists():
+        pytest.skip(f"fixture missing: {path}")
+    return path
+
+
+@pytest.fixture(scope="session")
+def heavy_font_path() -> Path:
+    if not HEAVY_FONT.exists():
+        pytest.skip(f"fixture missing: {HEAVY_FONT}")
+    return HEAVY_FONT

--- a/bindings/python-pptx/tests/test_presentation.py
+++ b/bindings/python-pptx/tests/test_presentation.py
@@ -436,6 +436,150 @@ def test_path_io_releases_the_gil(sample_path, tmp_path, mode):
     assert probe.returncode == 0, probe.stderr
 
 
+GIL_PROGRESS_PROBE = """
+import ctypes
+import json
+import queue
+import sys
+import threading
+
+import betteroffice_pptx as bo
+
+source, heavy_font_path, control = sys.argv[1:4]
+
+data = open(source, "rb").read()
+heavy_font = open(heavy_font_path, "rb").read()
+
+template = bo.Presentation.open(data)
+for _ in range(200):
+    template.insert_slide(1)
+for column in range(64):
+    template.add_text_box(
+        0, x=(column % 20) * 609_600, y=(column // 20) * 457_200,
+        width=1_828_800, height=457_200,
+        text="The quick brown fox jumps over the lazy dog.",
+    )
+saved = template.save()
+del template
+
+switch_interval = sys.getswitchinterval()
+sys.setswitchinterval(1e-6)
+counter = [0]
+jobs = queue.SimpleQueue()
+
+
+def laborer():
+    while True:
+        op, started, finished, outcome = jobs.get()
+        if op is None:
+            return
+        started.set()
+        try:
+            op()
+            outcome["ok"] = True
+        except BaseException as error:
+            outcome["error"] = error
+        finally:
+            finished.set()
+
+
+worker = threading.Thread(target=laborer, daemon=True)
+worker.start()
+
+
+def measure(op):
+    started = threading.Event()
+    finished = threading.Event()
+    outcome = {}
+    jobs.put((op, started, finished, outcome))
+    started.wait()
+    before = counter[0]
+    while not finished.is_set():
+        counter[0] += 1
+    if "error" in outcome:
+        raise outcome["error"]
+    return counter[0] - before
+
+
+holder = {}
+measure(lambda: holder.update(peer=bo.Presentation.open_collaborative(saved)))
+measure(lambda: holder.update(
+    update=bo.Presentation.open_collaborative(saved).state_as_update()))
+
+if control == "usleep":
+    sleep_fn = ctypes.PyDLL(None).usleep
+    held_call = lambda: sleep_fn(200_000)
+else:
+    sleep_fn = ctypes.PyDLL("kernel32").Sleep
+    held_call = lambda: sleep_fn(200)
+
+ops = {
+    "open": lambda: holder.setdefault("deck", bo.Presentation.open(saved)),
+    "register_font": lambda: holder["deck"].register_font("Noto Serif SC", heavy_font),
+    "render_slide": lambda: holder["deck"].render_slide(0),
+    "save": lambda: holder["deck"].save(),
+    "apply_update": lambda: holder["peer"].apply_update(holder["update"]),
+}
+
+deltas = {}
+try:
+    for name, op in ops.items():
+        deltas[name] = measure(op)
+    deltas["held_sleep_control"] = measure(held_call)
+finally:
+    measure(lambda: holder.clear())
+    jobs.put((None, None, None, None))
+    worker.join(timeout=5)
+    sys.setswitchinterval(switch_interval)
+
+print(json.dumps(deltas))
+
+released = [deltas[name] for name in ops]
+for name in ops:
+    assert deltas[name] > 5_000, f"{name} seems to hold the GIL: {deltas[name]} ticks in window"
+control_delta = deltas["held_sleep_control"]
+cap = min(min(released) // 20, 20_000)
+assert control_delta < cap, f"GIL-holding sleep scored {control_delta} ticks, cap {cap}"
+"""
+
+
+def held_sleep_control():
+    """Name of a platform sleep that blocks 200ms without releasing the GIL, or None."""
+    try:
+        import ctypes
+    except ImportError:
+        return None
+    try:
+        ctypes.PyDLL(None).usleep
+    except (OSError, AttributeError):
+        try:
+            ctypes.PyDLL("kernel32").Sleep
+        except (OSError, AttributeError):
+            return None
+        return "Sleep"
+    return "usleep"
+
+
+def test_heavy_ops_release_the_gil(sample_path, heavy_font_path):
+    """Ticks accrue only inside each op's event window; a GIL-holding sleep stays near zero."""
+    control = held_sleep_control()
+    if control is None:
+        pytest.skip("no GIL-holding sleep primitive on this platform")
+
+    try:
+        probe = subprocess.run(
+            [sys.executable, "-c", GIL_PROGRESS_PROBE,
+             str(sample_path), str(heavy_font_path), control],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("deadlocked: the GIL was held across a heavy op")
+    assert probe.returncode == 0, probe.stderr
+    print(probe.stdout.strip())
+
+
 def test_missing_file_raises_file_not_found(tmp_path):
     missing = tmp_path / "nope.pptx"
     with pytest.raises(FileNotFoundError) as caught:

--- a/bindings/python-pptx/tests/test_presentation.py
+++ b/bindings/python-pptx/tests/test_presentation.py
@@ -442,6 +442,7 @@ import json
 import queue
 import sys
 import threading
+import time
 
 import betteroffice_pptx as bo
 
@@ -457,14 +458,16 @@ for column in range(64):
     template.add_text_box(
         0, x=(column % 20) * 609_600, y=(column // 20) * 457_200,
         width=1_828_800, height=457_200,
-        text="The quick brown fox jumps over the lazy dog.",
+        text="The quick brown fox jumps over the lazy dog. " * 8,
     )
 saved = template.save()
 del template
 
 switch_interval = sys.getswitchinterval()
-sys.setswitchinterval(1e-6)
-counter = [0]
+# Long on purpose. Releasing the GIL hands it over whatever this is set to, but
+# plain bytecode no longer does, so the probe cannot slip into the handshake
+# below and read an op that never let go as if it had.
+sys.setswitchinterval(0.1)
 jobs = queue.SimpleQueue()
 
 
@@ -473,38 +476,73 @@ def laborer():
         op, started, finished, outcome = jobs.get()
         if op is None:
             return
+        # Banked before the handshake, so subtracting the handoff below can
+        # never eat into the probe's own reading.
+        outcome["clock"] = time.perf_counter()
         started.set()
         try:
             op()
-            outcome["ok"] = True
         except BaseException as error:
             outcome["error"] = error
         finally:
+            outcome["elapsed"] = time.perf_counter() - outcome["clock"]
             finished.set()
 
 
 worker = threading.Thread(target=laborer, daemon=True)
 worker.start()
 
+spin_steps = 100_000
 
-def measure(op):
+
+def spin():
+    for _ in range(spin_steps):
+        pass
+
+
+def timed_spin():
+    clock = time.perf_counter()
+    spin()
+    return time.perf_counter() - clock
+
+
+def once(op):
     started = threading.Event()
     finished = threading.Event()
     outcome = {}
+    # The clock starts before the worker can claim the job: an op that keeps the
+    # GIL strands this thread inside `started.wait()` for its whole run, and that
+    # wait has to land inside the reading.
+    clock = time.perf_counter()
     jobs.put((op, started, finished, outcome))
     started.wait()
-    before = counter[0]
-    while not finished.is_set():
-        counter[0] += 1
+    spin()
+    blocked = time.perf_counter() - clock
+    finished.wait()
     if "error" in outcome:
         raise outcome["error"]
-    return counter[0] - before
+    handoff = outcome["clock"] - clock
+    return max(blocked - handoff, 0.0), outcome["elapsed"]
+
+
+def measure(op, samples=4, best=min):
+    \"\"\"How much of the op's own runtime this thread needed for one fixed slice
+    of pure Python: near zero once the op lets go of the GIL, about one while it
+    holds on. Reading it as a share is what survives a loaded machine, where a
+    raw progress count collapses because this thread is slower too. Whether this
+    thread can get through at all is the question, so an op that should release
+    takes its best sample and one that should not takes its worst.\"\"\"
+    trials = [once(op) for _ in range(samples)]
+    blocked, run = best(trials, key=lambda trial: trial[0] / trial[1])
+    return blocked / run, run
 
 
 holder = {}
-measure(lambda: holder.update(peer=bo.Presentation.open_collaborative(saved)))
-measure(lambda: holder.update(
-    update=bo.Presentation.open_collaborative(saved).state_as_update()))
+once(lambda: holder.update(
+    deck=bo.Presentation.open(saved),
+    peer=bo.Presentation.open_collaborative(saved),
+    update=bo.Presentation.open_collaborative(saved).state_as_update(),
+))
 
 if control == "usleep":
     sleep_fn = ctypes.PyDLL(None).usleep
@@ -513,33 +551,51 @@ else:
     sleep_fn = ctypes.PyDLL("kernel32").Sleep
     held_call = lambda: sleep_fn(200)
 
+# One binding call each. Two calls in a window would let a build that never
+# releases the GIL hand the probe the gap between them and read as if it had.
 ops = {
-    "open": lambda: holder.setdefault("deck", bo.Presentation.open(saved)),
-    "register_font": lambda: holder["deck"].register_font("Noto Serif SC", heavy_font),
+    "open": lambda: bo.Presentation.open(saved),
+    "register_font": lambda: holder["deck"].register_font("Probe", heavy_font),
     "render_slide": lambda: holder["deck"].render_slide(0),
     "save": lambda: holder["deck"].save(),
     "apply_update": lambda: holder["peer"].apply_update(holder["update"]),
 }
 
-deltas = {}
+shares = {}
 try:
+    # Size the probe's slice against the shortest op there is to read, so the
+    # share stays small on every one of them however fast the box is. The floor
+    # keeps the slice longer than the worker's own run-up into the binding,
+    # which a shorter one can slip through and read as released.
+    shortest = min(once(op)[1] for _ in range(2) for op in ops.values())
+    reference = min(timed_spin() for _ in range(5))
+    spin_steps = max(1, round(spin_steps * max(shortest / 30, 2e-5) / reference))
+    solo = min(timed_spin() for _ in range(5))
+
     for name, op in ops.items():
-        deltas[name] = measure(op)
-    deltas["held_sleep_control"] = measure(held_call)
+        shares[name] = measure(op)
+    shares["held_sleep_control"] = measure(held_call, best=max)
 finally:
-    measure(lambda: holder.clear())
+    once(lambda: holder.clear())
     jobs.put((None, None, None, None))
     worker.join(timeout=5)
     sys.setswitchinterval(switch_interval)
 
-print(json.dumps(deltas))
+print(json.dumps({name: round(share, 4) for name, (share, _) in shares.items()}))
 
-released = [deltas[name] for name in ops]
 for name in ops:
-    assert deltas[name] > 5_000, f"{name} seems to hold the GIL: {deltas[name]} ticks in window"
-control_delta = deltas["held_sleep_control"]
-cap = min(min(released) // 20, 20_000)
-assert control_delta < cap, f"GIL-holding sleep scored {control_delta} ticks, cap {cap}"
+    share, run = shares[name]
+    assert run > 4 * solo, (
+        f"{name} ran {run * 1e3:.1f} ms, too short to read against a "
+        f"{solo * 1e3:.3f} ms slice")
+    assert share < 0.4, (
+        f"{name} seems to hold the GIL: the probe thread needed "
+        f"{share:.1%} of its runtime to finish")
+control_share, control_run = shares["held_sleep_control"]
+assert control_run > 4 * solo, f"control ran only {control_run * 1e3:.1f} ms"
+assert control_share > 0.75, (
+    f"the GIL-holding sleep let the probe thread through at {control_share:.1%}, "
+    "so the control proves nothing")
 """
 
 
@@ -561,7 +617,7 @@ def held_sleep_control():
 
 
 def test_heavy_ops_release_the_gil(sample_path, heavy_font_path):
-    """Ticks accrue only inside each op's event window; a GIL-holding sleep stays near zero."""
+    """Each op leaves a probe thread free to run; a GIL-holding sleep does not."""
     control = held_sleep_control()
     if control is None:
         pytest.skip("no GIL-holding sleep primitive on this platform")
@@ -572,7 +628,7 @@ def test_heavy_ops_release_the_gil(sample_path, heavy_font_path):
              str(sample_path), str(heavy_font_path), control],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=120,
         )
     except subprocess.TimeoutExpired:
         pytest.fail("deadlocked: the GIL was held across a heavy op")


### PR DESCRIPTION
TL;DR:

Summary:
- `open`, `open_path`, `save`, `save_path`, `register_font`, `render_slide` and `apply_update` run under `py.detach`, releasing the GIL for parse/layout/zip/yrs work (matching the xlsx/docx bindings)
- input bytes cross the boundary through `PyBackedBytes`, so nothing is copied to release the GIL and the engine's own resource limits still reject an oversized input before it costs anything; parse limits are validated before the input is touched at all
- `DetachedDeck`'s `Send` is named per deck type rather than blanket, so the compiler still refuses a `Bound` or a `Py<T>` across the boundary
- errors map outside the closure, so Python-visible semantics — exception types, messages and ordering — are unchanged
- new GIL probe reads the share of each op's own runtime a probe thread gets, one binding call per window, with a held-GIL negative control (ctypes `PyDLL` usleep/Sleep)

Test plan:
- [x] `maturin develop --release` then `pytest` green in bindings/python-pptx (81 tests)
- [x] multi-threaded Python: rendering one deck while another thread runs pure-Python work no longer stalls
- [x] README threading notes updated
