### PR TITLE
perf(docx): page-local interaction cost on large documents

### DIFF
--- a/.changeset/docx-large-doc-latency.md
+++ b/.changeset/docx-large-doc-latency.md
@@ -1,0 +1,7 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/docx-react": patch
+"@betteroffice/rust-crates": patch
+---
+
+Make editing cost page-local on large documents: fix the section count that disabled the resident fast path, coalesce per-cluster text primitives into per-run primitives, merge selection rects per line, bound display rebuilds to damaged pages, reuse retained measures on structural relayouts, and stop shipping the measured arena to the host.

--- a/apps/native-viewer/src/document.rs
+++ b/apps/native-viewer/src/document.rs
@@ -1090,7 +1090,7 @@ fn load_docx(
     let request = region_request(&package, Some(&fonts.chain_ids))?;
     let layout_request = request.to_string();
     engine
-        .layout_document_with_regions_json(&layout_request)
+        .layout_document_with_regions_retained_json(&layout_request)
         .map_err(anyhow::Error::msg)?;
     let extras = json!({ "fontChains": fonts.chain_ids }).to_string();
     engine

--- a/apps/native-viewer/src/editing.rs
+++ b/apps/native-viewer/src/editing.rs
@@ -766,7 +766,7 @@ impl DocxEditor {
 
     pub fn recover_layout(&mut self) -> Result<()> {
         self.engine
-            .layout_document_with_regions_json(&self.layout_request)
+            .layout_document_with_regions_retained_json(&self.layout_request)
             .map_err(anyhow::Error::msg)?;
         let frame = self
             .engine

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -479,6 +479,24 @@ fn measure_template_is_resident_safe(value: &serde_json::Value) -> bool {
             .is_none_or(|offset| offset == 0.0)
 }
 
+/// Stable identity of any layout block, for retained-measure reuse across a
+/// full region pass (paragraph splits and merges keep every other key).
+fn layout_block_key(block: &LayoutBlock) -> Option<String> {
+    let id = match block {
+        LayoutBlock::Paragraph(value) => &value.id,
+        LayoutBlock::Table(value) => &value.id,
+        LayoutBlock::Image(value) => &value.id,
+        LayoutBlock::TextBox(value) => &value.id,
+        LayoutBlock::Shape(value) => &value.id,
+        LayoutBlock::Chart(value) => &value.id,
+        LayoutBlock::SectionBreak(value) => &value.id,
+        LayoutBlock::PageBreak(value) => &value.id,
+        LayoutBlock::ColumnBreak(value) => &value.id,
+        LayoutBlock::Unsupported => return None,
+    };
+    Some(block_key(id))
+}
+
 fn options_fingerprint(input: &LayoutInput) -> Result<u64, String> {
     serde_json::to_vec(&input.options)
         .map(|bytes| hash_bytes(&bytes))
@@ -959,6 +977,155 @@ impl EngineSession {
         )
     }
 
+    /// Measurement for the full region pass. Shaping every block is the
+    /// dominant cost of a structural relayout (Enter, paste), so when the
+    /// measurement world is unchanged — one uniform measure width, identical
+    /// layout options, no floating zones — fingerprint-identical blocks reuse
+    /// their retained measures by stable block key, which survives paragraph
+    /// splits and merges. Anything else falls back to the float-aware
+    /// full measurement.
+    fn measure_full_pass_blocks(
+        &self,
+        blocks: &mut [LayoutBlock],
+        widths: &[f64],
+        measurement: &docx_layout::measure_blocks::MeasurementConfig,
+        geometry: &docx_layout::measure_blocks::FloatPageGeometry,
+        input: &LayoutInput,
+    ) -> Result<(Vec<BlockExtent>, Option<Vec<Option<u64>>>), String> {
+        let default_width = widths.first().copied().unwrap_or(0.0);
+        let uniform_width =
+            !widths.is_empty() && widths.iter().all(|width| *width == default_width);
+        let retained = {
+            let pagination = self.pagination.borrow();
+            let eligible = uniform_width
+                && pagination.input.is_some()
+                && pagination.options_fingerprint == options_fingerprint(input)?
+                && !docx_layout::measure_blocks::has_floating_zones(
+                    blocks,
+                    default_width,
+                    measurement,
+                    Some(geometry),
+                )?;
+            eligible.then(|| {
+                let previous = pagination
+                    .input
+                    .as_ref()
+                    .expect("eligibility checked input");
+                let mut retained = HashMap::with_capacity(previous.measured.len());
+                for (index, measured) in previous.measured.iter().enumerate() {
+                    if let Some(key) = layout_block_key(&measured.block)
+                        && let Ok(fingerprint) = block_fingerprint(&measured.block)
+                    {
+                        let measured_fingerprint =
+                            pagination.block_fingerprints.get(index).copied();
+                        retained.insert(
+                            key,
+                            (fingerprint, measured.measure.clone(), measured_fingerprint),
+                        );
+                    }
+                }
+                retained
+            })
+        };
+        let Some(retained) = retained else {
+            let measures = docx_layout::measure_blocks::measure_blocks_with_floats(
+                blocks,
+                widths,
+                measurement,
+                Some(geometry),
+            )?;
+            return Ok((measures, None));
+        };
+        let mut measures = Vec::with_capacity(blocks.len());
+        // Reused blocks also carry their retained MEASURED fingerprint, so the
+        // pagination step never re-serializes the (large) clean measures just
+        // to hash them; only re-measured blocks fingerprint afresh.
+        let mut fingerprints = Vec::with_capacity(blocks.len());
+        let mut measure_calls = 0_u64;
+        let mut reused_blocks = 0_u64;
+        for block in blocks.iter_mut() {
+            let reuse = layout_block_key(block)
+                .and_then(|key| retained.get(&key))
+                .filter(|(fingerprint, _, _)| {
+                    block_fingerprint(block).is_ok_and(|next| next == *fingerprint)
+                })
+                .map(|(_, measure, measured_fingerprint)| (measure.clone(), *measured_fingerprint));
+            if let Some((measure, measured_fingerprint)) = reuse {
+                measures.push(measure);
+                fingerprints.push(measured_fingerprint);
+                reused_blocks = reused_blocks.wrapping_add(1);
+            } else {
+                measures.push(docx_layout::measure_blocks::measure_block(
+                    block,
+                    default_width,
+                    measurement,
+                )?);
+                fingerprints.push(None);
+                measure_calls = measure_calls.wrapping_add(1);
+            }
+        }
+        let mut state = self.measurement.borrow_mut();
+        state.resident_measure_calls = state.resident_measure_calls.wrapping_add(measure_calls);
+        state.resident_reused_blocks = state.resident_reused_blocks.wrapping_add(reused_blocks);
+        Ok((measures, Some(fingerprints)))
+    }
+
+    /// Region layout that only returns the pagination result: the full pass
+    /// runs and lands in retained state, but the reply omits the measured
+    /// arena — tens of MB of shaping data on a large document that hosts on
+    /// the render path never read. A host that needs the compat display-list
+    /// inputs fetches them on demand via
+    /// [`Self::retained_kernel_inputs_json`].
+    pub fn layout_document_with_regions_retained_json(
+        &self,
+        input_json: &str,
+    ) -> Result<String, String> {
+        let notes_converged = self.layout_document_with_regions_value(input_json)?;
+        let pagination = self.pagination.borrow();
+        let regions_state = self.regions.borrow();
+        let state = regions_state
+            .as_ref()
+            .expect("region state retained after successful region layout");
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RetainedRegionLayoutOutput<'a> {
+            layout: &'a Layout,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            headers_footers: Option<&'a serde_json::Value>,
+            notes_converged: bool,
+        }
+        serde_json::to_string(&RetainedRegionLayoutOutput {
+            layout: pagination
+                .layout
+                .as_ref()
+                .expect("layout retained after successful pagination"),
+            headers_footers: state.headers_footers.as_ref(),
+            notes_converged,
+        })
+        .map_err(|error| format!("serialize: {error}"))
+    }
+
+    /// The retained measured arena and layout options, for a host taking the
+    /// main-thread display-list fallback after a retained-only region layout.
+    pub fn retained_kernel_inputs_json(&self) -> Result<String, String> {
+        let pagination = self.pagination.borrow();
+        let input = pagination
+            .input
+            .as_ref()
+            .ok_or_else(|| "resident pagination input is not built".to_owned())?;
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct RetainedKernelInputs<'a> {
+            measured: &'a [MeasuredBlock],
+            options: &'a docx_layout::types::LayoutOptions,
+        }
+        serde_json::to_string(&RetainedKernelInputs {
+            measured: &input.measured,
+            options: &input.options,
+        })
+        .map_err(|error| format!("serialize: {error}"))
+    }
+
     /// The full region pass minus the JSON envelope: pagination, note
     /// stabilization, and header/footer measurement all land in retained
     /// state. `apply_input`'s fallback consumes this directly so a keystroke
@@ -976,6 +1143,7 @@ impl EngineSession {
             )
         };
         let resident_body = body_story.is_some();
+        let mut measured_fingerprint_hints: Option<Vec<Option<u64>>> = None;
         if let Some(story) = body_story.as_deref() {
             let render_env = parsed_render_env
                 .as_ref()
@@ -986,17 +1154,19 @@ impl EngineSession {
             apply_section_geometry_to_blocks(&mut blocks, &mut input.options, &regions);
             let widths = region_measurement_widths(&blocks, &input, &regions);
             let geometry = initial_float_page_geometry(&input, &regions);
-            let measures = docx_layout::measure_blocks::measure_blocks_with_floats(
+            let (measures, fingerprints) = self.measure_full_pass_blocks(
                 &mut blocks,
                 &widths,
                 &measurement,
-                Some(&geometry),
+                &geometry,
+                &input,
             )?;
             input.measured = blocks
                 .into_iter()
                 .zip(measures)
                 .map(|(block, measure)| MeasuredBlock { block, measure })
                 .collect();
+            measured_fingerprint_hints = fingerprints;
         } else {
             apply_section_geometry(&mut input, &regions);
         }
@@ -1005,7 +1175,20 @@ impl EngineSession {
         } else {
             None
         };
-        self.layout_document_value(input.clone())?;
+        match measured_fingerprint_hints.take() {
+            Some(hints) => {
+                let fingerprints = hints
+                    .iter()
+                    .zip(&input.measured)
+                    .map(|(hint, measured)| match hint {
+                        Some(fingerprint) => Ok(*fingerprint),
+                        None => measured_fingerprint(measured),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.layout_document_value_with_fingerprints(input.clone(), fingerprints)?;
+            }
+            None => self.layout_document_value(input.clone())?,
+        }
         let mut initial_layout = self
             .pagination
             .borrow()

--- a/crates/docx-edit/src/engine.rs
+++ b/crates/docx-edit/src/engine.rs
@@ -1,7 +1,7 @@
 //! Resident editor-engine state.
 
 use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
 use docx_layout::display_list::DisplayList;
@@ -514,6 +514,115 @@ fn resident_block_slots_match(previous: &LayoutBlock, next: &LayoutBlock) -> boo
         }
         (None, None) => true,
         _ => false,
+    }
+}
+
+/// Keys of blocks whose measure fingerprints changed in this apply.
+fn dirty_block_keys(
+    previous_fingerprints: &[u64],
+    next_fingerprints: &[u64],
+    measured: &[MeasuredBlock],
+) -> HashSet<String> {
+    previous_fingerprints
+        .iter()
+        .zip(next_fingerprints)
+        .zip(measured)
+        .filter(|((previous, next), _)| previous != next)
+        .filter_map(|(_, measured)| {
+            paragraph_identity(&measured.block).map(|(id, _)| block_key(id))
+        })
+        .collect()
+}
+
+fn pm_matches_shifted(previous: Option<f64>, next: Option<f64>, delta: f64) -> bool {
+    match (previous, next) {
+        (Some(previous), Some(next)) => next == previous + delta,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// A paragraph fragment is unchanged-modulo-shift when its block's measure is
+/// clean, its geometry and line window are identical, and its document range
+/// moved by exactly the block's known position delta. Resolved lines derive
+/// deterministically from those inputs, so they need no deep comparison.
+/// Non-paragraph fragments conservatively report damage.
+fn fragment_matches_shifted(
+    previous: &docx_layout::types::Fragment,
+    next: &docx_layout::types::Fragment,
+    dirty: &HashSet<String>,
+    deltas: &HashMap<String, i64>,
+) -> bool {
+    let (
+        docx_layout::types::Fragment::Paragraph(previous),
+        docx_layout::types::Fragment::Paragraph(next),
+    ) = (previous, next)
+    else {
+        return false;
+    };
+    let key = block_key(&previous.block_id);
+    if key != block_key(&next.block_id) || dirty.contains(&key) {
+        return false;
+    }
+    let delta = deltas.get(&key).copied().unwrap_or(0) as f64;
+    previous.x == next.x
+        && previous.y == next.y
+        && previous.width == next.width
+        && previous.height == next.height
+        && previous.from_line == next.from_line
+        && previous.to_line == next.to_line
+        && previous.carried_from_prev == next.carried_from_prev
+        && previous.carried_to_next == next.carried_to_next
+        && pm_matches_shifted(previous.pm_start, next.pm_start, delta)
+        && pm_matches_shifted(previous.pm_end, next.pm_end, delta)
+}
+
+fn page_matches_shifted(
+    previous: &docx_layout::types::Page,
+    next: &docx_layout::types::Page,
+    dirty: &HashSet<String>,
+    deltas: &HashMap<String, i64>,
+) -> bool {
+    previous.number == next.number
+        && previous.margins == next.margins
+        && previous.size == next.size
+        && previous.orientation == next.orientation
+        && previous.columns == next.columns
+        && previous.footnote_ids == next.footnote_ids
+        && previous.footnote_reserved_height == next.footnote_reserved_height
+        && previous.fragments.len() == next.fragments.len()
+        && previous
+            .fragments
+            .iter()
+            .zip(&next.fragments)
+            .all(|(previous, next)| fragment_matches_shifted(previous, next, dirty, deltas))
+}
+
+/// Contiguous page range whose content genuinely changed, comparing the new
+/// layout against the retained one modulo the per-block position deltas. A
+/// non-converged incremental placement re-emits every page, but almost all of
+/// them are byte-equal-modulo-shift; the display rebuild and frame encoding
+/// only need the truly damaged span. `None` when the page count changed.
+fn damaged_page_span(
+    previous: &Layout,
+    next: &Layout,
+    dirty: &HashSet<String>,
+    deltas: &HashMap<String, i64>,
+) -> Option<(usize, usize)> {
+    if previous.pages.len() != next.pages.len() {
+        return None;
+    }
+    let mut first = None;
+    let mut last = None;
+    for (index, (previous, next)) in previous.pages.iter().zip(&next.pages).enumerate() {
+        if !page_matches_shifted(previous, next, dirty, deltas) {
+            first.get_or_insert(index);
+            last = Some(index);
+        }
+    }
+    match (first, last) {
+        (Some(first), Some(last)) => Some((first, last + 1)),
+        _ => Some((0, 0)),
     }
 }
 
@@ -1201,8 +1310,20 @@ impl EngineSession {
                     dirty_index,
                 );
                 match attempted {
-                    Ok(run) => {
+                    Ok(mut run) => {
                         incremental = true;
+                        let dirty = dirty_block_keys(
+                            &previous.block_fingerprints,
+                            &block_fingerprints,
+                            &input.measured,
+                        );
+                        if let Some(previous_layout) = previous.layout.as_ref()
+                            && let Some((start, end)) =
+                                damaged_page_span(previous_layout, &run.layout, &dirty, &deltas)
+                        {
+                            run.rebuilt_page_start = start;
+                            run.rebuilt_page_end = end;
+                        }
                         run
                     }
                     Err(docx_layout::LayoutError::Unsupported(_)) => {
@@ -1565,7 +1686,9 @@ impl EngineSession {
             Ok(resident) => resident,
             // Structural mismatch (beyond the supported plain-edit shapes) —
             // the full pass handles it.
-            Err(_) => return Ok(false),
+            Err(_) => {
+                return Ok(false);
+            }
         };
         phase(RegionResidentPhase::Measured);
         self.layout_document_value_with_fingerprints(resident.input, resident.block_fingerprints)?;

--- a/crates/docx-edit/src/wasm.rs
+++ b/crates/docx-edit/src/wasm.rs
@@ -1236,6 +1236,27 @@ impl EditSession {
             .map_err(|error| JsValue::from_str(&error))
     }
 
+    /// Same full region pass as [`Self::layout_document_with_regions_json`],
+    /// but the reply carries only `{ layout, headersFooters?, notesConverged }`
+    /// — the measured arena stays retained wasm-side and is fetched on demand
+    /// via [`Self::retained_kernel_inputs_json`].
+    pub fn layout_document_with_regions_retained_json(
+        &self,
+        input: &str,
+    ) -> Result<String, JsValue> {
+        self.engine
+            .layout_document_with_regions_retained_json(input)
+            .map_err(|error| JsValue::from_str(&error))
+    }
+
+    /// Retained `{ measured, options }` for the main-thread display-list
+    /// fallback after a retained-only region layout.
+    pub fn retained_kernel_inputs_json(&self) -> Result<String, JsValue> {
+        self.engine
+            .retained_kernel_inputs_json()
+            .map_err(|error| JsValue::from_str(&error))
+    }
+
     /// `{ measured, options, layout }` JSON in, `DisplayList` JSON out, built
     /// against the same resident font store this session measures with.
     pub fn build_display_list_json(&self, input: &str) -> Result<String, JsValue> {

--- a/crates/docx-edit/tests/incremental_typing.rs
+++ b/crates/docx-edit/tests/incremental_typing.rs
@@ -1,0 +1,155 @@
+//! Sustained typing on a many-page body must stay incremental: each keystroke
+//! re-places only a local block window and rebuilds only the damaged pages,
+//! including after a reflow that changes the page count (which collapses the
+//! block-aligned pagination checkpoints).
+
+use docx_edit::{EditCtx, EngineSession, FormatPolicy, Position, seed_from_docx};
+
+const SENTENCE: &str = "The issuer shall maintain and make available to the competent authority a complete and accurate record of every crypto-asset service provided during the reporting period, including the identity of the client, the nature of the instruction and the timestamp at which it was executed.";
+
+const CONTENT_TYPES: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#;
+
+const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#;
+
+fn build_docx(paragraph_count: usize) -> Vec<u8> {
+    let mut body = String::new();
+    for i in 1..=paragraph_count {
+        body.push_str(&format!(
+            r#"<w:p><w:r><w:t xml:space="preserve">Section {i}. {SENTENCE}</w:t></w:r></w:p>"#
+        ));
+    }
+    body.push_str(
+        r#"<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>"#,
+    );
+    let document = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body}</w:body></w:document>"#
+    );
+    ooxml_opc::rezip_parts(&[
+        ("[Content_Types].xml".to_owned(), CONTENT_TYPES.into()),
+        ("_rels/.rels".to_owned(), ROOT_RELS.into()),
+        ("word/document.xml".to_owned(), document.into_bytes()),
+    ])
+    .unwrap()
+}
+
+fn bootstrap() -> EngineSession {
+    const FONT: &[u8] = include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+    docx_layout::clear_measure_fonts();
+    let font_id = docx_layout::register_measure_font(FONT).unwrap();
+    let engine = EngineSession::new(1);
+    seed_from_docx(engine.doc(), &build_docx(400)).unwrap();
+    let request = serde_json::json!({
+        "bodyStory": "body",
+        "regions": {"sections": [{
+            "sectionId": "main",
+            "properties": {
+                "pageWidth": 12240, "pageHeight": 15840,
+                "marginTop": 1440, "marginRight": 1440,
+                "marginBottom": 1440, "marginLeft": 1440
+            }
+        }]},
+        "measurement": {
+            "fontChains": {"calibri|0|0": [font_id]},
+            "defaults": {"fontSize": 11, "fontFamily": "Calibri"},
+            "authoritativeShaping": true
+        },
+        "renderEnv": {}
+    });
+    engine
+        .layout_document_with_regions_json(&request.to_string())
+        .unwrap();
+    let extras = serde_json::json!({"fontChains": {"calibri|0|0": [font_id]}}).to_string();
+    engine.build_display_list_frame(&extras, 0).unwrap();
+    engine
+}
+
+fn insert(engine: &EngineSession, pos: u32, text: &str) {
+    engine
+        .doc()
+        .insert_text(
+            &EditCtx::local("", ""),
+            Position::new("body", pos),
+            text,
+            FormatPolicy::Inherit,
+        )
+        .unwrap();
+}
+
+#[test]
+fn sustained_typing_stays_incremental_across_a_page_count_change() {
+    let engine = bootstrap();
+    let mut epoch = 1_u64;
+    let mut pos = 25_u32;
+    let key = |engine: &EngineSession, pos: &mut u32, text: &str, epoch: &mut u64| {
+        insert(engine, *pos, text);
+        *pos += text.len() as u32;
+        let frame = engine.apply_and_layout("body", *epoch).unwrap();
+        *epoch += 1;
+        frame
+    };
+
+    let initial_pages = engine.stats().retained_pages;
+    assert!(initial_pages >= 30, "fixture must paginate to many pages");
+
+    // steady state: each keystroke is incremental and rebuilds a local window
+    for _ in 0..5 {
+        let before = engine.stats();
+        let frame = key(&engine, &mut pos, "x", &mut epoch);
+        let stats = engine.stats();
+        assert_eq!(stats.pagination_calls - before.pagination_calls, 1);
+        assert_eq!(
+            stats.incremental_pagination_calls - before.incremental_pagination_calls,
+            1,
+            "typing must take the incremental pagination path"
+        );
+        assert!(
+            stats.rebuilt_pages <= 3,
+            "a keystroke must not rebuild the whole document ({} pages)",
+            stats.rebuilt_pages
+        );
+        assert!(
+            frame.len() < 4_000_000,
+            "a keystroke frame must stay page-sized ({} bytes)",
+            frame.len()
+        );
+    }
+
+    // grow the caret paragraph until the document gains a page: this reflow
+    // legitimately rebuilds everything once and collapses the block-aligned
+    // checkpoints (page starts land mid-paragraph afterwards)
+    while engine.stats().retained_pages == initial_pages {
+        key(&engine, &mut pos, "grow the paragraph ", &mut epoch);
+    }
+
+    // typing after the reflow must return to page-local work even though the
+    // checkpoint set is sparse: the damaged-page-span diff bounds the rebuild
+    for _ in 0..5 {
+        let before = engine.stats();
+        let frame = key(&engine, &mut pos, "x", &mut epoch);
+        let stats = engine.stats();
+        assert_eq!(
+            stats.incremental_pagination_calls - before.incremental_pagination_calls,
+            1,
+            "post-reflow typing must stay on the incremental pagination path"
+        );
+        assert!(
+            stats.rebuilt_pages <= 3,
+            "post-reflow keystroke must not rebuild the whole document ({} pages)",
+            stats.rebuilt_pages
+        );
+        assert!(
+            frame.len() < 4_000_000,
+            "post-reflow keystroke frame must stay page-sized ({} bytes)",
+            frame.len()
+        );
+    }
+}

--- a/crates/docx-edit/tests/structural_relayout.rs
+++ b/crates/docx-edit/tests/structural_relayout.rs
@@ -1,0 +1,103 @@
+//! A structural relayout (Enter, paste) re-measures only the touched blocks:
+//! the full region pass reuses retained measures by stable block key, which
+//! survives paragraph splits.
+
+use docx_edit::{EditCtx, EngineSession, Position, seed_from_docx};
+
+const SENTENCE: &str = "The issuer shall maintain and make available to the competent authority a complete and accurate record of every crypto-asset service provided during the reporting period, including the identity of the client, the nature of the instruction and the timestamp at which it was executed.";
+
+const CONTENT_TYPES: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#;
+
+const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#;
+
+fn build_docx(paragraph_count: usize) -> Vec<u8> {
+    let mut body = String::new();
+    for i in 1..=paragraph_count {
+        body.push_str(&format!(
+            r#"<w:p><w:r><w:t xml:space="preserve">Section {i}. {SENTENCE}</w:t></w:r></w:p>"#
+        ));
+    }
+    body.push_str(
+        r#"<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>"#,
+    );
+    let document = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body}</w:body></w:document>"#
+    );
+    ooxml_opc::rezip_parts(&[
+        ("[Content_Types].xml".to_owned(), CONTENT_TYPES.into()),
+        ("_rels/.rels".to_owned(), ROOT_RELS.into()),
+        ("word/document.xml".to_owned(), document.into_bytes()),
+    ])
+    .unwrap()
+}
+
+#[test]
+fn structural_relayout_reuses_retained_measures() {
+    const FONT: &[u8] = include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+    docx_layout::clear_measure_fonts();
+    let font_id = docx_layout::register_measure_font(FONT).unwrap();
+    let engine = EngineSession::new(1);
+    seed_from_docx(engine.doc(), &build_docx(400)).unwrap();
+    let request = serde_json::json!({
+        "bodyStory": "body",
+        "regions": {"sections": [{
+            "sectionId": "main",
+            "properties": {
+                "pageWidth": 12240, "pageHeight": 15840,
+                "marginTop": 1440, "marginRight": 1440,
+                "marginBottom": 1440, "marginLeft": 1440
+            }
+        }]},
+        "measurement": {
+            "fontChains": {"calibri|0|0": [font_id]},
+            "defaults": {"fontSize": 11, "fontFamily": "Calibri"},
+            "authoritativeShaping": true
+        },
+        "renderEnv": {}
+    })
+    .to_string();
+    engine.layout_document_with_regions_json(&request).unwrap();
+
+    engine
+        .doc()
+        .split_paragraph(&EditCtx::local("", ""), Position::new("body", 700), None)
+        .unwrap();
+    let before = engine.stats();
+    let retained = engine
+        .layout_document_with_regions_retained_json(&request)
+        .unwrap();
+    let stats = engine.stats();
+
+    // only the two halves of the split re-measure; every other block reuses
+    // its retained measure by stable key
+    assert_eq!(
+        stats.resident_measure_calls - before.resident_measure_calls,
+        2
+    );
+    assert_eq!(
+        stats.resident_reused_blocks - before.resident_reused_blocks,
+        399
+    );
+    assert_eq!(stats.retained_measured_blocks, 401);
+
+    // the retained reply carries pagination only — no measured arena
+    let value: serde_json::Value = serde_json::from_str(&retained).unwrap();
+    assert!(value.get("measured").is_none());
+    assert!(value.get("layout").is_some());
+    assert_eq!(value["notesConverged"], true);
+
+    // the measured arena stays fetchable on demand for the display fallback
+    let kernel: serde_json::Value =
+        serde_json::from_str(&engine.retained_kernel_inputs_json().unwrap()).unwrap();
+    assert_eq!(kernel["measured"].as_array().unwrap().len(), 401);
+    assert!(kernel.get("options").is_some());
+}

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -5575,6 +5575,15 @@ struct LinePaintMetrics {
 /// no width is inferred from the number of Unicode scalars. `bidiSlices` wins
 /// because it carries explicit visual order, followed by cluster metadata and
 /// finally exact run slices for older authoritative payloads.
+/// Representative logical order of a merged slice: the smallest member, so a
+/// coalesced range sorts where its logically-first cluster did.
+fn merged_logical_order(previous: Option<u64>, next: Option<u64>) -> Option<u64> {
+    match (previous, next) {
+        (Some(previous), Some(next)) => Some(previous.min(next)),
+        (previous, next) => previous.or(next),
+    }
+}
+
 fn authoritative_line_items<'a>(
     block: &'a ParagraphBlockIn,
     line: &LineIn,
@@ -5635,6 +5644,48 @@ fn authoritative_line_items<'a>(
     } else {
         return None;
     }
+
+    // Coalesce visually-consecutive, logically-contiguous cluster slices of the
+    // same plain-text run into one slice. Authoritative cluster metadata
+    // arrives one slice per glyph cluster, and one primitive per cluster
+    // multiplies every downstream cost (frame payloads, the a11y mirror, hit
+    // walks) by the run length. Positioning is unaffected: items advance the
+    // pen by their summed width, and the glyph path re-shapes the merged text
+    // and snaps its total advance to that width. Letter-spaced or char-scaled
+    // runs keep per-cluster slices — their spacing lives in the measured
+    // per-cluster advances, not in shaping — as do browser-path formats
+    // (small caps, emphasis marks, …), whose Text primitives interpolate
+    // caret stops and emphasis spread proportionally over the width.
+    let mut merged: Vec<(usize, usize, usize, f64, u8, u64, Option<u64>)> =
+        Vec::with_capacity(slices.len());
+    for slice in slices {
+        if let Some(previous) = merged.last_mut()
+            && previous.0 == slice.0
+            && previous.4 == slice.4
+            && matches!(
+                block.runs.get(slice.0),
+                Some(RunIn::Text(text))
+                    if text.fmt.letter_spacing.unwrap_or(0.0) == 0.0
+                        && horizontal_scale_of(&text.fmt).is_none()
+                        && !text_primitive_requires_browser_path(&text.fmt)
+            )
+        {
+            if previous.2 == slice.1 {
+                previous.2 = slice.2;
+                previous.3 += slice.3;
+                previous.6 = merged_logical_order(previous.6, slice.6);
+                continue;
+            }
+            if previous.1 == slice.2 {
+                previous.1 = slice.1;
+                previous.3 += slice.3;
+                previous.6 = merged_logical_order(previous.6, slice.6);
+                continue;
+            }
+        }
+        merged.push(slice);
+    }
+    let slices = merged;
 
     let item_count = slices.len();
     let mut out = Vec::with_capacity(item_count);
@@ -5897,8 +5948,13 @@ fn emit_line(
             if let Some(items) = &authoritative_items {
                 space_count = items
                     .iter()
-                    .filter(|item| matches!(item, LinePaintItem::Text(text) if text.text == " "))
-                    .count();
+                    .map(|item| match item {
+                        LinePaintItem::Text(text) => {
+                            text.text.chars().filter(|&ch| ch == ' ').count()
+                        }
+                        _ => 0,
+                    })
+                    .sum();
             } else {
                 for seg in &segments {
                     let text = match seg.run {
@@ -6035,8 +6091,8 @@ fn emit_line(
         match item {
             LinePaintItem::Text(item) => {
                 let paint_width = item.width
-                    + if item.exact_advance && item.text == " " {
-                        word_space_extra
+                    + if item.exact_advance {
+                        word_space_extra * item.text.chars().filter(|&ch| ch == ' ').count() as f64
                     } else {
                         0.0
                     };
@@ -9970,6 +10026,99 @@ mod tests {
         assert_eq!(marker["listMarkerRevision"], "ins");
         assert_eq!(marker["color"], REVISION_INS_COLOR);
         assert!(marker["font"].as_str().unwrap().contains("Aptos"));
+    }
+
+    #[test]
+    fn contiguous_cluster_advances_coalesce_into_one_primitive_per_run() {
+        let clusters = |run_index: usize, text: &str, advance: f64, x_base: f64| -> Vec<Value> {
+            (0..text.chars().count())
+                .map(|i| {
+                    json!({
+                        "runIndex": run_index,
+                        "startChar": i,
+                        "endChar": i + 1,
+                        "advance": advance,
+                        "xOffset": x_base + advance * i as f64,
+                        "bidiLevel": 0,
+                        "logicalOrder": i
+                    })
+                })
+                .collect()
+        };
+        let mut cluster_advances = clusters(0, "hello world", 4.0, 0.0);
+        cluster_advances.extend(clusters(1, "abc", 6.0, 44.0));
+        let input = json!({
+            "contractVersion": 1,
+            "measured": [{
+                "block": {
+                    "kind": "paragraph",
+                    "id": "p",
+                    "runs": [
+                        { "kind": "text", "text": "hello world", "pmStart": 1, "pmEnd": 12 },
+                        { "kind": "text", "text": "abc", "pmStart": 12, "pmEnd": 15, "letterSpacing": 2 }
+                    ],
+                    "pmStart": 0,
+                    "pmEnd": 15
+                },
+                "measure": {
+                    "kind": "paragraph",
+                    "totalHeight": 20,
+                    "lines": [{
+                        "headRun": 0,
+                        "headChar": 0,
+                        "tailRun": 1,
+                        "tailChar": 2,
+                        "width": 62,
+                        "ascent": 14,
+                        "descent": 4,
+                        "lineHeight": 20,
+                        "clusterAdvances": serde_json::Value::Array(cluster_advances)
+                    }]
+                }
+            }],
+            "options": {},
+            "layout": {
+                "pages": [{
+                    "number": 1,
+                    "size": { "w": 300, "h": 400 },
+                    "margins": { "top": 20, "right": 20, "bottom": 20, "left": 20 },
+                    "fragments": [{
+                        "kind": "paragraph", "blockId": "p", "x": 20, "y": 20,
+                        "width": 260, "height": 20, "fromLine": 0, "toLine": 1,
+                        "pmStart": 0, "pmEnd": 15
+                    }]
+                }]
+            }
+        });
+        let output: Value = serde_json::from_str(
+            &build_display_list_json(&input.to_string()).expect("display list builds"),
+        )
+        .expect("valid display JSON");
+        let text: Vec<&Value> = output["pages"][0]["primitives"]
+            .as_array()
+            .expect("primitive array")
+            .iter()
+            .filter(|primitive| primitive["kind"] == "text")
+            .collect();
+
+        // the plain run's per-cluster slices coalesce into ONE primitive with
+        // the summed advance and the full doc span
+        assert_eq!(text[0]["text"], "hello world");
+        assert_eq!(text[0]["width"], 44.0);
+        assert_eq!(text[0]["docStart"], 1);
+        assert_eq!(text[0]["docEnd"], 12);
+        assert_eq!(text[0]["logicalOrder"], 0);
+
+        // the letter-spaced run keeps per-cluster primitives: its spacing is
+        // baked into the measured advances, which shaping would not reproduce
+        assert_eq!(
+            text[1..]
+                .iter()
+                .map(|p| p["text"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
+        assert_eq!(text.len(), 4);
     }
 
     #[test]

--- a/crates/docx-layout/src/hit.rs
+++ b/crates/docx-layout/src/hit.rs
@@ -61,6 +61,7 @@ use unicode_segmentation::UnicodeSegmentation;
 thread_local! {
     static TEXT_HIT_BUILD_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static LINE_OWNER_COMPARE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static CARET_STOPS_BUILD_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 /// Vertical slack (px) added on each side of a run's band when testing a
@@ -87,6 +88,9 @@ fn font_px(font: &str) -> f64 {
 }
 
 /// a positioned text-bearing primitive flattened to shared hit geometry.
+/// Caret stops are built lazily: most queries walk every text primitive of a
+/// region for range overlap but resolve caret x for only the few that
+/// intersect, and stop construction is the expensive part.
 struct TextHit<'a> {
     attrs: &'a DocAttrs,
     x: f64,
@@ -96,7 +100,49 @@ struct TextHit<'a> {
     bottom: f64,
     doc_start: i64,
     doc_end: i64,
-    caret_stops: Vec<CaretStop>,
+    stops_source: StopsSource<'a>,
+    caret_stops: std::cell::OnceCell<Vec<CaretStop>>,
+}
+
+enum StopsSource<'a> {
+    Text {
+        text: &'a str,
+        rtl: bool,
+    },
+    Glyphs {
+        text: &'a str,
+        glyphs: &'a [crate::display_list::PlacedGlyph],
+        rtl: bool,
+    },
+}
+
+impl TextHit<'_> {
+    fn stops(&self) -> &[CaretStop] {
+        self.caret_stops.get_or_init(|| {
+            #[cfg(test)]
+            CARET_STOPS_BUILD_COUNT.with(|count| count.set(count.get() + 1));
+            match self.stops_source {
+                StopsSource::Text { text, rtl } => {
+                    text_caret_stops(text, self.x, self.width, rtl, self.doc_start, self.doc_end)
+                }
+                StopsSource::Glyphs { text, glyphs, rtl } => {
+                    let stops = glyph_caret_stops(text, glyphs, rtl, self.doc_start, self.doc_end);
+                    if stops.is_empty() {
+                        text_caret_stops(
+                            text,
+                            self.x,
+                            self.width,
+                            rtl,
+                            self.doc_start,
+                            self.doc_end,
+                        )
+                    } else {
+                        stops
+                    }
+                }
+            }
+        })
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -190,18 +236,23 @@ fn glyph_caret_stops(
         .collect();
     let utf16_len = text.encode_utf16().count() as i64;
     let mut stops = Vec::with_capacity(clusters.len() * 2);
+    // clusters are byte-ordered and contiguous (each ends where the next
+    // starts), so UTF-16 offsets accumulate in one linear pass — a per-cluster
+    // prefix rescan would be quadratic in the run length
+    let mut logical_cursor = clusters.first().map_or(0, |(byte, _, _)| {
+        text.get(..*byte)
+            .map_or(0, |prefix| prefix.encode_utf16().count() as i64)
+    });
     for (index, (byte_start, left, right)) in clusters.iter().copied().enumerate() {
         let byte_end = clusters
             .get(index + 1)
             .map_or(text.len(), |(byte, _, _)| *byte);
-        let Some(prefix) = text.get(..byte_start) else {
-            continue;
-        };
         let Some(cluster_text) = text.get(byte_start..byte_end) else {
             continue;
         };
-        let logical_start = prefix.encode_utf16().count() as i64;
+        let logical_start = logical_cursor;
         let logical_end = logical_start + cluster_text.encode_utf16().count() as i64;
+        logical_cursor = logical_end;
         let start_position = doc_position_at_utf16(doc_start, doc_end, logical_start, utf16_len);
         let end_position = doc_position_at_utf16(doc_start, doc_end, logical_end, utf16_len);
         stops.push(CaretStop {
@@ -253,7 +304,11 @@ fn text_hit(primitive: &Primitive) -> Option<TextHit<'_>> {
                 bottom: baseline + fp * 0.25,
                 doc_start: ds,
                 doc_end: de,
-                caret_stops: text_caret_stops(&t.text, x, width, is_rtl(&t.attrs, t.rtl), ds, de),
+                stops_source: StopsSource::Text {
+                    text: &t.text,
+                    rtl: is_rtl(&t.attrs, t.rtl),
+                },
+                caret_stops: std::cell::OnceCell::new(),
             })
         }
         Primitive::GlyphRun(g) => {
@@ -280,10 +335,6 @@ fn text_hit(primitive: &Primitive) -> Option<TextHit<'_>> {
                 .fold(f64::NEG_INFINITY, f64::max);
             let width = (right - min_x).max(0.0);
             let rtl = is_rtl(&g.attrs, g.rtl);
-            let mut caret_stops = glyph_caret_stops(&g.text, &g.glyphs, rtl, ds, de);
-            if caret_stops.is_empty() {
-                caret_stops = text_caret_stops(&g.text, min_x, width, rtl, ds, de);
-            }
             Some(TextHit {
                 attrs: &g.attrs,
                 x: min_x,
@@ -293,7 +344,12 @@ fn text_hit(primitive: &Primitive) -> Option<TextHit<'_>> {
                 bottom: baseline + fp * 0.25,
                 doc_start: ds,
                 doc_end: de,
-                caret_stops,
+                stops_source: StopsSource::Glyphs {
+                    text: &g.text,
+                    glyphs: &g.glyphs,
+                    rtl,
+                },
+                caret_stops: std::cell::OnceCell::new(),
             })
         }
         _ => None,
@@ -305,12 +361,13 @@ fn text_hits(prims: &[Primitive]) -> Vec<TextHit<'_>> {
 }
 
 fn position_in_run(hit: &TextHit<'_>, x: f64) -> i64 {
-    let mut best = hit.caret_stops.first().copied().unwrap_or(CaretStop {
+    let stops = hit.stops();
+    let mut best = stops.first().copied().unwrap_or(CaretStop {
         x: hit.x,
         position: hit.doc_start,
     });
     let mut best_distance = (x - best.x).abs();
-    for stop in hit.caret_stops.iter().copied().skip(1) {
+    for stop in stops.iter().copied().skip(1) {
         let distance = (x - stop.x).abs();
         if distance < best_distance || (distance == best_distance && stop.x > best.x) {
             best = stop;
@@ -321,7 +378,7 @@ fn position_in_run(hit: &TextHit<'_>, x: f64) -> i64 {
 }
 
 fn x_at_position(hit: &TextHit<'_>, position: i64) -> f64 {
-    hit.caret_stops
+    hit.stops()
         .iter()
         .min_by(|left, right| {
             (left.position - position)
@@ -1773,6 +1830,44 @@ mod tests {
 
         assert_eq!(movement.position, 2511);
         assert_eq!(hit_builds, 4);
+    }
+
+    /// Range queries walk every text primitive for overlap, but caret-stop
+    /// construction (grapheme/cluster segmentation) must only run for the
+    /// primitives the range actually touches.
+    #[test]
+    fn range_rects_build_caret_stops_only_for_overlapping_runs() {
+        let runs: Vec<serde_json::Value> = (0..200)
+            .map(|index| {
+                let doc_start = 1 + index * 10;
+                serde_json::json!({
+                    "kind": "text",
+                    "text": "aaaaaaaaaa",
+                    "x": 100.0 + index as f64,
+                    "baselineY": 200,
+                    "width": 40,
+                    "font": "400 16px Calibri",
+                    "color": "#000000",
+                    "docStart": doc_start,
+                    "docEnd": doc_start + 10,
+                    "blockId": index,
+                    "lineIndex": index
+                })
+            })
+            .collect();
+        let dl: DisplayList = serde_json::from_value(serde_json::json!({
+            "pages": [{ "pageIndex": 0, "width": 816, "height": 1056, "primitives": runs }]
+        }))
+        .unwrap();
+
+        CARET_STOPS_BUILD_COUNT.with(|count| count.set(0));
+        let rects = range_rects(&dl, 15, 18);
+        let stop_builds = CARET_STOPS_BUILD_COUNT.with(std::cell::Cell::get);
+        assert_eq!(rects.len(), 1);
+        assert!(
+            stop_builds <= 2,
+            "a 3-char selection must not segment every run on the page ({stop_builds} builds)"
+        );
     }
 
     /// Dense pages (fine-print tables, per-character formatting) must not cost

--- a/crates/docx-layout/src/hit.rs
+++ b/crates/docx-layout/src/hit.rs
@@ -1132,6 +1132,7 @@ fn collect_range_rects(
     to: i64,
     out: &mut Vec<RangeRect>,
 ) {
+    let merge_from = out.len();
     for h in text_hits(prims) {
         // blank-line marker: zero-length span selects as a thin sliver
         if h.doc_start == h.doc_end {
@@ -1178,6 +1179,36 @@ fn collect_range_rects(
             width: img.w.as_f64().unwrap_or(0.0),
             height: img.h.as_f64().unwrap_or(0.0),
         });
+    }
+    merge_line_rects(out, merge_from);
+}
+
+const LINE_MERGE_BAND_EPSILON: f64 = 1.0;
+const LINE_MERGE_GAP: f64 = 2.0;
+
+/// Coalesce this page's freshly collected rects into per-line bands: rects on
+/// the same line (equal band within 1px) that touch or nearly touch
+/// horizontally union into one. Selection highlights are per line visually, so
+/// per-run (or per-cluster) granularity only multiplies the rect count — a
+/// full-document selection must stay O(lines), not O(runs).
+fn merge_line_rects(out: &mut Vec<RangeRect>, from: usize) {
+    if out.len() - from < 2 {
+        return;
+    }
+    let mut tail = out.split_off(from);
+    tail.sort_by(|a, b| a.y.total_cmp(&b.y).then(a.x.total_cmp(&b.x)));
+    for rect in tail {
+        if out.len() > from
+            && let Some(previous) = out.last_mut()
+            && (rect.y - previous.y).abs() <= LINE_MERGE_BAND_EPSILON
+            && (rect.height - previous.height).abs() <= LINE_MERGE_BAND_EPSILON
+            && rect.x <= previous.x + previous.width + LINE_MERGE_GAP
+        {
+            let right = (previous.x + previous.width).max(rect.x + rect.width);
+            previous.width = right - previous.x;
+            continue;
+        }
+        out.push(rect);
     }
 }
 
@@ -1602,6 +1633,37 @@ mod tests {
     /// Selection geometry follows the same scoping: a range in a note's story
     /// highlights that note's glyphs, and the identical body range highlights
     /// the body's — the two documents never share rectangles.
+    #[test]
+    fn range_rects_merge_same_line_runs_into_one_band() {
+        // three adjacent same-line runs (a formatted or per-cluster line) and
+        // one run on the next line: selecting across them yields one rect per
+        // LINE, never one per run
+        let dl = page(
+            serde_json::Value::Null,
+            vec![
+                run(100.0, 200.0, 40.0, 1),
+                run(140.0, 200.0, 40.0, 6),
+                run(180.0, 200.0, 40.0, 11),
+                run(100.0, 230.0, 40.0, 16),
+            ],
+        );
+
+        let rects = range_rects(&dl, 1, 21);
+        assert_eq!(rects.len(), 2, "one merged band per line: {rects:?}");
+        assert!((rects[0].x - 100.0).abs() < 0.01);
+        assert!(
+            (rects[0].width - 120.0).abs() < 0.01,
+            "merged width {}",
+            rects[0].width
+        );
+        assert!((rects[1].width - 40.0).abs() < 0.01);
+
+        // a selection whose runs do not touch horizontally stays split
+        let sparse = range_rects(&dl, 1, 3);
+        assert_eq!(sparse.len(), 1);
+        assert!(sparse[0].width < 40.0);
+    }
+
     #[test]
     fn range_rects_in_a_note_cover_that_note_only() {
         let dl = note_fixture();

--- a/crates/docx-layout/src/session.rs
+++ b/crates/docx-layout/src/session.rs
@@ -119,6 +119,14 @@ struct DisplayListUpdate {
     reuse: Vec<(usize, usize)>,
     #[serde(default)]
     replace: Vec<(usize, DisplayPage)>,
+    /// Retained pages whose doc positions moved: `[next_index, previous_index,
+    /// run_lists]`, where each run list is applied in order and a run is
+    /// `[start, count, mask, delta]` over the canonical primitive order (body,
+    /// note separators+primitives per area, header, footer). Mask bits: 1
+    /// docStart, 2 docEnd, 4 fragmentDocStart, 8 fragmentDocEnd, 16 inline
+    /// widget pos — the owned frame-delta shift contract.
+    #[serde(default)]
+    shift: Vec<(usize, usize, Vec<Vec<(usize, usize, u8, i64)>>)>,
 }
 
 /// Apply a page-delta update to a stored display list, so an incremental
@@ -147,11 +155,146 @@ pub fn update_display_list(handle: u32, update_json: &str) -> Result<(), String>
     result
 }
 
+const SHIFT_DOC_START: u8 = 1 << 0;
+const SHIFT_DOC_END: u8 = 1 << 1;
+const SHIFT_FRAGMENT_START: u8 = 1 << 2;
+const SHIFT_FRAGMENT_END: u8 = 1 << 3;
+const SHIFT_INLINE_WIDGET: u8 = 1 << 4;
+
+fn primitive_attrs_mut(
+    primitive: &mut crate::display_list::Primitive,
+) -> &mut crate::display_list::DocAttrs {
+    use crate::display_list::Primitive;
+    match primitive {
+        Primitive::Text(value) => &mut value.attrs,
+        Primitive::GlyphRun(value) => &mut value.attrs,
+        Primitive::Rect(value) => &mut value.attrs,
+        Primitive::Line(value) => &mut value.attrs,
+        Primitive::Image(value) => &mut value.attrs,
+        Primitive::Shape(value) => &mut value.attrs,
+        Primitive::Decoration(value) => &mut value.attrs,
+    }
+}
+
+fn shift_position_field(
+    mask: u8,
+    bit: u8,
+    field: &mut Option<i64>,
+    name: &str,
+    delta: i64,
+) -> Result<(), String> {
+    if mask & bit == 0 {
+        return Ok(());
+    }
+    let value = field.ok_or_else(|| format!("position shift requires retained {name}"))?;
+    *field = Some(
+        value
+            .checked_add(delta)
+            .ok_or_else(|| format!("position shift overflows {name}"))?,
+    );
+    Ok(())
+}
+
+fn shift_primitive_positions(
+    primitive: &mut crate::display_list::Primitive,
+    mask: u8,
+    delta: i64,
+) -> Result<(), String> {
+    let attrs = primitive_attrs_mut(primitive);
+    shift_position_field(
+        mask,
+        SHIFT_DOC_START,
+        &mut attrs.doc_start,
+        "docStart",
+        delta,
+    )?;
+    shift_position_field(mask, SHIFT_DOC_END, &mut attrs.doc_end, "docEnd", delta)?;
+    shift_position_field(
+        mask,
+        SHIFT_FRAGMENT_START,
+        &mut attrs.fragment_doc_start,
+        "fragmentDocStart",
+        delta,
+    )?;
+    shift_position_field(
+        mask,
+        SHIFT_FRAGMENT_END,
+        &mut attrs.fragment_doc_end,
+        "fragmentDocEnd",
+        delta,
+    )?;
+    if mask & SHIFT_INLINE_WIDGET != 0 {
+        let widget = attrs
+            .inline_sdt_widget
+            .as_mut()
+            .ok_or_else(|| "position shift requires retained inline widget metadata".to_owned())?;
+        widget.pos = widget
+            .pos
+            .checked_add(delta)
+            .ok_or_else(|| "position shift overflows inline widget pos".to_owned())?;
+    }
+    Ok(())
+}
+
+/// Replays one owned-frame position-shift run list onto a retained page, in
+/// the same canonical primitive order the encoder used: body primitives, each
+/// note area's separators then primitives, header, footer.
+fn shift_page_positions(
+    page: &mut DisplayPage,
+    runs: &[(usize, usize, u8, i64)],
+) -> Result<(), String> {
+    let mut index = 0usize;
+    let mut cursor = 0usize;
+    let mut apply = |primitive: &mut crate::display_list::Primitive| -> Result<(), String> {
+        while cursor < runs.len() && runs[cursor].0 + runs[cursor].1 <= index {
+            cursor += 1;
+        }
+        if let Some(run) = runs.get(cursor)
+            && index >= run.0
+            && index < run.0 + run.1
+        {
+            shift_primitive_positions(primitive, run.2, run.3)?;
+        }
+        index += 1;
+        Ok(())
+    };
+    for primitive in &mut page.primitives {
+        apply(primitive)?;
+    }
+    for area in &mut page.note_areas {
+        for primitive in &mut area.separator_primitives {
+            apply(primitive)?;
+        }
+        for primitive in &mut area.primitives {
+            apply(primitive)?;
+        }
+    }
+    if let Some(header) = &mut page.header {
+        for primitive in &mut header.primitives {
+            apply(primitive)?;
+        }
+    }
+    if let Some(footer) = &mut page.footer {
+        for primitive in &mut footer.primitives {
+            apply(primitive)?;
+        }
+    }
+    if runs.last().is_some_and(|run| run.0 + run.1 > index) {
+        return Err("position shift range exceeds page primitive count".to_owned());
+    }
+    Ok(())
+}
+
 fn apply_display_list_update(
     dl: &mut DisplayList,
     update: DisplayListUpdate,
 ) -> Result<(), String> {
-    if update.reuse.len().saturating_add(update.replace.len()) != update.total {
+    let slots = update
+        .reuse
+        .len()
+        .saturating_add(update.replace.len())
+        .saturating_add(update.shift.len());
+    if slots != update.total {
         return Err("update slots do not cover the page total exactly".to_owned());
     }
     let mut previous: Vec<Option<DisplayPage>> = dl.pages.drain(..).map(Some).collect();
@@ -171,6 +314,22 @@ fn apply_display_list_update(
         *slot = Some(page);
     }
     for (next_index, page) in update.replace {
+        let slot = next
+            .get_mut(next_index)
+            .ok_or_else(|| format!("page target {next_index} out of range"))?;
+        if slot.is_some() {
+            return Err(format!("duplicate page target {next_index}"));
+        }
+        *slot = Some(page);
+    }
+    for (next_index, previous_index, run_lists) in update.shift {
+        let mut page = previous
+            .get_mut(previous_index)
+            .and_then(Option::take)
+            .ok_or_else(|| format!("shifted page {previous_index} is missing"))?;
+        for runs in &run_lists {
+            shift_page_positions(&mut page, runs)?;
+        }
         let slot = next
             .get_mut(next_index)
             .ok_or_else(|| format!("page target {next_index} out of range"))?;
@@ -418,6 +577,66 @@ mod tests {
         }
         close_display_list(handle);
         close_display_list(fresh);
+    }
+
+    #[test]
+    fn shift_update_matches_a_fresh_open_of_shifted_positions() {
+        drain();
+        let two_pages = |first_start: i64, second_start: i64| {
+            format!(
+                r##"{{"pages": [
+                    {{"pageIndex": 0, "width": 816, "height": 1056, "primitives": [{{
+                        "kind": "text", "text": "Hello", "x": 100, "baselineY": 200,
+                        "width": 50, "font": "400 16px Arial", "color": "#000000",
+                        "docStart": {first_start}, "docEnd": {first_end}
+                    }}]}},
+                    {{"pageIndex": 1, "width": 816, "height": 1056, "primitives": [{{
+                        "kind": "text", "text": "World", "x": 100, "baselineY": 200,
+                        "width": 50, "font": "400 16px Arial", "color": "#000000",
+                        "docStart": {second_start}, "docEnd": {second_end}
+                    }}]}}
+                ]}}"##,
+                first_end = first_start + 5,
+                second_end = second_start + 5,
+            )
+        };
+        let handle = open_display_list(&two_pages(1, 7)).expect("opens");
+
+        // shift page 1's doc positions by +3 (mask 15: doc + fragment fields;
+        // fragments are absent here so only doc positions move) — applied as
+        // two sequential run lists (+2 then +1) to cover multi-revision replay
+        let update = serde_json::json!({
+            "total": 2,
+            "reuse": [[0, 0]],
+            "shift": [[1, 1, [[[0, 1, 3, 2]], [[0, 1, 3, 1]]]]],
+        });
+        update_display_list(handle, &update.to_string()).expect("updates");
+
+        let fresh = open_display_list(&two_pages(1, 10)).expect("opens");
+        for (from, to) in [(1, 6), (10, 15), (7, 12), (0, 0)] {
+            assert_eq!(
+                range_rects_by_handle(handle, from, to).unwrap(),
+                range_rects_by_handle(fresh, from, to).unwrap(),
+                "range ({from},{to}) differs from a fresh open"
+            );
+        }
+        close_display_list(handle);
+        close_display_list(fresh);
+    }
+
+    #[test]
+    fn shift_update_beyond_primitive_count_closes_the_handle() {
+        drain();
+        let handle = open_display_list(SAMPLE).expect("opens");
+        let bad = serde_json::json!({
+            "total": 1,
+            "shift": [[0, 0, [[[0, 2, 3, 1]]]]],
+        });
+        assert!(update_display_list(handle, &bad.to_string()).is_err());
+        assert!(
+            hit_test_regions_by_handle(handle, 0, 120.0, 195.0).is_err(),
+            "a failed shift update closes the handle so callers fall back"
+        );
     }
 
     #[test]

--- a/packages/docx-react/src/components/DocxEditor/CanvasInteractiveOverlay.tsx
+++ b/packages/docx-react/src/components/DocxEditor/CanvasInteractiveOverlay.tsx
@@ -15,29 +15,27 @@
  * trigger that re-rasters the canvas.
  */
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { buildInteractiveOverlayPage, type DisplayPage } from '@betteroffice/docx/layout/render';
 import { useTranslation } from '../../i18n';
+import { useCoalescedSubtreeMount } from './hooks/useCoalescedSubtreeMount';
 
 export function CanvasInteractiveOverlay({ page, zoom = 1 }: { page: DisplayPage; zoom?: number }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-    const overlay = buildInteractiveOverlayPage(page, {
-      labels: {
-        control: t('a11y.contentControl'),
-        addRepeatingItem: t('a11y.addRepeatingItem'),
-        removeRepeatingItem: t('a11y.removeRepeatingItem'),
-      },
-    });
-    host.replaceChildren(overlay);
-    return () => {
-      host.replaceChildren();
-    };
-  }, [page, t]);
+  useCoalescedSubtreeMount(
+    hostRef,
+    () =>
+      buildInteractiveOverlayPage(page, {
+        labels: {
+          control: t('a11y.contentControl'),
+          addRepeatingItem: t('a11y.addRepeatingItem'),
+          removeRepeatingItem: t('a11y.removeRepeatingItem'),
+        },
+      }),
+    [page, t]
+  );
 
   return (
     <div

--- a/packages/docx-react/src/components/DocxEditor/CanvasPageMirror.tsx
+++ b/packages/docx-react/src/components/DocxEditor/CanvasPageMirror.tsx
@@ -10,29 +10,27 @@
  * Focus never lands here: the hidden input remains the editing surface.
  */
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { buildMirrorPage, type DisplayPage } from '@betteroffice/docx/layout/render';
 import { useTranslation } from '../../i18n';
+import { useCoalescedSubtreeMount } from './hooks/useCoalescedSubtreeMount';
 
 export function CanvasPageMirror({ page, zoom = 1 }: { page: DisplayPage; zoom?: number }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-    const mirror = buildMirrorPage(page, {
-      labels: {
-        page: t('a11y.pageLabel', { number: page.pageIndex + 1 }),
-        header: t('a11y.headerLabel'),
-        footer: t('a11y.footerLabel'),
-      },
-    });
-    // Keep the previous mirror connected until this replacement is ready.
-    // Clearing in effect cleanup creates a detached-DOM window on every page
-    // update; unmounting already removes the host and its complete subtree.
-    host.replaceChildren(mirror);
-  }, [page, t]);
+  useCoalescedSubtreeMount(
+    hostRef,
+    () =>
+      buildMirrorPage(page, {
+        labels: {
+          page: t('a11y.pageLabel', { number: page.pageIndex + 1 }),
+          header: t('a11y.headerLabel'),
+          footer: t('a11y.footerLabel'),
+        },
+      }),
+    [page, t]
+  );
 
   return (
     <div

--- a/packages/docx-react/src/components/DocxEditor/CanvasPagesView.tsx
+++ b/packages/docx-react/src/components/DocxEditor/CanvasPagesView.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -15,6 +16,7 @@ import {
   GlyphCache,
   loadGlyphOutlineProvider,
   type DisplayList,
+  type DisplayPage,
   type GlyphOutlineProvider,
   type ImageResolver,
   type RetainedFrame,
@@ -117,6 +119,45 @@ function nextPageWindow(
 }
 
 /** Replays display-list pages to canvas with accessibility mirrors. */
+
+/**
+ * One page's surface: canvas + a11y mirror + optional interactive overlay.
+ * Memoized so a keystroke's snapshot commit re-renders only the pages whose
+ * `DisplayPage` identity actually changed — the owned frame-delta path keeps
+ * untouched pages' identity stable across keystrokes.
+ */
+const CanvasPageSurface = memo(function CanvasPageSurface({
+  page,
+  pageKey,
+  zoom,
+  interactive,
+  registerCanvas,
+}: {
+  page: DisplayPage;
+  pageKey: string;
+  zoom: number;
+  interactive: boolean;
+  registerCanvas: (pageKey: string, el: HTMLCanvasElement | null) => void;
+}) {
+  return (
+    <div className="canvas-page" style={{ position: 'relative' }}>
+      <canvas
+        ref={(el) => registerCanvas(pageKey, el)}
+        data-page-index={page.pageIndex}
+        style={{
+          display: 'block',
+          width: page.width * zoom,
+          height: page.height * zoom,
+          background: '#ffffff',
+          boxShadow: '0 1px 3px var(--doc-shadow)',
+        }}
+      />
+      <CanvasPageMirror page={page} zoom={zoom} />
+      {interactive ? <CanvasInteractiveOverlay page={page} zoom={zoom} /> : null}
+    </div>
+  );
+});
+
 export function CanvasPagesView({
   displayList,
   frame,
@@ -158,6 +199,10 @@ export function CanvasPagesView({
   onWorkerPresentationChange?: (active: boolean) => void;
 }) {
   const canvasesRef = useRef(new Map<string, HTMLCanvasElement>());
+  const registerCanvas = useCallback((pageKey: string, el: HTMLCanvasElement | null) => {
+    if (el) canvasesRef.current.set(pageKey, el);
+    else canvasesRef.current.delete(pageKey);
+  }, []);
   const transferredCanvasesRef = useRef(new WeakSet<HTMLCanvasElement>());
   const presentedCanvasesRef = useRef(new WeakSet<HTMLCanvasElement>());
   const offscreenSignatureRef = useRef('');
@@ -514,29 +559,19 @@ export function CanvasPagesView({
           const retainedPage = frame?.pages[i];
           const pageKey = retainedPage ? retainedPage.pageId.toString() : `index:${page.pageIndex}`;
           const surfaceKey = `${pageKey}:${offscreenEligible && !offscreenFailed ? 'offscreen' : 'dom'}`;
+          // per-page wrapper so the mirror positions 1:1 over its canvas.
+          // Every page keeps its full DOM (canvas element, a11y mirror, SDT
+          // overlay) — the page window releases only bitmap backing stores,
+          // so the accessible document and page geometry never shrink.
           return (
-            // per-page wrapper so the mirror positions 1:1 over its canvas.
-            // Every page keeps its full DOM (canvas element, a11y mirror, SDT
-            // overlay) — the page window releases only bitmap backing stores,
-            // so the accessible document and page geometry never shrink.
-            <div key={surfaceKey} className="canvas-page" style={{ position: 'relative' }}>
-              <canvas
-                ref={(el) => {
-                  if (el) canvasesRef.current.set(pageKey, el);
-                  else canvasesRef.current.delete(pageKey);
-                }}
-                data-page-index={page.pageIndex}
-                style={{
-                  display: 'block',
-                  width: page.width * zoom,
-                  height: page.height * zoom,
-                  background: '#ffffff',
-                  boxShadow: '0 1px 3px var(--doc-shadow)',
-                }}
-              />
-              <CanvasPageMirror page={page} zoom={zoom} />
-              {interactive ? <CanvasInteractiveOverlay page={page} zoom={zoom} /> : null}
-            </div>
+            <CanvasPageSurface
+              key={surfaceKey}
+              page={page}
+              pageKey={pageKey}
+              zoom={zoom}
+              interactive={interactive}
+              registerCanvas={registerCanvas}
+            />
           );
         })}
       </div>

--- a/packages/docx-react/src/components/DocxEditor/hooks/useCoalescedSubtreeMount.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useCoalescedSubtreeMount.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+
+const REBUILD_DEBOUNCE_MS = 150;
+const REBUILD_MAX_WAIT_MS = 1000;
+
+/**
+ * Mounts an imperatively built DOM subtree under `hostRef`, coalescing rapid
+ * successive rebuilds: the first mount builds synchronously, later dependency
+ * changes are trailing-debounced with a max wait. Sustained typing re-renders
+ * the owning component per keystroke, but the subtree (thousands of nodes for
+ * an a11y mirror page) is rebuilt at most once per pause or per max-wait
+ * window instead of once per keystroke. The painted canvas carries the visual
+ * update, so deferring these DOM consumers (screen readers, plugin DOM
+ * queries) is not user-visible.
+ */
+export function useCoalescedSubtreeMount(
+  hostRef: React.RefObject<HTMLElement | null>,
+  build: () => Node,
+  deps: readonly unknown[]
+): void {
+  const timerRef = useRef<number | null>(null);
+  const deadlineRef = useRef<number | null>(null);
+  const buildRef = useRef(build);
+  buildRef.current = build;
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const run = () => {
+      timerRef.current = null;
+      deadlineRef.current = null;
+      // Keep the previous subtree connected until the replacement is ready.
+      host.replaceChildren(buildRef.current());
+    };
+    if (!host.hasChildNodes() && timerRef.current === null) {
+      run();
+      return;
+    }
+    const now = performance.now();
+    deadlineRef.current ??= now + REBUILD_MAX_WAIT_MS;
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(
+      run,
+      Math.min(REBUILD_DEBOUNCE_MS, Math.max(0, deadlineRef.current - now))
+    );
+    // The pending rebuild intentionally survives dependency changes — each
+    // change reschedules it above; only unmount cancels.
+  }, deps);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    },
+    []
+  );
+}

--- a/packages/docx-react/src/components/DocxEditor/hooks/useDisplayList.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useDisplayList.ts
@@ -530,9 +530,17 @@ export function useRustDisplayList(
     // Merged doc-wide font chains from the Rust measure source (when active).
     // A non-empty map activates GlyphRun emission; absent ⇒ TextRunPrimitive.
     const fontChains = fontChainsProviderRef?.current?.();
+    // `measured`/`options` delegate to the kernel-input getters so the
+    // worker-rendered path (which only encodes extras) never materializes the
+    // retained measured arena; the main-thread fallback build reads them and
+    // pays the fetch exactly once.
     const buildInputs = {
-      measured: inputs.measured,
-      options: inputs.options,
+      get measured() {
+        return inputs.measured;
+      },
+      get options() {
+        return inputs.options;
+      },
       layout,
       ...(inputs.headersFooters ? { headersFooters: inputs.headersFooters } : {}),
       ...(fontChains ? { fontChains } : {}),

--- a/packages/docx-react/src/components/DocxEditor/hooks/useLayoutPipeline.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useLayoutPipeline.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import type { LayoutBlock, Layout, BlockExtent } from '@betteroffice/docx/layout/pagination';
+import type { LayoutBlock, Layout } from '@betteroffice/docx/layout/pagination';
 import {
   buildResidentRegionLayoutRequest,
   computeLayout,
@@ -92,8 +92,6 @@ export interface UseLayoutPipelineOptions {
 
 export interface UseLayoutPipelineReturn {
   layout: Layout | null;
-  blocks: LayoutBlock[];
-  measures: BlockExtent[];
   layoutUpdateOrigin: LayoutUpdateOrigin;
   runLayoutPipeline: () => void;
   scheduleLayout: (origin?: LayoutUpdateOrigin) => void;
@@ -124,8 +122,6 @@ export function useLayoutPipeline(opts: UseLayoutPipelineOptions): UseLayoutPipe
   } = opts;
 
   const [layout, setLayout] = useState<Layout | null>(null);
-  const [blocks, setBlocks] = useState<LayoutBlock[]>([]);
-  const [measures, setMeasures] = useState<BlockExtent[]>([]);
 
   // Callback refs — parent may hand in a fresh closure every render. Mirroring
   // these in refs keeps `runLayoutPipeline`'s dep array stable; otherwise
@@ -270,7 +266,7 @@ export function useLayoutPipeline(opts: UseLayoutPipelineOptions): UseLayoutPipe
 
       // Step 4+: paint + scroll/events with the computed values.
       const applyComputation = (computation: LayoutComputation) => {
-        const { blocks: newBlocks, measures: newMeasures, layout: newLayout } = computation;
+        const { layout: newLayout } = computation;
 
         const pagesEl = pagesContainerRef.current;
         const scrollParent =
@@ -299,8 +295,6 @@ export function useLayoutPipeline(opts: UseLayoutPipelineOptions): UseLayoutPipe
             : null;
 
         viewportAnchorCaptureReadyRef.current = false;
-        setBlocks(newBlocks);
-        setMeasures(newMeasures);
         layoutUpdateOriginRef.current = layoutUpdateOrigin;
         setLayout(newLayout);
 
@@ -320,7 +314,7 @@ export function useLayoutPipeline(opts: UseLayoutPipelineOptions): UseLayoutPipe
         if (totalTime > 2000) {
           console.warn(
             `[PagedEditor] Layout pipeline took ${Math.round(totalTime)}ms total ` +
-              `(${newBlocks.length} blocks, ${newMeasures.length} measures)`
+              `(${newLayout.pages.length} pages)`
           );
         }
       };
@@ -502,8 +496,6 @@ export function useLayoutPipeline(opts: UseLayoutPipelineOptions): UseLayoutPipe
 
   return {
     layout,
-    blocks,
-    measures,
     layoutUpdateOrigin: layoutUpdateOriginRef.current,
     runLayoutPipeline,
     scheduleLayout,

--- a/packages/docx-react/src/components/DocxEditor/hooks/useScrollPageInfo.ts
+++ b/packages/docx-react/src/components/DocxEditor/hooks/useScrollPageInfo.ts
@@ -58,7 +58,15 @@ export function useScrollPageInfo({
       }
       currentPage = Math.min(currentPage, totalPages);
 
-      setScrollPageInfo({ currentPage, totalPages, visible: true });
+      // bail out on unchanged values: this fires per scroll event, and a new
+      // object every time re-renders the whole editor tree every frame
+      setScrollPageInfo((previous) =>
+        previous.currentPage === currentPage &&
+        previous.totalPages === totalPages &&
+        previous.visible
+          ? previous
+          : { currentPage, totalPages, visible: true }
+      );
 
       if (scrollFadeTimerRef.current) {
         clearTimeout(scrollFadeTimerRef.current);

--- a/packages/docx/src/editor/computeLayout.test.ts
+++ b/packages/docx/src/editor/computeLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { buildResidentRegionLayoutRequest } from './computeLayout';
+import { buildResidentRegionLayoutRequest, computeLayout, getLayoutKernelInputs } from './computeLayout';
 import type { Document } from '../types/document';
 
 function documentWith(body: Record<string, unknown>): Document {
@@ -54,5 +54,34 @@ describe('buildResidentRegionLayoutRequest sections', () => {
     const document = documentWith({ finalSectionProperties: final });
     const request = buildResidentRegionLayoutRequest(document, 24, {});
     expect(request.regions.sections).toEqual([{ sectionId: 'final', properties: final }]);
+  });
+});
+
+describe('computeLayout retained kernel inputs', () => {
+  test('the measured arena is fetched lazily, once, and only on demand', () => {
+    const layout = { pages: [] };
+    let kernelFetches = 0;
+    const session = {
+      layoutDocumentWithRegionsRetainedJson: () =>
+        JSON.stringify({ layout, notesConverged: true }),
+      retainedKernelInputsJson: () => {
+        kernelFetches += 1;
+        return JSON.stringify({ measured: [{ block: { kind: 'paragraph' } }], options: { pageGap: 24 } });
+      },
+    };
+    const computation = computeLayout({
+      document: null,
+      pageGap: 24,
+      session: session as never,
+      renderEnv: {},
+      measurement: { fontChains: {}, defaults: { fontSize: 11, fontFamily: 'Calibri' }, authoritativeShaping: true } as never,
+    });
+    expect(computation.notesConverged).toBe(true);
+    const inputs = getLayoutKernelInputs(computation.layout);
+    expect(inputs).toBeDefined();
+    expect(kernelFetches).toBe(0);
+    expect(inputs!.measured.length).toBe(1);
+    expect(inputs!.options).toEqual({ pageGap: 24 });
+    expect(kernelFetches).toBe(1);
   });
 });

--- a/packages/docx/src/editor/computeLayout.test.ts
+++ b/packages/docx/src/editor/computeLayout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { buildResidentRegionLayoutRequest } from './computeLayout';
+import type { Document } from '../types/document';
+
+function documentWith(body: Record<string, unknown>): Document {
+  return {
+    package: {
+      document: body,
+      footnotes: [],
+      endnotes: [],
+    },
+  } as unknown as Document;
+}
+
+describe('buildResidentRegionLayoutRequest sections', () => {
+  test('a single-section document yields exactly one region section', () => {
+    const final = { sectionId: 'final', pageWidth: 12240 };
+    const document = documentWith({
+      // the parser's `sections` always ends with the final section
+      sections: [{ properties: final }],
+      finalSectionProperties: final,
+    });
+    const request = buildResidentRegionLayoutRequest(document, 24, {});
+    expect(request.regions.sections).toEqual([{ sectionId: 'final', properties: final }]);
+  });
+
+  test('intermediate sections precede the final section, without duplication', () => {
+    const intermediate = { sectionId: 'one', pageWidth: 10000 };
+    const final = { sectionId: 'final', pageWidth: 12240 };
+    const document = documentWith({
+      sections: [{ properties: intermediate }, { properties: final }],
+      finalSectionProperties: final,
+    });
+    const request = buildResidentRegionLayoutRequest(document, 24, {});
+    expect(request.regions.sections.map((section) => section.sectionId)).toEqual([
+      'one',
+      'final',
+    ]);
+  });
+
+  test('the final entry always reflects the editor-maintained final properties', () => {
+    const stale = { sectionId: 'final', pageWidth: 12240 };
+    const edited = { sectionId: 'final', pageWidth: 11906 };
+    const document = documentWith({
+      sections: [{ properties: stale }],
+      finalSectionProperties: edited,
+    });
+    const request = buildResidentRegionLayoutRequest(document, 24, {});
+    expect(request.regions.sections).toEqual([{ sectionId: 'final', properties: edited }]);
+  });
+
+  test('a body without parsed sections still yields the final section', () => {
+    const final = { sectionId: 'final' };
+    const document = documentWith({ finalSectionProperties: final });
+    const request = buildResidentRegionLayoutRequest(document, 24, {});
+    expect(request.regions.sections).toEqual([{ sectionId: 'final', properties: final }]);
+  });
+});

--- a/packages/docx/src/editor/computeLayout.ts
+++ b/packages/docx/src/editor/computeLayout.ts
@@ -1,21 +1,18 @@
 import type { ResidentMeasurementConfig } from '../layout/measure';
-import type {
-  BlockExtent,
-  Layout,
-  LayoutBlock,
-  LayoutOptions,
-  MeasuredBlock,
-} from '../layout/pagination';
+import type { Layout, LayoutOptions, MeasuredBlock } from '../layout/pagination';
 import type { DisplayListHeadersFooters } from '../layout/render/rustDisplayList';
 import type { Document, NoteKind, SectionProperties } from '../types/document';
 import type { YrsRenderEnv, YrsSession } from '../yrs';
 
-interface ResidentRegionLayoutOutput {
-  measured: MeasuredBlock[];
-  options: LayoutOptions;
+interface ResidentRegionLayoutRetainedOutput {
   layout: Layout;
   headersFooters?: DisplayListHeadersFooters;
   notesConverged: boolean;
+}
+
+interface RetainedKernelInputs {
+  measured: MeasuredBlock[];
+  options: LayoutOptions;
 }
 
 export interface ResidentRegionLayoutRequest {
@@ -43,14 +40,15 @@ export interface ResidentRegionLayoutRequest {
 export interface ComputeLayoutInputs {
   document: Document | null;
   pageGap: number;
-  session: Pick<YrsSession, 'layoutDocumentWithRegionsJson'>;
+  session: Pick<
+    YrsSession,
+    'layoutDocumentWithRegionsRetainedJson' | 'retainedKernelInputsJson'
+  >;
   renderEnv: YrsRenderEnv;
   measurement: ResidentMeasurementConfig;
 }
 
 export interface LayoutComputation {
-  blocks: LayoutBlock[];
-  measures: BlockExtent[];
   layout: Layout;
   notesConverged: boolean;
 }
@@ -134,16 +132,29 @@ export function computeLayout(inputs: ComputeLayoutInputs): LayoutComputation {
   );
   request.measurement = inputs.measurement;
   const output = JSON.parse(
-    inputs.session.layoutDocumentWithRegionsJson(JSON.stringify(request))
-  ) as ResidentRegionLayoutOutput;
+    inputs.session.layoutDocumentWithRegionsRetainedJson(JSON.stringify(request))
+  ) as ResidentRegionLayoutRetainedOutput;
+  // The measured arena is tens of MB of shaping JSON on a large document and
+  // the worker-rendered path never reads it, so it stays wasm-side until the
+  // main-thread display fallback actually asks. The fetch reads the CURRENT
+  // retained state: coherent for same-commit readers (the display effect runs
+  // against the layout it was just given); an async fallback racing a newer
+  // relayout renders one transiently newer arena, then reconverges on the
+  // next pipeline pass.
+  const session = inputs.session;
+  let kernel: RetainedKernelInputs | null = null;
+  const fetchKernel = (): RetainedKernelInputs =>
+    (kernel ??= JSON.parse(session.retainedKernelInputsJson()) as RetainedKernelInputs);
   kernelInputsByLayout.set(output.layout, {
-    measured: output.measured,
-    options: output.options,
+    get measured() {
+      return fetchKernel().measured;
+    },
+    get options() {
+      return fetchKernel().options;
+    },
     ...(output.headersFooters ? { headersFooters: output.headersFooters } : {}),
   });
   return {
-    blocks: output.measured.map((item) => item.block),
-    measures: output.measured.map((item) => item.measure),
     layout: output.layout,
     notesConverged: output.notesConverged,
   };

--- a/packages/docx/src/editor/computeLayout.ts
+++ b/packages/docx/src/editor/computeLayout.ts
@@ -64,10 +64,18 @@ const kernelInputsByLayout = new WeakMap<
   }
 >();
 
+/**
+ * One entry per paragraph-level section break plus the final section. The
+ * parser's `body.sections` already ends with the final section, so only the
+ * intermediate entries come from it; the final entry always comes from
+ * `finalSectionProperties`, which editor mutations (page setup, header/footer
+ * refs) keep current without rewriting `sections`. Appending both would
+ * over-count sections and disable the engine's single-section fast path.
+ */
 function orderedSections(document: Document | null): ResidentRegionLayoutRequest['regions']['sections'] {
   const body = document?.package.document;
   if (!body) return [{ properties: {} }];
-  const sections = (body.sections ?? []).map((section) => ({
+  const sections = (body.sections ?? []).slice(0, -1).map((section) => ({
     sectionId: section.id ?? section.properties.sectionId,
     properties: section.properties,
   }));

--- a/packages/docx/src/layout/render/displayListQueries.ts
+++ b/packages/docx/src/layout/render/displayListQueries.ts
@@ -42,7 +42,11 @@
  */
 
 import type { DisplayList, DisplayPrimitive } from './displayList';
-import { displayPageRevision } from './frameDelta';
+import {
+  displayPageRevision,
+  displayPageShiftsSince,
+  type FramePositionShiftRun,
+} from './frameDelta';
 import { displayPrimitiveRect, type GeoRect } from './displayListGeometry';
 import {
   findImagePrimitiveAtPoint,
@@ -297,10 +301,12 @@ const handleFinalizers: HandleFinalizationRegistry | null = (() => {
  */
 interface FacadeDeltaSeed {
   list: DisplayList;
-  /** Per-page in-place mutation revisions captured at facade creation. The
-   * owned frame-delta path patches positions through the SAME page objects,
-   * so identity alone cannot prove a page still matches the parsed store. */
-  pageRevisions: number[];
+  /** Per-page in-place mutation revisions of the list AS PARSED INTO the Rust
+   * store (set when the handle opened or adopted, null before). The owned
+   * frame-delta path patches positions through the SAME page objects, so
+   * identity alone cannot prove a page still matches the parsed store, and
+   * later mutations can advance a page past what the store parsed. */
+  storeRevisions(): readonly number[] | null;
   engine(): RustDisplayListQueryEngine | null;
   /** Relinquish the live handle (the donor's queries fall back to JSON-arg). */
   takeHandle(): number | null;
@@ -346,33 +352,62 @@ function isWasmTrap(error: unknown): boolean {
   return error.name === 'RuntimeError';
 }
 
+type StoreShiftRun = [start: number, count: number, mask: number, delta: number];
+
 /**
  * Page-delta between two display lists, exploiting the retained-frame
  * invariant that unchanged pages keep object identity across builds. A page
- * is reusable only when both its identity and its in-place mutation revision
- * are unchanged since the donor parsed it. Returns null when nothing is
- * reusable (a full open costs the same).
+ * whose identity and in-place mutation revision are unchanged since the store
+ * parsed it is reused outright; a page that only accumulated recorded
+ * position shifts ships those shifts as compact ops the store replays,
+ * instead of re-serializing the page. Returns null when nothing is reusable
+ * (a full open costs the same).
  */
 function buildDisplayListUpdateJson(seed: FacadeDeltaSeed, next: DisplayList): string | null {
+  const storeRevisions = seed.storeRevisions();
+  if (!storeRevisions) return null;
   const previousIndex = new Map<unknown, number>();
   seed.list.pages.forEach((page, index) => previousIndex.set(page, index));
   const reuse: Array<[number, number]> = [];
   const replace: Array<[number, unknown]> = [];
+  const shift: Array<[number, number, StoreShiftRun[][]]> = [];
   next.pages.forEach((page, index) => {
     const from = previousIndex.get(page);
-    if (from !== undefined && displayPageRevision(page) === seed.pageRevisions[from]) {
-      reuse.push([index, from]);
-      previousIndex.delete(page);
-    } else {
+    if (from === undefined) {
       replace.push([index, page]);
+      return;
+    }
+    previousIndex.delete(page);
+    const storeRevision = storeRevisions[from];
+    if (storeRevision === undefined) {
+      replace.push([index, page]);
+      return;
+    }
+    const runLists =
+      displayPageRevision(page) === storeRevision
+        ? []
+        : displayPageShiftsSince(page, storeRevision);
+    if (runLists === null) {
+      replace.push([index, page]);
+    } else if (runLists.length === 0) {
+      reuse.push([index, from]);
+    } else {
+      shift.push([
+        index,
+        from,
+        runLists.map((runs: readonly FramePositionShiftRun[]) =>
+          runs.map((run): StoreShiftRun => [run.start, run.count, run.changedMask, run.delta])
+        ),
+      ]);
     }
   });
-  if (reuse.length === 0) return null;
+  if (reuse.length === 0 && shift.length === 0) return null;
   return JSON.stringify({
     total: next.pages.length,
     ...(next.contractVersion !== undefined ? { contractVersion: next.contractVersion } : {}),
     reuse,
     replace,
+    ...(shift.length > 0 ? { shift } : {}),
   });
 }
 
@@ -393,7 +428,17 @@ export function createDisplayListQueries(
   previous?: DisplayListQueries | null
 ): DisplayListQueries {
   let json: string | null = null;
-  const getJson = (): string => (json ??= JSON.stringify(list));
+  let jsonRevisions: readonly number[] | null = null;
+  const getJson = (): string => {
+    if (json === null) {
+      jsonRevisions = list.pages.map(displayPageRevision);
+      json = JSON.stringify(list);
+    }
+    return json;
+  };
+  // Revisions of the pages as parsed into the Rust store; null until a handle
+  // is opened or adopted. Kept exact so shift replay can never double-apply.
+  let storeRevisions: readonly number[] | null = null;
 
   const resident: ResidentDisplayListQueryEngine | null = isResidentQueryEngine(engine)
     ? engine
@@ -492,6 +537,7 @@ export function createDisplayListQueries(
     if (!donor || !eng?.updateDisplayList || !eng.hasDisplayListUpdate?.()) return false;
     const seed = facadeDeltaSeeds.get(donor);
     if (!seed || seed.engine() !== eng) return false;
+    const revisionsAtBuild = list.pages.map(displayPageRevision);
     const update = buildDisplayListUpdateJson(seed, list);
     if (!update) return false;
     const adopted = seed.takeHandle();
@@ -499,6 +545,7 @@ export function createDisplayListQueries(
     try {
       eng.updateDisplayList(adopted, update);
       handle = adopted;
+      storeRevisions = revisionsAtBuild;
       return true;
     } catch (error) {
       // the Rust side closes the handle on a failed update; close defensively
@@ -523,6 +570,7 @@ export function createDisplayListQueries(
     if (adoptHandle()) return;
     try {
       handle = eng.openDisplayList(getJson());
+      storeRevisions = jsonRevisions;
     } catch (error) {
       handle = null;
       if (isWasmTrap(error)) {
@@ -1076,7 +1124,7 @@ export function createDisplayListQueries(
 
   facadeDeltaSeeds.set(queries, {
     list,
-    pageRevisions: list.pages.map(displayPageRevision),
+    storeRevisions: () => storeRevisions,
     engine: () => eng,
     hasHandle: () => handle !== null,
     donor: () => donorFacade,

--- a/packages/docx/src/layout/render/frameDelta.test.ts
+++ b/packages/docx/src/layout/render/frameDelta.test.ts
@@ -3,7 +3,15 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { createEditSession, preloadEditWasm } from '../../wasm/edit';
-import { applyFrameDelta, decodeFrameDelta } from './frameDelta';
+import {
+  applyFrameDelta,
+  applyFrameDeltaOwned,
+  decodeFrameDelta,
+  displayPageRevision,
+  displayPageShiftsSince,
+} from './frameDelta';
+import { createDisplayListQueries } from './displayListQueries';
+import type { RustDisplayListQueryEngine } from './rustDisplayList';
 import type { DisplayList } from './displayList';
 
 const WASM = resolve(import.meta.dir, '../../wasm/generated/edit/docx_edit_bg.wasm');
@@ -60,5 +68,116 @@ describe('FrameDelta wire round-trip', () => {
       .map((primitive) => ('text' in primitive ? (primitive.text ?? '') : ''))
       .join('');
     expect(pageText).toContain('typed');
+  });
+
+  it('records owned position shifts and ships them as query-store shift ops', () => {
+    const session = createEditSession(13);
+    const sentence = 'shift the following pages with enough text to fill several tiny pages. ';
+    const { paraId } = JSON.parse(
+      session.create_story('body', `start me. ${sentence.repeat(12)}`, 'Normal', 'left')
+    );
+    // split into paragraphs so trailing pages hold untouched blocks whose doc
+    // positions merely shift when the first paragraph grows
+    let splitId = paraId as string;
+    for (let i = 0; i < 10; i++) {
+      const receipt = JSON.parse(session.split_paragraph('body', splitId, 60, undefined, undefined)) as {
+        secondParaId: string;
+      };
+      splitId = receipt.secondParaId;
+    }
+    const fontId = session.register_measure_font(new Uint8Array(readFileSync(FONT)));
+    const request = JSON.stringify({
+      bodyStory: 'body',
+      regions: {
+        sections: [
+          {
+            sectionId: 'main',
+            properties: {
+              pageWidth: 4320,
+              pageHeight: 2880,
+              marginTop: 300,
+              marginRight: 300,
+              marginBottom: 300,
+              marginLeft: 300,
+            },
+          },
+        ],
+      },
+      measurement: {
+        fontChains: { 'calibri|0|0': [fontId] },
+        defaults: { fontSize: 11, fontFamily: 'Calibri' },
+        authoritativeShaping: true,
+      },
+      renderEnv: {},
+    });
+    const envelopeFor = (): string => {
+      const output = JSON.parse(session.layout_document_with_regions_json(request)) as {
+        measured: unknown;
+        options: unknown;
+        layout: unknown;
+      };
+      return JSON.stringify({
+        measured: output.measured,
+        options: output.options,
+        layout: output.layout,
+        fontChains: { 'calibri|0|0': [fontId] },
+      });
+    };
+
+    const first = envelopeFor();
+    const retained = applyFrameDeltaOwned(null, decodeFrameDelta(session.build_display_list_frame(first, 0)));
+    expect(retained.displayList.pages.length).toBeGreaterThan(1);
+    const trailingPage = retained.displayList.pages.at(-1)!;
+    const revisionBefore = displayPageRevision(trailingPage);
+
+    const updates: string[] = [];
+    let nextHandle = 1;
+    const engine: RustDisplayListQueryEngine = {
+      hitTestRegionsJson: () => 'null',
+      verticalMoveJson: () => 'null',
+      rangeRectsJson: () => '[]',
+      hasDisplayListSession: () => true,
+      openDisplayList: () => nextHandle++,
+      closeDisplayList: () => {},
+      updateDisplayList: (_handle, update) => {
+        updates.push(update);
+      },
+      hasDisplayListUpdate: () => true,
+      rangeRectsByHandle: () => '[]',
+      verticalMoveByHandle: () => 'null',
+    };
+    const firstQueries = createDisplayListQueries(retained.displayList, engine);
+    firstQueries.prime();
+
+    session.insert_text('body', paraId, 5, 'x', undefined, undefined);
+    const second = envelopeFor();
+    const next = applyFrameDeltaOwned(
+      retained,
+      decodeFrameDelta(session.build_display_list_frame(second, retained.frameEpoch))
+    );
+
+    // trailing pages absorb the insert as an in-place position shift with a
+    // recorded, replayable run log
+    expect(next.displayList.pages.at(-1)).toBe(trailingPage);
+    expect(displayPageRevision(trailingPage)).toBe(revisionBefore + 1);
+    const runLists = displayPageShiftsSince(trailingPage, revisionBefore);
+    expect(runLists).not.toBeNull();
+    expect(runLists!.length).toBe(1);
+    expect(runLists![0].length).toBeGreaterThan(0);
+    expect(displayPageShiftsSince(trailingPage, revisionBefore + 1)).toEqual([]);
+
+    // handle adoption ships those shifts as compact ops instead of replacing
+    // the page's serialized payload
+    const secondQueries = createDisplayListQueries(next.displayList, engine, firstQueries);
+    secondQueries.prime();
+    expect(updates.length).toBe(1);
+    const update = JSON.parse(updates[0]!) as {
+      total: number;
+      replace?: Array<[number, unknown]>;
+      shift?: Array<[number, number, number[][][]]>;
+    };
+    const trailingIndex = next.displayList.pages.length - 1;
+    expect(update.shift?.some(([to]) => to === trailingIndex)).toBe(true);
+    expect(update.replace?.some(([to]) => to === trailingIndex)).toBeFalsy();
   });
 });

--- a/packages/docx/src/layout/render/frameDelta.ts
+++ b/packages/docx/src/layout/render/frameDelta.ts
@@ -556,6 +556,54 @@ function bumpDisplayPageRevision(page: DisplayPage): void {
   });
 }
 
+const DISPLAY_PAGE_SHIFT_LOG = '__betterofficePageShiftLog';
+// Deep enough that a long typing burst between two query-store primes (one
+// recorded shift per applied frame) still replays as compact ops.
+const SHIFT_LOG_LIMIT = 64;
+
+interface DisplayPageShiftLogEntry {
+  /** Revision the page reached when these runs were applied. */
+  readonly revision: number;
+  readonly runs: readonly FramePositionShiftRun[];
+}
+
+function displayPageShiftLog(page: DisplayPage): DisplayPageShiftLogEntry[] {
+  return ((page as unknown as Record<string, unknown>)[DISPLAY_PAGE_SHIFT_LOG] as
+    | DisplayPageShiftLogEntry[]
+    | undefined) ?? [];
+}
+
+function recordDisplayPageShift(page: DisplayPage, runs: readonly FramePositionShiftRun[]): void {
+  const log = displayPageShiftLog(page);
+  log.push({ revision: displayPageRevision(page), runs });
+  if (log.length > SHIFT_LOG_LIMIT) log.splice(0, log.length - SHIFT_LOG_LIMIT);
+  Object.defineProperty(page, DISPLAY_PAGE_SHIFT_LOG, {
+    value: log,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Ordered shift-run lists that advance the page from `sinceRevision` to its
+ * current revision, or null when the bounded log no longer covers that span.
+ * Every in-place revision bump is a recorded position shift, so a contiguous
+ * log suffix reconstructs the exact mutations a retained copy (the Rust query
+ * store's parsed page) is missing.
+ */
+export function displayPageShiftsSince(
+  page: DisplayPage,
+  sinceRevision: number
+): ReadonlyArray<readonly FramePositionShiftRun[]> | null {
+  const current = displayPageRevision(page);
+  if (current === sinceRevision) return [];
+  if (current < sinceRevision) return null;
+  const entries = displayPageShiftLog(page).filter((entry) => entry.revision > sinceRevision);
+  if (entries.length !== current - sinceRevision) return null;
+  return entries.map((entry) => entry.runs);
+}
+
 function shiftDisplayPagePositionsOwned(
   page: DisplayPage,
   runs: readonly FramePositionShiftRun[],
@@ -564,6 +612,7 @@ function shiftDisplayPagePositionsOwned(
   // primitives are mutated through this object below, whether or not a new
   // page wrapper is returned
   bumpDisplayPageRevision(page);
+  recordDisplayPageShift(page, runs);
   let primitiveIndex = 0;
   let runIndex = 0;
   const visit = (primitives: readonly DisplayPrimitive[]): void => {

--- a/packages/docx/src/wasm/generated/edit/docx_edit.d.ts
+++ b/packages/docx/src/wasm/generated/edit/docx_edit.d.ts
@@ -392,6 +392,13 @@ export class EditSession {
      */
     layout_document_with_regions_json(input: string): string;
     /**
+     * Same full region pass as [`Self::layout_document_with_regions_json`],
+     * but the reply carries only `{ layout, headersFooters?, notesConverged }`
+     * — the measured arena stays retained wasm-side and is fetched on demand
+     * via [`Self::retained_kernel_inputs_json`].
+     */
+    layout_document_with_regions_retained_json(input: string): string;
+    /**
      * Region-layout input JSON in, the font families and sizes that input
      * needs as JSON out, so the host can register fonts before laying out.
      */
@@ -561,6 +568,11 @@ export class EditSession {
      * or the position no longer resolves in `story`.
      */
     resolve_sticky_position(story: string, position: Uint8Array): string;
+    /**
+     * Retained `{ measured, options }` for the main-thread display-list
+     * fallback after a retained-only region layout.
+     */
+    retained_kernel_inputs_json(): string;
     /**
      * [`EditSession::open_docx`] with seeding always on.
      */
@@ -1083,6 +1095,7 @@ export interface InitOutput {
     readonly editsession_insert_watermark: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => [number, number];
     readonly editsession_layout_document_json: (a: number, b: number, c: number) => [number, number, number, number];
     readonly editsession_layout_document_with_regions_json: (a: number, b: number, c: number) => [number, number, number, number];
+    readonly editsession_layout_document_with_regions_retained_json: (a: number, b: number, c: number) => [number, number, number, number];
     readonly editsession_layout_font_requirements_json: (a: number, b: number, c: number) => [number, number, number, number];
     readonly editsession_list_revisions: (a: number) => [number, number, number, number];
     readonly editsession_load_json: (a: number, b: number, c: number) => [number, number, number, number];
@@ -1105,6 +1118,7 @@ export interface InitOutput {
     readonly editsession_resolve_comment: (a: number, b: number, c: number) => [number, number, number, number];
     readonly editsession_resolve_encoded_selection: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => [number, number, number, number];
     readonly editsession_resolve_sticky_position: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
+    readonly editsession_retained_kernel_inputs_json: (a: number) => [number, number, number, number];
     readonly editsession_seed_from_docx: (a: number, b: number, c: number) => [number, number, number, number];
     readonly editsession_selection: (a: number) => [number, number, number, number];
     readonly editsession_selection_context: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => [number, number, number, number];

--- a/packages/docx/src/wasm/generated/edit/docx_edit_bg.wasm.d.ts
+++ b/packages/docx/src/wasm/generated/edit/docx_edit_bg.wasm.d.ts
@@ -53,6 +53,7 @@ export const editsession_insert_text: (a: number, b: number, c: number, d: numbe
 export const editsession_insert_watermark: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => [number, number];
 export const editsession_layout_document_json: (a: number, b: number, c: number) => [number, number, number, number];
 export const editsession_layout_document_with_regions_json: (a: number, b: number, c: number) => [number, number, number, number];
+export const editsession_layout_document_with_regions_retained_json: (a: number, b: number, c: number) => [number, number, number, number];
 export const editsession_layout_font_requirements_json: (a: number, b: number, c: number) => [number, number, number, number];
 export const editsession_list_revisions: (a: number) => [number, number, number, number];
 export const editsession_load_json: (a: number, b: number, c: number) => [number, number, number, number];
@@ -75,6 +76,7 @@ export const editsession_resident_caret_snapshot_json: (a: number) => [number, n
 export const editsession_resolve_comment: (a: number, b: number, c: number) => [number, number, number, number];
 export const editsession_resolve_encoded_selection: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => [number, number, number, number];
 export const editsession_resolve_sticky_position: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
+export const editsession_retained_kernel_inputs_json: (a: number) => [number, number, number, number];
 export const editsession_seed_from_docx: (a: number, b: number, c: number) => [number, number, number, number];
 export const editsession_selection: (a: number) => [number, number, number, number];
 export const editsession_selection_context: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => [number, number, number, number];

--- a/packages/docx/src/yrs/index.ts
+++ b/packages/docx/src/yrs/index.ts
@@ -636,6 +636,11 @@ export interface YrsSession extends CollaborationReplica {
   layoutFontRequirementsJson(input: string): string;
   /** Paginate and compose section/page regions in the resident engine. */
   layoutDocumentWithRegionsJson(input: string): string;
+  /** Same pass, but the reply omits the measured arena (fetch it on demand
+   * through {@link YrsSession.retainedKernelInputsJson}). */
+  layoutDocumentWithRegionsRetainedJson(input: string): string;
+  /** Retained `{ measured, options }` for the main-thread display fallback. */
+  retainedKernelInputsJson(): string;
   /** Build display primitives against the session's resident font store. */
   buildDisplayListJson(input: string): string;
   /** Build a binary FrameDelta v1 against the last host-applied frame. */
@@ -1160,6 +1165,14 @@ function wrapSession(session: EditSession, clientId: number): YrsSession {
       residentLayoutRevision += 1;
       return output;
     },
+    layoutDocumentWithRegionsRetainedJson: (input) => {
+      const output = session.layout_document_with_regions_retained_json(input);
+      residentLayoutInput = input;
+      residentLayoutWithRegions = true;
+      residentLayoutRevision += 1;
+      return output;
+    },
+    retainedKernelInputsJson: () => session.retained_kernel_inputs_json(),
     buildDisplayListJson: (input) => session.build_display_list_json(input),
     buildDisplayListFrame: (input, expectedFrameEpoch) =>
       session.build_display_list_frame(input, expectedFrameEpoch),

--- a/packages/docx/src/yrs/residentEngineSession.ts
+++ b/packages/docx/src/yrs/residentEngineSession.ts
@@ -24,7 +24,7 @@ export type ResidentEngineSession = Pick<
   | 'encodeStateVector'
   | 'layoutDocumentJson'
   | 'layoutFontRequirementsJson'
-  | 'layoutDocumentWithRegionsJson'
+  | 'layoutDocumentWithRegionsRetainedJson'
   | 'loadState'
   | 'measureParagraphJson'
   | 'onUpdate'
@@ -71,7 +71,8 @@ export async function createResidentEngineSession(): Promise<ResidentEngineSessi
     measureParagraphJson: (input) => session.measure_paragraph_json(input),
     layoutDocumentJson: (input) => session.layout_document_json(input),
     layoutFontRequirementsJson: (input) => session.layout_font_requirements_json(input),
-    layoutDocumentWithRegionsJson: (input) => session.layout_document_with_regions_json(input),
+    layoutDocumentWithRegionsRetainedJson: (input) =>
+      session.layout_document_with_regions_retained_json(input),
     buildDisplayListFrame: (input, expectedFrameEpoch) =>
       session.build_display_list_frame(input, expectedFrameEpoch),
     residentCaretSnapshot: () =>

--- a/packages/docx/src/yrs/residentEngineWorker.ts
+++ b/packages/docx/src/yrs/residentEngineWorker.ts
@@ -226,7 +226,9 @@ function hydrate(snapshot: YrsResidentWorkerSnapshot) {
   for (const { story, env } of snapshot.renderInputs) session.yrsBlocksForStory(story, env);
   for (const input of snapshot.measureInputs) session.measureParagraphJson(input);
   if (snapshot.layoutWithRegions) {
-    session.layoutDocumentWithRegionsJson(snapshot.layoutInput);
+    // retained variant: the reply is discarded here, and the full envelope
+    // serializes the measured arena — tens of MB on a large document
+    session.layoutDocumentWithRegionsRetainedJson(snapshot.layoutInput);
   } else {
     session.layoutDocumentJson(snapshot.layoutInput);
   }


### PR DESCRIPTION
TL;DR:

Repro file:
`crates/docx-edit/tests/incremental_typing.rs` and `crates/docx-edit/tests/structural_relayout.rs` build the reference document synthetically (400 × a ~290-char paragraph → 32 US-Letter pages) and pin the regressions; loading the same content as a .docx in the demo editor reproduces every number below.

Summary:
- typing on a large document re-ran a full O(document) region relayout in the engine on every keystroke: `orderedSections()` appended `finalSectionProperties` after `body.sections`, which already ends with the final section, so every single-section document reported two sections and permanently failed the engine's `single_section` resident fast path. One-line count fix: per-keystroke engine time 1,050 ms → 155 ms on the 32-page fixture
- authoritative cluster metadata emitted one text primitive per glyph cluster — effectively one per character, 115k primitives on the fixture. Contiguous same-run, same-bidi-level slices now coalesce into one primitive; the glyph path re-shapes the merged text, folds per-space justification stretch, and snaps the total advance to the summed measured width, so painting is pixel-identical and caret stops stay cluster-exact. Letter-spaced, char-scaled and browser-path runs keep per-cluster slices. Primitives 115k → 1.6k, DOM 117k → 2.7k nodes, bootstrap frame 30 MB → 5.3 MB, keystroke frame 992 KB → 176 KB
- selection painted one div per primitive: `Ctrl+A` created 115,969 rects and doubled the DOM. `collect_range_rects` now merges each page's rects into per-line bands: 1,200 rects, select-all 822 ms → 70 ms
- caret stops were built eagerly for every text primitive on every range/hit query, with a per-cluster UTF-16 prefix rescan that is quadratic in run length once runs are coalesced; stops are now computed lazily, only for primitives a query resolves, in one linear pass. Extend-selection 140 ms → 20 ms
- a reflow that changes the page count collapses the block-aligned pagination checkpoints, so incremental placement never converges again and every later keystroke rebuilt every display page. A damaged-page-span diff (page equality modulo the known per-block position deltas) bounds the rebuild to the truly changed pages, so the editor returns to page-local work instead of staying O(document) until reload
- the owned frame path shifts every downstream page's doc positions in place per keystroke, which made query-store handle adoption treat every page as changed and re-serialize ~30 MB of display-list JSON per prime; shifts are now recorded per page and replayed into the Rust store as compact ops
- structural edits (Enter, paste) re-measured all blocks and shipped a 27 MB reply, 26.9 MB of which is the measured arena nothing on the render path reads. The full region pass now reuses retained measures and their fingerprints by stable block key (survives paragraph splits), and a `retained` reply variant keeps the arena wasm-side, fetched lazily by the main-thread display fallback; the worker's `hydrate`, which always discarded the reply, uses it too. Enter relayout 351 ms → 21 ms native, ~1.2 s → ~0.4 s of main-thread blocking in the browser
- React side: a11y mirror and interactive overlay rebuilds are debounced off the keystroke path, per-page canvas surfaces are memoized on stable `DisplayPage` identity, and the scroll page-info state bails out on unchanged values instead of re-rendering the whole editor every scroll frame

End-to-end on the 32-page fixture (production build, Apple Silicon, 120 Hz): sustained typing goes from ×7.81 starvation / 42.6 s blocking on the published 0.1.0 demo (×1.6–2.0 / 2.9–8.4 s on main) to ×1.03 with zero long tasks including a page-count reflow mid-burst; scroll p95 20.4 → 9.3 ms; idle blocking stays 0.

Test plan:
- [ ] `cargo test -p betteroffice-docx-edit --features wasm -p betteroffice-docx-layout -p betteroffice-docx-raster` green (includes the new incremental-typing, structural-relayout, store shift-replay, line-band and cluster-coalescing tests)
- [ ] `bun run typecheck:packages && bun run test` green
- [ ] demo, 32-page fixture: sustained typing (76 chars @ 12/s) shows no long task; `Ctrl+A` ≤ 150 ms; DOM census ≤ 5k nodes
- [ ] visual spot-check of the formatted demo document (Title/Subtitle tracking, bold/italic/underline/highlight, lists, table, headers/footers) — rendering unchanged
- [ ] two tabs on one collaboration room stay in sync while both edit
