### PR TITLE
fix(pptx): resolve a:grpFill against the enclosing group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ version = "0.1.0"
 dependencies = [
  "betteroffice-drawingml",
  "betteroffice-ooxml-text",
+ "betteroffice-opc",
  "betteroffice-pptx-edit",
  "betteroffice-pptx-parse",
  "serde",

--- a/crates/pptx-parse/src/drawing.rs
+++ b/crates/pptx-parse/src/drawing.rs
@@ -256,6 +256,15 @@ fn parse_group(
     budget: &mut ParseBudget<'_>,
 ) -> Result<GroupShape, PptxError> {
     budget.charge_shape(part)?;
+    let own_fill = element.child("grpSpPr").and_then(parse_fill);
+    let mut children = parse_shape_children(element, relationships, part, budget)?;
+    // A group whose own fill is itself inherited leaves the markers in place for its ancestor.
+    if let Some(fill) = own_fill
+        .as_ref()
+        .filter(|fill| fill.fill_type != GROUP_FILL)
+    {
+        resolve_group_fill(&mut children, fill);
+    }
     Ok(GroupShape {
         base: parse_base(
             element.child("nvGrpSpPr"),
@@ -263,7 +272,7 @@ fn parse_group(
                 .child("grpSpPr")
                 .and_then(|value| value.child("xfrm")),
         ),
-        children: parse_shape_children(element, relationships, part, budget)?,
+        children,
     })
 }
 
@@ -579,7 +588,42 @@ fn parse_fill(element: &XmlElement) -> Option<ShapeFill> {
     if element.child("blipFill").is_some() {
         return Some(ShapeFill::named("picture"));
     }
+    if element.child("grpFill").is_some() {
+        return Some(ShapeFill::named(GROUP_FILL));
+    }
     None
+}
+
+/// Marker left by `<a:grpFill/>`: this shape takes the fill of the group that contains it.
+/// It survives until an ancestor group resolves it, so a group nested inside a filled group
+/// needs no second pass.
+const GROUP_FILL: &str = "group";
+
+fn fill_slot(node: &mut ShapeNode) -> Option<&mut Option<ShapeFill>> {
+    match node {
+        ShapeNode::Shape(shape) => Some(&mut shape.fill),
+        ShapeNode::Picture(picture) => Some(&mut picture.fill),
+        ShapeNode::GraphicFrame(_) | ShapeNode::Group(_) => None,
+    }
+}
+
+/// Hand `fill` to every descendant still waiting on `<a:grpFill/>`. Groups resolve their own
+/// children first, so a nested group that declares a fill has already claimed its subtree and
+/// only the shapes still carrying the marker are touched here.
+fn resolve_group_fill(children: &mut [ShapeNode], fill: &ShapeFill) {
+    for child in children {
+        if let Some(slot) = fill_slot(child) {
+            if slot
+                .as_ref()
+                .is_some_and(|current| current.fill_type == GROUP_FILL)
+            {
+                *slot = Some(fill.clone());
+            }
+        }
+        if let ShapeNode::Group(group) = child {
+            resolve_group_fill(&mut group.children, fill);
+        }
+    }
 }
 
 fn parse_gradient_fill(element: &XmlElement) -> ShapeFill {
@@ -952,6 +996,51 @@ mod tests {
     use super::*;
     use crate::ParseLimits;
     use crate::xml::parse_xml;
+
+    #[test]
+    fn group_fill_reaches_every_shape_that_asks_for_it() {
+        let limits = ParseLimits::default();
+        let mut budget = ParseBudget::new(&limits);
+        let root = parse_xml(
+            br#"<p:sld><p:cSld><p:spTree><p:grpSp><p:nvGrpSpPr><p:cNvPr id="10" name="Outer"/></p:nvGrpSpPr><p:grpSpPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="11" name="Inherits"/><p:nvPr/></p:nvSpPr><p:spPr><a:grpFill/></p:spPr></p:sp><p:sp><p:nvSpPr><p:cNvPr id="12" name="Explicit none"/><p:nvPr/></p:nvSpPr><p:spPr><a:noFill/></p:spPr></p:sp><p:grpSp><p:nvGrpSpPr><p:cNvPr id="13" name="Middle"/></p:nvGrpSpPr><p:grpSpPr><a:grpFill/></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="14" name="Two levels up"/><p:nvPr/></p:nvSpPr><p:spPr><a:grpFill/></p:spPr></p:sp></p:grpSp><p:grpSp><p:nvGrpSpPr><p:cNvPr id="15" name="Own fill"/></p:nvGrpSpPr><p:grpSpPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="16" name="Nearest wins"/><p:nvPr/></p:nvSpPr><p:spPr><a:grpFill/></p:spPr></p:sp></p:grpSp></p:grpSp></p:spTree></p:cSld></p:sld>"#,
+            "ppt/slides/slide1.xml",
+            &mut budget,
+        )
+        .unwrap();
+        let data = common_slide_data(&root, &[], "ppt/slides/slide1.xml", &mut budget).unwrap();
+        let ShapeNode::Group(outer) = &data.shapes[0] else {
+            panic!("expected a group");
+        };
+
+        let fill_of = |node: &ShapeNode| match node {
+            ShapeNode::Shape(shape) => shape.fill.clone(),
+            _ => panic!("expected a shape"),
+        };
+
+        // A direct child takes the group's own fill.
+        let inherited = fill_of(&outer.children[0]).expect("the child should have a fill");
+        assert_eq!(inherited.fill_type, "solid");
+        assert_eq!(
+            inherited.color.as_ref().unwrap().theme_color.as_deref(),
+            Some("accent1")
+        );
+
+        // An explicit noFill is left alone.
+        assert_eq!(fill_of(&outer.children[1]).unwrap().fill_type, "none");
+
+        // A group that inherits passes the fill down to its own children.
+        let ShapeNode::Group(middle) = &outer.children[2] else {
+            panic!("expected a nested group");
+        };
+        assert_eq!(fill_of(&middle.children[0]), Some(inherited));
+
+        // The nearest ancestor that declares a fill wins.
+        let ShapeNode::Group(own) = &outer.children[3] else {
+            panic!("expected a nested group");
+        };
+        let nearest = fill_of(&own.children[0]).expect("the child should have a fill");
+        assert_eq!(nearest.color.as_ref().unwrap().rgb.as_deref(), Some("FF0000"));
+    }
 
     #[test]
     fn parses_text_formatting_and_nested_shape_types() {

--- a/crates/pptx-parse/src/drawing.rs
+++ b/crates/pptx-parse/src/drawing.rs
@@ -52,11 +52,12 @@ pub(crate) fn common_slide_data(
     let background = common
         .and_then(|value| value.child("bg"))
         .and_then(parse_background);
-    let shapes = if let Some(tree) = common.and_then(|value| value.child("spTree")) {
+    let mut shapes = if let Some(tree) = common.and_then(|value| value.child("spTree")) {
         parse_shape_children(tree, relationships, part, budget)?
     } else {
         Vec::new()
     };
+    resolve_group_fill(&mut shapes, None);
     Ok(CommonSlideData {
         name,
         background,
@@ -263,7 +264,7 @@ fn parse_group(
         .as_ref()
         .filter(|fill| fill.fill_type != GROUP_FILL)
     {
-        resolve_group_fill(&mut children, fill);
+        resolve_group_fill(&mut children, Some(fill));
     }
     Ok(GroupShape {
         base: parse_base(
@@ -562,7 +563,7 @@ fn guide_operand(token: &str, values: &BTreeMap<String, GuideValue>) -> Option<G
 
 fn parse_background(element: &XmlElement) -> Option<ShapeFill> {
     if let Some(properties) = element.child("bgPr") {
-        return parse_fill(properties);
+        return parse_fill(properties).filter(|fill| fill.fill_type != GROUP_FILL);
     }
     element.child("bgRef").map(|reference| ShapeFill {
         fill_type: "theme".to_owned(),
@@ -596,7 +597,7 @@ fn parse_fill(element: &XmlElement) -> Option<ShapeFill> {
 
 /// Marker left by `<a:grpFill/>`: this shape takes the fill of the group that contains it.
 /// It survives until an ancestor group resolves it, so a group nested inside a filled group
-/// needs no second pass.
+/// needs no second pass; the tree root clears whatever is left so no consumer ever sees it.
 const GROUP_FILL: &str = "group";
 
 fn fill_slot(node: &mut ShapeNode) -> Option<&mut Option<ShapeFill>> {
@@ -607,18 +608,18 @@ fn fill_slot(node: &mut ShapeNode) -> Option<&mut Option<ShapeFill>> {
     }
 }
 
-/// Hand `fill` to every descendant still waiting on `<a:grpFill/>`. Groups resolve their own
-/// children first, so a nested group that declares a fill has already claimed its subtree and
-/// only the shapes still carrying the marker are touched here.
-fn resolve_group_fill(children: &mut [ShapeNode], fill: &ShapeFill) {
+/// Hand `fill` to every descendant still waiting on `<a:grpFill/>`, or clear the marker when
+/// there is no group left to inherit from. Groups resolve their own children first, so a nested
+/// group that declares a fill has already claimed its subtree and only the shapes still carrying
+/// the marker are touched here.
+fn resolve_group_fill(children: &mut [ShapeNode], fill: Option<&ShapeFill>) {
     for child in children {
-        if let Some(slot) = fill_slot(child) {
-            if slot
+        if let Some(slot) = fill_slot(child)
+            && slot
                 .as_ref()
                 .is_some_and(|current| current.fill_type == GROUP_FILL)
-            {
-                *slot = Some(fill.clone());
-            }
+        {
+            *slot = fill.cloned();
         }
         if let ShapeNode::Group(group) = child {
             resolve_group_fill(&mut group.children, fill);
@@ -1043,6 +1044,32 @@ mod tests {
             nearest.color.as_ref().unwrap().rgb.as_deref(),
             Some("FF0000")
         );
+    }
+
+    #[test]
+    fn a_group_fill_with_no_group_to_inherit_from_is_no_fill() {
+        let limits = ParseLimits::default();
+        let mut budget = ParseBudget::new(&limits);
+        let root = parse_xml(
+            br#"<p:sld><p:cSld><p:bg><p:bgPr><a:grpFill/></p:bgPr></p:bg><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr><p:spPr><a:grpFill/></p:spPr></p:sp><p:grpSp><p:nvGrpSpPr><p:cNvPr id="3" name="Unfilled"/></p:nvGrpSpPr><p:grpSpPr><a:grpFill/></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="4" name="Nested"/></p:nvPicPr><p:spPr><a:grpFill/></p:spPr></p:pic></p:grpSp></p:spTree></p:cSld></p:sld>"#,
+            "ppt/slides/slide1.xml",
+            &mut budget,
+        )
+        .unwrap();
+        let data = common_slide_data(&root, &[], "ppt/slides/slide1.xml", &mut budget).unwrap();
+
+        assert_eq!(data.background, None);
+        let ShapeNode::Shape(placeholder) = &data.shapes[0] else {
+            panic!("expected a shape");
+        };
+        assert_eq!(placeholder.fill, None);
+        let ShapeNode::Group(group) = &data.shapes[1] else {
+            panic!("expected a group");
+        };
+        let ShapeNode::Picture(nested) = &group.children[0] else {
+            panic!("expected a picture");
+        };
+        assert_eq!(nested.fill, None);
     }
 
     #[test]

--- a/crates/pptx-parse/src/drawing.rs
+++ b/crates/pptx-parse/src/drawing.rs
@@ -1039,7 +1039,10 @@ mod tests {
             panic!("expected a nested group");
         };
         let nearest = fill_of(&own.children[0]).expect("the child should have a fill");
-        assert_eq!(nearest.color.as_ref().unwrap().rgb.as_deref(), Some("FF0000"));
+        assert_eq!(
+            nearest.color.as_ref().unwrap().rgb.as_deref(),
+            Some("FF0000")
+        );
     }
 
     #[test]

--- a/crates/pptx-parse/src/drawing.rs
+++ b/crates/pptx-parse/src/drawing.rs
@@ -259,7 +259,6 @@ fn parse_group(
     budget.charge_shape(part)?;
     let own_fill = element.child("grpSpPr").and_then(parse_fill);
     let mut children = parse_shape_children(element, relationships, part, budget)?;
-    // A group whose own fill is itself inherited leaves the markers in place for its ancestor.
     if let Some(fill) = own_fill
         .as_ref()
         .filter(|fill| fill.fill_type != GROUP_FILL)
@@ -595,9 +594,8 @@ fn parse_fill(element: &XmlElement) -> Option<ShapeFill> {
     None
 }
 
-/// Marker left by `<a:grpFill/>`: this shape takes the fill of the group that contains it.
-/// It survives until an ancestor group resolves it, so a group nested inside a filled group
-/// needs no second pass; the tree root clears whatever is left so no consumer ever sees it.
+/// Marker left by `<a:grpFill/>`, standing until an ancestor group resolves it or the tree
+/// root clears it.
 const GROUP_FILL: &str = "group";
 
 fn fill_slot(node: &mut ShapeNode) -> Option<&mut Option<ShapeFill>> {
@@ -608,10 +606,8 @@ fn fill_slot(node: &mut ShapeNode) -> Option<&mut Option<ShapeFill>> {
     }
 }
 
-/// Hand `fill` to every descendant still waiting on `<a:grpFill/>`, or clear the marker when
-/// there is no group left to inherit from. Groups resolve their own children first, so a nested
-/// group that declares a fill has already claimed its subtree and only the shapes still carrying
-/// the marker are touched here.
+/// Hands `fill` to every descendant still waiting on `<a:grpFill/>`, or clears the marker when
+/// there is no group left to inherit from.
 fn resolve_group_fill(children: &mut [ShapeNode], fill: Option<&ShapeFill>) {
     for child in children {
         if let Some(slot) = fill_slot(child)

--- a/crates/pptx-render/Cargo.toml
+++ b/crates/pptx-render/Cargo.toml
@@ -22,3 +22,6 @@ pptx-parse.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+
+[dev-dependencies]
+ooxml-opc.workspace = true

--- a/crates/pptx-render/tests/group_fill.rs
+++ b/crates/pptx-render/tests/group_fill.rs
@@ -1,0 +1,148 @@
+//! A placeholder asking for its group's fill has no group to take it from, so the layout
+//! placeholder's fill must still reach the display list.
+
+use pptx_edit::DeckSession;
+use pptx_render::{Paint, Primitive, SlideRenderer};
+
+const FONT: &[u8] = include_bytes!("../../ooxml-text/tests/fonts/LiberationSans-Regular.ttf");
+
+const CONTENT_TYPES: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+<Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+</Types>"#;
+
+const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>"#;
+
+const PRESENTATION: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>
+<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>
+<p:sldSz cx="12192000" cy="6858000"/><p:notesSz cx="6858000" cy="9144000"/>
+</p:presentation>"#;
+
+const PRESENTATION_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>"#;
+
+const SLIDE: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+<p:cSld><p:spTree>
+<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+<p:grpSpPr/>
+<p:sp><p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+<p:spPr><a:grpFill/></p:spPr>
+<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr><a:latin typeface="Arial"/></a:rPr><a:t>Title</a:t></a:r></a:p></p:txBody></p:sp>
+</p:spTree></p:cSld></p:sld>"#;
+
+const SLIDE_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>"#;
+
+const LAYOUT: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="title">
+<p:cSld><p:spTree>
+<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+<p:grpSpPr/>
+<p:sp><p:nvSpPr><p:cNvPr id="2" name="Title Placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+<p:spPr><a:xfrm><a:off x="762000" y="457200"/><a:ext cx="10668000" cy="1143000"/></a:xfrm><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></p:spPr>
+<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr/></a:p></p:txBody></p:sp>
+</p:spTree></p:cSld></p:sldLayout>"#;
+
+const LAYOUT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>"#;
+
+const MASTER: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+<p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+<p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst></p:sldMaster>"#;
+
+const MASTER_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>"#;
+
+const THEME: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Fixture">
+<a:themeElements><a:clrScheme name="Fixture">
+<a:dk1><a:srgbClr val="000000"/></a:dk1><a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+<a:dk2><a:srgbClr val="222222"/></a:dk2><a:lt2><a:srgbClr val="EEEEEE"/></a:lt2>
+<a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+<a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+<a:accent5><a:srgbClr val="5B9BD5"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+<a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+</a:clrScheme></a:themeElements></a:theme>"#;
+
+fn fixture() -> Vec<u8> {
+    let parts: Vec<(String, Vec<u8>)> = [
+        ("[Content_Types].xml", CONTENT_TYPES),
+        ("_rels/.rels", ROOT_RELS),
+        ("ppt/presentation.xml", PRESENTATION),
+        ("ppt/_rels/presentation.xml.rels", PRESENTATION_RELS),
+        ("ppt/slides/slide1.xml", SLIDE),
+        ("ppt/slides/_rels/slide1.xml.rels", SLIDE_RELS),
+        ("ppt/slideLayouts/slideLayout1.xml", LAYOUT),
+        ("ppt/slideLayouts/_rels/slideLayout1.xml.rels", LAYOUT_RELS),
+        ("ppt/slideMasters/slideMaster1.xml", MASTER),
+        ("ppt/slideMasters/_rels/slideMaster1.xml.rels", MASTER_RELS),
+        ("ppt/theme/theme1.xml", THEME),
+    ]
+    .into_iter()
+    .map(|(path, body)| (path.to_owned(), body.as_bytes().to_vec()))
+    .collect();
+    ooxml_opc::rezip_parts(&parts).unwrap()
+}
+
+fn open() -> DeckSession {
+    DeckSession::open(&fixture(), 21).unwrap()
+}
+
+#[test]
+fn a_placeholder_asking_for_a_group_fill_keeps_its_layout_fill() {
+    let session = open();
+    let snapshot = session.snapshot().unwrap();
+    let mut renderer = SlideRenderer::new();
+    renderer.register_font("Arial", false, false, FONT).unwrap();
+    let rendered = renderer
+        .layout_slide(session.package(), &snapshot, 0)
+        .unwrap();
+    let fill = rendered
+        .display_list
+        .primitives
+        .iter()
+        .find_map(|primitive| match primitive {
+            Primitive::Shape {
+                object_id: 2, fill, ..
+            } => Some(fill.clone()),
+            _ => None,
+        })
+        .expect("the title placeholder is drawn");
+    assert_eq!(
+        fill,
+        Some(Paint::Solid {
+            color: "#FF0000".to_owned()
+        })
+    );
+}
+
+#[test]
+fn a_placeholder_asking_for_a_group_fill_has_no_fill_of_its_own() {
+    let snapshot = open().snapshot().unwrap();
+    let title = &snapshot.slides[0].shapes[0];
+    assert_eq!(title.name, "Title");
+    assert_eq!(title.fill, None);
+}


### PR DESCRIPTION
TL;DR:

Before/After:

A shape taking its fill from the parent group now paints its badge. The square beside it is the documented interaction, not a regression in this change: resolving `grpFill` gives `custGeom` icons a fill, and each is drawn as its bounding box until #285 lands.

![pr271-tpl-double-exposure-business-templates-35.png](https://raw.githubusercontent.com/dsaad68/betteroffice/render-evidence/images/pr271-tpl-double-exposure-business-templates-35.png)

Magnified:

![pr271-tpl-double-exposure-business-templates-35-detail.png](https://raw.githubusercontent.com/dsaad68/betteroffice/render-evidence/images/pr271-tpl-double-exposure-business-templates-35-detail.png)

Repro file:

The *Double Exposure Business* template from [free-powerpoint-templates-design.com](http://www.free-powerpoint-templates-design.com), slide 35.

Test decks are PowerPoint design templates carrying only placeholder text, so the renders can be published without redistributing anyone's business material. Sources and licences are listed with the images: https://github.com/dsaad68/betteroffice/tree/render-evidence

Summary:

- `parse_fill` had no `grpFill` arm, so a shape asking for its group's fill was indistinguishable from one with no fill at all, and `parse_group` read only the group's `xfrm`, so there was no fill to inherit from either.
- The marker is now parsed and resolved in `parse_group` once the children are known. Groups resolve bottom-up, so a nested group that declares its own fill has already claimed its subtree and only shapes still carrying the marker are filled: the nearest ancestor wins, however many levels up it sits.
- An explicit `noFill` is never overwritten.
- A marker with no filled ancestor (a top-level shape, a placeholder, a background) is cleared back to no fill once the slide, layout, or master tree is parsed, so the model holds what it held before: the renderer still falls back to the layout and master placeholder fill, and the editor still exposes `fillJson: null`. Left in place, the marker would suppress both, since consumers treat any fill as authoritative.
- Tests cover the resolution cases (direct child, explicit `noFill`, two-level inheritance, nearest ancestor wins), the unresolved-marker cases at parse level (top-level placeholder, group with no filled ancestor, background), and, in `pptx-render`, a placeholder carrying `grpFill` keeping its layout placeholder's fill in the display list with `fillJson` null. Each fails without its change.
- No tracked deck contains `grpFill`, so every tracked slide's display list and the demo deck's save round-trip are byte-identical before and after.

Measured over the 16 affected slides: 14 improve, two of them by more than 14 points, and two move from major to minor. The two that regress are the icon slides above, each by 0.23 points, for the reason given.

Test plan:

- [ ] `cargo test -p betteroffice-pptx-parse`
- [ ] `cargo clippy --all-targets`
- [ ] Confirm a deck opened and saved round-trips `<a:grpFill/>` untouched
- [ ] Sanity-check a deck with deeply nested groups

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)



