### PR TITLE
fix(xlsx): support whole-column formula references

### DIFF
--- a/.changeset/xlsx-whole-column-lookups.md
+++ b/.changeset/xlsx-whole-column-lookups.md
@@ -1,0 +1,7 @@
+---
+"@betteroffice/xlsx": patch
+"@betteroffice/python-xlsx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Support whole-column formula references such as `VLOOKUP(...,S:V,...)`.

--- a/bindings/python-xlsx/tests/test_column_formulas.py
+++ b/bindings/python-xlsx/tests/test_column_formulas.py
@@ -1,0 +1,46 @@
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import betteroffice_xlsx as bo
+
+
+@pytest.mark.parametrize(
+    "columns", ["S:V", "$S:$V", "$S:V", "S:$V", "Budget!S:V", "'Budget'!$S:$V"]
+)
+def test_whole_column_lookup_recalculates_and_round_trips(sample_bytes, columns):
+    fixture = (
+        Path(__file__).resolve().parents[3]
+        / "crates/xlsx-calc/tests/fixtures/whole-column-vlookup.xml"
+    )
+    worksheet = fixture.read_bytes().replace(b"S:V", columns.encode())
+    buffer = io.BytesIO()
+    with (
+        zipfile.ZipFile(io.BytesIO(sample_bytes)) as source,
+        zipfile.ZipFile(buffer, "w") as target,
+    ):
+        for part in source.infolist():
+            data = source.read(part.filename)
+            if part.filename == "xl/worksheets/sheet1.xml":
+                data = worksheet
+            target.writestr(part, data)
+    workbook = bo.Workbook.open(buffer.getvalue())
+    sheet = workbook[0]
+    formula = f"VLOOKUP(2,{columns},4,FALSE)"
+    assert sheet.formula("A1") == formula
+    assert sheet["A1"] == "two"
+    sheet["V2"] = "updated"
+    assert sheet["A1"] == "updated"
+    workbook.recalculate()
+    assert sheet["A1"] == "updated"
+    sheet["B1"] = "=" + formula
+    assert sheet.formula("B1") == formula
+    assert sheet["B1"] == "updated"
+    reopened = bo.Workbook.open(workbook.save())
+    assert reopened[0].formula("A1") == formula
+    assert reopened[0]["A1"] == "updated"
+    reopened[0]["V2"] = "reopened"
+    assert reopened[0]["A1"] == "reopened"
+    assert reopened[0]["B1"] == "reopened"

--- a/crates/xlsx-calc/README.md
+++ b/crates/xlsx-calc/README.md
@@ -24,6 +24,10 @@ receives its arguments **unevaluated**, so control-flow functions (`IF`, `IFS`,
 `SWITCH`, `IFERROR`, `IFNA`, `CHOOSE`, `AND`, `OR`) evaluate only the branches
 they take.
 
+Whole-column references (`S:V`, `$S:$V`, `'Data Sheet'!S:V`) retain their anchors
+and full-height dependencies. Lookups read cells on demand; the existing
+evaluation limits still apply to large scans and aggregates.
+
 ## Registry
 
 Function names resolve **case-insensitively** (`sum`, `SUM`, `Sum` are one

--- a/crates/xlsx-calc/src/deps.rs
+++ b/crates/xlsx-calc/src/deps.rs
@@ -35,6 +35,9 @@ fn walk(
         Expr::Range { sheet, range } => {
             push_unique(out, seen, sheet.clone(), *range);
         }
+        Expr::ColumnRange { sheet, range } => {
+            push_unique(out, seen, sheet.clone(), range.cell_range());
+        }
         Expr::Unary { expr, .. } | Expr::Percent(expr) => walk(expr, out, seen),
         Expr::Binary { lhs, rhs, .. } => {
             walk(lhs, out, seen);

--- a/crates/xlsx-calc/src/eval.rs
+++ b/crates/xlsx-calc/src/eval.rs
@@ -206,7 +206,7 @@ pub fn evaluate(expr: &Expr, ctx: &EvalContext<'_>) -> CellValue {
         Expr::Error(e) => err(*e),
         Expr::Ref { sheet, cell } => resolve_ref(sheet, *cell, ctx),
         // no implicit intersection: a bare range in scalar context is #VALUE!
-        Expr::Range { .. } => err(ErrorValue::Value),
+        Expr::Range { .. } | Expr::ColumnRange { .. } => err(ErrorValue::Value),
         Expr::Name { scope, name } => evaluate_defined_name(scope, name, ctx),
         Expr::Unary { op, expr } => eval_unary(*op, expr, ctx),
         Expr::Binary { op, lhs, rhs } => eval_binary(*op, lhs, rhs, ctx),
@@ -575,6 +575,12 @@ pub(crate) fn as_area(arg: &Expr, ctx: &EvalContext<'_>) -> Option<Area> {
             start: range.start,
             rows: (range.end.row - range.start.row + 1) as usize,
             cols: (range.end.col - range.start.col + 1) as usize,
+        }),
+        Expr::ColumnRange { sheet, range } => Some(Area {
+            sheet: resolve_sheet(sheet, ctx)?,
+            start: CellRef::new(0, range.start),
+            rows: xlsx_model::addr::MAX_ROWS as usize,
+            cols: (range.end - range.start + 1) as usize,
         }),
         Expr::Name { scope, name } => {
             let key = defined_name_key(scope, name, ctx).ok()?;

--- a/crates/xlsx-calc/src/graph.rs
+++ b/crates/xlsx-calc/src/graph.rs
@@ -301,7 +301,8 @@ fn push_defined_name_uses(owner: SheetId, expr: &Expr, pending: &mut Vec<Defined
             | Expr::Bool(_)
             | Expr::Error(_)
             | Expr::Ref { .. }
-            | Expr::Range { .. } => {}
+            | Expr::Range { .. }
+            | Expr::ColumnRange { .. } => {}
         }
     }
     pending.extend(uses.into_iter().rev());
@@ -330,7 +331,8 @@ fn push_volatile_name_uses(owner: SheetId, expr: &Expr, pending: &mut Vec<Define
             | Expr::Bool(_)
             | Expr::Error(_)
             | Expr::Ref { .. }
-            | Expr::Range { .. } => {}
+            | Expr::Range { .. }
+            | Expr::ColumnRange { .. } => {}
         }
     }
     pending.extend(uses.into_iter().rev());
@@ -400,6 +402,20 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn whole_column_dependencies_cover_future_rows() {
+        let mut wb = wb2();
+        wb.sheets[0].set_cell(a1("A1"), formula_cell("VLOOKUP(2,Data!$S:$V,4,FALSE)"));
+        let graph = DepGraph::build(&wb);
+        for cell in ["S1", "T999999", "V1048576"] {
+            assert_eq!(deps_a1(&graph, "Data", cell, &wb), vec!["Sheet1!A1"]);
+        }
+        assert!(deps_a1(&graph, "Data", "W1", &wb).is_empty());
+        assert!(deps_a1(&graph, "Sheet1", "S1", &wb).is_empty());
+        assert_eq!(graph.by_sheet[&SheetId(1)].len(), 1);
+        assert_eq!(wb.sheets[1].iter_cells().count(), 0);
     }
 
     #[test]

--- a/crates/xlsx-calc/src/lexer.rs
+++ b/crates/xlsx-calc/src/lexer.rs
@@ -5,6 +5,9 @@ use std::fmt;
 
 use xlsx_model::{CellRange, CellRef, ErrorValue};
 
+use crate::ColumnRange;
+use crate::reference::column;
+
 pub const MAX_TOKENS: usize = 10_000;
 pub const MAX_FORMULA_BYTES: usize = 32_768;
 
@@ -71,6 +74,10 @@ pub enum TokKind {
     Range {
         sheet: Option<String>,
         range: CellRange,
+    },
+    ColumnRange {
+        sheet: Option<String>,
+        range: ColumnRange,
     },
     Plus,
     Minus,
@@ -332,6 +339,9 @@ impl Lexer<'_> {
             return Ok(TokKind::Ident(word));
         }
 
+        if self.input[self.pos..].trim_start().starts_with(':') && column(&word).is_ok() {
+            return self.finish_columns(None, &word, start);
+        }
         if self.peek() == Some(':') && CellRef::parse_a1(&word).is_ok() {
             return self.finish_range(None, &word, start);
         }
@@ -351,6 +361,9 @@ impl Lexer<'_> {
         let word = self.read_word();
         if word.is_empty() {
             return Err(ParseError::new(start, "expected reference or defined name"));
+        }
+        if self.input[self.pos..].trim_start().starts_with(':') && column(&word).is_ok() {
+            return self.finish_columns(sheet, &word, start);
         }
         if self.peek() == Some(':') && CellRef::parse_a1(&word).is_ok() {
             return self.finish_range(sheet, &word, start);
@@ -382,6 +395,21 @@ impl Lexer<'_> {
             sheet,
             range: CellRange::new(a, b),
         })
+    }
+
+    fn finish_columns(
+        &mut self,
+        sheet: Option<String>,
+        start_word: &str,
+        start: usize,
+    ) -> Result<TokKind, ParseError> {
+        self.skip_ws();
+        self.bump();
+        self.skip_ws();
+        let end_word = self.read_word();
+        let range = ColumnRange::parse_a1(&format!("{start_word}:{end_word}"))
+            .map_err(|error| ParseError::new(start, format!("invalid column range: {error}")))?;
+        Ok(TokKind::ColumnRange { sheet, range })
     }
 }
 

--- a/crates/xlsx-calc/src/lib.rs
+++ b/crates/xlsx-calc/src/lib.rs
@@ -20,9 +20,11 @@ pub mod graph;
 pub mod lexer;
 pub mod parser;
 pub mod printer;
+mod reference;
 
 pub use deps::references;
 pub use engine::{RecalcResult, rebuild_and_recalc_all, recalc_after};
 pub use eval::{EvalContext, evaluate};
 pub use lexer::{ParseError, TokKind, Token, lex};
 pub use parser::{BinaryOp, Expr, MAX_DEPTH, UnaryOp, parse_formula};
+pub use reference::ColumnRange;

--- a/crates/xlsx-calc/src/parser.rs
+++ b/crates/xlsx-calc/src/parser.rs
@@ -3,6 +3,7 @@
 
 use xlsx_model::{CellRange, CellRef, ErrorValue};
 
+use crate::ColumnRange;
 use crate::lexer::{ParseError, TokKind, Token, lex};
 
 /// maximum expression nesting depth before we bail with a `ParseError`.
@@ -25,6 +26,10 @@ pub enum Expr {
     Range {
         sheet: Option<String>,
         range: CellRange,
+    },
+    ColumnRange {
+        sheet: Option<String>,
+        range: ColumnRange,
     },
     Name {
         scope: Option<String>,
@@ -215,6 +220,9 @@ impl Parser<'_> {
             TokKind::ErrLit(e) => Ok(ParsedExpr::leaf(Expr::Error(e))),
             TokKind::Ref { sheet, cell } => Ok(ParsedExpr::leaf(Expr::Ref { sheet, cell })),
             TokKind::Range { sheet, range } => Ok(ParsedExpr::leaf(Expr::Range { sheet, range })),
+            TokKind::ColumnRange { sheet, range } => {
+                Ok(ParsedExpr::leaf(Expr::ColumnRange { sheet, range }))
+            }
             TokKind::LParen => {
                 let inner = self.expr_bp(0, depth + 1)?;
                 self.expect(&TokKind::RParen, "')'")?;

--- a/crates/xlsx-calc/src/printer.rs
+++ b/crates/xlsx-calc/src/printer.rs
@@ -82,6 +82,9 @@ impl Expr {
             Expr::Range { sheet, range } => {
                 format!("{}{}", sheet_prefix(sheet), range.to_a1())
             }
+            Expr::ColumnRange { sheet, range } => {
+                format!("{}{}", sheet_prefix(sheet), range.to_a1())
+            }
             Expr::Name { scope, name } => format!("{}{name}", sheet_prefix(scope)),
             Expr::Unary { op, expr } => {
                 // 6 > every binary bp: unary minus binds tighter than all binary ops

--- a/crates/xlsx-calc/src/reference.rs
+++ b/crates/xlsx-calc/src/reference.rs
@@ -1,0 +1,60 @@
+//! Whole-column formula references, distinct from finite cell rectangles.
+
+use xlsx_model::addr::{AddrError, MAX_ROWS, col_to_letters};
+use xlsx_model::{CellRange, CellRef};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnRange {
+    pub start: u32,
+    pub end: u32,
+    pub abs_start: bool,
+    pub abs_end: bool,
+}
+
+impl ColumnRange {
+    pub fn parse_a1(source: &str) -> Result<Self, AddrError> {
+        let (start, end) = source.split_once(':').ok_or(AddrError::Malformed)?;
+        let mut start = column(start)?;
+        let mut end = column(end)?;
+        if start.col > end.col {
+            std::mem::swap(&mut start, &mut end);
+        }
+        Ok(Self {
+            start: start.col,
+            end: end.col,
+            abs_start: start.abs_col,
+            abs_end: end.abs_col,
+        })
+    }
+
+    pub fn cell_range(&self) -> CellRange {
+        CellRange {
+            start: CellRef {
+                abs_col: self.abs_start,
+                ..CellRef::new(0, self.start)
+            },
+            end: CellRef {
+                abs_col: self.abs_end,
+                ..CellRef::new(MAX_ROWS - 1, self.end)
+            },
+        }
+    }
+
+    pub fn to_a1(&self) -> String {
+        format!(
+            "{}{}:{}{}",
+            if self.abs_start { "$" } else { "" },
+            col_to_letters(self.start),
+            if self.abs_end { "$" } else { "" },
+            col_to_letters(self.end),
+        )
+    }
+}
+
+pub(crate) fn column(source: &str) -> Result<CellRef, AddrError> {
+    let letters = source.strip_prefix('$').unwrap_or(source);
+    if letters.is_empty() || !letters.bytes().all(|byte| byte.is_ascii_alphabetic()) {
+        return Err(AddrError::Malformed);
+    }
+    CellRef::parse_a1(&format!("{}1", source.to_ascii_uppercase()))
+}

--- a/crates/xlsx-calc/tests/column_references.rs
+++ b/crates/xlsx-calc/tests/column_references.rs
@@ -1,0 +1,150 @@
+use std::cell::Cell as Counter;
+
+use xlsx_calc::{ColumnRange, EvalContext, Expr, evaluate, parse_formula, references};
+use xlsx_model::addr::{MAX_COLS, MAX_ROWS};
+use xlsx_model::{CellProvider, CellRef, CellValue, ErrorValue, SheetId};
+
+#[test]
+fn parses_and_prints_anchored_column_ranges() {
+    for (source, expected) in [
+        ("S:V", "S:V"),
+        ("$S:$V", "$S:$V"),
+        ("S:$V", "S:$V"),
+        ("$S:V", "$S:V"),
+        ("$V:S", "S:$V"),
+        ("a : $b", "A:$B"),
+        ("A:A", "A:A"),
+        ("A:XFD", "A:XFD"),
+        ("Sheet1!S:V", "Sheet1!S:V"),
+        ("'Other Sheet'!$S:$V", "'Other Sheet'!$S:$V"),
+        ("'O''Brien'!S:$V", "'O''Brien'!S:$V"),
+    ] {
+        let expression = parse_formula(source).unwrap();
+        assert!(matches!(expression, Expr::ColumnRange { .. }), "{source}");
+        assert_eq!(expression.to_formula(), expected);
+        assert_eq!(parse_formula(expected).unwrap(), expression);
+    }
+    assert!(matches!(parse_formula("S").unwrap(), Expr::Name { .. }));
+    assert!(matches!(parse_formula("V1").unwrap(), Expr::Ref { .. }));
+    assert!(matches!(parse_formula("1E3").unwrap(), Expr::Number(_)));
+    assert!(matches!(
+        parse_formula("LOG10(A1)").unwrap(),
+        Expr::FuncCall { .. }
+    ));
+}
+
+#[test]
+fn rejects_invalid_column_ranges() {
+    for source in [
+        "A:", ":B", "A:B1", "A1:B", "A:1", "$:B", "A$:B", "XFE:XFF", "A:B:C",
+    ] {
+        assert!(parse_formula(source).is_err(), "{source}");
+    }
+}
+
+#[test]
+fn full_height_dependencies_do_not_allocate_cells() {
+    let expression = parse_formula("VLOOKUP(A1,Data!$S:$V,4,FALSE)").unwrap();
+    let dependencies = references(&expression);
+    assert_eq!(dependencies.len(), 2);
+    assert_eq!(dependencies[1].0.as_deref(), Some("Data"));
+    assert_eq!(dependencies[1].1.to_a1(), "S1:V1048576");
+    let range = ColumnRange::parse_a1("A:XFD").unwrap().cell_range();
+    assert!(range.contains(CellRef::new(MAX_ROWS - 1, MAX_COLS - 1)));
+}
+
+struct CountedData {
+    visits: Counter<usize>,
+}
+
+impl CellProvider for CountedData {
+    fn value(&self, _sheet: SheetId, at: CellRef) -> CellValue {
+        self.visits.set(self.visits.get() + 1);
+        match (at.row, at.col) {
+            (1, 18) => CellValue::Number { value: 2.0 },
+            (1, 21) => CellValue::Text {
+                value: "two".into(),
+            },
+            (2, 18) => CellValue::Number { value: 3.0 },
+            (2, 21) => CellValue::Text {
+                value: "three".into(),
+            },
+            (row, 21) if row == MAX_ROWS - 1 => CellValue::Number { value: 42.0 },
+            _ => CellValue::Empty,
+        }
+    }
+
+    fn formula(&self, _sheet: SheetId, _at: CellRef) -> Option<&str> {
+        None
+    }
+
+    fn sheet_id(&self, name: &str) -> Option<SheetId> {
+        name.eq_ignore_ascii_case("Data").then_some(SheetId(0))
+    }
+}
+
+#[test]
+fn lookups_and_metadata_do_not_materialize_entire_columns() {
+    for (formula, expected, visits) in [
+        (
+            "VLOOKUP(2,S:XFD,4,FALSE)",
+            CellValue::Text {
+                value: "two".into(),
+            },
+            3,
+        ),
+        (
+            "VLOOKUP(2.5,S:V,4,TRUE)",
+            CellValue::Text {
+                value: "two".into(),
+            },
+            4,
+        ),
+        (
+            "ROWS(S:V)",
+            CellValue::Number {
+                value: MAX_ROWS as f64,
+            },
+            0,
+        ),
+        (
+            "COLUMNS(A:XFD)",
+            CellValue::Number {
+                value: MAX_COLS as f64,
+            },
+            0,
+        ),
+        ("INDEX(S:V,1048576,4)", CellValue::Number { value: 42.0 }, 1),
+        ("VLOOKUP(0,S:V,4,FALSE)", CellValue::Empty, 2),
+        (
+            "VLOOKUP(42,V:X,1,FALSE)",
+            CellValue::Number { value: 42.0 },
+            MAX_ROWS as usize + 1,
+        ),
+        (
+            "SUM(A:XFD)",
+            CellValue::Error {
+                value: ErrorValue::Num,
+            },
+            0,
+        ),
+        (
+            "XLOOKUP(2,Data!S:S,Data!V:V)",
+            CellValue::Text {
+                value: "two".into(),
+            },
+            3,
+        ),
+    ] {
+        let data = CountedData {
+            visits: Counter::new(0),
+        };
+        let context = EvalContext::new(&data, SheetId(0));
+        assert_eq!(
+            evaluate(&parse_formula(formula).unwrap(), &context),
+            expected,
+            "{formula}"
+        );
+        assert_eq!(data.visits.get(), visits, "{formula}");
+    }
+}

--- a/crates/xlsx-calc/tests/fixtures/whole-column-vlookup.xml
+++ b/crates/xlsx-calc/tests/fixtures/whole-column-vlookup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="str"><f>VLOOKUP(2,S:V,4,FALSE)</f><v>two</v></c></row>
+    <row r="2">
+      <c r="S2"><v>2</v></c>
+      <c r="V2" t="inlineStr"><is><t>two</t></is></c>
+    </row>
+    <row r="3">
+      <c r="S3"><v>3</v></c>
+      <c r="V3" t="inlineStr"><is><t>three</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>

--- a/crates/xlsx-calc/tests/functions.rs
+++ b/crates/xlsx-calc/tests/functions.rs
@@ -63,6 +63,28 @@ fn eval(src: &str) -> CellValue {
     evaluate(&expr, &ctx)
 }
 
+#[test]
+fn vlookup_accepts_whole_columns() {
+    for columns in [
+        "E:F",
+        "$E:$F",
+        "E:$F",
+        "$E:F",
+        "Sheet1!E:F",
+        "'Sheet1'!$E:$F",
+    ] {
+        assert_eq!(eval(&format!("VLOOKUP(2,{columns},2,FALSE)")), t("two"));
+    }
+    check(&[
+        ("VLOOKUP(2.5,E:F,2)", t("two")),
+        ("VLOOKUP(9,E:F,2,FALSE)", e(ErrorValue::NA)),
+        ("VLOOKUP(2,E:F,3,FALSE)", e(ErrorValue::Ref)),
+        ("VLOOKUP(2,E:F,0,FALSE)", e(ErrorValue::Value)),
+        ("SUM(E:E)", n(10.0)),
+        ("MATCH(2,E:E,0)", n(2.0)),
+    ]);
+}
+
 /// like `eval` but with an injected clock (2020-01-01 12:00) for TODAY/NOW.
 fn eval_now(src: &str) -> CellValue {
     let wb = fixture();

--- a/crates/xlsx-ops/src/remap.rs
+++ b/crates/xlsx-ops/src/remap.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 
 use xlsx_calc::lexer::MAX_FORMULA_BYTES;
-use xlsx_calc::parse_formula;
 use xlsx_calc::parser::Expr;
+use xlsx_calc::{ColumnRange, parse_formula};
 use xlsx_model::addr::{MAX_COLS, MAX_ROWS, col_to_letters};
 use xlsx_model::{
     AnchorCell, AnchorEditAs, CellRange, CellRef, ChartAnchor, DefinedName, ErrorValue, SheetId,
@@ -753,7 +753,11 @@ fn rewrite_defined_name(
             }
             continue;
         }
-        let Ok(expr) = parse_formula(component) else {
+        // Whole-column names still need the token rewriter's ambiguity checks.
+        let Some(expr) = parse_formula(component)
+            .ok()
+            .filter(|expr| !contains_column_range(expr))
+        else {
             match rewrite_reference_tokens(component, op, matches_target, global, names) {
                 DefinedNameRewrite::Unchanged => {
                     rewritten.push(component.to_owned());
@@ -1254,12 +1258,24 @@ fn endpoints_share_a_sheet(first: &Endpoint<'_>, second: &Endpoint<'_>) -> bool 
 
 fn contains_unqualified_reference(expr: &Expr) -> bool {
     match expr {
-        Expr::Ref { sheet: None, .. } | Expr::Range { sheet: None, .. } => true,
+        Expr::Ref { sheet: None, .. }
+        | Expr::Range { sheet: None, .. }
+        | Expr::ColumnRange { sheet: None, .. } => true,
         Expr::Unary { expr, .. } | Expr::Percent(expr) => contains_unqualified_reference(expr),
         Expr::Binary { lhs, rhs, .. } => {
             contains_unqualified_reference(lhs) || contains_unqualified_reference(rhs)
         }
         Expr::FuncCall { args, .. } => args.iter().any(contains_unqualified_reference),
+        _ => false,
+    }
+}
+
+fn contains_column_range(expr: &Expr) -> bool {
+    match expr {
+        Expr::ColumnRange { .. } => true,
+        Expr::Unary { expr, .. } | Expr::Percent(expr) => contains_column_range(expr),
+        Expr::Binary { lhs, rhs, .. } => contains_column_range(lhs) || contains_column_range(rhs),
+        Expr::FuncCall { args, .. } => args.iter().any(contains_column_range),
         _ => false,
     }
 }
@@ -1350,8 +1366,7 @@ fn split_union(source: &str) -> Option<Vec<&str>> {
     Some(components)
 }
 
-/// A whole-row (`Sheet!$1:$5`) or whole-column (`Sheet!$A:$C`) reference. Print
-/// titles are written this way and the formula lexer has no token for it.
+/// A whole-row or whole-column reference, including print titles.
 struct AxisRange<'a> {
     qualifier: &'a str,
     sheet: Option<String>,
@@ -2004,6 +2019,22 @@ fn transform(
                 Expr::Error(ErrorValue::Ref)
             }
         },
+        Expr::ColumnRange { sheet, range } if matches_target(sheet) => {
+            match remap_columns(*range, op) {
+                Remapped::Unchanged => expr.clone(),
+                Remapped::Moved(range) => {
+                    *changed = true;
+                    Expr::ColumnRange {
+                        sheet: sheet.clone(),
+                        range,
+                    }
+                }
+                Remapped::Deleted => {
+                    *changed = true;
+                    Expr::Error(ErrorValue::Ref)
+                }
+            }
+        }
         Expr::Unary { op: u, expr: e } => Expr::Unary {
             op: *u,
             expr: Box::new(transform(e, op, matches_target, changed)),
@@ -2022,6 +2053,27 @@ fn transform(
                 .collect(),
         },
         _ => expr.clone(),
+    }
+}
+
+fn remap_columns(range: ColumnRange, op: &Op) -> Remapped<ColumnRange> {
+    let axis = AxisRange {
+        qualifier: "",
+        sheet: None,
+        axis: Axis::Col,
+        start: range.start,
+        end: range.end,
+        start_absolute: range.abs_start,
+        end_absolute: range.abs_end,
+    };
+    match axis.shifted(op) {
+        Remapped::Unchanged => Remapped::Unchanged,
+        Remapped::Moved((start, end)) => Remapped::Moved(ColumnRange {
+            start,
+            end,
+            ..range
+        }),
+        Remapped::Deleted => Remapped::Deleted,
     }
 }
 
@@ -2163,6 +2215,84 @@ mod tests {
 
     fn formula(wb: &Workbook, sheet: SheetId, at: &str) -> Option<String> {
         wb.formula(sheet, r(at)).map(str::to_string)
+    }
+
+    #[test]
+    fn whole_column_formulas_survive_row_edits_and_follow_column_edits() {
+        for (op, expected) in [
+            (
+                Op::InsertRows {
+                    sheet: SheetId(0),
+                    at: 0,
+                    count: 1,
+                },
+                "$S:V",
+            ),
+            (
+                Op::DeleteRows {
+                    sheet: SheetId(0),
+                    at: 0,
+                    count: 100,
+                },
+                "$S:V",
+            ),
+            (
+                Op::InsertCols {
+                    sheet: SheetId(0),
+                    at: 0,
+                    count: 1,
+                },
+                "$T:W",
+            ),
+            (
+                Op::InsertCols {
+                    sheet: SheetId(0),
+                    at: 19,
+                    count: 1,
+                },
+                "$S:W",
+            ),
+            (
+                Op::DeleteCols {
+                    sheet: SheetId(0),
+                    at: 19,
+                    count: 1,
+                },
+                "$S:U",
+            ),
+            (
+                Op::DeleteCols {
+                    sheet: SheetId(0),
+                    at: 18,
+                    count: 4,
+                },
+                "#REF!",
+            ),
+        ] {
+            let mut workbook = wb(&["Data", "Other"]);
+            set_formula(&mut workbook, SheetId(0), "A1", "VLOOKUP(2,$S:V,4,FALSE)");
+            set_formula(&mut workbook, SheetId(1), "A1", "VLOOKUP(2,$S:V,4,FALSE)");
+            set_formula(
+                &mut workbook,
+                SheetId(1),
+                "A2",
+                "VLOOKUP(2,Data!$S:V,4,FALSE)",
+            );
+            remap_formulas(&mut workbook, &op).unwrap();
+            assert_eq!(
+                formula(&workbook, SheetId(0), "A1").unwrap(),
+                format!("VLOOKUP(2,{expected},4,FALSE)")
+            );
+            assert_eq!(
+                formula(&workbook, SheetId(1), "A1").unwrap(),
+                "VLOOKUP(2,$S:V,4,FALSE)"
+            );
+            let qualifier = if expected == "#REF!" { "" } else { "Data!" };
+            assert_eq!(
+                formula(&workbook, SheetId(1), "A2").unwrap(),
+                format!("VLOOKUP(2,{qualifier}{expected},4,FALSE)")
+            );
+        }
     }
 
     fn charted(wb: &mut Workbook, sheet: SheetId, formulas: &[&str]) {


### PR DESCRIPTION
TL;DR:

Repro file:
[Whole-column VLOOKUP worksheet](https://github.com/openooxml/betteroffice/blob/bd125ab72b1dea845c501c4bb2973a7ef587c550/crates/xlsx-calc/tests/fixtures/whole-column-vlookup.xml), wrapped into an XLSX by the Python regression.

Summary:

- Support whole-column formula references, including `VLOOKUP(...,S:V,...)`, anchored and sheet-qualified forms.
- Track changes across all rows, preserve column references through row/column edits, and retain calculation limits and named-range safety checks.

Closes #323.

Test plan:

- [x] Reproduce stale VLOOKUP results before the fix; verify input edits, new formulas, and save/reopen afterward.
- [x] Run all-feature Rust tests for xlsx-calc, xlsx-ops, xlsx-parse, and betteroffice-xlsx: 546 passed, one existing test ignored.
- [x] Rebuild the native Python binding and run its XLSX suite: 74 passed.
- [x] Pass Clippy with warnings denied, formatting, and wasm32 checks with default/minimal XLSX features.
