### PR TITLE
opc: make the wasm feature opt-in rather than default

### DIFF
--- a/.changeset/opc-wasm-opt-in.md
+++ b/.changeset/opc-wasm-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/rust-crates": minor
+---
+
+The `betteroffice-opc` `wasm` feature is opt-in instead of default, so native dependants no longer pull wasm-bindgen and js-sys; wasm consumers enable it explicitly.

--- a/apps/native-viewer/Cargo.lock
+++ b/apps/native-viewer/Cargo.lock
@@ -276,9 +276,7 @@ dependencies = [
 name = "betteroffice-opc"
 version = "0.1.0"
 dependencies = [
- "js-sys",
  "quick-xml",
- "wasm-bindgen",
  "zip",
 ]
 

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -166,9 +166,7 @@ dependencies = [
 name = "betteroffice-opc"
 version = "0.1.0"
 dependencies = [
- "js-sys",
  "quick-xml",
- "wasm-bindgen",
  "zip",
 ]
 
@@ -549,30 +547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
-
-[[package]]
-name = "futures-util"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,7 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
- "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1032,12 +1005,6 @@ dependencies = [
  "bytemuck",
  "read-fonts",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallstr"

--- a/crates/ooxml-opc/Cargo.toml
+++ b/crates/ooxml-opc/Cargo.toml
@@ -16,7 +16,7 @@ name = "ooxml_opc"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["wasm"]
+default = []
 wasm = ["dep:wasm-bindgen", "dep:js-sys"]
 
 [dependencies]


### PR DESCRIPTION
Fixes #340.

`betteroffice-opc` declares `default = ["wasm"]`, so `wasm-bindgen` and `js-sys` enter **every native build** of any crate that depends on it — all eleven format crates. Downstream cannot remove them, because cargo features are additive: `default-features = false` on one dependant is overridden by another that leaves defaults on.

```diff
 [features]
-default = ["wasm"]
+default = []
 wasm = ["dep:wasm-bindgen", "dep:js-sys"]
```

The feature gates only the JS wrappers (`unzip_docx`, `rezip_docx` → `JsValue`). Every native entry point — including `unzip_parts` and `rezip_parts` — is outside the gate, so nothing native changes.

### Verified in this tree

| check | result |
|---|---|
| native consumer of `betteroffice-pptx-parse` | `js-sys` + `wasm-bindgen` nodes **7 → 0** |
| `xlsx-wasm` still builds | ✅ — it uses `ooxml_opc::rezip_parts`, which is native, not the gated API |
| `betteroffice-opc` builds | ✅ |

### Note on the breaking-change surface

Any crate that *does* want the JS wrappers now needs `ooxml-opc/wasm` explicitly. Within this repo nothing did — `xlsx-wasm` was the only candidate and it calls the native path. For external consumers on 0.1.x this is a one-line addition, and it is the usual shape for a library whose bindings target one platform among several.

Happy to adjust if you'd rather keep the default and add a `native` feature instead, though that inverts the usual convention.
