### PR TITLE
fix(pptx): editor affordances and justified text

### DIFF
--- a/.changeset/pptx-editor-affordances.md
+++ b/.changeset/pptx-editor-affordances.md
@@ -1,0 +1,7 @@
+---
+"@betteroffice/pptx": patch
+"@betteroffice/pptx-react": patch
+"@betteroffice/rust-crates": patch
+---
+
+Paint justified lines at their caret positions and keep editor gestures consistent.

--- a/bindings/python-pptx/python/betteroffice_pptx/__init__.py
+++ b/bindings/python-pptx/python/betteroffice_pptx/__init__.py
@@ -297,6 +297,17 @@ class Presentation:
     ) -> TransformEdit:
         return self._inner.resize_shape(slide, shape_id, width, height)
 
+    def set_shape_rect(
+        self,
+        slide: SlideKey,
+        shape_id: str,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+    ) -> TransformEdit:
+        return self._inner.set_shape_rect(slide, shape_id, x, y, width, height)
+
     def insert_text(
         self,
         story_id: str,

--- a/bindings/python-pptx/python/betteroffice_pptx/_betteroffice_pptx.pyi
+++ b/bindings/python-pptx/python/betteroffice_pptx/_betteroffice_pptx.pyi
@@ -333,6 +333,15 @@ class Presentation:
     def resize_shape(
         self, slide: int | str, shape_id: str, width: int, height: int
     ) -> TransformEdit: ...
+    def set_shape_rect(
+        self,
+        slide: int | str,
+        shape_id: str,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+    ) -> TransformEdit: ...
     def insert_text(
         self,
         story_id: str,

--- a/bindings/python-pptx/src/lib.rs
+++ b/bindings/python-pptx/src/lib.rs
@@ -1440,6 +1440,25 @@ impl PyPresentation {
         Ok(PyTransformEdit::from_core(receipt))
     }
 
+    fn set_shape_rect(
+        &self,
+        slide: &Bound<'_, PyAny>,
+        shape_id: &str,
+        x: i64,
+        y: i64,
+        width: i64,
+        height: i64,
+    ) -> PyResult<PyTransformEdit> {
+        let slide_id = self.resolve_slide_id(slide)?;
+        let receipt = self.committed(self.presentation.set_shape_rect(
+            &self.edit_ctx(),
+            &slide_id,
+            shape_id,
+            rect(x, y, width, height),
+        ))?;
+        Ok(PyTransformEdit::from_core(receipt))
+    }
+
     /// `index` is a UTF-16 offset into the story.
     #[pyo3(signature = (
         story_id, index, text, *,

--- a/bindings/python-pptx/tests/test_presentation.py
+++ b/bindings/python-pptx/tests/test_presentation.py
@@ -115,6 +115,24 @@ def test_resize_shape(deck):
     assert (deck[0].shapes[0].width, deck[0].shapes[0].height) == (4000, 5000)
 
 
+def test_set_shape_rect_is_one_undo_step(deck):
+    shape = deck[0].shapes[0]
+    before = (shape.x, shape.y, shape.width, shape.height)
+
+    edit = deck.set_shape_rect(0, shape.id, 111, 222, 4000, 5000)
+
+    assert (edit.after.x, edit.after.y, edit.after.width, edit.after.height) == (
+        111,
+        222,
+        4000,
+        5000,
+    )
+    assert deck.undo() is True
+    restored = deck[0].shapes[0]
+    assert (restored.x, restored.y, restored.width, restored.height) == before
+    assert deck.can_undo is False
+
+
 def test_add_text_box_creates_an_editable_story(deck):
     before = len(deck[0].shapes)
     edit = deck.add_text_box(

--- a/crates/betteroffice-pptx/src/presentation.rs
+++ b/crates/betteroffice-pptx/src/presentation.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 
 use pptx_edit::{
     CaretAnchor, DeckSession, DeckSnapshot, EditCtx, PresetShapeDraft, ShapeAdjustReceipt,
-    ShapeDraft, ShapeFillReceipt, ShapeReceipt, ShapeStroke, ShapeStrokeReceipt, SlideReceipt,
-    StorySnapshot, TextReceipt, TextStyle, TextStylePatch, TransformReceipt, UpdateEvent,
-    UpdateSubscription,
+    ShapeDraft, ShapeFillReceipt, ShapeReceipt, ShapeRect, ShapeStroke, ShapeStrokeReceipt,
+    SlideReceipt, StorySnapshot, TextReceipt, TextStyle, TextStylePatch, TransformReceipt,
+    UpdateEvent, UpdateSubscription,
 };
 use pptx_parse::{
     MediaPart, ParseLimits, PptxPackage, Presentation as PresentationModel, Slide, SlideLayout,
@@ -212,6 +212,18 @@ impl Presentation {
         Ok(self
             .session
             .resize_shape(context, slide_id, shape_id, width, height)?)
+    }
+
+    pub fn set_shape_rect(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        shape_id: &str,
+        rect: ShapeRect,
+    ) -> Result<TransformReceipt> {
+        Ok(self
+            .session
+            .set_shape_rect(context, slide_id, shape_id, rect)?)
     }
 
     pub fn insert_text(

--- a/crates/pptx-edit/src/deck.rs
+++ b/crates/pptx-edit/src/deck.rs
@@ -621,6 +621,30 @@ impl DeckSession {
             },
         })
     }
+
+    pub fn set_shape_rect(
+        &self,
+        context: &EditCtx,
+        slide_id: &str,
+        shape_id: &str,
+        rect: ShapeRect,
+    ) -> EditResult<TransformReceipt> {
+        validate_rect(rect)?;
+        let mut txn = self.transact_for(context);
+        require_shape_membership(&txn, slide_id, shape_id)?;
+        let shape = shape_ref(&txn, shape_id)?;
+        let before = shape_rect(&shape, &txn)?;
+        shape.insert(&mut txn, "x", rect.x as f64);
+        shape.insert(&mut txn, "y", rect.y as f64);
+        shape.insert(&mut txn, "width", rect.width as f64);
+        shape.insert(&mut txn, "height", rect.height as f64);
+        Ok(TransformReceipt {
+            slide_id: slide_id.to_owned(),
+            shape_id: shape_id.to_owned(),
+            before,
+            after: rect,
+        })
+    }
 }
 
 pub(crate) fn validate_doc(doc: &Doc) -> EditResult<()> {

--- a/crates/pptx-edit/src/wasm.rs
+++ b/crates/pptx-edit/src/wasm.rs
@@ -6,8 +6,8 @@ use wasm_bindgen::prelude::*;
 use yrs::Subscription;
 
 use crate::{
-    DeckSession, DeckSnapshot, EditCtx, PresetShapeDraft, ShapeDraft, ShapeStroke, TextStyle,
-    TextStylePatch, UpdateEvent, UpdateOrigin,
+    DeckSession, DeckSnapshot, EditCtx, PresetShapeDraft, ShapeDraft, ShapeRect, ShapeStroke,
+    TextStyle, TextStylePatch, UpdateEvent, UpdateOrigin,
 };
 
 #[wasm_bindgen]
@@ -129,6 +129,14 @@ struct ResizeShapeArgs {
     shape_id: String,
     width: i64,
     height: i64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetShapeRectArgs {
+    slide_id: String,
+    shape_id: String,
+    rect: ShapeRect,
 }
 
 #[derive(Deserialize)]
@@ -464,6 +472,16 @@ impl PptxDocument {
                     args.width,
                     args.height,
                 )
+                .map_err(js_error)?,
+        )
+    }
+
+    #[wasm_bindgen(js_name = setShapeRectJson)]
+    pub fn set_shape_rect_json(&self, args: &str) -> Result<String, JsValue> {
+        let args: SetShapeRectArgs = parse_args(args)?;
+        json(
+            self.session
+                .set_shape_rect(&local_context(), &args.slide_id, &args.shape_id, args.rect)
                 .map_err(js_error)?,
         )
     }

--- a/crates/pptx-edit/tests/shape_ops.rs
+++ b/crates/pptx-edit/tests/shape_ops.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use ooxml_drawingml::{ColorValue, ShapeFill, ShapeOutline};
 use pptx_edit::{
@@ -87,6 +89,55 @@ fn shape_operations_round_trip_through_history_and_updates() {
     let update = session.encode_state_as_update_v1();
     let replica = DeckSession::open_from_update(&update, 702).unwrap();
     assert_eq!(replica.snapshot().unwrap(), session.snapshot().unwrap());
+}
+
+#[test]
+fn set_shape_rect_is_one_update_and_one_undo_step() {
+    let session = DeckSession::open(FIXTURE, 707).unwrap();
+    let context = EditCtx::local("test");
+    let snapshot = session.snapshot().unwrap();
+    let slide = &snapshot.slides[0];
+    let shape = &slide.shapes[0];
+    let before = ShapeRect {
+        x: shape.x,
+        y: shape.y,
+        width: shape.width,
+        height: shape.height,
+    };
+    let after = ShapeRect {
+        x: before.x + 120_000,
+        y: before.y + 80_000,
+        width: before.width + 300_000,
+        height: before.height + 200_000,
+    };
+    let updates = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&updates);
+    let _subscription = session
+        .observe_update_v1(move |_| {
+            observed.fetch_add(1, Ordering::Relaxed);
+        })
+        .unwrap();
+
+    session.add_undo_barrier();
+    let receipt = session
+        .set_shape_rect(&context, &slide.id, &shape.id, after)
+        .unwrap();
+    assert_eq!((receipt.before, receipt.after), (before, after));
+    assert_eq!(updates.load(Ordering::Relaxed), 1);
+    let resized = &session.snapshot().unwrap().slides[0].shapes[0];
+    assert_eq!(
+        (resized.x, resized.y, resized.width, resized.height),
+        (after.x, after.y, after.width, after.height)
+    );
+
+    session.add_undo_barrier();
+    assert!(session.undo());
+    let restored = &session.snapshot().unwrap().slides[0].shapes[0];
+    assert_eq!(
+        (restored.x, restored.y, restored.width, restored.height),
+        (before.x, before.y, before.width, before.height)
+    );
+    assert!(!session.can_undo());
 }
 
 #[test]

--- a/crates/pptx-render/src/layout.rs
+++ b/crates/pptx-render/src/layout.rs
@@ -1205,11 +1205,23 @@ fn layout_paragraph(
         }]);
     }
     let ranges = wrap_clusters(&clusters, width);
-    let mut output = Vec::with_capacity(ranges.len());
+    let line_count = ranges.len();
+    let mut output = Vec::with_capacity(line_count);
     let mut line_y = y;
-    for (start, end) in ranges {
+    for (line_index, (start, end)) in ranges.into_iter().enumerate() {
         let slice = &clusters[start..end];
         let line_width = slice.iter().map(|cluster| cluster.width).sum::<f32>();
+        // A paragraph's last line and a line ended by a hard break keep their
+        // natural spacing, the way PowerPoint leaves them.
+        let stretched = matches!(paragraph.align, TextAlign::Justify)
+            && line_index + 1 < line_count
+            && !slice.last().is_some_and(|cluster| cluster.mandatory);
+        let padding = if stretched {
+            justification_padding(&justify_clusters(slice), width)
+        } else {
+            vec![0.0; slice.len()]
+        };
+        let padded_width = line_width + padding.iter().sum::<f32>();
         let line_x = match paragraph.align {
             TextAlign::Center => x + ((width - line_width) / 2.0).max(0.0),
             TextAlign::Right => x + (width - line_width).max(0.0),
@@ -1221,8 +1233,8 @@ fn layout_paragraph(
             x: line_x,
         }];
         let mut cursor_x = line_x;
-        for cluster in slice {
-            cursor_x += cluster.width;
+        for (index, cluster) in slice.iter().enumerate() {
+            cursor_x += cluster.width + padding[index];
             caret_stops.push(CaretStop {
                 position: cluster.end,
                 x: cursor_x,
@@ -1231,11 +1243,11 @@ fn layout_paragraph(
         caret_stops.dedup_by(|left, right| {
             left.position == right.position && left.x.to_bits() == right.x.to_bits()
         });
-        let runs = positioned_runs(slice, line_x, line_y + line_box.ascent, scale);
+        let runs = positioned_runs(slice, &padding, line_x, line_y + line_box.ascent, scale);
         output.push(PositionedTextLine {
             x: line_x,
             y: line_y,
-            width: line_width,
+            width: padded_width,
             height: line_box.height(),
             baseline: line_y + line_box.ascent,
             start: slice[0].start,
@@ -1459,13 +1471,14 @@ fn wrap_clusters(clusters: &[ShapedCluster], width: f32) -> Vec<(usize, usize)> 
 
 fn positioned_runs(
     clusters: &[ShapedCluster],
+    padding: &[f32],
     line_x: f32,
     baseline: f32,
     scale: f32,
 ) -> Vec<PositionedTextRun> {
     let mut output: Vec<PositionedTextRun> = Vec::new();
     let mut cursor_x = line_x;
-    for cluster in clusters {
+    for (index, cluster) in clusters.iter().enumerate() {
         if cluster.text == "\n" {
             continue;
         }
@@ -1504,10 +1517,66 @@ fn positioned_runs(
                 y_offset: baseline + glyph.y_offset,
             });
         }
-        run.width += cluster.width;
-        cursor_x += cluster.width;
+        let advance = cluster.width + padding.get(index).copied().unwrap_or(0.0);
+        run.width += advance;
+        cursor_x += advance;
     }
     output
+}
+
+/// What justification needs to know about one cluster.
+struct JustifyCluster {
+    width: f32,
+    break_after: bool,
+    blank: bool,
+}
+
+fn justify_clusters(clusters: &[ShapedCluster]) -> Vec<JustifyCluster> {
+    clusters
+        .iter()
+        .map(|cluster| JustifyCluster {
+            width: cluster.width,
+            break_after: cluster.break_after,
+            blank: !cluster.text.is_empty() && cluster.text.chars().all(char::is_whitespace),
+        })
+        .collect()
+}
+
+/// Extra width to add after each cluster so the line fills `available`. Only
+/// the break opportunities inside the line stretch, so the glyphs spread while
+/// the words stay whole; trailing blanks are excluded from both the measurement
+/// and the stretch, which lands the last glyph on the far edge.
+fn justification_padding(clusters: &[JustifyCluster], available: f32) -> Vec<f32> {
+    let mut padding = vec![0.0; clusters.len()];
+    let trailing = clusters
+        .iter()
+        .rev()
+        .take_while(|cluster| cluster.blank)
+        .count();
+    let visible = clusters.len() - trailing;
+    let width: f32 = clusters[..visible]
+        .iter()
+        .map(|cluster| cluster.width)
+        .sum();
+    let extra = available - width;
+    if !extra.is_finite() || extra <= 0.0 || visible == 0 {
+        return padding;
+    }
+    let gaps: Vec<usize> = clusters[..visible]
+        .iter()
+        .enumerate()
+        .take(visible.saturating_sub(1))
+        .filter(|(_, cluster)| cluster.break_after)
+        .map(|(index, _)| index)
+        .collect();
+    if gaps.is_empty() {
+        return padding;
+    }
+    let share = extra / gaps.len() as f32;
+    for index in gaps {
+        padding[index] = share;
+    }
+    padding
 }
 
 fn clusters_line_box(
@@ -2008,6 +2077,77 @@ mod tests {
             renderer.register_font("Arial", bold, false, FONT).unwrap();
         }
         renderer
+    }
+
+    fn justify(widths: &[(f32, bool, bool)]) -> Vec<JustifyCluster> {
+        widths
+            .iter()
+            .map(|(width, break_after, blank)| JustifyCluster {
+                width: *width,
+                break_after: *break_after,
+                blank: *blank,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn justification_spreads_the_slack_across_the_gaps() {
+        // "aa bb cc" laid out in 100px: 80px of clusters, two gaps to share 20px
+        let line = justify(&[
+            (20.0, false, false),
+            (10.0, true, true),
+            (20.0, false, false),
+            (10.0, true, true),
+            (20.0, false, false),
+        ]);
+        let padding = justification_padding(&line, 100.0);
+        assert_eq!(padding, vec![0.0, 10.0, 0.0, 10.0, 0.0]);
+        let width: f32 = line
+            .iter()
+            .zip(&padding)
+            .map(|(cluster, pad)| cluster.width + pad)
+            .sum();
+        assert_eq!(width, 100.0);
+    }
+
+    #[test]
+    fn justification_ignores_a_trailing_blank() {
+        // the wrap keeps the space that ended the line; stretching to it would
+        // leave the last glyph short of the edge
+        let line = justify(&[
+            (20.0, false, false),
+            (10.0, true, true),
+            (20.0, false, false),
+            (10.0, true, true),
+        ]);
+        let padding = justification_padding(&line, 60.0);
+        assert_eq!(padding, vec![0.0, 10.0, 0.0, 0.0]);
+        let width: f32 = line[..3]
+            .iter()
+            .zip(&padding)
+            .map(|(cluster, pad)| cluster.width + pad)
+            .sum();
+        assert_eq!(width, 60.0);
+    }
+
+    #[test]
+    fn justification_leaves_a_line_it_cannot_stretch() {
+        // one unbroken word has no gap to widen, and an overfull line no slack
+        assert_eq!(
+            justification_padding(&justify(&[(80.0, false, false)]), 100.0),
+            vec![0.0]
+        );
+        assert_eq!(
+            justification_padding(
+                &justify(&[
+                    (80.0, false, false),
+                    (10.0, true, true),
+                    (80.0, false, false)
+                ]),
+                100.0
+            ),
+            vec![0.0, 0.0, 0.0]
+        );
     }
 
     #[test]

--- a/crates/pptx-render/src/layout.rs
+++ b/crates/pptx-render/src/layout.rs
@@ -897,6 +897,7 @@ struct ResolvedContent {
 
 struct ResolvedParagraph {
     align: TextAlign,
+    justify: bool,
     level: u32,
     margin_left_px: f32,
     runs: Vec<ResolvedRun>,
@@ -979,13 +980,13 @@ fn resolve_content(
                 )?,
             });
         }
+        let alignment = paragraph
+            .alignment
+            .as_deref()
+            .or(properties.alignment.as_deref());
         paragraphs.push(ResolvedParagraph {
-            align: parse_align(
-                paragraph
-                    .alignment
-                    .as_deref()
-                    .or(properties.alignment.as_deref()),
-            ),
+            align: parse_align(alignment),
+            justify: is_full_justification(alignment),
             level: paragraph.level,
             margin_left_px: emu_to_px(properties.margin_left.unwrap_or_default()),
             runs,
@@ -1210,21 +1211,41 @@ fn layout_paragraph(
     let mut line_y = y;
     for (line_index, (start, end)) in ranges.into_iter().enumerate() {
         let slice = &clusters[start..end];
-        let line_width = slice.iter().map(|cluster| cluster.width).sum::<f32>();
-        // A paragraph's last line and a line ended by a hard break keep their
-        // natural spacing, the way PowerPoint leaves them.
-        let stretched = matches!(paragraph.align, TextAlign::Justify)
+        let natural_width = slice.iter().map(|cluster| cluster.width).sum::<f32>();
+        let stretchable = paragraph.justify
             && line_index + 1 < line_count
             && !slice.last().is_some_and(|cluster| cluster.mandatory);
-        let padding = if stretched {
+        let padding = if stretchable {
             justification_padding(&justify_clusters(slice), width)
         } else {
             vec![0.0; slice.len()]
         };
-        let padded_width = line_width + padding.iter().sum::<f32>();
+        let stretched = padding.iter().any(|value| *value > 0.0);
+        let trailing = if stretched {
+            slice
+                .iter()
+                .rev()
+                .take_while(|cluster| cluster_is_blank(cluster))
+                .count()
+        } else {
+            0
+        };
+        let visible = slice.len() - trailing;
+        let advances = slice
+            .iter()
+            .enumerate()
+            .map(|(index, cluster)| {
+                if index < visible {
+                    cluster.width + padding[index]
+                } else {
+                    0.0
+                }
+            })
+            .collect::<Vec<_>>();
+        let line_width = advances.iter().sum::<f32>();
         let line_x = match paragraph.align {
-            TextAlign::Center => x + ((width - line_width) / 2.0).max(0.0),
-            TextAlign::Right => x + (width - line_width).max(0.0),
+            TextAlign::Center => x + ((width - natural_width) / 2.0).max(0.0),
+            TextAlign::Right => x + (width - natural_width).max(0.0),
             TextAlign::Left | TextAlign::Justify => x,
         };
         let line_box = clusters_line_box(fonts, slice, scale)?;
@@ -1233,8 +1254,8 @@ fn layout_paragraph(
             x: line_x,
         }];
         let mut cursor_x = line_x;
-        for (index, cluster) in slice.iter().enumerate() {
-            cursor_x += cluster.width + padding[index];
+        for (cluster, advance) in slice.iter().zip(&advances) {
+            cursor_x += advance;
             caret_stops.push(CaretStop {
                 position: cluster.end,
                 x: cursor_x,
@@ -1243,11 +1264,11 @@ fn layout_paragraph(
         caret_stops.dedup_by(|left, right| {
             left.position == right.position && left.x.to_bits() == right.x.to_bits()
         });
-        let runs = positioned_runs(slice, &padding, line_x, line_y + line_box.ascent, scale);
+        let runs = positioned_runs(slice, &advances, line_x, line_y + line_box.ascent, scale);
         output.push(PositionedTextLine {
             x: line_x,
             y: line_y,
-            width: padded_width,
+            width: line_width,
             height: line_box.height(),
             baseline: line_y + line_box.ascent,
             start: slice[0].start,
@@ -1471,7 +1492,7 @@ fn wrap_clusters(clusters: &[ShapedCluster], width: f32) -> Vec<(usize, usize)> 
 
 fn positioned_runs(
     clusters: &[ShapedCluster],
-    padding: &[f32],
+    advances: &[f32],
     line_x: f32,
     baseline: f32,
     scale: f32,
@@ -1517,7 +1538,7 @@ fn positioned_runs(
                 y_offset: baseline + glyph.y_offset,
             });
         }
-        let advance = cluster.width + padding.get(index).copied().unwrap_or(0.0);
+        let advance = advances.get(index).copied().unwrap_or(cluster.width);
         run.width += advance;
         cursor_x += advance;
     }
@@ -1537,9 +1558,13 @@ fn justify_clusters(clusters: &[ShapedCluster]) -> Vec<JustifyCluster> {
         .map(|cluster| JustifyCluster {
             width: cluster.width,
             break_after: cluster.break_after,
-            blank: !cluster.text.is_empty() && cluster.text.chars().all(char::is_whitespace),
+            blank: cluster_is_blank(cluster),
         })
         .collect()
+}
+
+fn cluster_is_blank(cluster: &ShapedCluster) -> bool {
+    !cluster.text.is_empty() && cluster.text.chars().all(char::is_whitespace)
 }
 
 /// Extra width to add after each cluster so the line fills `available`. Only
@@ -2032,6 +2057,10 @@ fn parse_align(value: Option<&str>) -> TextAlign {
     }
 }
 
+fn is_full_justification(value: Option<&str>) -> bool {
+    value == Some("just")
+}
+
 fn normalize_family(value: &str) -> String {
     value.trim().to_lowercase()
 }
@@ -2088,6 +2117,29 @@ mod tests {
                 blank: *blank,
             })
             .collect()
+    }
+
+    fn paragraph(renderer: &SlideRenderer, alignment: &str, text: &str) -> ResolvedParagraph {
+        let face = renderer.resolve_face("Arial", false, false).unwrap();
+        ResolvedParagraph {
+            align: parse_align(Some(alignment)),
+            justify: is_full_justification(Some(alignment)),
+            level: 0,
+            margin_left_px: 0.0,
+            runs: vec![ResolvedRun {
+                text: text.to_owned(),
+                start: 0,
+                style: ResolvedStyle {
+                    face,
+                    family: "Arial".to_owned(),
+                    font_size_pt: 18.0,
+                    bold: false,
+                    italic: false,
+                    underline: false,
+                    color: "#000000".to_owned(),
+                },
+            }],
+        }
     }
 
     #[test]
@@ -2148,6 +2200,76 @@ mod tests {
             ),
             vec![0.0, 0.0, 0.0]
         );
+    }
+
+    #[test]
+    fn justified_layout_stretches_non_last_lines_only() {
+        let renderer = renderer();
+        let text = "alpha beta \t  gamma delta";
+        let justified = paragraph(&renderer, "just", text);
+        let clusters = shape_paragraph(&renderer.fonts, &justified, 1.0).unwrap();
+        let second_break = clusters
+            .iter()
+            .enumerate()
+            .find(|(_, cluster)| cluster.end == utf16_len("alpha beta \t  "))
+            .map(|(index, _)| index + 1)
+            .unwrap();
+        let prefix_width = clusters[..second_break]
+            .iter()
+            .map(|cluster| cluster.width)
+            .sum::<f32>();
+        let trailing_count = clusters[..second_break]
+            .iter()
+            .rev()
+            .take_while(|cluster| cluster_is_blank(cluster))
+            .count();
+        let width = prefix_width + clusters[second_break].width / 2.0;
+        let lines = layout_paragraph(&renderer.fonts, &justified, 20.0, 30.0, width, 1.0).unwrap();
+        let natural = layout_paragraph(
+            &renderer.fonts,
+            &paragraph(&renderer, "justLow", text),
+            20.0,
+            30.0,
+            width,
+            1.0,
+        )
+        .unwrap();
+
+        assert!(lines.len() > 1);
+        assert_eq!(lines.len(), natural.len());
+        let beta = utf16_len("alpha ");
+        let stretched_beta = lines[0]
+            .caret_stops
+            .iter()
+            .find(|stop| stop.position == beta)
+            .unwrap();
+        let natural_beta = natural[0]
+            .caret_stops
+            .iter()
+            .find(|stop| stop.position == beta)
+            .unwrap();
+        assert!(stretched_beta.x > natural_beta.x);
+        assert!((lines[0].width - width).abs() < 0.001);
+        let trailing = &lines[0].caret_stops;
+        let edge = trailing.last().unwrap().x;
+        assert!(trailing_count >= 2);
+        assert!(
+            trailing
+                .iter()
+                .rev()
+                .take(trailing_count + 1)
+                .all(|stop| stop.x == edge)
+        );
+        assert_eq!(lines.last(), natural.last());
+    }
+
+    #[test]
+    fn only_full_justification_enables_stretching() {
+        assert!(is_full_justification(Some("just")));
+        for alignment in ["justLow", "dist", "thaiDist"] {
+            assert_eq!(parse_align(Some(alignment)), TextAlign::Justify);
+            assert!(!is_full_justification(Some(alignment)));
+        }
     }
 
     #[test]

--- a/packages/pptx-react/src/PptxEditor.test.tsx
+++ b/packages/pptx-react/src/PptxEditor.test.tsx
@@ -132,12 +132,12 @@ describe('PptxEditor caret painting', () => {
     paintSelection(
       ctx,
       frame,
-      { shapeId: 'shape', storyId: 'story', anchor: 5, focus: 5, focusLine: 1 },
+      { shapeId: 'shape', storyId: 'story', anchor: 5, focus: 5, focusLine: 0 },
       1,
       1
     );
 
-    expect(calls).toEqual([[20, 40, 1.5, 20]]);
+    expect(calls).toEqual([[120, 10, 1.5, 20]]);
   });
 
   it('stops caret blinking while blurred or hidden', async () => {

--- a/packages/pptx-react/src/PptxEditor.test.tsx
+++ b/packages/pptx-react/src/PptxEditor.test.tsx
@@ -9,9 +9,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { initWasm } from '@betteroffice/pptx';
-import type { PptxFontFace } from '@betteroffice/pptx';
+import type { PptxFontFace, SlideDisplayList } from '@betteroffice/pptx';
 import type { PptxEditorApi } from './PptxEditor';
-import { PptxEditor } from './PptxEditor';
+import { paintSelection, PptxEditor, SelectionOverlay } from './PptxEditor';
 
 const root = resolve(import.meta.dir, '../../..');
 
@@ -19,7 +19,7 @@ const root = resolve(import.meta.dir, '../../..');
 // installed it may tear it down.
 const ownsDom = !GlobalRegistrator.isRegistered;
 if (ownsDom) GlobalRegistrator.register();
-const { act, cleanup, render, waitFor } = await import('@testing-library/react');
+const { act, cleanup, fireEvent, render, waitFor } = await import('@testing-library/react');
 
 let fixture: Uint8Array;
 let fontBytes: Uint8Array;
@@ -66,4 +66,149 @@ describe('PptxEditor font stability', () => {
     },
     60_000
   );
+});
+
+describe('PptxEditor caret painting', () => {
+  const frame: SlideDisplayList = {
+    contractVersion: 1,
+    width: 320,
+    height: 180,
+    primitives: [
+      {
+        kind: 'textBox',
+        objectId: 1,
+        shapeId: 'shape',
+        storyId: 'story',
+        x: 20,
+        y: 10,
+        w: 200,
+        h: 80,
+        anchor: 'top',
+        paragraphs: [],
+        lines: [
+          {
+            x: 20,
+            y: 10,
+            width: 100,
+            height: 20,
+            baseline: 25,
+            start: 0,
+            end: 5,
+            runs: [],
+            caretStops: [
+              { position: 0, x: 20 },
+              { position: 5, x: 120 },
+            ],
+          },
+          {
+            x: 20,
+            y: 40,
+            width: 100,
+            height: 20,
+            baseline: 55,
+            start: 5,
+            end: 10,
+            runs: [],
+            caretStops: [
+              { position: 5, x: 20 },
+              { position: 10, x: 120 },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('paints a shared endpoint on its visual line', () => {
+    const calls: number[][] = [];
+    const ctx = {
+      save: () => undefined,
+      restore: () => undefined,
+      setTransform: () => undefined,
+      fillRect: (...values: number[]) => calls.push(values),
+      fillStyle: '',
+    } as unknown as CanvasRenderingContext2D;
+
+    paintSelection(
+      ctx,
+      frame,
+      { shapeId: 'shape', storyId: 'story', anchor: 5, focus: 5, focusLine: 1 },
+      1,
+      1
+    );
+
+    expect(calls).toEqual([[20, 40, 1.5, 20]]);
+  });
+
+  it('stops caret blinking while blurred or hidden', async () => {
+    const originalSetInterval = window.setInterval;
+    const originalClearInterval = window.clearInterval;
+    const visibility = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+    const started: number[] = [];
+    const cleared: number[] = [];
+    const active = new Set<number>();
+    window.setInterval = ((() => {
+      const id = started.length + 1;
+      started.push(id);
+      active.add(id);
+      return id;
+    }) as unknown) as typeof window.setInterval;
+    window.clearInterval = (((id?: number) => {
+      if (id !== undefined) {
+        cleared.push(id);
+        active.delete(id);
+      }
+    }) as unknown) as typeof window.clearInterval;
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    const selection = {
+      shapeId: 'shape',
+      storyId: 'story',
+      anchor: 5,
+      focus: 5,
+    };
+    const view = render(
+      <SelectionOverlay frame={frame} selection={selection} scale={1} focused />
+    );
+
+    try {
+      await waitFor(() => expect(started.length).toBeGreaterThan(0));
+      const focusedTimer = started[started.length - 1];
+      await act(async () => {
+        view.rerender(
+          <SelectionOverlay frame={frame} selection={selection} scale={1} focused={false} />
+        );
+      });
+      expect(cleared).toContain(focusedTimer);
+      expect(active.size).toBe(0);
+
+      const beforeRefocus = started.length;
+      await act(async () => {
+        view.rerender(
+          <SelectionOverlay frame={frame} selection={selection} scale={1} focused />
+        );
+      });
+      expect(started.length).toBeGreaterThan(beforeRefocus);
+      expect(active.size).toBe(1);
+
+      const visibleTimer = started[started.length - 1];
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'hidden',
+      });
+      await act(async () => {
+        fireEvent(document, new Event('visibilitychange'));
+      });
+      expect(cleared).toContain(visibleTimer);
+      expect(active.size).toBe(0);
+    } finally {
+      view.unmount();
+      window.setInterval = originalSetInterval;
+      window.clearInterval = originalClearInterval;
+      if (visibility) Object.defineProperty(document, 'visibilityState', visibility);
+      else Reflect.deleteProperty(document, 'visibilityState');
+    }
+  });
 });

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -55,6 +55,7 @@ import {
   movedShapePosition,
   passedDragThreshold,
   handleAnchor,
+  resizeCommitDelta,
   resizeCursor,
   resizedBounds,
   resizedShapeBox,
@@ -283,6 +284,7 @@ function PptxEditorContent({
     start: SlidePoint;
     slideId: string;
     shapeId: string;
+    delta: SlidePoint;
   } | null>(null);
   const [resizeDelta, setResizeDelta] = useState<SlidePoint | null>(null);
   const pointerGestureRef = useRef<PointerGesture | null>(null);
@@ -1501,27 +1503,51 @@ function PptxEditorContent({
         start: point,
         slideId: shapeSelection.slideId,
         shapeId: shapeSelection.shapeId,
+        delta: { x: 0, y: 0 },
       };
       setResizeDelta({ x: 0, y: 0 });
       event.currentTarget.setPointerCapture(event.pointerId);
     };
 
-  const resizePointerMove = (event: PointerEvent<HTMLSpanElement>) => {
+  /** The gesture's geometry lives on the ref, and the state only mirrors it for
+   *  the preview: the release commits the pointer's own position, so a move
+   *  whose render has not landed yet cannot resize the shape to a stale size. */
+  const resizeDeltaFrom = (event: PointerEvent<HTMLSpanElement>): SlidePoint | null => {
     const gesture = resizeRef.current;
-    if (!gesture) return;
-    const point = slidePointFromClient(event.clientX, event.clientY);
-    if (!point) return;
-    setResizeDelta({ x: point.x - gesture.start.x, y: point.y - gesture.start.y });
+    if (!gesture) return null;
+    return resizeCommitDelta(
+      gesture.start,
+      gesture.delta,
+      slidePointFromClient(event.clientX, event.clientY)
+    );
   };
 
-  const resizePointerUp = (event: PointerEvent<HTMLSpanElement>) => {
+  const resizePointerMove = (event: PointerEvent<HTMLSpanElement>) => {
     const gesture = resizeRef.current;
-    const delta = resizeDelta;
+    const delta = resizeDeltaFrom(event);
+    if (!gesture || !delta) return;
+    gesture.delta = delta;
+    setResizeDelta(delta);
+  };
+
+  const endResizeGesture = (event: PointerEvent<HTMLSpanElement>) => {
+    const gesture = resizeRef.current;
     resizeRef.current = null;
     setResizeDelta(null);
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
+    return gesture;
+  };
+
+  /** A cancelled pointer abandons the drag; the shape keeps the size it had. */
+  const resizePointerCancel = (event: PointerEvent<HTMLSpanElement>) => {
+    endResizeGesture(event);
+  };
+
+  const resizePointerUp = (event: PointerEvent<HTMLSpanElement>) => {
+    const delta = resizeDeltaFrom(event);
+    const gesture = endResizeGesture(event);
     const api = handleRef.current;
     if (!gesture || !delta || !api || !model?.frame || !selectedShape) return;
     if (delta.x === 0 && delta.y === 0) return;
@@ -1766,7 +1792,7 @@ function PptxEditorContent({
                           onPointerDown={resizePointerDown(handle)}
                           onPointerMove={resizePointerMove}
                           onPointerUp={resizePointerUp}
-                          onPointerCancel={resizePointerUp}
+                          onPointerCancel={resizePointerCancel}
                           style={{
                             ...styles.resizeHandle,
                             left: anchor.x * scale - HANDLE_SIZE / 2,

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -45,18 +45,23 @@ import type {
 } from './components/Toolbar';
 import { SHAPE_PRESETS } from './components/Toolbar';
 import {
+  RESIZE_HANDLES,
   canMoveShape,
   findShape,
   findTopLevelShape,
   frameBoundsForShape,
-  hoverTargetAtPoint,
+  pointerTargetAtPoint,
   indexShapes,
   movedShapePosition,
   passedDragThreshold,
+  handleAnchor,
+  resizeCursor,
+  resizedBounds,
+  resizedShapeBox,
   slidePoint,
   textPositionAtPoint,
 } from './interactions';
-import type { FrameBounds, HoverTarget, SlidePoint } from './interactions';
+import type { FrameBounds, HoverTarget, ResizeHandle, SlidePoint } from './interactions';
 import {
   groupPresenceBySlide,
   groupShapePresence,
@@ -71,8 +76,15 @@ import {
 } from './textFormatting';
 import type { EffectiveTextStyle } from './textFormatting';
 import { shapeFormattingFromShape } from './shapeFormatting';
-import { extendTextRange, textRangeAt } from './textSelection';
-import type { TextSelectionGranularity } from './textSelection';
+import {
+  caretGoalX,
+  extendTextRange,
+  lineEdge,
+  textRangeAt,
+  verticalCaretMove,
+  wordBoundary,
+} from './textSelection';
+import type { CaretLine, TextSelectionGranularity } from './textSelection';
 
 export interface PptxTextSelection {
   shapeId: string;
@@ -211,6 +223,12 @@ function downloadBytes(bytes: Uint8Array, name: string, mime: string): void {
   URL.revokeObjectURL(url);
 }
 
+/** Windows/Office caret phase. */
+const CARET_BLINK_MS = 530;
+
+/** Screen-space diameter of a resize grip. */
+const HANDLE_SIZE = 9;
+
 const initialStyle: EffectiveTextStyle = {
   bold: false,
   italic: false,
@@ -258,6 +276,15 @@ function PptxEditorContent({
   const canvasHostRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
+  const [caretVisible, setCaretVisible] = useState(true);
+  const caretGoalRef = useRef<{ goalX: number; focus: number } | null>(null);
+  const resizeRef = useRef<{
+    handle: ResizeHandle;
+    start: SlidePoint;
+    slideId: string;
+    shapeId: string;
+  } | null>(null);
+  const [resizeDelta, setResizeDelta] = useState<SlidePoint | null>(null);
   const pointerGestureRef = useRef<PointerGesture | null>(null);
   const recentClickRef = useRef<RecentCanvasClick | null>(null);
   const imageCacheRef = useRef(new Map<string, Promise<CanvasImageSource | null>>());
@@ -484,6 +511,18 @@ function PptxEditorContent({
     };
   }, [decodeImageError, model?.frame, reportError, scale]);
 
+  // Every caret move replaces `selection`, which restarts the phase: the caret
+  // is solid the instant it lands, as it is in PowerPoint.
+  useEffect(() => {
+    if (!selection || selection.anchor !== selection.focus) return;
+    setCaretVisible(true);
+    const timer = window.setInterval(
+      () => setCaretVisible((visible) => !visible),
+      CARET_BLINK_MS
+    );
+    return () => window.clearInterval(timer);
+  }, [selection]);
+
   useEffect(() => {
     const canvas = overlayCanvasRef.current;
     const frame = model?.frame;
@@ -492,8 +531,8 @@ function PptxEditorContent({
     if (!ctx) return;
     const dpr = window.devicePixelRatio || 1;
     sizeCanvasForSlide(canvas, frame, dpr, scale);
-    paintSelection(ctx, frame, selection, dpr, scale);
-  }, [model?.frame, scale, selection]);
+    paintSelection(ctx, frame, selection, dpr, scale, caretVisible);
+  }, [caretVisible, model?.frame, scale, selection]);
 
   const selectedShape = useMemo(() => {
     if (!model?.frame || !shapeSelection) return null;
@@ -514,6 +553,13 @@ function PptxEditorContent({
         : null,
     [model, selectedShape]
   );
+
+  const editedShapeBounds = useMemo<FrameBounds | null>(() => {
+    if (!model?.frame || !selection || selectedShapeBounds) return null;
+    const slide = model.snapshot.slides[model.slideIndex];
+    const shape = slide ? findShape(slide.shapes, selection.shapeId) : null;
+    return shape ? frameBoundsForShape(model.snapshot, model.frame, shape) : null;
+  }, [model, selectedShapeBounds, selection]);
 
   const activeSlide = model?.snapshot.slides[model.slideIndex];
   const currentSlideId = activeSlide?.id;
@@ -810,7 +856,14 @@ function PptxEditorContent({
     }
     try {
       handle.layoutSlide(current.slideIndex);
-      const hit = handle.hitTest(point.x, point.y);
+      const engineHit = handle.hitTest(point.x, point.y);
+      // The edge band grabs the box rather than typing in it, so a click there
+      // reads as a shape hit and matches the cursor the pointer showed.
+      const hit =
+        engineHit?.kind === 'text' &&
+        pointerTargetAtPoint(current.frame, point) === 'shape'
+          ? { kind: 'shape' as const, shapeId: engineHit.shapeId }
+          : engineHit;
       const shape = slide && hit ? findTopLevelShape(slide, hit.shapeId) : null;
       const recentClick = recentClickRef.current;
       const repeatedClick = Boolean(
@@ -1028,7 +1081,7 @@ function PptxEditorContent({
       event.clientX,
       event.clientY
     );
-    setHoverTarget(point ? hoverTargetAtPoint(current.frame, point) : null);
+    setHoverTarget(point ? pointerTargetAtPoint(current.frame, point) : null);
   };
 
   const pointerLeave = () => {
@@ -1172,15 +1225,13 @@ function PptxEditorContent({
     const start = Math.min(selection.anchor, selection.focus);
     const end = Math.max(selection.anchor, selection.focus);
     try {
-      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      const moved = caretDestination(event, selection);
+      if (moved !== null) {
         event.preventDefault();
-        const story = handle.story(selection.storyId);
-        const delta = event.key === 'ArrowLeft' ? -1 : 1;
-        const focus = Math.max(0, Math.min(story.length - 1, selection.focus + delta));
         setSelection({
           ...selection,
-          anchor: event.shiftKey ? selection.anchor : focus,
-          focus,
+          anchor: event.shiftKey ? selection.anchor : moved,
+          focus: moved,
         });
         return;
       }
@@ -1260,6 +1311,52 @@ function PptxEditorContent({
     } catch (value) {
       reportError(value);
     }
+  };
+
+  /** Where a caret-movement key lands, or `null` when the key moves nothing.
+   *  Vertical steps hold the column they started from; the goal is tied to the
+   *  position it produced, so a click or a keystroke in between drops it. */
+  const caretDestination = (
+    event: KeyboardEvent<HTMLDivElement>,
+    selection: PptxTextSelection
+  ): number | null => {
+    const handle = handleRef.current;
+    if (!handle) return null;
+    const story = handle.story(selection.storyId);
+    const last = Math.max(0, story.length - 1);
+    const clamp = (position: number) => Math.max(0, Math.min(last, position));
+    const lines = caretLinesFor(model?.frame, selection);
+    // macOS reads Option as word-wise and Command as line-edge; Control is the
+    // Windows word-wise modifier.
+    const wordWise = event.altKey || (event.ctrlKey && !event.metaKey);
+    const toEdge = event.metaKey;
+
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      const goal =
+        caretGoalRef.current?.focus === selection.focus
+          ? caretGoalRef.current.goalX
+          : caretGoalX(lines, selection.focus);
+      const direction = event.key === 'ArrowUp' ? 'up' : 'down';
+      const destination = clamp(verticalCaretMove(lines, selection.focus, direction, goal));
+      caretGoalRef.current = goal === undefined ? null : { goalX: goal, focus: destination };
+      return destination;
+    }
+    caretGoalRef.current = null;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      const direction = event.key === 'ArrowLeft' ? -1 : 1;
+      if (toEdge) {
+        return clamp(lineEdge(lines, selection.focus, direction < 0 ? 'start' : 'end'));
+      }
+      if (wordWise) return clamp(wordBoundary(storyText(story), selection.focus, direction));
+      return clamp(selection.focus + direction);
+    }
+    if (event.key === 'Home') {
+      return toEdge || event.ctrlKey ? 0 : clamp(lineEdge(lines, selection.focus, 'start'));
+    }
+    if (event.key === 'End') {
+      return toEdge || event.ctrlKey ? last : clamp(lineEdge(lines, selection.focus, 'end'));
+    }
+    return null;
   };
 
   const applyAlignment = (alignment: ParagraphAlignment) => {
@@ -1385,10 +1482,83 @@ function PptxEditorContent({
     }
   };
 
+  const slidePointFromClient = (clientX: number, clientY: number): SlidePoint | null => {
+    const canvas = canvasRef.current;
+    const frame = model?.frame;
+    if (!canvas || !frame) return null;
+    return slidePoint(canvas.getBoundingClientRect(), frame, clientX, clientY);
+  };
+
+  const resizePointerDown =
+    (handle: ResizeHandle) => (event: PointerEvent<HTMLSpanElement>) => {
+      if (!shapeSelection) return;
+      const point = slidePointFromClient(event.clientX, event.clientY);
+      if (!point) return;
+      event.preventDefault();
+      event.stopPropagation();
+      resizeRef.current = {
+        handle,
+        start: point,
+        slideId: shapeSelection.slideId,
+        shapeId: shapeSelection.shapeId,
+      };
+      setResizeDelta({ x: 0, y: 0 });
+      event.currentTarget.setPointerCapture(event.pointerId);
+    };
+
+  const resizePointerMove = (event: PointerEvent<HTMLSpanElement>) => {
+    const gesture = resizeRef.current;
+    if (!gesture) return;
+    const point = slidePointFromClient(event.clientX, event.clientY);
+    if (!point) return;
+    setResizeDelta({ x: point.x - gesture.start.x, y: point.y - gesture.start.y });
+  };
+
+  const resizePointerUp = (event: PointerEvent<HTMLSpanElement>) => {
+    const gesture = resizeRef.current;
+    const delta = resizeDelta;
+    resizeRef.current = null;
+    setResizeDelta(null);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    const api = handleRef.current;
+    if (!gesture || !delta || !api || !model?.frame || !selectedShape) return;
+    if (delta.x === 0 && delta.y === 0) return;
+    try {
+      const box = resizedShapeBox(
+        model.snapshot,
+        model.frame,
+        selectedShape,
+        gesture.handle,
+        delta
+      );
+      if (box.x !== selectedShape.x || box.y !== selectedShape.y) {
+        api.moveShape(gesture.slideId, gesture.shapeId, box.x, box.y);
+      }
+      if (box.width !== selectedShape.width || box.height !== selectedShape.height) {
+        api.resizeShape(gesture.slideId, gesture.shapeId, box.width, box.height);
+      }
+      refreshAt(undefined, true);
+    } catch (value) {
+      reportError(value);
+    }
+  };
+
   const slideCount = model?.snapshot.slides.length ?? 0;
   const currentSlide = model?.slideIndex ?? 0;
   const shapeDragDelta =
     dragPreview && dragPreview.shapeId === shapeSelection?.shapeId ? dragPreview.delta : null;
+  const resizingHandle = resizeRef.current?.handle;
+  const selectionBox = selectedShapeBounds
+    ? resizeDelta && resizingHandle
+      ? resizedBounds(selectedShapeBounds, resizingHandle, resizeDelta)
+      : {
+          ...selectedShapeBounds,
+          x: selectedShapeBounds.x + (shapeDragDelta?.x ?? 0),
+          y: selectedShapeBounds.y + (shapeDragDelta?.y ?? 0),
+        }
+    : null;
 
   return (
     <div className={className} style={styles.root}>
@@ -1575,14 +1745,47 @@ function PptxEditorContent({
                     +{remoteShapePresence.overflow} selections
                   </span>
                 ) : null}
-                {selectedShapeBounds ? (
+                {selectionBox ? (
+                  <>
+                    <span
+                      style={{
+                        ...styles.shapeSelection,
+                        left: selectionBox.x * scale,
+                        top: selectionBox.y * scale,
+                        width: Math.max(1, selectionBox.width * scale),
+                        height: Math.max(1, selectionBox.height * scale),
+                      }}
+                      aria-hidden="true"
+                    />
+                    {RESIZE_HANDLES.map((handle) => {
+                      const anchor = handleAnchor(selectionBox, handle);
+                      return (
+                        <span
+                          key={handle}
+                          data-testid={`pptx-resize-${handle}`}
+                          onPointerDown={resizePointerDown(handle)}
+                          onPointerMove={resizePointerMove}
+                          onPointerUp={resizePointerUp}
+                          onPointerCancel={resizePointerUp}
+                          style={{
+                            ...styles.resizeHandle,
+                            left: anchor.x * scale - HANDLE_SIZE / 2,
+                            top: anchor.y * scale - HANDLE_SIZE / 2,
+                            cursor: resizeCursor(handle),
+                          }}
+                        />
+                      );
+                    })}
+                  </>
+                ) : null}
+                {editedShapeBounds ? (
                   <span
                     style={{
-                      ...styles.shapeSelection,
-                      left: (selectedShapeBounds.x + (shapeDragDelta?.x ?? 0)) * scale,
-                      top: (selectedShapeBounds.y + (shapeDragDelta?.y ?? 0)) * scale,
-                      width: Math.max(1, selectedShapeBounds.width * scale),
-                      height: Math.max(1, selectedShapeBounds.height * scale),
+                      ...styles.textEditOutline,
+                      left: editedShapeBounds.x * scale,
+                      top: editedShapeBounds.y * scale,
+                      width: Math.max(1, editedShapeBounds.width * scale),
+                      height: Math.max(1, editedShapeBounds.height * scale),
                     }}
                     aria-hidden="true"
                   />
@@ -1838,12 +2041,26 @@ async function decodeImage(
   }
 }
 
+function caretLinesFor(
+  frame: SlideDisplayList | null | undefined,
+  selection: PptxTextSelection
+): CaretLine[] {
+  const textBox = frame?.primitives.find(
+    (primitive): primitive is TextBoxPrimitive =>
+      primitive.kind === 'textBox' &&
+      primitive.storyId === selection.storyId &&
+      primitive.shapeId === selection.shapeId
+  );
+  return textBox?.lines ?? [];
+}
+
 function paintSelection(
   ctx: CanvasRenderingContext2D,
   frame: SlideDisplayList,
   selection: PptxTextSelection | null,
   dpr: number,
-  scale: number
+  scale: number,
+  caretVisible = true
 ): void {
   if (!selection) return;
   const textBox = frame.primitives.find(
@@ -1867,7 +2084,7 @@ function paintSelection(
       const x2 = caretX(line, lineEnd);
       ctx.fillRect(Math.min(x1, x2), line.y, Math.max(1, Math.abs(x2 - x1)), line.height);
     }
-  } else {
+  } else if (caretVisible) {
     const line =
       textBox.lines.find((candidate) => start >= candidate.start && start <= candidate.end) ??
       textBox.lines[textBox.lines.length - 1];
@@ -1986,6 +2203,26 @@ const styles: Record<string, CSSProperties> = {
   canvasFrame: { position: 'relative', flex: '0 0 auto' },
   canvas: { display: 'block', flex: '0 0 auto', background: '#fff', boxShadow: '0 8px 32px rgba(27, 39, 61, 0.2)', touchAction: 'none' },
   canvasOverlay: { position: 'absolute', inset: 0, display: 'block', pointerEvents: 'none' },
+  textEditOutline: {
+    position: 'absolute',
+    zIndex: 3,
+    border: '2px dashed #6b7280',
+    boxSizing: 'border-box',
+    boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.9)',
+    pointerEvents: 'none',
+  },
+  resizeHandle: {
+    position: 'absolute',
+    zIndex: 4,
+    width: HANDLE_SIZE,
+    height: HANDLE_SIZE,
+    borderRadius: '50%',
+    border: '1px solid #2563eb',
+    background: '#ffffff',
+    boxShadow: '0 1px 2px rgba(15, 23, 42, 0.35)',
+    boxSizing: 'border-box',
+    touchAction: 'none',
+  },
   shapeSelection: {
     position: 'absolute',
     zIndex: 3,

--- a/packages/pptx-react/src/PptxEditor.tsx
+++ b/packages/pptx-react/src/PptxEditor.tsx
@@ -46,10 +46,12 @@ import type {
 import { SHAPE_PRESETS } from './components/Toolbar';
 import {
   RESIZE_HANDLES,
+  canResizeShape,
   canMoveShape,
   findShape,
   findTopLevelShape,
   frameBoundsForShape,
+  gestureOwnsPointer,
   pointerTargetAtPoint,
   indexShapes,
   movedShapePosition,
@@ -57,10 +59,11 @@ import {
   handleAnchor,
   resizeCommitDelta,
   resizeCursor,
-  resizedBounds,
   resizedShapeBox,
+  resizedShapeBounds,
+  shapeTargetExists,
   slidePoint,
-  textPositionAtPoint,
+  textLocationAtPoint,
 } from './interactions';
 import type { FrameBounds, HoverTarget, ResizeHandle, SlidePoint } from './interactions';
 import {
@@ -79,8 +82,10 @@ import type { EffectiveTextStyle } from './textFormatting';
 import { shapeFormattingFromShape } from './shapeFormatting';
 import {
   caretGoalX,
+  caretLineIndex,
   extendTextRange,
   lineEdge,
+  sameCaretGoalKey,
   textRangeAt,
   verticalCaretMove,
   wordBoundary,
@@ -92,6 +97,7 @@ export interface PptxTextSelection {
   storyId: string;
   anchor: number;
   focus: number;
+  focusLine?: number;
 }
 
 export interface PptxEditorApi {
@@ -146,6 +152,7 @@ type PointerGesture =
       storyId: string;
       anchor: number;
       focus: number;
+      focusLine?: number;
       granularity: 'character' | TextSelectionGranularity;
       clickCount: number;
       clickShapeId: string;
@@ -276,10 +283,15 @@ function PptxEditorContent({
   const stageRef = useRef<HTMLDivElement>(null);
   const canvasHostRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
-  const [caretVisible, setCaretVisible] = useState(true);
-  const caretGoalRef = useRef<{ goalX: number; focus: number } | null>(null);
+  const [stageFocused, setStageFocused] = useState(false);
+  const caretGoalRef = useRef<{
+    shapeId: string;
+    position: number;
+    lineIndex?: number;
+    goalX: number;
+  } | null>(null);
   const resizeRef = useRef<{
+    pointerId: number;
     handle: ResizeHandle;
     start: SlidePoint;
     slideId: string;
@@ -324,6 +336,7 @@ function PptxEditorContent({
       const handle = handleRef.current;
       if (!handle) return null;
       try {
+        caretGoalRef.current = null;
         const snapshot = handle.snapshot();
         const index = clampSlideIndex(
           requestedIndex ?? modelRef.current?.slideIndex ?? 0,
@@ -364,6 +377,11 @@ function PptxEditorContent({
           setDragPreview(null);
           setTextBoxPreview(null);
         }
+        const resize = resizeRef.current;
+        if (resize && !shapeTargetExists(activeSlide, resize)) {
+          resizeRef.current = null;
+          setResizeDelta(null);
+        }
         modelRef.current = next;
         setModel(next);
         setHistoryState({ canUndo: handle.canUndo(), canRedo: handle.canRedo() });
@@ -396,9 +414,12 @@ function PptxEditorContent({
     setShapeSelection(null);
     setDragPreview(null);
     setTextBoxPreview(null);
+    setResizeDelta(null);
     setHistoryState({ canUndo: false, canRedo: false });
     setActiveTool('select');
     pointerGestureRef.current = null;
+    resizeRef.current = null;
+    caretGoalRef.current = null;
     recentClickRef.current = null;
     setError(null);
     imageCacheRef.current.clear();
@@ -512,29 +533,6 @@ function PptxEditorContent({
       cancelled = true;
     };
   }, [decodeImageError, model?.frame, reportError, scale]);
-
-  // Every caret move replaces `selection`, which restarts the phase: the caret
-  // is solid the instant it lands, as it is in PowerPoint.
-  useEffect(() => {
-    if (!selection || selection.anchor !== selection.focus) return;
-    setCaretVisible(true);
-    const timer = window.setInterval(
-      () => setCaretVisible((visible) => !visible),
-      CARET_BLINK_MS
-    );
-    return () => window.clearInterval(timer);
-  }, [selection]);
-
-  useEffect(() => {
-    const canvas = overlayCanvasRef.current;
-    const frame = model?.frame;
-    if (!canvas || !frame) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    const dpr = window.devicePixelRatio || 1;
-    sizeCanvasForSlide(canvas, frame, dpr, scale);
-    paintSelection(ctx, frame, selection, dpr, scale, caretVisible);
-  }, [caretVisible, model?.frame, scale, selection]);
 
   const selectedShape = useMemo(() => {
     if (!model?.frame || !shapeSelection) return null;
@@ -688,6 +686,9 @@ function PptxEditorContent({
   }, [model?.snapshot]);
 
   const selectSlide = (index: number) => {
+    caretGoalRef.current = null;
+    resizeRef.current = null;
+    setResizeDelta(null);
     setSelection(null);
     setShapeSelection(null);
     setDragPreview(null);
@@ -749,7 +750,13 @@ function PptxEditorContent({
       );
       const story = shape?.textStories[0];
       if (story) {
-        setSelection({ shapeId: shape.id, storyId: story.id, anchor: 0, focus: 0 });
+        setSelection({
+          shapeId: shape.id,
+          storyId: story.id,
+          anchor: 0,
+          focus: 0,
+          focusLine: 0,
+        });
         stageRef.current?.focus();
       }
     } catch (value) {
@@ -827,6 +834,9 @@ function PptxEditorContent({
       event.clientY
     );
     if (!point) return;
+    caretGoalRef.current = null;
+    resizeRef.current = null;
+    setResizeDelta(null);
     const slide = current.snapshot.slides[current.slideIndex];
     const shapePreset = shapePresetFromTool(activeTool);
     if ((activeTool === 'textBox' || shapePreset) && slide) {
@@ -863,7 +873,7 @@ function PptxEditorContent({
       // reads as a shape hit and matches the cursor the pointer showed.
       const hit =
         engineHit?.kind === 'text' &&
-        pointerTargetAtPoint(current.frame, point) === 'shape'
+        pointerTargetAtPoint(current.frame, point, scale) === 'shape'
           ? { kind: 'shape' as const, shapeId: engineHit.shapeId }
           : engineHit;
       const shape = slide && hit ? findTopLevelShape(slide, hit.shapeId) : null;
@@ -881,6 +891,10 @@ function PptxEditorContent({
       );
       const clickCount =
         repeatedClick && recentClick ? Math.min(recentClick.count + 1, 3) : 1;
+      const hitLocation =
+        hit?.kind === 'text'
+          ? textLocationAtPoint(current.frame, hit.shapeId, hit.storyId, point)
+          : null;
       recentClickRef.current = null;
       if (
         slide &&
@@ -896,6 +910,7 @@ function PptxEditorContent({
           storyId: hit.storyId,
           anchor: range.start,
           focus: range.end,
+          focusLine: hitLocation?.lineIndex,
         });
         setShapeSelection(null);
         setDragPreview(null);
@@ -907,6 +922,7 @@ function PptxEditorContent({
           storyId: hit.storyId,
           anchor: range.start,
           focus: range.end,
+          focusLine: hitLocation?.lineIndex,
           granularity,
           clickCount,
           clickShapeId: shape.id,
@@ -929,6 +945,7 @@ function PptxEditorContent({
           storyId: hit.storyId,
           anchor,
           focus: hit.position,
+          focusLine: hitLocation?.lineIndex,
         });
         setShapeSelection(null);
         setDragPreview(null);
@@ -940,6 +957,7 @@ function PptxEditorContent({
           storyId: hit.storyId,
           anchor,
           focus: hit.position,
+          focusLine: hitLocation?.lineIndex,
           granularity: 'character',
           clickCount,
           clickShapeId: shape?.id ?? hit.shapeId,
@@ -1017,21 +1035,21 @@ function PptxEditorContent({
       ) {
         gesture.dragging = true;
       }
-      const focus = textPositionAtPoint(
+      const focus = textLocationAtPoint(
         current.frame,
         gesture.shapeId,
         gesture.storyId,
         point
       );
-      if (focus !== null) {
+      if (focus) {
         const range =
           gesture.granularity === 'character'
-            ? { anchor: gesture.anchor, focus }
+            ? { anchor: gesture.anchor, focus: focus.position }
             : extendTextRange(
                 { start: gesture.anchor, end: gesture.focus },
                 textRangeAt(
                   storyText(handle.story(gesture.storyId)),
-                  focus,
+                  focus.position,
                   gesture.granularity
                 )
               );
@@ -1039,6 +1057,7 @@ function PptxEditorContent({
           shapeId: gesture.shapeId,
           storyId: gesture.storyId,
           ...range,
+          focusLine: focus.lineIndex,
         });
       }
     } else if (gesture.kind === 'shape') {
@@ -1083,7 +1102,7 @@ function PptxEditorContent({
       event.clientX,
       event.clientY
     );
-    setHoverTarget(point ? pointerTargetAtPoint(current.frame, point) : null);
+    setHoverTarget(point ? pointerTargetAtPoint(current.frame, point, scale) : null);
   };
 
   const pointerLeave = () => {
@@ -1168,7 +1187,7 @@ function PptxEditorContent({
   };
 
   const commit = (nextSelection: PptxTextSelection | null) => {
-    setSelection(nextSelection);
+    setSelection(nextSelection ? { ...nextSelection, focusLine: undefined } : null);
     setShapeSelection(null);
     recentClickRef.current = null;
     refreshAt(undefined, true);
@@ -1182,6 +1201,8 @@ function PptxEditorContent({
       setActiveTool('select');
       setTextBoxPreview(null);
       pointerGestureRef.current = null;
+      resizeRef.current = null;
+      setResizeDelta(null);
       event.preventDefault();
       return;
     }
@@ -1232,8 +1253,9 @@ function PptxEditorContent({
         event.preventDefault();
         setSelection({
           ...selection,
-          anchor: event.shiftKey ? selection.anchor : moved,
-          focus: moved,
+          anchor: event.shiftKey ? selection.anchor : moved.position,
+          focus: moved.position,
+          focusLine: moved.lineIndex,
         });
         return;
       }
@@ -1321,42 +1343,62 @@ function PptxEditorContent({
   const caretDestination = (
     event: KeyboardEvent<HTMLDivElement>,
     selection: PptxTextSelection
-  ): number | null => {
+  ): { position: number; lineIndex?: number } | null => {
     const handle = handleRef.current;
     if (!handle) return null;
     const story = handle.story(selection.storyId);
     const last = Math.max(0, story.length - 1);
     const clamp = (position: number) => Math.max(0, Math.min(last, position));
     const lines = caretLinesFor(model?.frame, selection);
+    const current = { position: selection.focus, lineIndex: selection.focusLine };
     // macOS reads Option as word-wise and Command as line-edge; Control is the
     // Windows word-wise modifier.
     const wordWise = event.altKey || (event.ctrlKey && !event.metaKey);
     const toEdge = event.metaKey;
 
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      const goalKey = { shapeId: selection.shapeId, ...current };
       const goal =
-        caretGoalRef.current?.focus === selection.focus
+        caretGoalRef.current && sameCaretGoalKey(caretGoalRef.current, goalKey)
           ? caretGoalRef.current.goalX
-          : caretGoalX(lines, selection.focus);
+          : caretGoalX(lines, current);
       const direction = event.key === 'ArrowUp' ? 'up' : 'down';
-      const destination = clamp(verticalCaretMove(lines, selection.focus, direction, goal));
-      caretGoalRef.current = goal === undefined ? null : { goalX: goal, focus: destination };
+      const moved = verticalCaretMove(lines, current, direction, goal);
+      const destination = { ...moved, position: clamp(moved.position) };
+      caretGoalRef.current =
+        goal === undefined
+          ? null
+          : {
+              shapeId: selection.shapeId,
+              goalX: goal,
+              position: destination.position,
+              lineIndex: destination.lineIndex,
+            };
       return destination;
     }
     caretGoalRef.current = null;
     if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
       const direction = event.key === 'ArrowLeft' ? -1 : 1;
       if (toEdge) {
-        return clamp(lineEdge(lines, selection.focus, direction < 0 ? 'start' : 'end'));
+        const destination = lineEdge(lines, current, direction < 0 ? 'start' : 'end');
+        return { ...destination, position: clamp(destination.position) };
       }
-      if (wordWise) return clamp(wordBoundary(storyText(story), selection.focus, direction));
-      return clamp(selection.focus + direction);
+      const position = wordWise
+        ? wordBoundary(storyText(story), selection.focus, direction)
+        : selection.focus + direction;
+      return { position: clamp(position), lineIndex: selection.focusLine };
     }
     if (event.key === 'Home') {
-      return toEdge || event.ctrlKey ? 0 : clamp(lineEdge(lines, selection.focus, 'start'));
+      if (toEdge || event.ctrlKey) return { position: 0, lineIndex: 0 };
+      const destination = lineEdge(lines, current, 'start');
+      return { ...destination, position: clamp(destination.position) };
     }
     if (event.key === 'End') {
-      return toEdge || event.ctrlKey ? last : clamp(lineEdge(lines, selection.focus, 'end'));
+      if (toEdge || event.ctrlKey) {
+        return { position: last, lineIndex: Math.max(0, lines.length - 1) };
+      }
+      const destination = lineEdge(lines, current, 'end');
+      return { ...destination, position: clamp(destination.position) };
     }
     return null;
   };
@@ -1448,6 +1490,8 @@ function PptxEditorContent({
       setActiveTool('select');
       pointerGestureRef.current = null;
       recentClickRef.current = null;
+      resizeRef.current = null;
+      setResizeDelta(null);
       refreshAt(index, true, true);
     } catch (value) {
       reportError(value);
@@ -1466,6 +1510,8 @@ function PptxEditorContent({
       setActiveTool('select');
       pointerGestureRef.current = null;
       recentClickRef.current = null;
+      resizeRef.current = null;
+      setResizeDelta(null);
       refreshAt(undefined, true);
     } catch (value) {
       reportError(value);
@@ -1493,12 +1539,13 @@ function PptxEditorContent({
 
   const resizePointerDown =
     (handle: ResizeHandle) => (event: PointerEvent<HTMLSpanElement>) => {
-      if (!shapeSelection) return;
+      if (!shapeSelection || !selectedShape || !canResizeShape(selectedShape)) return;
       const point = slidePointFromClient(event.clientX, event.clientY);
       if (!point) return;
       event.preventDefault();
       event.stopPropagation();
       resizeRef.current = {
+        pointerId: event.pointerId,
         handle,
         start: point,
         slideId: shapeSelection.slideId,
@@ -1514,7 +1561,7 @@ function PptxEditorContent({
    *  whose render has not landed yet cannot resize the shape to a stale size. */
   const resizeDeltaFrom = (event: PointerEvent<HTMLSpanElement>): SlidePoint | null => {
     const gesture = resizeRef.current;
-    if (!gesture) return null;
+    if (!gestureOwnsPointer(gesture, event.pointerId)) return null;
     return resizeCommitDelta(
       gesture.start,
       gesture.delta,
@@ -1525,13 +1572,14 @@ function PptxEditorContent({
   const resizePointerMove = (event: PointerEvent<HTMLSpanElement>) => {
     const gesture = resizeRef.current;
     const delta = resizeDeltaFrom(event);
-    if (!gesture || !delta) return;
+    if (!gestureOwnsPointer(gesture, event.pointerId) || !delta) return;
     gesture.delta = delta;
     setResizeDelta(delta);
   };
 
   const endResizeGesture = (event: PointerEvent<HTMLSpanElement>) => {
     const gesture = resizeRef.current;
+    if (!gestureOwnsPointer(gesture, event.pointerId)) return null;
     resizeRef.current = null;
     setResizeDelta(null);
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -1549,23 +1597,38 @@ function PptxEditorContent({
     const delta = resizeDeltaFrom(event);
     const gesture = endResizeGesture(event);
     const api = handleRef.current;
-    if (!gesture || !delta || !api || !model?.frame || !selectedShape) return;
+    const current = modelRef.current;
+    const slide = current?.snapshot.slides[current.slideIndex];
+    const shape = slide && gesture ? findShape(slide.shapes, gesture.shapeId) : null;
+    if (
+      !gesture ||
+      !delta ||
+      !api ||
+      !current?.frame ||
+      slide?.id !== gesture.slideId ||
+      !shape
+    ) {
+      return;
+    }
     if (delta.x === 0 && delta.y === 0) return;
     try {
       const box = resizedShapeBox(
-        model.snapshot,
-        model.frame,
-        selectedShape,
+        current.snapshot,
+        current.frame,
+        shape,
         gesture.handle,
         delta
       );
-      if (box.x !== selectedShape.x || box.y !== selectedShape.y) {
-        api.moveShape(gesture.slideId, gesture.shapeId, box.x, box.y);
+      if (
+        box &&
+        (box.x !== shape.x ||
+          box.y !== shape.y ||
+          box.width !== shape.width ||
+          box.height !== shape.height)
+      ) {
+        api.setShapeRect(gesture.slideId, gesture.shapeId, box);
+        refreshAt(undefined, true);
       }
-      if (box.width !== selectedShape.width || box.height !== selectedShape.height) {
-        api.resizeShape(gesture.slideId, gesture.shapeId, box.width, box.height);
-      }
-      refreshAt(undefined, true);
     } catch (value) {
       reportError(value);
     }
@@ -1576,9 +1639,19 @@ function PptxEditorContent({
   const shapeDragDelta =
     dragPreview && dragPreview.shapeId === shapeSelection?.shapeId ? dragPreview.delta : null;
   const resizingHandle = resizeRef.current?.handle;
+  const resizePreview =
+    model?.frame && selectedShape && resizeDelta && resizingHandle
+      ? resizedShapeBounds(
+          model.snapshot,
+          model.frame,
+          selectedShape,
+          resizingHandle,
+          resizeDelta
+        )
+      : null;
   const selectionBox = selectedShapeBounds
     ? resizeDelta && resizingHandle
-      ? resizedBounds(selectedShapeBounds, resizingHandle, resizeDelta)
+      ? resizePreview ?? selectedShapeBounds
       : {
           ...selectedShapeBounds,
           x: selectedShapeBounds.x + (shapeDragDelta?.x ?? 0),
@@ -1615,6 +1688,8 @@ function PptxEditorContent({
             }
             setTextBoxPreview(null);
             pointerGestureRef.current = null;
+            resizeRef.current = null;
+            setResizeDelta(null);
             stageRef.current?.focus();
           }}
           disabled={!model || slideCount === 0}
@@ -1710,6 +1785,8 @@ function PptxEditorContent({
           role="application"
           aria-label={t('editor.appLabel')}
           onKeyDown={keyDown}
+          onFocus={() => setStageFocused(true)}
+          onBlur={() => setStageFocused(false)}
         >
           <div ref={canvasHostRef} style={styles.canvasHost}>
             {model?.frame ? (
@@ -1753,7 +1830,12 @@ function PptxEditorContent({
                         })
                   }
                 />
-                <canvas ref={overlayCanvasRef} style={styles.canvasOverlay} aria-hidden="true" />
+                <SelectionOverlay
+                  frame={model.frame}
+                  selection={selection}
+                  scale={scale}
+                  focused={stageFocused}
+                />
                 {remoteShapePresence.visible.map(
                   ({ peer, peerCount, shapeId, bounds }, index) => (
                     <RemoteShapeOutline
@@ -1783,25 +1865,28 @@ function PptxEditorContent({
                       }}
                       aria-hidden="true"
                     />
-                    {RESIZE_HANDLES.map((handle) => {
-                      const anchor = handleAnchor(selectionBox, handle);
-                      return (
-                        <span
-                          key={handle}
-                          data-testid={`pptx-resize-${handle}`}
-                          onPointerDown={resizePointerDown(handle)}
-                          onPointerMove={resizePointerMove}
-                          onPointerUp={resizePointerUp}
-                          onPointerCancel={resizePointerCancel}
-                          style={{
-                            ...styles.resizeHandle,
-                            left: anchor.x * scale - HANDLE_SIZE / 2,
-                            top: anchor.y * scale - HANDLE_SIZE / 2,
-                            cursor: resizeCursor(handle),
-                          }}
-                        />
-                      );
-                    })}
+                    {selectedShape && canResizeShape(selectedShape)
+                      ? RESIZE_HANDLES.map((handle) => {
+                          const anchor = handleAnchor(selectionBox, handle);
+                          return (
+                            <span
+                              key={handle}
+                              data-testid={`pptx-resize-${handle}`}
+                              onPointerDown={resizePointerDown(handle)}
+                              onPointerMove={resizePointerMove}
+                              onPointerUp={resizePointerUp}
+                              onPointerCancel={resizePointerCancel}
+                              onLostPointerCapture={resizePointerCancel}
+                              style={{
+                                ...styles.resizeHandle,
+                                left: anchor.x * scale - HANDLE_SIZE / 2,
+                                top: anchor.y * scale - HANDLE_SIZE / 2,
+                                cursor: resizeCursor(handle),
+                              }}
+                            />
+                          );
+                        })
+                      : null}
                   </>
                 ) : null}
                 {editedShapeBounds ? (
@@ -1930,6 +2015,55 @@ function SlideThumbnail({
     void paintSlide(ctx, frame, dpr, scale, { resolveImage }).catch(() => undefined);
   }, [frame, resolveImage]);
   return <canvas ref={canvasRef} style={styles.thumbnailCanvas} aria-hidden="true" />;
+}
+
+export function SelectionOverlay({
+  frame,
+  selection,
+  scale,
+  focused,
+}: {
+  frame: SlideDisplayList;
+  selection: PptxTextSelection | null;
+  scale: number;
+  focused: boolean;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [pageVisible, setPageVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState === 'visible'
+  );
+  const [caretVisible, setCaretVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const update = () => setPageVisible(document.visibilityState === 'visible');
+    document.addEventListener('visibilitychange', update);
+    return () => document.removeEventListener('visibilitychange', update);
+  }, []);
+
+  useEffect(() => {
+    const blinking =
+      focused && pageVisible && selection !== null && selection.anchor === selection.focus;
+    setCaretVisible(blinking);
+    if (!blinking) return;
+    const timer = window.setInterval(
+      () => setCaretVisible((visible) => !visible),
+      CARET_BLINK_MS
+    );
+    return () => window.clearInterval(timer);
+  }, [focused, pageVisible, selection]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    sizeCanvasForSlide(canvas, frame, dpr, scale);
+    paintSelection(ctx, frame, selection, dpr, scale, caretVisible);
+  }, [caretVisible, frame, scale, selection]);
+
+  return <canvas ref={canvasRef} style={styles.canvasOverlay} aria-hidden="true" />;
 }
 
 function clampSlideIndex(index: number, count: number): number {
@@ -2080,7 +2214,7 @@ function caretLinesFor(
   return textBox?.lines ?? [];
 }
 
-function paintSelection(
+export function paintSelection(
   ctx: CanvasRenderingContext2D,
   frame: SlideDisplayList,
   selection: PptxTextSelection | null,
@@ -2111,9 +2245,12 @@ function paintSelection(
       ctx.fillRect(Math.min(x1, x2), line.y, Math.max(1, Math.abs(x2 - x1)), line.height);
     }
   } else if (caretVisible) {
-    const line =
-      textBox.lines.find((candidate) => start >= candidate.start && start <= candidate.end) ??
-      textBox.lines[textBox.lines.length - 1];
+    const line = textBox.lines[
+      caretLineIndex(textBox.lines, {
+        position: start,
+        lineIndex: selection.focusLine,
+      })
+    ];
     if (line) {
       const x = caretX(line, start);
       ctx.fillStyle = '#1d4ed8';

--- a/packages/pptx-react/src/interactions.engine.test.ts
+++ b/packages/pptx-react/src/interactions.engine.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import JSZip from 'jszip';
 import type { PresentationHandle, SlideDisplayList } from '@betteroffice/pptx';
 import { initWasm, openPresentation } from '@betteroffice/pptx';
 import { farEdge, hoverTargetAtPoint } from './interactions';
@@ -10,11 +11,25 @@ let handle: PresentationHandle;
 let frame: SlideDisplayList;
 
 beforeAll(async () => {
-  const [wasm, deck, font] = await Promise.all([
+  const [wasm, sourceDeck, font] = await Promise.all([
     readFile(resolve(root, 'packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm')),
     readFile(resolve(root, 'apps/demo/public/betteroffice-demo.pptx')),
     readFile(resolve(root, 'crates/ooxml-text/tests/fonts/LiberationSans-Regular.ttf')),
   ]);
+  const zip = await JSZip.loadAsync(sourceDeck);
+  const slide = zip.file('ppt/slides/slide1.xml');
+  if (!slide) throw new Error('fixture slide is missing');
+  const xml = (await slide.async('string'))
+    .replace(
+      '<a:xfrm><a:off x="762000" y="533400"/>',
+      '<a:xfrm rot="1020000" flipH="1"><a:off x="762000" y="533400"/>'
+    )
+    .replace(
+      '<a:xfrm><a:off x="762000" y="1219200"/>',
+      '<a:xfrm rot="5400000" flipV="1"><a:off x="762000" y="1219200"/>'
+    );
+  zip.file('ppt/slides/slide1.xml', xml);
+  const deck = await zip.generateAsync({ type: 'uint8array' });
   await initWasm(wasm);
   handle = openPresentation(deck, {
     clientId: 9101,
@@ -28,15 +43,26 @@ afterAll(() => handle.dispose());
 describe('hover target parity with the engine', () => {
   test('agrees with hitTest across the slide', () => {
     const disagreements: string[] = [];
-    for (let y = 0; y < frame.height; y += 20) {
-      for (let x = 0; x < frame.width; x += 20) {
+    expect(
+      frame.primitives.some(
+        (primitive) => primitive.transform?.flipH && primitive.transform.rotationDeg === 17
+      ) &&
+        frame.primitives.some(
+          (primitive) => primitive.transform?.flipV && primitive.transform.rotationDeg === 90
+        )
+    ).toBe(true);
+    let checked = 0;
+    for (let y = 0; y < frame.height; y += 3) {
+      for (let x = 0; x < frame.width; x += 3) {
+        checked += 1;
         const hovered = hoverTargetAtPoint(frame, { x, y });
         const engine = handle.hitTest(x, y)?.kind ?? null;
-        if (hovered !== engine) {
+        if (hovered !== engine && disagreements.length < 25) {
           disagreements.push(`(${x},${y}) hover=${hovered} engine=${engine}`);
         }
       }
     }
+    expect(checked).toBeGreaterThan(100_000);
     expect(disagreements).toEqual([]);
   });
 
@@ -69,7 +95,7 @@ describe('hover target parity with the engine', () => {
           const [x, y] = [cx + delta, cy + delta];
           const hovered = hoverTargetAtPoint(frame, { x, y });
           const engine = handle.hitTest(x, y)?.kind ?? null;
-          if (hovered !== engine) {
+          if (hovered !== engine && disagreements.length < 25) {
             disagreements.push(`${primitive.shapeId} (${x},${y}) hover=${hovered} engine=${engine}`);
           }
         }

--- a/packages/pptx-react/src/interactions.test.ts
+++ b/packages/pptx-react/src/interactions.test.ts
@@ -10,10 +10,15 @@ import {
   findShape,
   findTopLevelShape,
   frameBoundsForShape,
+  handleAnchor,
   hoverTargetAtPoint,
   indexShapes,
+  pointerTargetAtPoint,
   movedShapePosition,
   passedDragThreshold,
+  resizeCursor,
+  resizedBounds,
+  resizedShapeBox,
   slidePoint,
   textPositionAtPoint,
 } from './interactions';
@@ -144,6 +149,21 @@ describe('pptx interactions', () => {
     expect(hoverTargetAtPoint(frame, { x: 600, y: 600 })).toBeNull();
   });
 
+  it('reads a text box edge as the shape, so the border moves it', () => {
+    // the box spans x 100-400, y 100-200; a few px inside any edge grabs it
+    expect(pointerTargetAtPoint(frame, { x: 102, y: 150 })).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 398, y: 150 })).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 300, y: 102 })).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 300, y: 198 })).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 300, y: 150 })).toBe('text');
+  });
+
+  it('leaves the engine mirror without a border band', () => {
+    expect(hoverTargetAtPoint(frame, { x: 102, y: 150 })).toBe('text');
+    expect(pointerTargetAtPoint(frame, { x: 50, y: 60 })).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 600, y: 600 })).toBeNull();
+  });
+
   it('prefers the topmost primitive where they overlap', () => {
     expect(hoverTargetAtPoint(frame, { x: 110, y: 120 })).toBe('text');
   });
@@ -214,3 +234,57 @@ function shape(id: string, x: number, y: number, width: number, height: number):
     children: [],
   };
 }
+
+describe('pptx resize handles', () => {
+  const bounds = { x: 100, y: 200, width: 300, height: 100 };
+
+  it('anchors each grip on the selection box', () => {
+    expect(handleAnchor(bounds, 'nw')).toEqual({ x: 100, y: 200 });
+    expect(handleAnchor(bounds, 'se')).toEqual({ x: 400, y: 300 });
+    expect(handleAnchor(bounds, 'n')).toEqual({ x: 250, y: 200 });
+    expect(handleAnchor(bounds, 'w')).toEqual({ x: 100, y: 250 });
+  });
+
+  it('holds the edge opposite the dragged handle', () => {
+    expect(resizedBounds(bounds, 'se', { x: 50, y: 20 })).toEqual({
+      x: 100,
+      y: 200,
+      width: 350,
+      height: 120,
+    });
+    expect(resizedBounds(bounds, 'nw', { x: 50, y: 20 })).toEqual({
+      x: 150,
+      y: 220,
+      width: 250,
+      height: 80,
+    });
+    expect(resizedBounds(bounds, 'n', { x: 999, y: 20 })).toEqual({
+      x: 100,
+      y: 220,
+      width: 300,
+      height: 80,
+    });
+  });
+
+  it('never collapses the box past the minimum', () => {
+    const collapsed = resizedBounds(bounds, 'e', { x: -1000, y: 0 }, 8);
+    expect(collapsed.width).toBe(8);
+    const fromWest = resizedBounds(bounds, 'w', { x: 1000, y: 0 }, 8);
+    expect(fromWest.width).toBe(8);
+    expect(fromWest.x).toBe(392);
+  });
+
+  it('converts a drag into the shape box, in EMU', () => {
+    const box = resizedShapeBox(deck, frame, picture, 'se', { x: 128, y: 72 });
+    expect(box.width).toBe(picture.width + 1_219_200);
+    expect(box.height).toBe(picture.height + 685_800);
+    expect(box.x).toBe(picture.x);
+  });
+
+  it('names the cursor each grip carries', () => {
+    expect(resizeCursor('nw')).toBe('nwse-resize');
+    expect(resizeCursor('ne')).toBe('nesw-resize');
+    expect(resizeCursor('n')).toBe('ns-resize');
+    expect(resizeCursor('w')).toBe('ew-resize');
+  });
+});

--- a/packages/pptx-react/src/interactions.test.ts
+++ b/packages/pptx-react/src/interactions.test.ts
@@ -16,6 +16,7 @@ import {
   pointerTargetAtPoint,
   movedShapePosition,
   passedDragThreshold,
+  resizeCommitDelta,
   resizeCursor,
   resizedBounds,
   resizedShapeBox,
@@ -286,5 +287,19 @@ describe('pptx resize handles', () => {
     expect(resizeCursor('ne')).toBe('nesw-resize');
     expect(resizeCursor('n')).toBe('ns-resize');
     expect(resizeCursor('w')).toBe('ew-resize');
+  });
+});
+
+describe('pptx resize commit', () => {
+  const start = { x: 100, y: 100 };
+  const tracked = { x: 5, y: 5 };
+
+  it('commits the release position, not the last rendered delta', () => {
+    // the pointer travelled to 180,140 after the move React last rendered
+    expect(resizeCommitDelta(start, tracked, { x: 180, y: 140 })).toEqual({ x: 80, y: 40 });
+  });
+
+  it('falls back to the tracked delta when the release resolves nowhere', () => {
+    expect(resizeCommitDelta(start, tracked, null)).toEqual(tracked);
   });
 });

--- a/packages/pptx-react/src/interactions.test.ts
+++ b/packages/pptx-react/src/interactions.test.ts
@@ -6,10 +6,13 @@ import type {
   TextBoxPrimitive,
 } from '@betteroffice/pptx';
 import {
+  MIN_SHAPE_SIZE_EMU,
+  canResizeShape,
   canMoveShape,
   findShape,
   findTopLevelShape,
   frameBoundsForShape,
+  gestureOwnsPointer,
   handleAnchor,
   hoverTargetAtPoint,
   indexShapes,
@@ -20,7 +23,10 @@ import {
   resizeCursor,
   resizedBounds,
   resizedShapeBox,
+  resizedShapeBounds,
   slidePoint,
+  shapeTargetExists,
+  textLocationAtPoint,
   textPositionAtPoint,
 } from './interactions';
 
@@ -81,11 +87,11 @@ const frame: SlideDisplayList = {
           width: 100,
           height: 20,
           baseline: 155,
-          start: 6,
+          start: 5,
           end: 10,
           runs: [],
           caretStops: [
-            { position: 6, x: 110 },
+            { position: 5, x: 110 },
             { position: 10, x: 210 },
           ],
         },
@@ -112,6 +118,19 @@ describe('pptx interactions', () => {
       'group',
       'picture',
     ]);
+  });
+
+  it('invalidates a resize target when a remote refresh removes it', () => {
+    const target = { slideId: 'slide', shapeId: 'picture' };
+    expect(shapeTargetExists(deck.slides[0], target)).toBe(true);
+    expect(shapeTargetExists({ ...deck.slides[0], shapes: [group] }, target)).toBe(false);
+    expect(shapeTargetExists({ ...deck.slides[0], id: 'other' }, target)).toBe(false);
+  });
+
+  it('scopes a resize gesture to its captured pointer', () => {
+    expect(gestureOwnsPointer({ pointerId: 7 }, 7)).toBe(true);
+    expect(gestureOwnsPointer({ pointerId: 7 }, 8)).toBe(false);
+    expect(gestureOwnsPointer(null, 7)).toBe(false);
   });
 
   it('only moves shapes with a local transform', () => {
@@ -157,6 +176,13 @@ describe('pptx interactions', () => {
     expect(pointerTargetAtPoint(frame, { x: 300, y: 102 })).toBe('shape');
     expect(pointerTargetAtPoint(frame, { x: 300, y: 198 })).toBe('shape');
     expect(pointerTargetAtPoint(frame, { x: 300, y: 150 })).toBe('text');
+  });
+
+  it('keeps the text-box edge band six screen pixels wide', () => {
+    expect(pointerTargetAtPoint(frame, { x: 111, y: 150 }, 0.5)).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 113, y: 150 }, 0.5)).toBe('text');
+    expect(pointerTargetAtPoint(frame, { x: 101.4, y: 150 }, 4)).toBe('shape');
+    expect(pointerTargetAtPoint(frame, { x: 101.6, y: 150 }, 4)).toBe('text');
   });
 
   it('leaves the engine mirror without a border band', () => {
@@ -207,6 +233,17 @@ describe('pptx interactions', () => {
     expect(textPositionAtPoint(frame, 'text', 'story', { x: 999, y: 999 })).toBe(10);
     expect(textPositionAtPoint(frame, 'missing', 'story', { x: 110, y: 110 })).toBeNull();
   });
+
+  it('keeps a shared endpoint on the line under the pointer', () => {
+    expect(textLocationAtPoint(frame, 'text', 'story', { x: 110, y: 115 })).toEqual({
+      position: 0,
+      lineIndex: 0,
+    });
+    expect(textLocationAtPoint(frame, 'text', 'story', { x: 110, y: 145 })).toEqual({
+      position: 5,
+      lineIndex: 1,
+    });
+  });
 });
 
 function shape(id: string, x: number, y: number, width: number, height: number): ShapeSnapshot {
@@ -247,19 +284,19 @@ describe('pptx resize handles', () => {
   });
 
   it('holds the edge opposite the dragged handle', () => {
-    expect(resizedBounds(bounds, 'se', { x: 50, y: 20 })).toEqual({
+    expect(resizedBounds(bounds, 'se', { x: 50, y: 20 }, 0)).toEqual({
       x: 100,
       y: 200,
       width: 350,
       height: 120,
     });
-    expect(resizedBounds(bounds, 'nw', { x: 50, y: 20 })).toEqual({
+    expect(resizedBounds(bounds, 'nw', { x: 50, y: 20 }, 0)).toEqual({
       x: 150,
       y: 220,
       width: 250,
       height: 80,
     });
-    expect(resizedBounds(bounds, 'n', { x: 999, y: 20 })).toEqual({
+    expect(resizedBounds(bounds, 'n', { x: 999, y: 20 }, 0)).toEqual({
       x: 100,
       y: 220,
       width: 300,
@@ -277,9 +314,43 @@ describe('pptx resize handles', () => {
 
   it('converts a drag into the shape box, in EMU', () => {
     const box = resizedShapeBox(deck, frame, picture, 'se', { x: 128, y: 72 });
+    if (!box) throw new Error('shape should be resizable');
     expect(box.width).toBe(picture.width + 1_219_200);
     expect(box.height).toBe(picture.height + 685_800);
     expect(box.x).toBe(picture.x);
+  });
+
+  it('uses the same EMU floor for preview and commit', () => {
+    const box = resizedShapeBox(deck, frame, picture, 'e', { x: -1_000, y: 0 });
+    const preview = resizedShapeBounds(deck, frame, picture, 'e', { x: -1_000, y: 0 });
+    if (!box || !preview) throw new Error('shape should be resizable');
+    expect(MIN_SHAPE_SIZE_EMU).toBe(8 * (deck.widthEmu / frame.width));
+    expect(box.width).toBe(MIN_SHAPE_SIZE_EMU);
+    expect(preview.width).toBe((box.width * frame.width) / deck.widthEmu);
+    expect(preview.x).toBe((box.x * frame.width) / deck.widthEmu);
+  });
+
+  it('projects the committed rectangle exactly into the preview', () => {
+    const sizable = { ...picture, width: 3_000_000, height: 2_000_000 };
+    const delta = { x: 12.345, y: -6.789 };
+    const box = resizedShapeBox(deck, frame, sizable, 'nw', delta);
+    const preview = resizedShapeBounds(deck, frame, sizable, 'nw', delta);
+    if (!box) throw new Error('shape should be resizable');
+    expect(preview).toEqual({
+      x: (box.x * frame.width) / deck.widthEmu,
+      y: (box.y * frame.height) / deck.heightEmu,
+      width: (box.width * frame.width) / deck.widthEmu,
+      height: (box.height * frame.height) / deck.heightEmu,
+    });
+  });
+
+  it('offers neither preview nor commit for a 90-degree shape', () => {
+    const rotated = { ...picture, rotationDeg: 90 };
+    const preview = resizedShapeBounds(deck, frame, rotated, 'e', { x: 50, y: 0 });
+    const commit = resizedShapeBox(deck, frame, rotated, 'e', { x: 50, y: 0 });
+    expect(canResizeShape(rotated)).toBe(false);
+    expect(preview).toBe(commit);
+    expect(commit).toBeNull();
   });
 
   it('names the cursor each grip carries', () => {

--- a/packages/pptx-react/src/interactions.ts
+++ b/packages/pptx-react/src/interactions.ts
@@ -14,6 +14,24 @@ export interface SlidePoint {
 
 export type HoverTarget = 'text' | 'shape';
 
+export type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
+
+export const RESIZE_HANDLES: readonly ResizeHandle[] = [
+  'nw',
+  'n',
+  'ne',
+  'e',
+  'se',
+  's',
+  'sw',
+  'w',
+];
+
+/** Slide-space band along a text box's edge that grabs the box itself. Inside
+ *  it the pointer moves the shape; further in it edits text, as PowerPoint
+ *  splits the two. */
+const BORDER_BAND = 6;
+
 type PrimitiveGeometry = Pick<SlidePrimitive, 'x' | 'y' | 'w' | 'h' | 'transform'>;
 
 /** `f32::to_radians` folds PI/180 to one f32 constant before multiplying. */
@@ -259,4 +277,104 @@ function lineDistance(y: number, height: number, pointY: number): number {
   if (pointY < y) return y - pointY;
   if (pointY > y + height) return pointY - y - height;
   return 0;
+}
+
+/** Where a handle's grip sits on the selection box. */
+export function handleAnchor(bounds: FrameBounds, handle: ResizeHandle): SlidePoint {
+  const x = handle.includes('w')
+    ? bounds.x
+    : handle.includes('e')
+      ? bounds.x + bounds.width
+      : bounds.x + bounds.width / 2;
+  const y = handle.startsWith('n')
+    ? bounds.y
+    : handle.startsWith('s')
+      ? bounds.y + bounds.height
+      : bounds.y + bounds.height / 2;
+  return { x, y };
+}
+
+export function resizeCursor(handle: ResizeHandle): string {
+  if (handle === 'nw' || handle === 'se') return 'nwse-resize';
+  if (handle === 'ne' || handle === 'sw') return 'nesw-resize';
+  return handle === 'n' || handle === 's' ? 'ns-resize' : 'ew-resize';
+}
+
+/** The selection box a drag of `delta` on `handle` produces. Edges opposite
+ *  the handle stay put, and the box never collapses past `minimum`. */
+export function resizedBounds(
+  bounds: FrameBounds,
+  handle: ResizeHandle,
+  delta: SlidePoint,
+  minimum = 8
+): FrameBounds {
+  let { x, y, width, height } = bounds;
+  if (handle.includes('w')) {
+    const dx = Math.min(delta.x, width - minimum);
+    x += dx;
+    width -= dx;
+  } else if (handle.includes('e')) {
+    width = Math.max(minimum, width + delta.x);
+  }
+  if (handle.startsWith('n')) {
+    const dy = Math.min(delta.y, height - minimum);
+    y += dy;
+    height -= dy;
+  } else if (handle.startsWith('s')) {
+    height = Math.max(minimum, height + delta.y);
+  }
+  return { x, y, width, height };
+}
+
+/** The same resize in EMU, ready for `moveShape` and `resizeShape`. */
+export function resizedShapeBox(
+  deck: DeckSnapshot,
+  frame: SlideDisplayList,
+  shape: ShapeSnapshot,
+  handle: ResizeHandle,
+  delta: SlidePoint,
+  minimum = 1_000
+): { x: number; y: number; width: number; height: number } {
+  const emu = {
+    x: Math.round((delta.x * deck.widthEmu) / frame.width),
+    y: Math.round((delta.y * deck.heightEmu) / frame.height),
+  };
+  const box = resizedBounds(
+    { x: shape.x, y: shape.y, width: shape.width, height: shape.height },
+    handle,
+    emu,
+    minimum
+  );
+  return { x: box.x, y: box.y, width: box.width, height: box.height };
+}
+
+/** What a pointer gesture acts on. This is the engine's hit with one addition:
+ *  the band along a text box's edge reads as the shape, so the border grabs the
+ *  box while its middle types — the split PowerPoint draws. `hitTest` has no
+ *  such band, and `hoverTargetAtPoint` stays an exact mirror of it. */
+export function pointerTargetAtPoint(
+  frame: SlideDisplayList,
+  point: SlidePoint
+): HoverTarget | null {
+  const target = hoverTargetAtPoint(frame, point);
+  if (target !== 'text') return target;
+  const at = { x: Math.fround(point.x), y: Math.fround(point.y) };
+  for (let index = frame.primitives.length - 1; index >= 0; index -= 1) {
+    const primitive = frame.primitives[index];
+    if (!primitive.shapeId) continue;
+    const local = containedPoint(primitive, at);
+    if (!local) continue;
+    return withinBorderBand(primitive, local) ? 'shape' : 'text';
+  }
+  return target;
+}
+
+function withinBorderBand(primitive: PrimitiveGeometry, point: SlidePoint): boolean {
+  const band = Math.min(BORDER_BAND, primitive.w / 3, primitive.h / 3);
+  return (
+    point.x - primitive.x <= band ||
+    primitive.x + primitive.w - point.x <= band ||
+    point.y - primitive.y <= band ||
+    primitive.y + primitive.h - point.y <= band
+  );
 }

--- a/packages/pptx-react/src/interactions.ts
+++ b/packages/pptx-react/src/interactions.ts
@@ -326,6 +326,17 @@ export function resizedBounds(
   return { x, y, width, height };
 }
 
+/** The delta a resize commits. The release event's own position wins, so a
+ *  move whose render has not landed cannot commit a stale size; `tracked` is
+ *  the fallback for a release the canvas cannot resolve to a slide point. */
+export function resizeCommitDelta(
+  start: SlidePoint,
+  tracked: SlidePoint,
+  release: SlidePoint | null
+): SlidePoint {
+  return release ? { x: release.x - start.x, y: release.y - start.y } : tracked;
+}
+
 /** The same resize in EMU, ready for `moveShape` and `resizeShape`. */
 export function resizedShapeBox(
   deck: DeckSnapshot,

--- a/packages/pptx-react/src/interactions.ts
+++ b/packages/pptx-react/src/interactions.ts
@@ -12,6 +12,11 @@ export interface SlidePoint {
   y: number;
 }
 
+export interface TextPointLocation {
+  position: number;
+  lineIndex: number;
+}
+
 export type HoverTarget = 'text' | 'shape';
 
 export type ResizeHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
@@ -27,10 +32,8 @@ export const RESIZE_HANDLES: readonly ResizeHandle[] = [
   'w',
 ];
 
-/** Slide-space band along a text box's edge that grabs the box itself. Inside
- *  it the pointer moves the shape; further in it edits text, as PowerPoint
- *  splits the two. */
-const BORDER_BAND = 6;
+const BORDER_BAND_SCREEN_PX = 6;
+export const MIN_SHAPE_SIZE_EMU = 76_200;
 
 type PrimitiveGeometry = Pick<SlidePrimitive, 'x' | 'y' | 'w' | 'h' | 'transform'>;
 
@@ -97,8 +100,29 @@ export function findTopLevelShape(slide: SlideSnapshot, shapeId: string): ShapeS
   return null;
 }
 
+export function shapeTargetExists(
+  slide: SlideSnapshot | undefined,
+  target: { slideId: string; shapeId: string }
+): boolean {
+  return Boolean(
+    slide && slide.id === target.slideId && findShape(slide.shapes, target.shapeId)
+  );
+}
+
+export function gestureOwnsPointer<T extends { pointerId: number }>(
+  gesture: T | null,
+  pointerId: number
+): gesture is T {
+  return gesture?.pointerId === pointerId;
+}
+
 export function canMoveShape(shape: ShapeSnapshot): boolean {
   return shape.width > 0 && shape.height > 0;
+}
+
+export function canResizeShape(shape: ShapeSnapshot): boolean {
+  const rotation = ((shape.rotationDeg % 360) + 360) % 360;
+  return canMoveShape(shape) && rotation === 0 && !shape.flipH && !shape.flipV;
 }
 
 export function frameBoundsForShape(
@@ -151,6 +175,15 @@ export function textPositionAtPoint(
   storyId: string,
   point: SlidePoint
 ): number | null {
+  return textLocationAtPoint(frame, shapeId, storyId, point)?.position ?? null;
+}
+
+export function textLocationAtPoint(
+  frame: SlideDisplayList,
+  shapeId: string,
+  storyId: string,
+  point: SlidePoint
+): TextPointLocation | null {
   const textBox = frame.primitives.find(
     (primitive): primitive is TextBoxPrimitive =>
       primitive.kind === 'textBox' &&
@@ -158,23 +191,27 @@ export function textPositionAtPoint(
       primitive.storyId === storyId
   );
   if (!textBox || textBox.lines.length === 0) return null;
-  // lines are laid out unrotated, so a drag has to resolve in the same frame the
-  // engine's hitTest used when the gesture started
   const local = localPoint(textBox, point);
-  const line = textBox.lines.reduce((nearest, candidate) =>
-    lineDistance(candidate.y, candidate.height, local.y) <
-    lineDistance(nearest.y, nearest.height, local.y)
-      ? candidate
-      : nearest
-  );
+  let lineIndex = 0;
+  for (let index = 1; index < textBox.lines.length; index += 1) {
+    const candidate = textBox.lines[index];
+    const nearest = textBox.lines[lineIndex];
+    if (
+      lineDistance(candidate.y, candidate.height, local.y) <
+      lineDistance(nearest.y, nearest.height, local.y)
+    ) {
+      lineIndex = index;
+    }
+  }
+  const line = textBox.lines[lineIndex];
   const firstCaret = line.caretStops[0];
-  if (!firstCaret) return line.start;
+  if (!firstCaret) return { position: line.start, lineIndex };
   const caret = line.caretStops.reduce(
     (nearest, candidate) =>
       Math.abs(candidate.x - local.x) < Math.abs(nearest.x - local.x) ? candidate : nearest,
     firstCaret
   );
-  return caret.position;
+  return { position: caret.position, lineIndex };
 }
 
 /** Mirrors the engine's `hitTest`, which resolves text only where a caret can
@@ -306,7 +343,7 @@ export function resizedBounds(
   bounds: FrameBounds,
   handle: ResizeHandle,
   delta: SlidePoint,
-  minimum = 8
+  minimum: number
 ): FrameBounds {
   let { x, y, width, height } = bounds;
   if (handle.includes('w')) {
@@ -343,9 +380,9 @@ export function resizedShapeBox(
   frame: SlideDisplayList,
   shape: ShapeSnapshot,
   handle: ResizeHandle,
-  delta: SlidePoint,
-  minimum = 1_000
-): { x: number; y: number; width: number; height: number } {
+  delta: SlidePoint
+): { x: number; y: number; width: number; height: number } | null {
+  if (!canResizeShape(shape)) return null;
   const emu = {
     x: Math.round((delta.x * deck.widthEmu) / frame.width),
     y: Math.round((delta.y * deck.heightEmu) / frame.height),
@@ -354,9 +391,26 @@ export function resizedShapeBox(
     { x: shape.x, y: shape.y, width: shape.width, height: shape.height },
     handle,
     emu,
-    minimum
+    MIN_SHAPE_SIZE_EMU
   );
   return { x: box.x, y: box.y, width: box.width, height: box.height };
+}
+
+export function resizedShapeBounds(
+  deck: DeckSnapshot,
+  frame: SlideDisplayList,
+  shape: ShapeSnapshot,
+  handle: ResizeHandle,
+  delta: SlidePoint
+): FrameBounds | null {
+  const box = resizedShapeBox(deck, frame, shape, handle, delta);
+  if (!box || deck.widthEmu <= 0 || deck.heightEmu <= 0) return null;
+  return {
+    x: (box.x * frame.width) / deck.widthEmu,
+    y: (box.y * frame.height) / deck.heightEmu,
+    width: (box.width * frame.width) / deck.widthEmu,
+    height: (box.height * frame.height) / deck.heightEmu,
+  };
 }
 
 /** What a pointer gesture acts on. This is the engine's hit with one addition:
@@ -365,7 +419,8 @@ export function resizedShapeBox(
  *  such band, and `hoverTargetAtPoint` stays an exact mirror of it. */
 export function pointerTargetAtPoint(
   frame: SlideDisplayList,
-  point: SlidePoint
+  point: SlidePoint,
+  scale = 1
 ): HoverTarget | null {
   const target = hoverTargetAtPoint(frame, point);
   if (target !== 'text') return target;
@@ -375,13 +430,22 @@ export function pointerTargetAtPoint(
     if (!primitive.shapeId) continue;
     const local = containedPoint(primitive, at);
     if (!local) continue;
-    return withinBorderBand(primitive, local) ? 'shape' : 'text';
+    return withinBorderBand(primitive, local, scale) ? 'shape' : 'text';
   }
   return target;
 }
 
-function withinBorderBand(primitive: PrimitiveGeometry, point: SlidePoint): boolean {
-  const band = Math.min(BORDER_BAND, primitive.w / 3, primitive.h / 3);
+function withinBorderBand(
+  primitive: PrimitiveGeometry,
+  point: SlidePoint,
+  scale: number
+): boolean {
+  const normalizedScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const band = Math.min(
+    BORDER_BAND_SCREEN_PX / normalizedScale,
+    primitive.w / 3,
+    primitive.h / 3
+  );
   return (
     point.x - primitive.x <= band ||
     primitive.x + primitive.w - point.x <= band ||

--- a/packages/pptx-react/src/textSelection.test.ts
+++ b/packages/pptx-react/src/textSelection.test.ts
@@ -4,6 +4,7 @@ import {
   extendTextRange,
   lineEdge,
   paragraphRangeAt,
+  sameCaretGoalKey,
   textRangeAt,
   verticalCaretMove,
   wordBoundary,
@@ -48,31 +49,79 @@ describe('pptx text selection boundaries', () => {
 describe('pptx caret movement', () => {
   const lines: CaretLine[] = [
     { start: 0, end: 5, caretStops: stops(0, [0, 10, 20, 30, 40, 50]) },
-    { start: 6, end: 8, caretStops: stops(6, [0, 12, 24]) },
-    { start: 9, end: 14, caretStops: stops(9, [0, 10, 20, 30, 40, 50]) },
+    { start: 5, end: 8, caretStops: stops(5, [0, 12, 24, 36]) },
+    { start: 8, end: 13, caretStops: stops(8, [0, 10, 20, 30, 40, 50]) },
   ];
 
   it('moves between lines at the nearest column', () => {
-    expect(verticalCaretMove(lines, 3, 'down')).toBe(8);
-    expect(verticalCaretMove(lines, 8, 'up')).toBe(2);
+    expect(verticalCaretMove(lines, { position: 3, lineIndex: 0 }, 'down')).toEqual({
+      position: 7,
+      lineIndex: 1,
+    });
+    expect(verticalCaretMove(lines, { position: 7, lineIndex: 1 }, 'up')).toEqual({
+      position: 2,
+      lineIndex: 0,
+    });
   });
 
   it('stays put at the first and last line', () => {
-    expect(verticalCaretMove(lines, 2, 'up')).toBe(2);
-    expect(verticalCaretMove(lines, 11, 'down')).toBe(11);
+    expect(verticalCaretMove(lines, { position: 2, lineIndex: 0 }, 'up')).toEqual({
+      position: 2,
+      lineIndex: 0,
+    });
+    expect(verticalCaretMove(lines, { position: 11, lineIndex: 2 }, 'down')).toEqual({
+      position: 11,
+      lineIndex: 2,
+    });
   });
 
   it('holds the goal column across a short line', () => {
-    const goal = caretGoalX(lines, 5);
+    const goal = caretGoalX(lines, { position: 5, lineIndex: 0 });
     expect(goal).toBe(50);
-    const middle = verticalCaretMove(lines, 5, 'down', goal);
-    expect(middle).toBe(8);
-    expect(verticalCaretMove(lines, middle, 'down', goal)).toBe(14);
+    const middle = verticalCaretMove(lines, { position: 5, lineIndex: 0 }, 'down', goal);
+    expect(middle).toEqual({ position: 8, lineIndex: 1 });
+    expect(verticalCaretMove(lines, middle, 'down', goal)).toEqual({
+      position: 13,
+      lineIndex: 2,
+    });
   });
 
-  it('finds the edges of the line the caret sits in', () => {
-    expect(lineEdge(lines, 7, 'start')).toBe(6);
-    expect(lineEdge(lines, 7, 'end')).toBe(8);
+  it('keeps shared endpoints on their visual line', () => {
+    expect(lineEdge(lines, { position: 5, lineIndex: 0 }, 'start')).toEqual({
+      position: 0,
+      lineIndex: 0,
+    });
+    expect(lineEdge(lines, { position: 5, lineIndex: 1 }, 'start')).toEqual({
+      position: 5,
+      lineIndex: 1,
+    });
+    expect(lineEdge(lines, { position: 4, lineIndex: 0 }, 'end')).toEqual({
+      position: 5,
+      lineIndex: 0,
+    });
+  });
+
+  it('moves through an empty shared-endpoint line', () => {
+    const empty: CaretLine[] = [
+      { start: 0, end: 1, caretStops: stops(0, [0, 10]) },
+      { start: 1, end: 1, caretStops: [{ position: 1, x: 0 }] },
+      { start: 1, end: 2, caretStops: stops(1, [0, 10]) },
+    ];
+    const goal = caretGoalX(empty, { position: 1, lineIndex: 0 });
+    const middle = verticalCaretMove(empty, { position: 1, lineIndex: 0 }, 'down', goal);
+    expect(middle).toEqual({ position: 1, lineIndex: 1 });
+    expect(lineEdge(empty, middle, 'start')).toEqual({ position: 1, lineIndex: 1 });
+    expect(verticalCaretMove(empty, middle, 'down', goal)).toEqual({
+      position: 2,
+      lineIndex: 2,
+    });
+  });
+
+  it('keys the goal column by shape and visual line', () => {
+    const goal = { shapeId: 'first', position: 5, lineIndex: 1 };
+    expect(sameCaretGoalKey(goal, { ...goal })).toBe(true);
+    expect(sameCaretGoalKey(goal, { ...goal, shapeId: 'second' })).toBe(false);
+    expect(sameCaretGoalKey(goal, { ...goal, lineIndex: 0 })).toBe(false);
   });
 
   it('jumps whole words and stops at the text edges', () => {

--- a/packages/pptx-react/src/textSelection.test.ts
+++ b/packages/pptx-react/src/textSelection.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  caretGoalX,
   extendTextRange,
+  lineEdge,
   paragraphRangeAt,
   textRangeAt,
+  verticalCaretMove,
+  wordBoundary,
   wordRangeAt,
 } from './textSelection';
+import type { CaretLine } from './textSelection';
 
 describe('pptx text selection boundaries', () => {
   it('uses Unicode word boundaries', () => {
@@ -39,3 +44,46 @@ describe('pptx text selection boundaries', () => {
     ).toEqual({ anchor: 6, focus: 15 });
   });
 });
+
+describe('pptx caret movement', () => {
+  const lines: CaretLine[] = [
+    { start: 0, end: 5, caretStops: stops(0, [0, 10, 20, 30, 40, 50]) },
+    { start: 6, end: 8, caretStops: stops(6, [0, 12, 24]) },
+    { start: 9, end: 14, caretStops: stops(9, [0, 10, 20, 30, 40, 50]) },
+  ];
+
+  it('moves between lines at the nearest column', () => {
+    expect(verticalCaretMove(lines, 3, 'down')).toBe(8);
+    expect(verticalCaretMove(lines, 8, 'up')).toBe(2);
+  });
+
+  it('stays put at the first and last line', () => {
+    expect(verticalCaretMove(lines, 2, 'up')).toBe(2);
+    expect(verticalCaretMove(lines, 11, 'down')).toBe(11);
+  });
+
+  it('holds the goal column across a short line', () => {
+    const goal = caretGoalX(lines, 5);
+    expect(goal).toBe(50);
+    const middle = verticalCaretMove(lines, 5, 'down', goal);
+    expect(middle).toBe(8);
+    expect(verticalCaretMove(lines, middle, 'down', goal)).toBe(14);
+  });
+
+  it('finds the edges of the line the caret sits in', () => {
+    expect(lineEdge(lines, 7, 'start')).toBe(6);
+    expect(lineEdge(lines, 7, 'end')).toBe(8);
+  });
+
+  it('jumps whole words and stops at the text edges', () => {
+    expect(wordBoundary('Hello brave world', 0, 1)).toBe(5);
+    expect(wordBoundary('Hello brave world', 5, 1)).toBe(6);
+    expect(wordBoundary('Hello brave world', 8, -1)).toBe(6);
+    expect(wordBoundary('Hello brave world', 0, -1)).toBe(0);
+    expect(wordBoundary('Hello brave world', 17, 1)).toBe(17);
+  });
+});
+
+function stops(start: number, xs: number[]): Array<{ position: number; x: number }> {
+  return xs.map((x, index) => ({ position: start + index, x }));
+}

--- a/packages/pptx-react/src/textSelection.ts
+++ b/packages/pptx-react/src/textSelection.ts
@@ -65,3 +65,72 @@ function clampedIndex(text: string, index: number): number {
   if (!Number.isFinite(index)) return 0;
   return Math.max(0, Math.min(text.length, Math.trunc(index)));
 }
+
+/** The laid-out lines a caret can move through, as the display list reports
+ *  them. Only the fields caret movement reads are required. */
+export interface CaretLine {
+  start: number;
+  end: number;
+  caretStops: ReadonlyArray<{ position: number; x: number }>;
+}
+
+/** Vertical movement keeps the column the caret started from, so a run through
+ *  short lines and back does not drift left. `undefined` when the position has
+ *  no caret stop to measure. */
+export function caretGoalX(
+  lines: readonly CaretLine[],
+  position: number
+): number | undefined {
+  const line = lines[lineIndexAt(lines, position)];
+  return line?.caretStops.find((stop) => stop.position === position)?.x;
+}
+
+/** The position one line up or down, holding `goalX`. Stays put at the first
+ *  and last line, matching PowerPoint. */
+export function verticalCaretMove(
+  lines: readonly CaretLine[],
+  position: number,
+  direction: 'up' | 'down',
+  goalX?: number
+): number {
+  if (lines.length === 0) return position;
+  const index = lineIndexAt(lines, position);
+  const target = lines[index + (direction === 'up' ? -1 : 1)];
+  if (!target) return position;
+  const x = goalX ?? caretGoalX(lines, position);
+  if (x === undefined) return target.start;
+  const nearest = target.caretStops.reduce<{ position: number; x: number } | null>(
+    (best, stop) => (best === null || Math.abs(stop.x - x) < Math.abs(best.x - x) ? stop : best),
+    null
+  );
+  return nearest?.position ?? target.start;
+}
+
+/** The first or last position of the line the caret sits in. */
+export function lineEdge(
+  lines: readonly CaretLine[],
+  position: number,
+  edge: 'start' | 'end'
+): number {
+  const line = lines[lineIndexAt(lines, position)];
+  if (!line) return position;
+  return edge === 'start' ? line.start : line.end;
+}
+
+/** The next word boundary in `direction`, for a word-wise caret jump. */
+export function wordBoundary(text: string, index: number, direction: -1 | 1): number {
+  const position = clampedIndex(text, index);
+  const starts = [...wordSegmenter.segment(text)]
+    .filter((segment) => segment.isWordLike)
+    .flatMap((segment) => [segment.index, segment.index + segment.segment.length]);
+  const candidates = direction < 0 ? starts.filter((s) => s < position) : starts.filter((s) => s > position);
+  if (candidates.length === 0) return direction < 0 ? 0 : text.length;
+  return direction < 0 ? Math.max(...candidates) : Math.min(...candidates);
+}
+
+function lineIndexAt(lines: readonly CaretLine[], position: number): number {
+  const index = lines.findIndex(
+    (line) => position >= line.start && position <= line.end
+  );
+  return index === -1 ? Math.max(0, lines.length - 1) : index;
+}

--- a/packages/pptx-react/src/textSelection.ts
+++ b/packages/pptx-react/src/textSelection.ts
@@ -74,47 +74,63 @@ export interface CaretLine {
   caretStops: ReadonlyArray<{ position: number; x: number }>;
 }
 
-/** Vertical movement keeps the column the caret started from, so a run through
- *  short lines and back does not drift left. `undefined` when the position has
- *  no caret stop to measure. */
-export function caretGoalX(
-  lines: readonly CaretLine[],
-  position: number
-): number | undefined {
-  const line = lines[lineIndexAt(lines, position)];
-  return line?.caretStops.find((stop) => stop.position === position)?.x;
+export interface CaretLocation {
+  position: number;
+  lineIndex?: number;
 }
 
-/** The position one line up or down, holding `goalX`. Stays put at the first
- *  and last line, matching PowerPoint. */
+export interface CaretGoalKey extends CaretLocation {
+  shapeId: string;
+}
+
+export function sameCaretGoalKey(left: CaretGoalKey, right: CaretGoalKey): boolean {
+  return (
+    left.shapeId === right.shapeId &&
+    left.position === right.position &&
+    left.lineIndex === right.lineIndex
+  );
+}
+
+/** Returns the caret's visual column. */
+export function caretGoalX(
+  lines: readonly CaretLine[],
+  caret: CaretLocation
+): number | undefined {
+  const line = lines[caretLineIndex(lines, caret)];
+  return line?.caretStops.find((stop) => stop.position === caret.position)?.x;
+}
+
+/** Moves vertically while retaining `goalX`. */
 export function verticalCaretMove(
   lines: readonly CaretLine[],
-  position: number,
+  caret: CaretLocation,
   direction: 'up' | 'down',
   goalX?: number
-): number {
-  if (lines.length === 0) return position;
-  const index = lineIndexAt(lines, position);
-  const target = lines[index + (direction === 'up' ? -1 : 1)];
-  if (!target) return position;
-  const x = goalX ?? caretGoalX(lines, position);
-  if (x === undefined) return target.start;
+): Required<CaretLocation> {
+  if (lines.length === 0) return { position: caret.position, lineIndex: 0 };
+  const index = caretLineIndex(lines, caret);
+  const targetIndex = index + (direction === 'up' ? -1 : 1);
+  const target = lines[targetIndex];
+  if (!target) return { position: caret.position, lineIndex: index };
+  const x = goalX ?? caretGoalX(lines, caret);
+  if (x === undefined) return { position: target.start, lineIndex: targetIndex };
   const nearest = target.caretStops.reduce<{ position: number; x: number } | null>(
     (best, stop) => (best === null || Math.abs(stop.x - x) < Math.abs(best.x - x) ? stop : best),
     null
   );
-  return nearest?.position ?? target.start;
+  return { position: nearest?.position ?? target.start, lineIndex: targetIndex };
 }
 
 /** The first or last position of the line the caret sits in. */
 export function lineEdge(
   lines: readonly CaretLine[],
-  position: number,
+  caret: CaretLocation,
   edge: 'start' | 'end'
-): number {
-  const line = lines[lineIndexAt(lines, position)];
-  if (!line) return position;
-  return edge === 'start' ? line.start : line.end;
+): Required<CaretLocation> {
+  const lineIndex = caretLineIndex(lines, caret);
+  const line = lines[lineIndex];
+  if (!line) return { position: caret.position, lineIndex };
+  return { position: edge === 'start' ? line.start : line.end, lineIndex };
 }
 
 /** The next word boundary in `direction`, for a word-wise caret jump. */
@@ -128,9 +144,24 @@ export function wordBoundary(text: string, index: number, direction: -1 | 1): nu
   return direction < 0 ? Math.max(...candidates) : Math.min(...candidates);
 }
 
-function lineIndexAt(lines: readonly CaretLine[], position: number): number {
-  const index = lines.findIndex(
-    (line) => position >= line.start && position <= line.end
-  );
+export function caretLineIndex(
+  lines: readonly CaretLine[],
+  caret: CaretLocation
+): number {
+  const preferred = caret.lineIndex;
+  if (
+    preferred !== undefined &&
+    preferred >= 0 &&
+    preferred < lines.length &&
+    caret.position >= lines[preferred].start &&
+    caret.position <= lines[preferred].end
+  ) {
+    return preferred;
+  }
+  let index = -1;
+  for (let candidate = 0; candidate < lines.length; candidate += 1) {
+    const line = lines[candidate];
+    if (caret.position >= line.start && caret.position <= line.end) index = candidate;
+  }
   return index === -1 ? Math.max(0, lines.length - 1) : index;
 }

--- a/packages/pptx/README.md
+++ b/packages/pptx/README.md
@@ -46,7 +46,7 @@ and registered with the Rust shaper through `openPresentation`.
 Beyond rendering, `PresentationHandle` covers editing: text
 (`insertText` / `deleteText` / `formatText` / `setParagraphAlignment`), slides
 (`insertSlide` / `deleteSlide` / `moveSlide`), shapes
-(`addTextBox` / `moveShape` / `resizeShape`), `hitTest`, undo/redo, and
+(`addTextBox` / `moveShape` / `resizeShape` / `setShapeRect`), `hitTest`, undo/redo, and
 `save()`, which serializes the deck back to `.pptx` bytes with edits applied —
 untouched slides keep their exact source part bytes.
 

--- a/packages/pptx/src/render/canvas.test.ts
+++ b/packages/pptx/src/render/canvas.test.ts
@@ -206,4 +206,99 @@ describe('PPTX canvas replay', () => {
     expect(calls).toContain('fill');
     expect(calls).toContain('text:Q1');
   });
+
+  test('paints justified word starts at the engine caret positions', async () => {
+    const calls: Array<{ text: string; x: number }> = [];
+    const ctx = new Proxy(
+      {
+        fillText: (text: string, x: number) => calls.push({ text, x }),
+      } as Record<string, unknown>,
+      {
+        get(target, property) {
+          if (property in target) return target[property as string];
+          return () => undefined;
+        },
+        set(target, property, value) {
+          target[property as string] = value;
+          return true;
+        },
+      }
+    ) as unknown as CanvasRenderingContext2D;
+    const caretStops = [
+      { position: 0, x: 40 },
+      { position: 1, x: 50 },
+      { position: 2, x: 60 },
+      { position: 3, x: 70 },
+      { position: 4, x: 100 },
+      { position: 5, x: 110 },
+      { position: 6, x: 120 },
+      { position: 7, x: 130 },
+    ];
+    const glyphs = [
+      { glyphId: 1, cluster: 0, x: 40, advance: 10, xOffset: 0, yOffset: 68 },
+      { glyphId: 2, cluster: 1, x: 50, advance: 10, xOffset: 0, yOffset: 68 },
+      { glyphId: 3, cluster: 2, x: 60, advance: 10, xOffset: 0, yOffset: 68 },
+      { glyphId: 4, cluster: 3, x: 70, advance: 5, xOffset: 0, yOffset: 68 },
+      { glyphId: 5, cluster: 4, x: 100, advance: 10, xOffset: 0, yOffset: 68 },
+      { glyphId: 6, cluster: 5, x: 110, advance: 10, xOffset: 0, yOffset: 68 },
+      { glyphId: 7, cluster: 6, x: 120, advance: 10, xOffset: 0, yOffset: 68 },
+    ];
+    const list: SlideDisplayList = {
+      contractVersion: 1,
+      width: 320,
+      height: 180,
+      primitives: [
+        {
+          kind: 'textBox',
+          objectId: 1,
+          shapeId: 'shape:1',
+          storyId: 'story:1',
+          x: 40,
+          y: 50,
+          w: 240,
+          h: 80,
+          anchor: 'top',
+          paragraphs: [],
+          lines: [
+            {
+              x: 40,
+              y: 50,
+              width: 90,
+              height: 24,
+              baseline: 68,
+              start: 0,
+              end: 7,
+              caretStops,
+              runs: [
+                {
+                  text: 'one two',
+                  start: 0,
+                  end: 7,
+                  x: 40,
+                  width: 90,
+                  fontId: 1,
+                  fontFamily: 'Liberation Sans',
+                  fontSizePx: 20,
+                  bold: false,
+                  italic: false,
+                  underline: false,
+                  color: '#ffffff',
+                  glyphs,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    await paintSlide(ctx, list, 1);
+    const painted = calls.find((call) => call.text === 'two');
+    const engine = caretStops.find((stop) => stop.position === 4);
+    expect(painted?.x).toBe(engine?.x);
+    expect(calls).toEqual([
+      { text: 'one ', x: 40 },
+      { text: 'two', x: 100 },
+    ]);
+  });
 });

--- a/packages/pptx/src/render/canvas.ts
+++ b/packages/pptx/src/render/canvas.ts
@@ -259,7 +259,7 @@ function positionedTextChunks(run: PositionedTextRun): Array<{ text: string; x: 
       textStart = offset;
       x = glyph.x;
     }
-    expectedX = glyph.x + glyph.advance;
+    expectedX = Math.fround(Math.fround(glyph.x) + Math.fround(glyph.advance));
   }
   chunks.push({ text: run.text.slice(textStart), x });
   return chunks;

--- a/packages/pptx/src/render/canvas.ts
+++ b/packages/pptx/src/render/canvas.ts
@@ -234,10 +234,35 @@ function paintTextRun(
   const weight = run.bold ? 'bold ' : '';
   ctx.font = `${style}${weight}${run.fontSizePx}px ${quoteFamily(run.fontFamily)}`;
   ctx.fillStyle = run.color;
-  ctx.fillText(run.text, run.x, baseline);
+  for (const chunk of positionedTextChunks(run)) {
+    ctx.fillText(chunk.text, chunk.x, baseline);
+  }
   if (run.underline) {
     ctx.fillRect(run.x, baseline + run.fontSizePx * 0.08, run.width, Math.max(1, run.fontSizePx * 0.05));
   }
+}
+
+function positionedTextChunks(run: PositionedTextRun): Array<{ text: string; x: number }> {
+  if (run.glyphs.length < 2) return [{ text: run.text, x: run.x }];
+  const chunks: Array<{ text: string; x: number }> = [];
+  let textStart = 0;
+  let x = run.x;
+  let expectedX = run.glyphs[0].x;
+  for (const glyph of run.glyphs) {
+    const offset = glyph.cluster - run.start;
+    if (
+      offset > textStart &&
+      offset < run.text.length &&
+      Math.abs(glyph.x - expectedX) > 0.0001
+    ) {
+      chunks.push({ text: run.text.slice(textStart, offset), x });
+      textStart = offset;
+      x = glyph.x;
+    }
+    expectedX = glyph.x + glyph.advance;
+  }
+  chunks.push({ text: run.text.slice(textStart), x });
+  return chunks;
 }
 
 function quoteFamily(family: string): string {

--- a/packages/pptx/src/wasm/generated/pptx_wasm.d.ts
+++ b/packages/pptx/src/wasm/generated/pptx_wasm.d.ts
@@ -42,6 +42,7 @@ export class PptxDocument {
     setParagraphAlignmentJson(args: string): string;
     setShapeAdjustJson(args: string): string;
     setShapeFillJson(args: string): string;
+    setShapeRectJson(args: string): string;
     setShapeStrokeJson(args: string): string;
     snapshotJson(): string;
     startUpdateObservation(): void;
@@ -120,6 +121,7 @@ export interface InitOutput {
     readonly pptxdocument_setParagraphAlignmentJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_setShapeAdjustJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_setShapeFillJson: (a: number, b: number, c: number) => [number, number, number, number];
+    readonly pptxdocument_setShapeRectJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_setShapeStrokeJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_snapshotJson: (a: number) => [number, number, number, number];
     readonly pptxdocument_startUpdateObservation: (a: number) => [number, number];

--- a/packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm.d.ts
+++ b/packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm.d.ts
@@ -39,6 +39,7 @@ export const pptxdocument_saveBytes: (a: number) => [number, number, number, num
 export const pptxdocument_setParagraphAlignmentJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_setShapeAdjustJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_setShapeFillJson: (a: number, b: number, c: number) => [number, number, number, number];
+export const pptxdocument_setShapeRectJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_setShapeStrokeJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_snapshotJson: (a: number) => [number, number, number, number];
 export const pptxdocument_startUpdateObservation: (a: number) => [number, number];

--- a/packages/pptx/src/wasm/loader.test.ts
+++ b/packages/pptx/src/wasm/loader.test.ts
@@ -155,6 +155,36 @@ describe('PPTX wasm boundary', () => {
     ).toThrow();
   });
 
+  test('sets a shape rectangle in one update and one undo step', () => {
+    const source = openPresentation(fixture, { clientId: 9011 });
+    const slide = source.snapshot().slides[0];
+    const shape = slide.shapes[0];
+    const before = {
+      x: shape.x,
+      y: shape.y,
+      width: shape.width,
+      height: shape.height,
+    };
+    const after = {
+      x: before.x + 120_000,
+      y: before.y + 80_000,
+      width: before.width + 300_000,
+      height: before.height + 200_000,
+    };
+    const updates: Uint8Array[] = [];
+    source.onUpdate((update, origin) => {
+      if (origin === 'local') updates.push(update);
+    });
+
+    expect(source.setShapeRect(slide.id, shape.id, after).after).toEqual(after);
+    expect(updates).toHaveLength(1);
+    expect(shapeSnapshotFrom(source, shape.id)).toMatchObject(after);
+    expect(source.undo().applied).toBe(true);
+    expect(shapeSnapshotFrom(source, shape.id)).toMatchObject(before);
+    expect(source.canUndo()).toBe(false);
+    source.dispose();
+  });
+
   test('inserts and styles preset shapes with undo and redo', () => {
     const slide = handle.snapshot().slides[0];
     const receipt = handle.addShape(slide.id, {
@@ -256,7 +286,11 @@ describe('PPTX wasm boundary', () => {
 });
 
 function shapeSnapshot(shapeId: string) {
-  const shape = handle.snapshot().slides[0].shapes.find((candidate) => candidate.id === shapeId);
+  return shapeSnapshotFrom(handle, shapeId);
+}
+
+function shapeSnapshotFrom(source: PresentationHandle, shapeId: string) {
+  const shape = source.snapshot().slides[0].shapes.find((candidate) => candidate.id === shapeId);
   if (!shape) throw new Error(`shape ${shapeId} was not found`);
   return shape;
 }

--- a/packages/pptx/src/wasm/loader.test.ts
+++ b/packages/pptx/src/wasm/loader.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import type {
   PresentationHandle,
   ShapePrimitive,
+  SlidePrimitive,
   StorySnapshot,
   TextBoxPrimitive,
 } from '../index';
@@ -187,6 +188,43 @@ describe('PPTX wasm boundary', () => {
     source.dispose();
   });
 
+  test('paints the non-justified demo deck with one call per text run', async () => {
+    const source = openPresentation(fixture, {
+      clientId: 9013,
+      fonts: [{ family: 'Liberation Sans', bytes: fontBytes }],
+    });
+    const calls: Array<{ text: string; x: number; y: number }> = [];
+    const expected: Array<{ text: string; x: number; y: number }> = [];
+    const ctx = new Proxy(
+      {
+        fillText: (text: string, x: number, y: number) => calls.push({ text, x, y }),
+      } as Record<string, unknown>,
+      {
+        get(target, property) {
+          if (property in target) return target[property as string];
+          return () => undefined;
+        },
+        set(target, property, value) {
+          target[property as string] = value;
+          return true;
+        },
+      }
+    ) as unknown as CanvasRenderingContext2D;
+    try {
+      for (let slideIndex = 0; slideIndex < source.snapshot().slides.length; slideIndex += 1) {
+        const frame = source.layoutSlide(slideIndex);
+        expected.push(...oneCallPerTextRun(frame.primitives));
+        await paintSlide(ctx, frame);
+      }
+
+      expect(expected).toHaveLength(62);
+      expect(calls).toHaveLength(expected.length);
+      expect(calls).toEqual(expected);
+    } finally {
+      source.dispose();
+    }
+  });
+
   test('paints engine-produced justified word starts at caret positions', async () => {
     const source = openPresentation(fixture, {
       clientId: 9012,
@@ -365,4 +403,26 @@ function firstStory(shapes: Array<{ textStories: StorySnapshot[]; children: unkn
     if (shape.textStories[0]) return shape.textStories[0];
   }
   throw new Error('fixture has no text story');
+}
+
+function oneCallPerTextRun(
+  primitives: SlidePrimitive[]
+): Array<{ text: string; x: number; y: number }> {
+  const calls: Array<{ text: string; x: number; y: number }> = [];
+  for (const primitive of primitives) {
+    if (primitive.kind === 'textBox') {
+      for (const line of primitive.lines) {
+        for (const run of line.runs) calls.push({ text: run.text, x: run.x, y: line.baseline });
+      }
+    } else if (primitive.kind === 'chart') {
+      calls.push(...oneCallPerTextRun(primitive.primitives));
+    } else if (primitive.kind === 'placeholder' && primitive.label) {
+      calls.push({
+        text: primitive.label,
+        x: primitive.x + primitive.w / 2,
+        y: primitive.y + primitive.h / 2,
+      });
+    }
+  }
+  return calls;
 }

--- a/packages/pptx/src/wasm/loader.test.ts
+++ b/packages/pptx/src/wasm/loader.test.ts
@@ -7,11 +7,12 @@ import type {
   StorySnapshot,
   TextBoxPrimitive,
 } from '../index';
-import { initWasm, openPresentation } from '../index';
+import { initWasm, openPresentation, paintSlide } from '../index';
 
 const root = resolve(import.meta.dir, '../../../..');
 let handle: PresentationHandle;
 let fixture: Uint8Array;
+let fontBytes: Uint8Array;
 
 beforeAll(async () => {
   const [wasm, pptx, font] = await Promise.all([
@@ -21,6 +22,7 @@ beforeAll(async () => {
   ]);
   await initWasm(wasm);
   fixture = pptx;
+  fontBytes = font;
   handle = openPresentation(pptx, {
     clientId: 9001,
     fonts: [{ family: 'Liberation Sans', bytes: font }],
@@ -183,6 +185,69 @@ describe('PPTX wasm boundary', () => {
     expect(shapeSnapshotFrom(source, shape.id)).toMatchObject(before);
     expect(source.canUndo()).toBe(false);
     source.dispose();
+  });
+
+  test('paints engine-produced justified word starts at caret positions', async () => {
+    const source = openPresentation(fixture, {
+      clientId: 9012,
+      fonts: [{ family: 'Liberation Sans', bytes: fontBytes }],
+    });
+    try {
+      const shape = source.snapshot().slides[0].shapes.find(
+        (candidate) => candidate.name === 'Subtitle'
+      );
+      const story = shape?.textStories[0];
+      if (!story) throw new Error('subtitle story is missing');
+      source.setParagraphAlignment(story.id, 0, story.length, 'just');
+      const frame = source.layoutSlide(0);
+      const textBox = frame.primitives.find(
+        (primitive): primitive is TextBoxPrimitive =>
+          primitive.kind === 'textBox' && primitive.storyId === story.id
+      );
+      if (!textBox) throw new Error('subtitle layout is missing');
+      expect(textBox.lines.length).toBeGreaterThan(1);
+
+      const calls: Array<{ text: string; x: number; y: number }> = [];
+      const ctx = new Proxy(
+        {
+          fillText: (text: string, x: number, y: number) => calls.push({ text, x, y }),
+        } as Record<string, unknown>,
+        {
+          get(target, property) {
+            if (property in target) return target[property as string];
+            return () => undefined;
+          },
+          set(target, property, value) {
+            target[property as string] = value;
+            return true;
+          },
+        }
+      ) as unknown as CanvasRenderingContext2D;
+      await paintSlide(ctx, { ...frame, background: undefined, primitives: [textBox] });
+
+      const first = textBox.lines[0];
+      const painted = calls.filter((call) => call.y === first.baseline);
+      expect(painted.length).toBeGreaterThan(1);
+      let position = first.start;
+      for (const call of painted) {
+        const caret = first.caretStops.find((stop) => stop.position === position);
+        if (!caret) throw new Error(`caret stop ${position} is missing`);
+        expect(call.x).toBe(caret.x);
+        position += call.text.length;
+      }
+      expect(position).toBe(first.end);
+
+      const last = textBox.lines[textBox.lines.length - 1];
+      expect(calls.filter((call) => call.y === last.baseline)).toEqual([
+        {
+          text: last.runs.map((run) => run.text).join(''),
+          x: last.runs[0].x,
+          y: last.baseline,
+        },
+      ]);
+    } finally {
+      source.dispose();
+    }
   });
 
   test('inserts and styles preset shapes with undo and redo', () => {

--- a/packages/pptx/src/wasm/loader.ts
+++ b/packages/pptx/src/wasm/loader.ts
@@ -20,6 +20,7 @@ import type {
   ShapeDraft,
   ShapeFillReceipt,
   ShapeReceipt,
+  ShapeRect,
   ShapeStroke,
   ShapeStrokeReceipt,
   SlideDisplayList,
@@ -86,6 +87,7 @@ export interface PresentationHandle extends CollaborationReplica {
   removeShape(slideId: string, shapeId: string): ShapeReceipt;
   moveShape(slideId: string, shapeId: string, x: number, y: number): TransformReceipt;
   resizeShape(slideId: string, shapeId: string, width: number, height: number): TransformReceipt;
+  setShapeRect(slideId: string, shapeId: string, rect: ShapeRect): TransformReceipt;
   canUndo(): boolean;
   canRedo(): boolean;
   undo(): HistoryResult;
@@ -364,6 +366,12 @@ export function openPresentation(
     resizeShape(slideId, shapeId, width, height): TransformReceipt {
       return jsonWasmCall(
         () => doc.resizeShapeJson(JSON.stringify({ slideId, shapeId, width, height })),
+        true
+      );
+    },
+    setShapeRect(slideId, shapeId, rect): TransformReceipt {
+      return jsonWasmCall(
+        () => doc.setShapeRectJson(JSON.stringify({ slideId, shapeId, rect })),
         true
       );
     },


### PR DESCRIPTION
TL;DR:

Before/After:
<!-- drag in: the caret, the box outline while editing text, the resize grips, and a justified paragraph -->

Repro file:
[betteroffice-demo.pptx](https://github.com/PSchmiedl/betteroffice/blob/feat/pptx-editor-affordances/apps/demo/public/betteroffice-demo.pptx)

Summary:
- Add caret navigation, selection outlines, resize grips, and screen-space pointer affordances to the PPTX editor; resize grips are not offered on rotated or flipped shapes.
- Paint justified word spacing at the engine's caret positions while preserving `justLow`, `dist`, and `thaiDist` rendering.
- Keep resize preview and commit geometry identical with one EMU minimum and one atomic undo/update operation through the public `set_shape_rect` / `setShapeRect` API.
- Preserve visual-line caret affinity and isolate caret blinking from the editor render loop.
- Clear pointer, resize, and goal-column state across refreshes, deletions, focus changes, and document switches.
- Add regression coverage for transformed hit testing, canvas placement, shared line endpoints, collaboration refreshes, and resize transactions.

Test plan:
- [ ] Verify justified paragraphs paint, hit-test, select, and edit at matching word positions.
- [ ] Verify rotated and flipped shapes do not show resize grips.
- [ ] Verify west/north resize gestures undo in one step and never collapse below 8 px.
- [ ] Verify Home/End/Up/Down across wraps and empty lines keep the visible row.
- [ ] Verify collaboration deletion during resize leaves no stale preview.
- [ ] Run the Rust, Wasm, typecheck, and Bun gates listed in the PR.
