### PR TITLE
fix(xlsx): expand shared formulas on load

### DIFF
--- a/.changeset/xlsx-shared-formulas.md
+++ b/.changeset/xlsx-shared-formulas.md
@@ -1,0 +1,8 @@
+---
+"@betteroffice/xlsx": patch
+"@betteroffice/python-xlsx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Load Excel shared formulas with correct absolute and relative references for
+recalculation and round-trip saves.

--- a/bindings/python-xlsx/tests/test_formulas.py
+++ b/bindings/python-xlsx/tests/test_formulas.py
@@ -1,0 +1,49 @@
+import io
+import zipfile
+from xml.sax.saxutils import escape
+
+import pytest
+
+import betteroffice_xlsx as bo
+
+
+def formula_workbook(sample_bytes, formula):
+    worksheet = f"""<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+            <row r="1"><c r="A1" t="str"><f>{escape(formula)}</f><v/></c></row>
+            <row r="2"><c r="D2"><v>2</v></c></row>
+            <row r="4"><c r="B4"><v>4</v></c></row>
+            <row r="6"><c r="B6"><v>6</v></c></row>
+        </sheetData>
+    </worksheet>"""
+    buffer = io.BytesIO()
+    with (
+        zipfile.ZipFile(io.BytesIO(sample_bytes)) as source,
+        zipfile.ZipFile(buffer, "w") as target,
+    ):
+        for part in source.infolist():
+            data = source.read(part.filename)
+            if part.filename == "xl/worksheets/sheet1.xml":
+                data = worksheet.encode()
+            target.writestr(part, data)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    "formula",
+    ['$B$6&"A"&$B$4&"B"&$D$2', 'B6&"A"&B4&"B"&D2', '$B6&"A"&B$4&"B"&D2'],
+)
+def test_absolute_and_relative_concatenation(sample_bytes, formula, tmp_path):
+    path = tmp_path / "demo.xlsx"
+    path.write_bytes(formula_workbook(sample_bytes, formula))
+    workbook = bo.Workbook.open_path(path)
+    sheet = workbook[0]
+    assert sheet.formula("A1") == formula
+    assert sheet["A1"] == ""
+    workbook.recalculate()
+    assert sheet["A1"] == "6A4B2"
+    sheet["B6"] = 9
+    assert sheet["A1"] == "9A4B2"
+    reopened = bo.Workbook.open(workbook.save())
+    assert reopened[0].formula("A1") == formula
+    assert reopened[0]["A1"] == "9A4B2"

--- a/bindings/python-xlsx/tests/test_formulas.py
+++ b/bindings/python-xlsx/tests/test_formulas.py
@@ -1,5 +1,6 @@
 import io
 import zipfile
+from pathlib import Path
 from xml.sax.saxutils import escape
 
 import pytest
@@ -16,6 +17,10 @@ def formula_workbook(sample_bytes, formula):
             <row r="6"><c r="B6"><v>6</v></c></row>
         </sheetData>
     </worksheet>"""
+    return replace_worksheet(sample_bytes, worksheet.encode())
+
+
+def replace_worksheet(sample_bytes, worksheet):
     buffer = io.BytesIO()
     with (
         zipfile.ZipFile(io.BytesIO(sample_bytes)) as source,
@@ -24,7 +29,7 @@ def formula_workbook(sample_bytes, formula):
         for part in source.infolist():
             data = source.read(part.filename)
             if part.filename == "xl/worksheets/sheet1.xml":
-                data = worksheet.encode()
+                data = worksheet
             target.writestr(part, data)
     return buffer.getvalue()
 
@@ -47,3 +52,49 @@ def test_absolute_and_relative_concatenation(sample_bytes, formula, tmp_path):
     reopened = bo.Workbook.open(workbook.save())
     assert reopened[0].formula("A1") == formula
     assert reopened[0]["A1"] == "9A4B2"
+
+
+def test_shared_formulas_recalculate_and_survive_save(sample_bytes, tmp_path):
+    fixture = (
+        Path(__file__).resolve().parents[3]
+        / "crates/xlsx-parse/tests/fixtures/shared-formulas.xml"
+    )
+    path = tmp_path / "shared.xlsx"
+    path.write_bytes(replace_worksheet(sample_bytes, fixture.read_bytes()))
+    workbook = bo.Workbook.open_path(path)
+    sheet = workbook[0]
+    formula = '$B$6&"A"&$B$4&"B"&$D$2'
+    for address in ("A1", "A2", "A3"):
+        assert sheet.formula(address) == formula
+    workbook.recalculate()
+    assert [sheet[address] for address in ("A1", "A2", "A3")] == ["6A4B2"] * 3
+    sheet["B6"] = 9
+    assert [sheet[address] for address in ("A1", "A2", "A3")] == ["9A4B2"] * 3
+    reopened = bo.Workbook.open(workbook.save())
+    for address in ("A1", "A2", "A3"):
+        assert reopened[0].formula(address) == formula
+        assert reopened[0][address] == "9A4B2"
+
+
+def test_shared_mixed_references_track_translated_dependencies(sample_bytes):
+    worksheet = b"""<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+        <sheetData>
+            <row r="1"><c r="A1"><f t="shared" si="0" ref="A1:C1">A2+$D2+A$3+$D$3</f></c><c r="B1"><f t="shared" si="0"/></c><c r="C1"><f t="shared" si="0"/></c></row>
+            <row r="2"><c r="A2"><v>1</v></c><c r="B2"><v>2</v></c><c r="C2"><v>3</v></c><c r="D2"><v>4</v></c></row>
+            <row r="3"><c r="A3"><v>10</v></c><c r="B3"><v>20</v></c><c r="C3"><v>30</v></c><c r="D3"><v>40</v></c></row>
+        </sheetData>
+    </worksheet>"""
+    workbook = bo.Workbook.open(replace_worksheet(sample_bytes, worksheet))
+    sheet = workbook[0]
+    addresses = ("A1", "B1", "C1")
+    formulas = ("A2+$D2+A$3+$D$3", "B2+$D2+B$3+$D$3", "C2+$D2+C$3+$D$3")
+    assert [sheet.formula(address) for address in addresses] == list(formulas)
+    workbook.recalculate()
+    assert [sheet[address] for address in addresses] == [55, 66, 77]
+    sheet["B2"] = 5
+    assert [sheet[address] for address in addresses] == [55, 69, 77]
+    sheet["D2"] = 8
+    assert [sheet[address] for address in addresses] == [59, 73, 81]
+    reopened = bo.Workbook.open(workbook.save())[0]
+    assert [reopened.formula(address) for address in addresses] == list(formulas)
+    assert [reopened[address] for address in addresses] == [59, 73, 81]

--- a/crates/xlsx-calc/tests/eval_fixtures.rs
+++ b/crates/xlsx-calc/tests/eval_fixtures.rs
@@ -113,6 +113,32 @@ fn references_and_sheets() {
 }
 
 #[test]
+fn absolute_and_relative_concatenation() {
+    let mut wb = fixture();
+    for (address, value) in [("B6", 6.0), ("B4", 4.0), ("D2", 2.0)] {
+        wb.sheets[0].set_cell(
+            CellRef::parse_a1(address).unwrap(),
+            Cell {
+                value: n(value),
+                ..Cell::default()
+            },
+        );
+    }
+    for formula in [
+        r#"$B$6&"A"&$B$4&"B"&$D$2"#,
+        r#"B6&"A"&B4&"B"&D2"#,
+        r#"$B6&"A"&B$4&"B"&D2"#,
+    ] {
+        let expression = parse_formula(formula).unwrap();
+        assert_eq!(
+            evaluate(&expression, &EvalContext::new(&wb, SheetId(0))),
+            t("6A4B2"),
+            "{formula}"
+        );
+    }
+}
+
+#[test]
 fn functions() {
     let cases: &[(&str, CellValue)] = &[
         ("SUM(A1:A3)", n(60.0)),

--- a/crates/xlsx-parse/README.md
+++ b/crates/xlsx-parse/README.md
@@ -15,6 +15,11 @@ counts, and no allocation sized from a value in the file.
 | `MAX_HYPERLINKS` | 65,536 per worksheet |
 | `MAX_STYLE_ENTRIES` | 65,536 |
 
+Shared formulas expand only for explicitly shared cells, preserving absolute
+and mixed references. Expansion is limited to 32 KiB per formula and 32 MiB per
+worksheet; missing or invalid shared groups are rejected. Cached values remain
+unchanged until recalculation.
+
 `serialize_workbook` writes the model back out. It regenerates the parts the
 model represents; package parts the model does not cover are not retained.
 

--- a/crates/xlsx-parse/src/formula.rs
+++ b/crates/xlsx-parse/src/formula.rs
@@ -1,0 +1,469 @@
+//! Expand shared formulas while preserving their authored text and anchors.
+
+use std::collections::BTreeMap;
+
+use quick_xml::events::BytesStart;
+use xlsx_model::addr::{MAX_COLS, MAX_ROWS, col_to_letters};
+use xlsx_model::{CellRange, CellRef, Sheet};
+
+use crate::ParseError;
+use crate::xml::attr;
+
+const MAX_FORMULA_BYTES: usize = 32_768;
+const MAX_SHARED_FORMULA_BYTES: usize = 32 * 1024 * 1024;
+
+struct Master {
+    origin: CellRef,
+    range: CellRange,
+    source: String,
+}
+
+pub(crate) struct SharedFormulas {
+    masters: BTreeMap<u32, Master>,
+    members: BTreeMap<(u32, u32), u32>,
+    remaining: usize,
+}
+
+impl Default for SharedFormulas {
+    fn default() -> Self {
+        Self {
+            masters: BTreeMap::new(),
+            members: BTreeMap::new(),
+            remaining: MAX_SHARED_FORMULA_BYTES,
+        }
+    }
+}
+
+impl SharedFormulas {
+    pub(crate) fn record(
+        &mut self,
+        element: &BytesStart<'_>,
+        origin: CellRef,
+        source: &str,
+    ) -> Result<(), ParseError> {
+        let key = (origin.row, origin.col);
+        if attr(element, b"t")?.as_deref() != Some("shared") {
+            self.members.remove(&key);
+            return Ok(());
+        }
+        let index = attr(element, b"si")?
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            .ok_or_else(|| malformed("shared formula has no valid group index"))?;
+        self.members.insert(key, index);
+        if let Some(reference) = attr(element, b"ref")? {
+            let range = CellRange::parse_a1(&reference)
+                .map_err(|_| malformed("shared formula has an invalid range"))?;
+            if !range.contains(origin) || source.trim().is_empty() {
+                return Err(malformed("shared formula has an invalid master"));
+            }
+            if self.masters.contains_key(&index) {
+                return Err(malformed("shared formula group has multiple masters"));
+            }
+            if source.len() > MAX_FORMULA_BYTES {
+                return Err(malformed("shared formula exceeds the formula length limit"));
+            }
+            self.remaining = self
+                .remaining
+                .checked_sub(source.len())
+                .ok_or_else(budget_error)?;
+            self.masters.insert(
+                index,
+                Master {
+                    origin,
+                    range,
+                    source: source.to_owned(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resolve(mut self, sheet: &mut Sheet) -> Result<(), ParseError> {
+        for ((row, col), index) in self.members {
+            let at = CellRef::new(row, col);
+            let master = self
+                .masters
+                .get(&index)
+                .ok_or_else(|| malformed("shared formula group has no master"))?;
+            if !master.range.contains(at) {
+                return Err(malformed("shared formula is outside its master's range"));
+            }
+            if (row, col) == (master.origin.row, master.origin.col) {
+                continue;
+            }
+            let formula = translate(
+                &master.source,
+                i64::from(row) - i64::from(master.origin.row),
+                i64::from(col) - i64::from(master.origin.col),
+                self.remaining.min(MAX_FORMULA_BYTES),
+            )?;
+            self.remaining -= formula.len();
+            let cell = sheet
+                .cell_mut(at)
+                .ok_or_else(|| malformed("shared formula cell is missing"))?;
+            cell.formula = Some(formula);
+        }
+        Ok(())
+    }
+}
+
+fn malformed(message: &str) -> ParseError {
+    ParseError::Malformed(message.to_owned())
+}
+
+fn budget_error() -> ParseError {
+    malformed("shared formula expansion exceeds the byte limit")
+}
+
+fn append(output: &mut String, text: &str, limit: usize) -> Result<(), ParseError> {
+    if text.len() > limit.saturating_sub(output.len()) {
+        return Err(budget_error());
+    }
+    output.push_str(text);
+    Ok(())
+}
+
+fn translate(source: &str, rows: i64, cols: i64, limit: usize) -> Result<String, ParseError> {
+    if source.len() > limit {
+        return Err(budget_error());
+    }
+    let mut output = String::with_capacity(source.len());
+    let mut index = 0;
+    while index < source.len() {
+        let start = index;
+        let character = source[index..].chars().next().expect("within source");
+        if character == '"' {
+            index = skip_quoted(source, index, b'"');
+            append(&mut output, &source[start..index], limit)?;
+        } else if separator(character) {
+            index += character.len_utf8();
+            append(&mut output, &source[start..index], limit)?;
+        } else {
+            index = operand_end(source, index);
+            let operand = &source[start..index];
+            let function = source[index..].trim_start().starts_with('(');
+            translate_operand(&mut output, operand, rows, cols, limit, function)?;
+        }
+    }
+    Ok(output)
+}
+
+fn separator(character: char) -> bool {
+    character.is_whitespace()
+        || matches!(
+            character,
+            '+' | '-'
+                | '*'
+                | '/'
+                | '^'
+                | '&'
+                | '%'
+                | '='
+                | '<'
+                | '>'
+                | '('
+                | ')'
+                | ','
+                | ';'
+                | '{'
+                | '}'
+                | '@'
+                | '#'
+        )
+}
+
+fn skip_quoted(source: &str, start: usize, quote: u8) -> usize {
+    let bytes = source.as_bytes();
+    let mut index = start + 1;
+    while index < bytes.len() {
+        if bytes[index] == quote {
+            index += 1;
+            if bytes.get(index) != Some(&quote) {
+                return index;
+            }
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn skip_brackets(source: &str, start: usize) -> usize {
+    let bytes = source.as_bytes();
+    let mut depth = 1;
+    let mut index = start + 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' => index += usize::from(index + 1 < bytes.len()),
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return index + 1;
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn operand_end(source: &str, mut index: usize) -> usize {
+    while index < source.len() {
+        let character = source[index..].chars().next().expect("within source");
+        match character {
+            '\'' => index = skip_quoted(source, index, b'\''),
+            '[' => index = skip_brackets(source, index),
+            '"' => break,
+            c if c.is_whitespace() => {
+                let following = source[index..].trim_start();
+                if !source[..index].trim_end().ends_with(':') && !following.starts_with(':') {
+                    break;
+                }
+                index = source.len() - following.len();
+            }
+            c if separator(c) => break,
+            c => index += c.len_utf8(),
+        }
+    }
+    index
+}
+
+fn punctuation(source: &str, punctuation: u8) -> Vec<usize> {
+    let bytes = source.as_bytes();
+    let mut positions = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' => index = skip_quoted(source, index, bytes[index]),
+            b'[' => index = skip_brackets(source, index),
+            byte => {
+                if byte == punctuation {
+                    positions.push(index);
+                }
+                index += 1;
+            }
+        }
+    }
+    positions
+}
+
+fn address_part(source: &str) -> (&str, &str) {
+    match punctuation(source, b'!').last() {
+        Some(index) => source.split_at(index + 1),
+        None => ("", source),
+    }
+}
+
+fn column(source: &str) -> Option<CellRef> {
+    let letters = source.strip_prefix('$').unwrap_or(source);
+    if letters.is_empty() || !letters.bytes().all(|byte| byte.is_ascii_alphabetic()) {
+        return None;
+    }
+    CellRef::parse_a1(&format!("{}1", source.to_ascii_uppercase())).ok()
+}
+
+fn row(source: &str) -> Option<CellRef> {
+    let digits = source.strip_prefix('$').unwrap_or(source);
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    CellRef::parse_a1(&format!("A{source}")).ok()
+}
+
+fn shifted(index: u32, absolute: bool, delta: i64, limit: u32) -> Option<u32> {
+    let moved = i64::from(index).checked_add(if absolute { 0 } else { delta })?;
+    (0..i64::from(limit))
+        .contains(&moved)
+        .then_some(moved as u32)
+}
+
+fn translate_operand(
+    output: &mut String,
+    operand: &str,
+    rows: i64,
+    cols: i64,
+    limit: usize,
+    function: bool,
+) -> Result<(), ParseError> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    for colon in punctuation(operand, b':') {
+        parts.push(&operand[start..colon]);
+        start = colon + 1;
+    }
+    parts.push(&operand[start..]);
+    let three_dimensional = parts.len() > 1
+        && address_part(parts[0]).0.is_empty()
+        && !address_part(parts[1]).0.is_empty()
+        && CellRef::parse_a1(&parts[0].trim().to_ascii_uppercase()).is_err();
+    let addresses = &parts[usize::from(three_dimensional)..];
+    let whole_columns = addresses.len() > 1
+        && addresses
+            .iter()
+            .all(|part| column(address_part(part).1.trim()).is_some());
+    let whole_rows = addresses.len() > 1
+        && addresses
+            .iter()
+            .all(|part| row(address_part(part).1.trim()).is_some());
+    for (index, part) in parts.iter().enumerate() {
+        if index > 0 {
+            append(output, ":", limit)?;
+        }
+        if (index == 0 && three_dimensional) || (function && index + 1 == parts.len()) {
+            append(output, part, limit)?;
+            continue;
+        }
+        let (prefix, address) = address_part(part);
+        let trimmed = address.trim();
+        let parsed = if whole_columns {
+            column(trimmed)
+        } else if whole_rows {
+            row(trimmed)
+        } else {
+            CellRef::parse_a1(&trimmed.to_ascii_uppercase()).ok()
+        };
+        let Some(cell) = parsed else {
+            append(output, part, limit)?;
+            continue;
+        };
+        let moved_row = shifted(cell.row, cell.abs_row || whole_columns, rows, MAX_ROWS);
+        let moved_col = shifted(cell.col, cell.abs_col || whole_rows, cols, MAX_COLS);
+        let replacement = match (moved_row, moved_col) {
+            (Some(row), Some(col)) if row == cell.row && col == cell.col => trimmed.to_owned(),
+            (Some(_), Some(col)) if whole_columns => {
+                format!(
+                    "{}{}",
+                    if cell.abs_col { "$" } else { "" },
+                    col_to_letters(col)
+                )
+            }
+            (Some(row), Some(_)) if whole_rows => {
+                format!("{}{}", if cell.abs_row { "$" } else { "" }, row + 1)
+            }
+            (Some(row), Some(col)) => CellRef { row, col, ..cell }.to_a1(),
+            _ => "#REF!".to_owned(),
+        };
+        append(output, prefix, limit)?;
+        append(
+            output,
+            &address[..address.len() - address.trim_start().len()],
+            limit,
+        )?;
+        append(output, &replacement, limit)?;
+        append(output, &address[address.trim_end().len()..], limit)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shifts_references_without_rewriting_other_formula_text() {
+        for (source, expected) in [
+            (r#"$B$6&"A"&$B$4&"B"&$D$2"#, r#"$B$6&"A"&$B$4&"B"&$D$2"#),
+            ("A1+$B2+C$3+$D$4", "D3+$B4+F$3+$D$4"),
+            ("SUM(A1:B2,$C$3:D$4)", "SUM(D3:E4,$C$3:G$4)"),
+            ("SUM(B2:A1)", "SUM(E4:D3)"),
+            ("Sheet1!A1+'Other Sheet'!$B2", "Sheet1!D3+'Other Sheet'!$B4"),
+            ("'A1''s ! sheet'!C3", "'A1''s ! sheet'!F5"),
+            ("'A1:B2'!C3:D4", "'A1:B2'!F5:G6"),
+            ("Sheet1:Sheet3!A1:B2", "Sheet1:Sheet3!D3:E4"),
+            ("Sheet1!A1:Sheet2!B2", "Sheet1!D3:Sheet2!E4"),
+            ("A1:Sheet2!B2", "D3:Sheet2!E4"),
+            ("[1]Sheet1!A1+[1]Sheet1!$B$2", "[1]Sheet1!D3+[1]Sheet1!$B$2"),
+            (
+                "'C:\\A1\\[Book.xlsx]Sheet1'!A1",
+                "'C:\\A1\\[Book.xlsx]Sheet1'!D3",
+            ),
+            (r#"IF(A1="B2","A1""C3",D4)"#, r#"IF(D3="B2","A1""C3",G6)"#),
+            (
+                "LOG10(A1)+LOG10 (B2)+1E3+2.5e-4",
+                "LOG10(D3)+LOG10 (E4)+1E3+2.5e-4",
+            ),
+            (
+                "_xlfn.FOO(A1,Rate_A1,A1_rate,éA1,A1.Thing)",
+                "_xlfn.FOO(D3,Rate_A1,A1_rate,éA1,A1.Thing)",
+            ),
+            (
+                "Table1[A1]+Table1[[#Headers],[B2]]+A1",
+                "Table1[A1]+Table1[[#Headers],[B2]]+D3",
+            ),
+            ("Table1[A1']B2]+C3", "Table1[A1']B2]+F5"),
+            ("@A1+A1#+#REF!+#N/A", "@D3+D3#+#REF!+#N/A"),
+            (r#"SUM({1,2;3,4})+"A1"&A1"#, r#"SUM({1,2;3,4})+"A1"&D3"#),
+            ("SUM(A:C,$D:$E,1:3,$4:$5)", "SUM(D:F,$D:$E,3:5,$4:$5)"),
+            ("SUM(A : $C, 1 : $3)", "SUM(D : $C, 3 : $3)"),
+            ("SUM(Sheet1!A:Sheet2!B)", "SUM(Sheet1!D:Sheet2!E)"),
+            ("SUM(Sheet1:Sheet3!A:C)", "SUM(Sheet1:Sheet3!D:F)"),
+            ("SUM(A:A B:B)", "SUM(D:D E:E)"),
+            ("SUM(A1 : B$2)", "SUM(D3 : E$2)"),
+            ("SUM(A1:INDEX(B1:B9,2))", "SUM(D3:INDEX(E3:E11,2))"),
+            ("SUM(INDEX(B1:B9,2):A9)", "SUM(INDEX(E3:E11,2):D11)"),
+            ("SUM(A1:OFFSET(B1,1,0))", "SUM(D3:OFFSET(E3,1,0))"),
+            ("a1+$b$2", "D3+$b$2"),
+        ] {
+            assert_eq!(
+                translate(source, 2, 3, MAX_FORMULA_BYTES).unwrap(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn shifts_backwards_and_reports_out_of_grid_references() {
+        assert_eq!(
+            translate("A1+$A$1+B$1+$A2+B2", -1, -1, MAX_FORMULA_BYTES).unwrap(),
+            "#REF!+$A$1+A$1+$A1+A1"
+        );
+        assert_eq!(
+            translate("XFD1048576+$XFD$1048576", 1, 1, MAX_FORMULA_BYTES).unwrap(),
+            "#REF!+$XFD$1048576"
+        );
+        assert_eq!(
+            translate("SUM(A:B,1:2)", -1, -1, MAX_FORMULA_BYTES).unwrap(),
+            "SUM(#REF!:A,#REF!:1)"
+        );
+    }
+
+    #[test]
+    fn refuses_expansion_past_the_remaining_budget() {
+        assert!(translate("A9", 1, 0, 2).is_err());
+        assert_eq!(translate("A9", 1, 0, 3).unwrap(), "A10");
+        assert!(translate("$A$1", 0, 0, 3).is_err());
+    }
+
+    #[test]
+    fn charges_all_shared_groups_against_one_sheet_budget() {
+        let mut formulas = SharedFormulas {
+            remaining: 3,
+            ..SharedFormulas::default()
+        };
+        let master =
+            BytesStart::new("f").with_attributes([("t", "shared"), ("si", "0"), ("ref", "A1:A2")]);
+        formulas.record(&master, CellRef::new(0, 0), "B1").unwrap();
+        let follower = BytesStart::new("f").with_attributes([("t", "shared"), ("si", "0")]);
+        formulas.record(&follower, CellRef::new(1, 0), "").unwrap();
+        let mut sheet = Sheet::new("Sheet1");
+        sheet.set_cell(
+            CellRef::new(1, 0),
+            xlsx_model::Cell {
+                formula: Some(String::new()),
+                ..Default::default()
+            },
+        );
+        assert!(formulas.resolve(&mut sheet).is_err());
+
+        let mut formulas = SharedFormulas {
+            remaining: 3,
+            ..SharedFormulas::default()
+        };
+        formulas.record(&master, CellRef::new(0, 0), "B1").unwrap();
+        let second =
+            BytesStart::new("f").with_attributes([("t", "shared"), ("si", "1"), ("ref", "C1:C2")]);
+        assert!(formulas.record(&second, CellRef::new(0, 2), "D1").is_err());
+    }
+}

--- a/crates/xlsx-parse/src/lib.rs
+++ b/crates/xlsx-parse/src/lib.rs
@@ -2,6 +2,7 @@
 //! every byte as attacker-controlled with depth and collection caps.
 
 mod chart;
+mod formula;
 mod package;
 mod read;
 mod reference;

--- a/crates/xlsx-parse/src/read.rs
+++ b/crates/xlsx-parse/src/read.rs
@@ -10,6 +10,7 @@ use xlsx_model::{
     Hyperlink, Sheet, SheetId, Workbook,
 };
 
+use crate::formula::SharedFormulas;
 use crate::styles::parse_stylesheet;
 use crate::xml::{
     attr, collect_text, find_part, local_name, next_event, reader, resolve_part_path,
@@ -355,6 +356,7 @@ fn parse_worksheet(
     let mut cur: Option<CellBuild> = None;
     let mut cell_count: u64 = 0;
     let mut hyperlink_count: usize = 0;
+    let mut shared_formulas = SharedFormulas::default();
 
     loop {
         match next_event(&mut reader, &mut buf, &mut depth)? {
@@ -404,6 +406,9 @@ fn parse_worksheet(
                 b"f" => {
                     let text = collect_text(&mut reader, &mut buf, &mut depth)?;
                     if let Some(c) = cur.as_mut() {
+                        if let Some(origin) = c.addr {
+                            shared_formulas.record(&e, origin, &text)?;
+                        }
                         c.formula = Some(text);
                     }
                 }
@@ -454,6 +459,7 @@ fn parse_worksheet(
             _ => {}
         }
     }
+    shared_formulas.resolve(&mut sheet)?;
     normalize_merges(&mut sheet.merges);
     Ok(sheet)
 }

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -101,6 +101,22 @@ fn parses_shared_string_number_formula_bool_error() {
 }
 
 #[test]
+fn parses_absolute_and_relative_concatenation() {
+    for formula in [
+        r#"$B$6&"A"&$B$4&"B"&$D$2"#,
+        r#"B6&"A"&B4&"B"&D2"#,
+        r#"$B6&"A"&B$4&"B"&D2"#,
+    ] {
+        let body = format!(
+            r#"<sheetData><row r="1"><c r="A1" t="str"><f>{}</f><v/></c></row></sheetData>"#,
+            formula.replace('&', "&amp;")
+        );
+        let wb = parse_workbook(&package(&body, &[], false)).unwrap();
+        assert_eq!(cell_at(&wb, "A1").formula.as_deref(), Some(formula));
+    }
+}
+
+#[test]
 fn parses_inline_string() {
     let body = r#"<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>inline &lt;here&gt;</t></is></c></row></sheetData>"#;
     let wb = parse_workbook(&package(body, &[], false)).unwrap();

--- a/crates/xlsx-parse/src/tests.rs
+++ b/crates/xlsx-parse/src/tests.rs
@@ -117,6 +117,107 @@ fn parses_absolute_and_relative_concatenation() {
 }
 
 #[test]
+fn expands_shared_formulas_and_preserves_source_until_edited() {
+    let mut parts = package("", &[], false);
+    let source = include_bytes!("../tests/fixtures/shared-formulas.xml");
+    parts[2].1 = source.to_vec();
+    let parsed = parse_workbook_with_package(&parts).unwrap();
+    for address in ["A1", "A2", "A3"] {
+        assert_eq!(
+            cell_at(&parsed.workbook, address).formula.as_deref(),
+            Some(r#"$B$6&"A"&$B$4&"B"&$D$2"#)
+        );
+    }
+    let unchanged = serialize_workbook_with_package(&parsed.workbook, &parsed.package).unwrap();
+    assert_eq!(part_bytes(&unchanged, "xl/worksheets/sheet1.xml"), source);
+    let mut edited = parsed.workbook.clone();
+    edited.sheets[0].set_cell(
+        CellRef::parse_a1("C1").unwrap(),
+        Cell {
+            value: CellValue::Number { value: 7.0 },
+            ..Cell::default()
+        },
+    );
+    let saved = serialize_workbook_with_package(&edited, &parsed.package).unwrap();
+    let reopened = parse_workbook(&saved).unwrap();
+    for address in ["A1", "A2", "A3"] {
+        assert_eq!(
+            cell_at(&reopened, address).formula,
+            cell_at(&edited, address).formula
+        );
+    }
+}
+
+#[test]
+fn shared_formulas_resolve_late_masters_and_leave_unshared_cells_alone() {
+    let body = r#"<sheetData>
+        <row r="1"><c r="A1"><f t="shared" si="7">999</f><v>10</v></c></row>
+        <row r="2"><c r="A2"><f>99</f><v>99</v></c><c r="B2"><f t="shared" si="7" ref="A1:C3">A1+$A1+A$1+$A$1</f><v>20</v></c></row>
+        <row r="3"><c r="A3"><v>55</v></c><c r="C3"><f t="shared" si="7"/><v>30</v></c></row>
+    </sheetData>"#;
+    let wb = parse_workbook(&package(body, &[], false)).unwrap();
+    assert_eq!(
+        cell_at(&wb, "A1").formula.as_deref(),
+        Some("#REF!+#REF!+#REF!+$A$1")
+    );
+    assert_eq!(cell_at(&wb, "A1").value, CellValue::Number { value: 10.0 });
+    assert_eq!(
+        cell_at(&wb, "C3").formula.as_deref(),
+        Some("B2+$A2+B$1+$A$1")
+    );
+    assert_eq!(cell_at(&wb, "C3").value, CellValue::Number { value: 30.0 });
+    assert_eq!(cell_at(&wb, "A2").formula.as_deref(), Some("99"));
+    assert_eq!(cell_at(&wb, "A3").formula, None);
+    assert_eq!(wb.sheets[0].iter_cells().count(), 5);
+}
+
+#[test]
+fn shared_formula_indices_are_scoped_to_each_worksheet() {
+    let first = r#"<sheetData><row r="1"><c r="A1"><f t="shared" si="0" ref="A1:B1">C1</f></c><c r="B1"><f t="shared" si="0"/></c></row></sheetData>"#;
+    let second = first.replace(">C1</f>", ">$C$9</f>");
+    let wb = parse_workbook(&two_sheet_package(first, &second)).unwrap();
+    let address = CellRef::parse_a1("B1").unwrap();
+    assert_eq!(
+        wb.sheets[0].cell(address).unwrap().formula.as_deref(),
+        Some("D1")
+    );
+    assert_eq!(
+        wb.sheets[1].cell(address).unwrap().formula.as_deref(),
+        Some("$C$9")
+    );
+}
+
+#[test]
+fn shared_formula_ranges_do_not_allocate_implicit_cells() {
+    let body = r#"<sheetData><row r="1"><c r="A1"><f t="shared" si="0" ref="A1:XFD1048576">1</f></c></row></sheetData>"#;
+    let wb = parse_workbook(&package(body, &[], false)).unwrap();
+    assert_eq!(wb.sheets[0].iter_cells().count(), 1);
+}
+
+#[test]
+fn malformed_shared_groups_fail_instead_of_losing_formulas() {
+    for cells in [
+        r#"<c r="A1"><f t="shared" si="0"/></c>"#,
+        r#"<c r="A1"><f t="shared" ref="A1:A2">1</f></c>"#,
+        r#"<c r="A1"><f t="shared" si="-1" ref="A1:A2">1</f></c>"#,
+        r#"<c r="A1"><f t="shared" si="4294967296" ref="A1:A2">1</f></c>"#,
+        r#"<c r="A1"><f t="shared" si="0" ref="B1:B2">1</f></c>"#,
+        r#"<c r="A1"><f t="shared" si="0" ref="A1:A2"/></c>"#,
+        r#"<c r="A1"><f t="shared" si="0" ref="A1:A2">1</f></c><c r="B1"><f t="shared" si="0"/></c>"#,
+        r#"<c r="A1"><f t="shared" si="0" ref="A1:B1">1</f></c><c r="B1"><f t="shared" si="0" ref="A1:B1">2</f></c>"#,
+    ] {
+        let body = format!("<sheetData><row r=\"1\">{cells}</row></sheetData>");
+        assert!(
+            matches!(
+                parse_workbook(&package(&body, &[], false)),
+                Err(ParseError::Malformed(_))
+            ),
+            "{cells}"
+        );
+    }
+}
+
+#[test]
 fn parses_inline_string() {
     let body = r#"<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>inline &lt;here&gt;</t></is></c></row></sheetData>"#;
     let wb = parse_workbook(&package(body, &[], false)).unwrap();

--- a/crates/xlsx-parse/tests/fixtures/shared-formulas.xml
+++ b/crates/xlsx-parse/tests/fixtures/shared-formulas.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="str"><f t="shared" si="0" ref="A1:A3">$B$6&amp;"A"&amp;$B$4&amp;"B"&amp;$D$2</f><v/></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="str"><f t="shared" si="0"/><v/></c>
+      <c r="D2"><v>2</v></c>
+    </row>
+    <row r="3"><c r="A3" t="str"><f t="shared" si="0"/><v/></c></row>
+    <row r="4"><c r="B4"><v>4</v></c></row>
+    <row r="6"><c r="B6"><v>6</v></c></row>
+  </sheetData>
+</worksheet>


### PR DESCRIPTION
TL;DR:

Repro file:
[Synthetic shared-formula worksheet](https://github.com/openooxml/betteroffice/blob/5b1b24f2a76ac72735bfbb68144e5827ee60e5c1/crates/xlsx-parse/tests/fixtures/shared-formulas.xml), wrapped into an XLSX by the Python regression test.

Summary:

- Expand Excel shared formulas on load, preserving absolute/mixed references, cached values, and untouched worksheet XML.
- Bound expansion and reject malformed groups; cover recalculation, dependency updates, and save/reopen behavior.
- Refs #328. The supplied standalone expression already works. This fixes an independently reproduced shared-formula bug; without the original workbook, the reported `None` remains unconfirmed. This PR does not auto-close the issue.

Test plan:

- [x] Observe the shared-formula Python regression fail before the fix.
- [x] Run all-feature Rust tests for xlsx-parse, xlsx-calc, xlsx-ops, and betteroffice-xlsx: 539 passed, one existing test ignored.
- [x] Rebuild the native binding and run the Python XLSX suite: 68 passed.
- [x] Compare 6,030 A1 translations with openpyxl; separately test range-call and cross-qualified endpoints.
- [x] Pass Clippy with warnings denied, formatting, and wasm32 checks with default and minimal XLSX features.
