### PR TITLE
feat(pptx): paragraph alignment controls

### DIFF
--- a/.changeset/pptx-paragraph-alignment.md
+++ b/.changeset/pptx-paragraph-alignment.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/pptx": minor
+"@betteroffice/rust-crates": minor
+---
+
+Set paragraph alignment from the presentation toolbar.

--- a/crates/betteroffice-pptx/src/presentation.rs
+++ b/crates/betteroffice-pptx/src/presentation.rs
@@ -250,6 +250,19 @@ impl Presentation {
             .format_text(context, story_id, start, end, patch)?)
     }
 
+    pub fn set_paragraph_alignment(
+        &self,
+        context: &EditCtx,
+        story_id: &str,
+        start: u32,
+        end: u32,
+        alignment: Option<&str>,
+    ) -> Result<TextReceipt> {
+        Ok(self
+            .session
+            .set_paragraph_alignment(context, story_id, start, end, alignment)?)
+    }
+
     pub fn insert_paragraph_break(
         &self,
         context: &EditCtx,

--- a/crates/pptx-edit/src/story.rs
+++ b/crates/pptx-edit/src/story.rs
@@ -38,6 +38,8 @@ const UNDERLINE_TYPES: [&str; 18] = [
     "wavyDbl",
 ];
 
+const ALIGNMENTS: [&str; 7] = ["l", "ctr", "r", "just", "justLow", "dist", "thaiDist"];
+
 /// The values land in schema-typed attributes, so junk must fail the edit
 /// rather than the file.
 pub(crate) fn validate_style_values(
@@ -69,6 +71,17 @@ pub(crate) fn validate_style_values(
     {
         return Err(EditError::InvalidText(format!(
             "font size {size}pt is outside the 1-4000pt range"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_alignment(alignment: Option<&str>) -> EditResult<()> {
+    if let Some(alignment) = alignment
+        && !ALIGNMENTS.contains(&alignment)
+    {
+        return Err(EditError::InvalidText(format!(
+            "unrecognized paragraph alignment {alignment:?}"
         )));
     }
     Ok(())
@@ -282,6 +295,40 @@ impl DeckSession {
         })
     }
 
+    /// Sets `a:pPr@algn` on every paragraph the range touches; `None` clears
+    /// the value so the placeholder cascade applies again.
+    pub fn set_paragraph_alignment(
+        &self,
+        context: &crate::EditCtx,
+        story_id: &str,
+        start: u32,
+        end: u32,
+        alignment: Option<&str>,
+    ) -> EditResult<TextReceipt> {
+        validate_alignment(alignment)?;
+        let mut txn = self.transact_for(context);
+        let story = story_ref(&txn, story_id)?;
+        check_text_bounds(&story, &txn, start, end)?;
+        let text = text_in_range(&story, &txn, start, end);
+        let pilcrows = selected_pilcrows(&story, &txn, start, end);
+        for pilcrow in pilcrows {
+            match alignment {
+                Some(alignment) => {
+                    pilcrow.insert(&mut txn, "alignment", alignment);
+                }
+                None => {
+                    pilcrow.remove(&mut txn, "alignment");
+                }
+            }
+        }
+        Ok(TextReceipt {
+            story_id: story_id.to_owned(),
+            start,
+            end,
+            text,
+        })
+    }
+
     pub fn insert_paragraph_break(
         &self,
         context: &crate::EditCtx,
@@ -452,6 +499,27 @@ fn check_text_bounds<T: ReadTxn>(story: &TextRef, txn: &T, start: u32, end: u32)
         });
     }
     Ok(())
+}
+
+/// The pilcrow of every paragraph the range touches. A collapsed caret picks
+/// the paragraph it sits in; a range stopping at a paragraph start does not.
+fn selected_pilcrows<T: ReadTxn>(story: &TextRef, txn: &T, start: u32, end: u32) -> Vec<MapRef> {
+    let mut pilcrows = Vec::new();
+    let mut paragraph_start = 0;
+    let mut offset = 0;
+    for diff in story.diff(txn, YChange::identity) {
+        let item_length = out_len(&diff.insert);
+        if let Out::YMap(map) = diff.insert {
+            let touches = start <= offset
+                && (end > paragraph_start || (start == end && start >= paragraph_start));
+            if touches {
+                pilcrows.push(map);
+            }
+            paragraph_start = offset + item_length;
+        }
+        offset += item_length;
+    }
+    pilcrows
 }
 
 fn paragraph_text_segments<T: ReadTxn>(

--- a/crates/pptx-edit/src/story.rs
+++ b/crates/pptx-edit/src/story.rs
@@ -504,6 +504,7 @@ fn check_text_bounds<T: ReadTxn>(story: &TextRef, txn: &T, start: u32, end: u32)
 /// The pilcrow of every paragraph the range touches. A collapsed caret picks
 /// the paragraph it sits in; a range stopping at a paragraph start does not.
 fn selected_pilcrows<T: ReadTxn>(story: &TextRef, txn: &T, start: u32, end: u32) -> Vec<MapRef> {
+    let start = start.min(story.len(txn).saturating_sub(1));
     let mut pilcrows = Vec::new();
     let mut paragraph_start = 0;
     let mut offset = 0;

--- a/crates/pptx-edit/src/wasm.rs
+++ b/crates/pptx-edit/src/wasm.rs
@@ -57,6 +57,16 @@ struct FormatTextArgs {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct SetParagraphAlignmentArgs {
+    story_id: String,
+    start: u32,
+    end: u32,
+    #[serde(default)]
+    alignment: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ParagraphBreakArgs {
     story_id: String,
     index: u32,
@@ -331,6 +341,22 @@ impl PptxDocument {
                     args.start,
                     args.end,
                     &args.patch,
+                )
+                .map_err(js_error)?,
+        )
+    }
+
+    #[wasm_bindgen(js_name = setParagraphAlignmentJson)]
+    pub fn set_paragraph_alignment_json(&self, args: &str) -> Result<String, JsValue> {
+        let args: SetParagraphAlignmentArgs = parse_args(args)?;
+        json(
+            self.session
+                .set_paragraph_alignment(
+                    &local_context(),
+                    &args.story_id,
+                    args.start,
+                    args.end,
+                    args.alignment.as_deref(),
                 )
                 .map_err(js_error)?,
         )

--- a/crates/pptx-edit/tests/convergence.rs
+++ b/crates/pptx-edit/tests/convergence.rs
@@ -251,6 +251,37 @@ fn cross_paragraph_format_is_one_undoable_operation() {
 }
 
 #[test]
+fn cross_paragraph_alignment_is_one_undoable_operation() {
+    let session = DeckSession::open(FIXTURE, 407).unwrap();
+    let story_id = first_multi_paragraph_story(&session);
+    let before = session.story(&story_id).unwrap();
+
+    session
+        .set_paragraph_alignment(
+            &EditCtx::local("local"),
+            &story_id,
+            0,
+            before.length,
+            Some("r"),
+        )
+        .unwrap();
+
+    let aligned = session.story(&story_id).unwrap();
+    assert!(aligned.paragraphs.len() >= 2);
+    assert!(
+        aligned
+            .paragraphs
+            .iter()
+            .all(|paragraph| paragraph.alignment.as_deref() == Some("r"))
+    );
+
+    session.add_undo_barrier();
+    assert!(session.undo());
+    assert_eq!(session.story(&story_id).unwrap(), before);
+    assert!(!session.can_undo());
+}
+
+#[test]
 fn cross_paragraph_format_rejects_out_of_bounds_ranges() {
     let session = DeckSession::open(FIXTURE, 406).unwrap();
     let story_id = first_multi_paragraph_story(&session);

--- a/crates/pptx-edit/tests/save.rs
+++ b/crates/pptx-edit/tests/save.rs
@@ -165,6 +165,36 @@ fn a_formatted_range_survives_reopen() {
 }
 
 #[test]
+fn a_paragraph_alignment_survives_reopen() {
+    let session = open_fixture();
+    let (_, _, story_id) = first_story(&session.snapshot().unwrap());
+    session
+        .set_paragraph_alignment(&context(), &story_id, 0, 0, Some("ctr"))
+        .unwrap();
+
+    let reopened = reopen(&session);
+    let snapshot = reopened.snapshot().unwrap();
+    let story = snapshot
+        .slides
+        .iter()
+        .flat_map(|slide| &slide.shapes)
+        .flat_map(shape_stories)
+        .find(|story| story.id == story_id)
+        .unwrap();
+    assert_eq!(story.paragraphs[0].alignment.as_deref(), Some("ctr"));
+}
+
+#[test]
+fn an_unknown_paragraph_alignment_is_rejected() {
+    let session = open_fixture();
+    let (_, _, story_id) = first_story(&session.snapshot().unwrap());
+    let error = session
+        .set_paragraph_alignment(&context(), &story_id, 0, 0, Some("middle"))
+        .unwrap_err();
+    assert!(matches!(error, EditError::InvalidText(message) if message.contains("middle")));
+}
+
+#[test]
 fn fill_and_stroke_survive_reopen() {
     let session = open_fixture();
     let snapshot = session.snapshot().unwrap();

--- a/crates/pptx-edit/tests/save.rs
+++ b/crates/pptx-edit/tests/save.rs
@@ -185,6 +185,22 @@ fn a_paragraph_alignment_survives_reopen() {
 }
 
 #[test]
+fn an_alignment_with_the_caret_at_the_story_end_reaches_the_last_paragraph() {
+    let session = open_fixture();
+    let (_, _, story_id) = first_story(&session.snapshot().unwrap());
+    let length = session.story(&story_id).unwrap().length;
+    session
+        .set_paragraph_alignment(&context(), &story_id, length, length, Some("r"))
+        .unwrap();
+
+    let story = session.story(&story_id).unwrap();
+    assert_eq!(
+        story.paragraphs.last().unwrap().alignment.as_deref(),
+        Some("r")
+    );
+}
+
+#[test]
 fn an_unknown_paragraph_alignment_is_rejected() {
     let session = open_fixture();
     let (_, _, story_id) = first_story(&session.snapshot().unwrap());

--- a/crates/pptx-edit/tests/write_fidelity.rs
+++ b/crates/pptx-edit/tests/write_fidelity.rs
@@ -544,6 +544,28 @@ fn a_colour_write_replaces_an_existing_no_fill() {
 }
 
 #[test]
+fn an_alignment_write_reaches_the_paragraph_properties() {
+    let session = open();
+    let snapshot = session.snapshot().unwrap();
+    let story_id = snapshot.slides[0]
+        .shapes
+        .iter()
+        .find(|shape| shape.name == "Title")
+        .unwrap()
+        .text_stories[0]
+        .id
+        .clone();
+    session
+        .set_paragraph_alignment(&context(), &story_id, 0, 0, Some("ctr"))
+        .unwrap();
+
+    let saved = parts(&session.save().unwrap());
+    let slide = part_text(&saved, "ppt/slides/slide1.xml");
+    assert_eq!(slide.matches(r#"algn="ctr""#).count(), 1);
+    assert!(slide.contains("Accent"));
+}
+
+#[test]
 fn a_resize_keeps_a_partial_transforms_own_offset_and_rotation() {
     let session = open();
     let snapshot = session.snapshot().unwrap();

--- a/packages/pptx-i18n/de.json
+++ b/packages/pptx-i18n/de.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "Ausrichtung"
+    },
+    "align": {
+      "left": "Linksbündig",
+      "center": "Zentriert",
+      "right": "Rechtsbündig",
+      "justify": "Blocksatz"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/en.json
+++ b/packages/pptx-i18n/en.json
@@ -24,7 +24,14 @@
       "tools": "Tools",
       "font": "Font",
       "text": "Text formatting",
-      "shape": "Shape formatting"
+      "shape": "Shape formatting",
+      "alignment": "Alignment"
+    },
+    "align": {
+      "left": "Align Left",
+      "center": "Center",
+      "right": "Align Right",
+      "justify": "Justify"
     },
     "newSlide": "New slide",
     "newSlideWithLayout": "New slide with layout",

--- a/packages/pptx-i18n/fr.json
+++ b/packages/pptx-i18n/fr.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "Alignement"
+    },
+    "align": {
+      "left": "Aligner à gauche",
+      "center": "Centrer",
+      "right": "Aligner à droite",
+      "justify": "Justifier"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/he.json
+++ b/packages/pptx-i18n/he.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "יישור טקסט"
+    },
+    "align": {
+      "left": "יישור לשמאל",
+      "center": "יישור למרכז",
+      "right": "יישור לימין",
+      "justify": "יישור מלא"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/hi.json
+++ b/packages/pptx-i18n/hi.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "संरेखण"
+    },
+    "align": {
+      "left": "बाएं संरेखित करें",
+      "center": "केंद्रित करें",
+      "right": "दाएं संरेखित करें",
+      "justify": "दोनों ओर संरेखित करें"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/id.json
+++ b/packages/pptx-i18n/id.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "Perataan"
+    },
+    "align": {
+      "left": "Rata Kiri",
+      "center": "Tengah",
+      "right": "Rata Kanan",
+      "justify": "Rata Kiri-Kanan"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/pl.json
+++ b/packages/pptx-i18n/pl.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "Wyrównanie"
+    },
+    "align": {
+      "left": "Wyrównaj do lewej",
+      "center": "Wyśrodkuj",
+      "right": "Wyrównaj do prawej",
+      "justify": "Wyjustuj"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/pt-BR.json
+++ b/packages/pptx-i18n/pt-BR.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "Alinhamento"
+    },
+    "align": {
+      "left": "Alinhar à esquerda",
+      "center": "Centralizar",
+      "right": "Alinhar à direita",
+      "justify": "Justificar"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/tr.json
+++ b/packages/pptx-i18n/tr.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "Hizalama"
+    },
+    "align": {
+      "left": "Sola hizala",
+      "center": "Ortala",
+      "right": "Sağa hizala",
+      "justify": "İki yana yasla"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-i18n/zh-CN.json
+++ b/packages/pptx-i18n/zh-CN.json
@@ -24,7 +24,14 @@
       "tools": null,
       "font": null,
       "text": null,
-      "shape": null
+      "shape": null,
+      "alignment": "对齐"
+    },
+    "align": {
+      "left": "左对齐",
+      "center": "居中",
+      "right": "右对齐",
+      "justify": "两端对齐"
     },
     "newSlide": null,
     "newSlideWithLayout": null,

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -1176,7 +1176,7 @@ function PptxEditorContent({
         event.preventDefault();
         const story = handle.story(selection.storyId);
         const delta = event.key === 'ArrowLeft' ? -1 : 1;
-        const focus = Math.max(0, Math.min(story.length, selection.focus + delta));
+        const focus = Math.max(0, Math.min(story.length - 1, selection.focus + delta));
         setSelection({
           ...selection,
           anchor: event.shiftKey ? selection.anchor : focus,

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -9,6 +9,7 @@ import type {
   CanvasImageResolver,
   CollaborationReplica,
   DeckSnapshot,
+  ParagraphAlignment,
   PptxPresence,
   PptxPresencePeer,
   PptxFontFace,
@@ -64,6 +65,7 @@ import {
 } from './presence-rendering';
 import {
   effectiveStyleFromSelection,
+  paragraphAlignmentFromSelection,
   selectionFormattingFromStory,
   storyFormattingFromStory,
 } from './textFormatting';
@@ -612,6 +614,24 @@ function PptxEditorContent({
       return selectionFormattingFromStyle(textStyle);
     }
   }, [model, selectedShapeStoryId, selection, textStyle]);
+
+  const selectionAlignment = useMemo<ParagraphAlignment | undefined>(() => {
+    const handle = handleRef.current;
+    const storyId = selection?.storyId ?? selectedShapeStoryId;
+    if (!handle || !storyId) return undefined;
+    try {
+      const story = handle.story(storyId);
+      const textBox = model?.frame?.primitives.find(
+        (primitive): primitive is TextBoxPrimitive =>
+          primitive.kind === 'textBox' && primitive.storyId === storyId
+      );
+      return selection
+        ? paragraphAlignmentFromSelection(story, textBox, selection.anchor, selection.focus)
+        : paragraphAlignmentFromSelection(story, textBox, 0, story.length);
+    } catch {
+      return undefined;
+    }
+  }, [model, selectedShapeStoryId, selection]);
 
   const slideLayouts = useMemo<SlideLayoutOption[]>(() => {
     const unique = new Set<string | null>();
@@ -1242,6 +1262,27 @@ function PptxEditorContent({
     }
   };
 
+  const applyAlignment = (alignment: ParagraphAlignment) => {
+    const handle = handleRef.current;
+    const storyId = selection?.storyId ?? selectedShapeStoryId;
+    if (!handle || !storyId) return;
+    try {
+      if (selection) {
+        handle.setParagraphAlignment(
+          storyId,
+          Math.min(selection.anchor, selection.focus),
+          Math.max(selection.anchor, selection.focus),
+          alignment
+        );
+      } else {
+        handle.setParagraphAlignment(storyId, 0, handle.story(storyId).length, alignment);
+      }
+      refreshAt(undefined, true);
+    } catch (value) {
+      reportError(value);
+    }
+  };
+
   const formatSelection = (action: FormattingAction) => {
     if (action === 'bold') {
       applyFormatting({ bold: !selectionFormatting.bold });
@@ -1255,6 +1296,8 @@ function PptxEditorContent({
       applyFormatting({ fontSizePt: action.value });
     } else if (action.type === 'textColor') {
       applyFormatting({ color: action.value });
+    } else if (action.type === 'align') {
+      applyAlignment(action.value);
     }
   };
 
@@ -1351,7 +1394,7 @@ function PptxEditorContent({
     <div className={className} style={styles.root}>
       <div style={styles.toolbarShell}>
         <EditorToolbar
-          currentFormatting={selectionFormatting}
+          currentFormatting={{ ...selectionFormatting, align: selectionAlignment }}
           textSelectionActive={selection !== null || selectedShapeStoryId !== null}
           onFormat={formatSelection}
           currentShapeFormatting={selectedShapeFormatting}

--- a/packages/pptx-react/src/components/Toolbar.test.tsx
+++ b/packages/pptx-react/src/components/Toolbar.test.tsx
@@ -1,6 +1,6 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import { afterAll, afterEach, describe, expect, it } from 'bun:test';
-import type { ShapeFormattingAction } from './Toolbar';
+import type { FormattingAction, ShapeFormattingAction } from './Toolbar';
 import { LocaleProvider } from '../i18n';
 import { Toolbar } from './Toolbar';
 
@@ -19,6 +19,53 @@ afterAll(async () => {
   if (clientWidth) Object.defineProperty(elementPrototype, 'clientWidth', clientWidth);
   else Reflect.deleteProperty(elementPrototype, 'clientWidth');
   if (GlobalRegistrator.isRegistered) await GlobalRegistrator.unregister();
+});
+
+describe('Toolbar alignment controls', () => {
+  it('emits the alignment the button stands for', () => {
+    const actions: FormattingAction[] = [];
+    const { getByTestId } = render(
+      <LocaleProvider>
+        <Toolbar
+          textSelectionActive
+          currentFormatting={{ align: 'ctr' }}
+          onFormat={(action) => actions.push(action)}
+        />
+      </LocaleProvider>
+    );
+
+    fireEvent.click(getByTestId('pptx-align-right'));
+    fireEvent.click(getByTestId('pptx-align-justify'));
+
+    expect(actions).toEqual([
+      { type: 'align', value: 'r' },
+      { type: 'align', value: 'just' },
+    ]);
+  });
+
+  it('marks the alignment of the current selection', () => {
+    const { getByTestId } = render(
+      <LocaleProvider>
+        <Toolbar textSelectionActive currentFormatting={{ align: 'ctr' }} onFormat={() => {}} />
+      </LocaleProvider>
+    );
+
+    expect(getByTestId('pptx-align-center').getAttribute('aria-pressed')).toBe('true');
+    expect(getByTestId('pptx-align-left').getAttribute('aria-pressed')).toBeNull();
+  });
+
+  it('disables the buttons without a text selection', () => {
+    const actions: FormattingAction[] = [];
+    const { getByTestId } = render(
+      <LocaleProvider>
+        <Toolbar onFormat={(action) => actions.push(action)} />
+      </LocaleProvider>
+    );
+
+    fireEvent.click(getByTestId('pptx-align-center'));
+
+    expect(actions).toEqual([]);
+  });
 });
 
 describe('Toolbar shape controls', () => {

--- a/packages/pptx-react/src/components/Toolbar.tsx
+++ b/packages/pptx-react/src/components/Toolbar.tsx
@@ -1,11 +1,13 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
+import type { ParagraphAlignment } from '@betteroffice/pptx';
 import type { TranslationKey } from '@betteroffice/pptx-i18n';
 import { useTranslation } from '../i18n';
 import { EditorToolbarContext } from './EditorToolbarContext';
 import { ColorPicker } from './ui/ColorPicker';
 import { EditableCombobox } from './ui/EditableCombobox';
 import { ToolbarIcon } from './ui/ToolbarIcon';
+import type { ToolbarIconName } from './ui/ToolbarIcon';
 import {
   ToolbarButton,
   ToolbarDropdown,
@@ -46,6 +48,7 @@ export interface SelectionFormatting {
   italic?: boolean;
   underline?: boolean;
   textColor?: string;
+  align?: ParagraphAlignment;
 }
 
 export type FormattingAction =
@@ -54,7 +57,8 @@ export type FormattingAction =
   | 'underline'
   | { type: 'fontFamily'; value: string }
   | { type: 'fontSize'; value: number }
-  | { type: 'textColor'; value: string };
+  | { type: 'textColor'; value: string }
+  | { type: 'align'; value: ParagraphAlignment };
 
 export interface ShapeFormatting {
   geometry?: string;
@@ -119,6 +123,17 @@ const DEFAULT_FONT_FAMILIES = [
   'Verdana',
 ] as const;
 const DEFAULT_FONT_SIZES = [8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 36, 48, 72] as const;
+const ALIGNMENTS = [
+  { value: 'l', icon: 'alignLeft', labelKey: 'toolbar.align.left', testId: 'left' },
+  { value: 'ctr', icon: 'alignCenter', labelKey: 'toolbar.align.center', testId: 'center' },
+  { value: 'r', icon: 'alignRight', labelKey: 'toolbar.align.right', testId: 'right' },
+  { value: 'just', icon: 'alignJustify', labelKey: 'toolbar.align.justify', testId: 'justify' },
+] as const satisfies ReadonlyArray<{
+  value: ParagraphAlignment;
+  icon: ToolbarIconName;
+  labelKey: TranslationKey;
+  testId: string;
+}>;
 const BORDER_WIDTHS = [1, 2, 3, 4, 8] as const;
 const CORNER_RADIUS_OPTIONS = [0, 10, 17, 25, 33, 50] as const;
 const SHAPE_ADJUSTMENT_OPTIONS = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100] as const;
@@ -553,6 +568,29 @@ export function Toolbar(explicitProps: ToolbarProps) {
               onChange={(value) => apply({ type: 'textColor', value })}
               testId="pptx-text-color"
             />
+          </ToolbarGroup>
+        </>
+      ),
+    },
+    {
+      key: 'align',
+      width: 126,
+      node: (
+        <>
+          <ToolbarSeparator />
+          <ToolbarGroup label={t('toolbar.groups.alignment')}>
+            {ALIGNMENTS.map((alignment) => (
+              <ToolbarButton
+                key={alignment.value}
+                title={t(alignment.labelKey)}
+                active={currentFormatting.align === alignment.value}
+                disabled={!formattingEnabled}
+                onClick={() => apply({ type: 'align', value: alignment.value })}
+                testId={`pptx-align-${alignment.testId}`}
+              >
+                <ToolbarIcon name={alignment.icon} />
+              </ToolbarButton>
+            ))}
           </ToolbarGroup>
         </>
       ),

--- a/packages/pptx-react/src/components/ui/ToolbarIcon.tsx
+++ b/packages/pptx-react/src/components/ui/ToolbarIcon.tsx
@@ -15,6 +15,10 @@ export type ToolbarIconName =
   | 'italic'
   | 'underline'
   | 'textColor'
+  | 'alignLeft'
+  | 'alignCenter'
+  | 'alignRight'
+  | 'alignJustify'
   | 'more'
   | 'chevronDown'
   | 'remove'
@@ -90,6 +94,10 @@ export function ToolbarIcon({ name, size = 20, style }: ToolbarIconProps) {
           <path d="M5 20h14" strokeWidth="3" />
         </>
       )}
+      {name === 'alignLeft' && <path d="M4 6h16M4 10h10M4 14h16M4 18h10" />}
+      {name === 'alignCenter' && <path d="M4 6h16M7 10h10M4 14h16M7 18h10" />}
+      {name === 'alignRight' && <path d="M4 6h16M10 10h10M4 14h16M10 18h10" />}
+      {name === 'alignJustify' && <path d="M4 6h16M4 10h16M4 14h16M4 18h16" />}
       {name === 'more' && (
         <>
           <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />

--- a/packages/pptx-react/src/textFormatting.test.ts
+++ b/packages/pptx-react/src/textFormatting.test.ts
@@ -66,6 +66,12 @@ describe('pptx text formatting', () => {
     expect(paragraphAlignmentFromSelection(inherited, textBox('center', 'left'), 3, 3)).toBe('ctr');
   });
 
+  it('marks the last paragraph when the caret sits at the story end', () => {
+    const aligned = alignedStory('ctr', 'r');
+    expect(paragraphAlignmentFromSelection(aligned, undefined, 15, 15)).toBe('r');
+    expect(paragraphAlignmentFromSelection(aligned, undefined, 16, 16)).toBe('r');
+  });
+
   it('normalizes the justified variants', () => {
     expect(paragraphAlignmentFromSelection(alignedStory('dist', null), undefined, 3, 3)).toBe('just');
   });

--- a/packages/pptx-react/src/textFormatting.test.ts
+++ b/packages/pptx-react/src/textFormatting.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import type { StorySnapshot, TextStyleSnapshot } from '@betteroffice/pptx';
+import type { StorySnapshot, TextBoxPrimitive, TextStyleSnapshot } from '@betteroffice/pptx';
 import {
   effectiveStyleFromSelection,
+  paragraphAlignmentFromSelection,
   selectionFormattingFromStory,
   storyFormattingFromStory,
   storyTextRanges,
@@ -52,6 +53,27 @@ describe('pptx text formatting', () => {
       { start: 0, end: 10 },
       { start: 11, end: 15 },
     ]);
+  });
+
+  it('reads the alignment stored on the paragraph the caret sits in', () => {
+    const aligned = alignedStory('ctr', null);
+    expect(paragraphAlignmentFromSelection(aligned, undefined, 3, 3)).toBe('ctr');
+    expect(paragraphAlignmentFromSelection(aligned, undefined, 12, 12)).toBe('l');
+  });
+
+  it('falls back to the alignment the laid out text box resolved', () => {
+    const inherited = alignedStory(null, null);
+    expect(paragraphAlignmentFromSelection(inherited, textBox('center', 'left'), 3, 3)).toBe('ctr');
+  });
+
+  it('normalizes the justified variants', () => {
+    expect(paragraphAlignmentFromSelection(alignedStory('dist', null), undefined, 3, 3)).toBe('just');
+  });
+
+  it('leaves a selection spanning differently aligned paragraphs unset', () => {
+    const mixed = alignedStory('ctr', 'r');
+    expect(paragraphAlignmentFromSelection(mixed, undefined, 0, 15)).toBeUndefined();
+    expect(paragraphAlignmentFromSelection(mixed, undefined, 0, 10)).toBe('ctr');
   });
 
   it('uses the fallback style for an empty story', () => {
@@ -111,6 +133,33 @@ function shapeStory(): StorySnapshot {
         ],
       },
     ],
+  };
+}
+
+function alignedStory(first: string | null, second: string | null): StorySnapshot {
+  const base = shapeStory();
+  return {
+    ...base,
+    paragraphs: [
+      { ...base.paragraphs[0], alignment: first },
+      { ...base.paragraphs[1], alignment: second },
+    ],
+  };
+}
+
+function textBox(
+  ...aligns: Array<'left' | 'center' | 'right' | 'justify'>
+): TextBoxPrimitive {
+  return {
+    kind: 'textBox',
+    objectId: 1,
+    x: 0,
+    y: 0,
+    w: 100,
+    h: 100,
+    anchor: 'top',
+    paragraphs: aligns.map((align) => ({ align, level: 0, runs: [] })),
+    lines: [],
   };
 }
 

--- a/packages/pptx-react/src/textFormatting.ts
+++ b/packages/pptx-react/src/textFormatting.ts
@@ -72,9 +72,11 @@ export function paragraphAlignmentFromSelection(
   anchor: number,
   focus: number
 ): ParagraphAlignment | undefined {
-  const start = Math.min(anchor, focus);
+  const ranges = storyTextRanges(story);
+  const limit = ranges[ranges.length - 1]?.end ?? 0;
+  const start = Math.min(Math.min(anchor, focus), limit);
   const end = Math.max(anchor, focus);
-  const alignments = storyTextRanges(story)
+  const alignments = ranges
     .map((range, index) => ({ range, index }))
     .filter(({ range }) =>
       start === end

--- a/packages/pptx-react/src/textFormatting.ts
+++ b/packages/pptx-react/src/textFormatting.ts
@@ -1,4 +1,9 @@
-import type { StorySnapshot, TextStyleSnapshot } from '@betteroffice/pptx';
+import type {
+  ParagraphAlignment,
+  StorySnapshot,
+  TextBoxPrimitive,
+  TextStyleSnapshot,
+} from '@betteroffice/pptx';
 import type { SelectionFormatting } from './components/Toolbar';
 
 export interface EffectiveTextStyle {
@@ -39,6 +44,58 @@ export function storyFormattingFromStory(
   fallback: EffectiveTextStyle
 ): SelectionFormatting {
   return selectionFormattingFromStory(story, 0, story.length, fallback);
+}
+
+const RESOLVED_ALIGNMENTS: Record<string, ParagraphAlignment> = {
+  left: 'l',
+  center: 'ctr',
+  right: 'r',
+  justify: 'just',
+};
+
+const STORED_ALIGNMENTS: Record<string, ParagraphAlignment> = {
+  l: 'l',
+  ctr: 'ctr',
+  r: 'r',
+  just: 'just',
+  justLow: 'just',
+  dist: 'just',
+  thaiDist: 'just',
+};
+
+/** The alignment shared by every paragraph the selection touches, or
+ *  `undefined` when they differ. The laid-out text box supplies the value a
+ *  paragraph inherits from its layout or master. */
+export function paragraphAlignmentFromSelection(
+  story: StorySnapshot,
+  textBox: TextBoxPrimitive | undefined,
+  anchor: number,
+  focus: number
+): ParagraphAlignment | undefined {
+  const start = Math.min(anchor, focus);
+  const end = Math.max(anchor, focus);
+  const alignments = storyTextRanges(story)
+    .map((range, index) => ({ range, index }))
+    .filter(({ range }) =>
+      start === end
+        ? start >= range.start && start <= range.end
+        : start <= range.end && end > range.start
+    )
+    .map(({ index }) => paragraphAlignment(story, textBox, index));
+  if (alignments.length === 0) return undefined;
+  const first = alignments[0];
+  return alignments.every((alignment) => alignment === first) ? first : undefined;
+}
+
+function paragraphAlignment(
+  story: StorySnapshot,
+  textBox: TextBoxPrimitive | undefined,
+  index: number
+): ParagraphAlignment {
+  const stored = story.paragraphs[index]?.alignment;
+  if (stored) return STORED_ALIGNMENTS[stored] ?? 'l';
+  const resolved = textBox?.paragraphs[index]?.align;
+  return resolved ? RESOLVED_ALIGNMENTS[resolved] ?? 'l' : 'l';
 }
 
 export function storyTextRanges(story: StorySnapshot): Array<{ start: number; end: number }> {

--- a/packages/pptx/README.md
+++ b/packages/pptx/README.md
@@ -44,7 +44,7 @@ replays the resulting primitives on canvas. Font bytes are supplied by the host
 and registered with the Rust shaper through `openPresentation`.
 
 Beyond rendering, `PresentationHandle` covers editing: text
-(`insertText` / `deleteText` / `formatText`), slides
+(`insertText` / `deleteText` / `formatText` / `setParagraphAlignment`), slides
 (`insertSlide` / `deleteSlide` / `moveSlide`), shapes
 (`addTextBox` / `moveShape` / `resizeShape`), `hitTest`, undo/redo, and
 `save()`, which serializes the deck back to `.pptx` bytes with edits applied —

--- a/packages/pptx/src/index.ts
+++ b/packages/pptx/src/index.ts
@@ -42,6 +42,7 @@ export type {
   HitTestResult,
   ImagePrimitive,
   Paint,
+  ParagraphAlignment,
   ParagraphSnapshot,
   PlaceholderPrimitive,
   PositionedGlyph,

--- a/packages/pptx/src/types.ts
+++ b/packages/pptx/src/types.ts
@@ -23,6 +23,9 @@ export interface TextRunSnapshot {
   style: TextStyleSnapshot;
 }
 
+/** OOXML `a:pPr@algn` token. */
+export type ParagraphAlignment = 'l' | 'ctr' | 'r' | 'just';
+
 export interface ParagraphSnapshot {
   id: string;
   alignment: string | null;

--- a/packages/pptx/src/wasm/generated/pptx_wasm.d.ts
+++ b/packages/pptx/src/wasm/generated/pptx_wasm.d.ts
@@ -39,6 +39,7 @@ export class PptxDocument {
      * Serializes the deck back to `.pptx` bytes, edits included.
      */
     saveBytes(): Uint8Array;
+    setParagraphAlignmentJson(args: string): string;
     setShapeAdjustJson(args: string): string;
     setShapeFillJson(args: string): string;
     setShapeStrokeJson(args: string): string;
@@ -116,6 +117,7 @@ export interface InitOutput {
     readonly pptxdocument_removeShapeJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_resizeShapeJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_saveBytes: (a: number) => [number, number, number, number];
+    readonly pptxdocument_setParagraphAlignmentJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_setShapeAdjustJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_setShapeFillJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_setShapeStrokeJson: (a: number, b: number, c: number) => [number, number, number, number];

--- a/packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm.d.ts
+++ b/packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm.d.ts
@@ -36,6 +36,7 @@ export const pptxdocument_redoJson: (a: number) => [number, number, number, numb
 export const pptxdocument_removeShapeJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_resizeShapeJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_saveBytes: (a: number) => [number, number, number, number];
+export const pptxdocument_setParagraphAlignmentJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_setShapeAdjustJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_setShapeFillJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_setShapeStrokeJson: (a: number, b: number, c: number) => [number, number, number, number];

--- a/packages/pptx/src/wasm/loader.test.ts
+++ b/packages/pptx/src/wasm/loader.test.ts
@@ -131,6 +131,30 @@ describe('PPTX wasm boundary', () => {
     unsubscribe();
   });
 
+  test('aligns paragraphs, reflows the text box, and undoes in one step', () => {
+    const snapshot = handle.snapshot();
+    const story = firstStory(snapshot.slides.flatMap((slide) => slide.shapes));
+    const laidOut = () =>
+      handle.layoutSlide(0).primitives.find(
+        (primitive): primitive is TextBoxPrimitive =>
+          primitive.kind === 'textBox' && primitive.storyId === story.id
+      );
+    const storedBefore = handle.story(story.id).paragraphs[0].alignment;
+    const renderedBefore = laidOut()?.paragraphs[0]?.align;
+
+    handle.setParagraphAlignment(story.id, 0, 0, 'ctr');
+    expect(handle.story(story.id).paragraphs[0].alignment).toBe('ctr');
+    expect(laidOut()?.paragraphs[0]?.align).toBe('center');
+
+    expect(handle.undo().applied).toBe(true);
+    expect(handle.story(story.id).paragraphs[0].alignment).toBe(storedBefore);
+    expect(laidOut()?.paragraphs[0]?.align).toBe(renderedBefore);
+
+    expect(() =>
+      handle.setParagraphAlignment(story.id, 0, 0, 'middle' as never)
+    ).toThrow();
+  });
+
   test('inserts and styles preset shapes with undo and redo', () => {
     const slide = handle.snapshot().slides[0];
     const receipt = handle.addShape(slide.id, {

--- a/packages/pptx/src/wasm/loader.ts
+++ b/packages/pptx/src/wasm/loader.ts
@@ -13,6 +13,7 @@ import type {
   DeckSnapshot,
   HistoryResult,
   HitTestResult,
+  ParagraphAlignment,
   PresetShapeDraft,
   PptxFontFace,
   ShapeAdjustReceipt,
@@ -58,6 +59,14 @@ export interface PresentationHandle extends CollaborationReplica {
   deleteText(storyId: string, start: number, end: number): TextReceipt;
   formatText(storyId: string, start: number, end: number, patch: TextStylePatch): TextReceipt;
   insertParagraphBreak(storyId: string, index: number): TextReceipt;
+  /** Sets the alignment of every paragraph the range touches; `null` restores
+   *  the inherited value. */
+  setParagraphAlignment(
+    storyId: string,
+    start: number,
+    end: number,
+    alignment: ParagraphAlignment | null
+  ): TextReceipt;
   insertSlide(index: number, layoutPartPath?: string): SlideReceipt;
   deleteSlide(slideId: string): SlideReceipt;
   moveSlide(slideId: string, toIndex: number): SlideReceipt;
@@ -290,6 +299,13 @@ export function openPresentation(
     insertParagraphBreak(storyId, index): TextReceipt {
       return jsonWasmCall(
         () => doc.insertParagraphBreakJson(JSON.stringify({ storyId, index })),
+        true
+      );
+    },
+    setParagraphAlignment(storyId, start, end, alignment): TextReceipt {
+      return jsonWasmCall(
+        () =>
+          doc.setParagraphAlignmentJson(JSON.stringify({ storyId, start, end, alignment })),
         true
       );
     },


### PR DESCRIPTION
  - Add a separated toolbar section to the PPTX editor with left, center, right and justify
  buttons.
  - Add `DeckSession::set_paragraph_alignment`, setting `a:pPr@algn` on every paragraph the
  selection touches; `None` clears the value back to the inherited one. Rejects tokens outside the
  OOXML set.
  - Expose the command as `setParagraphAlignmentJson` over the wasm boundary, as
  `PresentationHandle.setParagraphAlignment` in `@betteroffice/pptx`, and on the
  `betteroffice-pptx` facade; add the `ParagraphAlignment` type.
  - Apply with a collapsed caret, a range selection, or a shape-only selection. One transaction per
  action, so it is a single undo step and a single CRDT update.
  - Derive the pressed button from the paragraph's own value, falling back to the alignment the
  laid-out text box resolved, so placeholders inheriting alignment from a layout or master show the
  right button.
  - Add `toolbar.groups.alignment` and `toolbar.align.*` to all ten locales.
  - No changes needed in `pptx-parse` or `pptx-render`: `algn` was already parsed, rendered and
  written back.
  
  TL;DR: pptx alignment, left, center, right and justify added.