### PR TITLE
build(wasm): regenerate declarations after the opc feature flip

### DIFF
--- a/packages/docx/src/wasm/generated/edit/docx_edit.d.ts
+++ b/packages/docx/src/wasm/generated/edit/docx_edit.d.ts
@@ -996,13 +996,6 @@ export function range_rects_region_json(display_list: string, region: string, pa
 export function register_measure_font(bytes: Uint8Array): number;
 
 /**
- * Rezip from a JS object `{ [path]: Uint8Array }` into a DOCX byte array.
- */
-export function rezip_docx(entries: any): Uint8Array;
-
-export function sanitizeOoxml(data: Uint8Array, expected_format: string): Uint8Array;
-
-/**
  * Serializes an S10 request.
  */
 export function serialize_docx_s10(request_json: string): string;
@@ -1016,11 +1009,6 @@ export function serialize_docx_s11(request_json: string): string;
  * Serializes an S12 request.
  */
 export function serialize_docx_s12(request_json: string): string;
-
-/**
- * Unzip a DOCX; returns a JS object `{ [path]: Uint8Array }`.
- */
-export function unzip_docx(data: Uint8Array): any;
 
 /**
  * wasm wrapper over [`session::update_display_list`]: apply a page-delta
@@ -1164,9 +1152,6 @@ export interface InitOutput {
     readonly serialize_docx_s11: (a: number, b: number) => [number, number, number, number];
     readonly serialize_docx_s12: (a: number, b: number) => [number, number, number, number];
     readonly write_docx_s13_wasm: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-    readonly rezip_docx: (a: any) => [number, number, number, number];
-    readonly sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-    readonly unzip_docx: (a: number, b: number) => [number, number, number];
     readonly build_display_list_json: (a: number, b: number) => [number, number, number, number];
     readonly hit_test_json: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
     readonly hit_test_regions_by_handle: (a: number, b: number, c: number, d: number) => [number, number, number, number];
@@ -1186,11 +1171,11 @@ export interface InitOutput {
     readonly install_panic_hook: () => void;
     readonly close_display_list: (a: number) => void;
     readonly clear_measure_fonts: () => void;
-    readonly __wbindgen_malloc: (a: number, b: number) => number;
-    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_exn_store: (a: number) => void;
     readonly __externref_table_alloc: () => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __externref_table_dealloc: (a: number) => void;
     readonly __wbindgen_free: (a: number, b: number, c: number) => void;
     readonly __externref_drop_slice: (a: number, b: number) => void;

--- a/packages/docx/src/wasm/generated/edit/docx_edit_bg.wasm.d.ts
+++ b/packages/docx/src/wasm/generated/edit/docx_edit_bg.wasm.d.ts
@@ -122,9 +122,6 @@ export const serialize_docx_s10: (a: number, b: number) => [number, number, numb
 export const serialize_docx_s11: (a: number, b: number) => [number, number, number, number];
 export const serialize_docx_s12: (a: number, b: number) => [number, number, number, number];
 export const write_docx_s13_wasm: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-export const rezip_docx: (a: any) => [number, number, number, number];
-export const sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-export const unzip_docx: (a: number, b: number) => [number, number, number];
 export const build_display_list_json: (a: number, b: number) => [number, number, number, number];
 export const hit_test_json: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
 export const hit_test_regions_by_handle: (a: number, b: number, c: number, d: number) => [number, number, number, number];
@@ -144,11 +141,11 @@ export const vertical_move_json: (a: number, b: number, c: number, d: number, e:
 export const install_panic_hook: () => void;
 export const close_display_list: (a: number) => void;
 export const clear_measure_fonts: () => void;
-export const __wbindgen_malloc: (a: number, b: number) => number;
-export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_exn_store: (a: number) => void;
 export const __externref_table_alloc: () => number;
 export const __wbindgen_externrefs: WebAssembly.Table;
+export const __wbindgen_malloc: (a: number, b: number) => number;
+export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __externref_table_dealloc: (a: number) => void;
 export const __wbindgen_free: (a: number, b: number, c: number) => void;
 export const __externref_drop_slice: (a: number, b: number) => void;

--- a/packages/docx/src/wasm/generated/parse/docx_parse.d.ts
+++ b/packages/docx/src/wasm/generated/parse/docx_parse.d.ts
@@ -52,13 +52,6 @@ export function parse_docx_s9(data: Uint8Array, options_json: string): string;
 export function parse_relationships_xml(xml: Uint8Array, part_path: string): string;
 
 /**
- * Rezip from a JS object `{ [path]: Uint8Array }` into a DOCX byte array.
- */
-export function rezip_docx(entries: any): Uint8Array;
-
-export function sanitizeOoxml(data: Uint8Array, expected_format: string): Uint8Array;
-
-/**
  * Serializes an S10 request.
  */
 export function serialize_docx_s10(request_json: string): string;
@@ -72,11 +65,6 @@ export function serialize_docx_s11(request_json: string): string;
  * Serializes an S12 request.
  */
 export function serialize_docx_s12(request_json: string): string;
-
-/**
- * Unzip a DOCX; returns a JS object `{ [path]: Uint8Array }`.
- */
-export function unzip_docx(data: Uint8Array): any;
 
 /**
  * Writes a DOCX from a typed model and original package.
@@ -101,16 +89,11 @@ export interface InitOutput {
     readonly serialize_docx_s11: (a: number, b: number) => [number, number, number, number];
     readonly serialize_docx_s12: (a: number, b: number) => [number, number, number, number];
     readonly write_docx_s13_wasm: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-    readonly rezip_docx: (a: any) => [number, number, number, number];
-    readonly sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-    readonly unzip_docx: (a: number, b: number) => [number, number, number];
-    readonly __wbindgen_malloc: (a: number, b: number) => number;
-    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
-    readonly __wbindgen_exn_store: (a: number) => void;
-    readonly __externref_table_alloc: () => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
     readonly __externref_table_dealloc: (a: number) => void;
     readonly __wbindgen_free: (a: number, b: number, c: number) => void;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_start: () => void;
 }
 

--- a/packages/docx/src/wasm/generated/parse/docx_parse_bg.wasm.d.ts
+++ b/packages/docx/src/wasm/generated/parse/docx_parse_bg.wasm.d.ts
@@ -15,14 +15,9 @@ export const serialize_docx_s10: (a: number, b: number) => [number, number, numb
 export const serialize_docx_s11: (a: number, b: number) => [number, number, number, number];
 export const serialize_docx_s12: (a: number, b: number) => [number, number, number, number];
 export const write_docx_s13_wasm: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-export const rezip_docx: (a: any) => [number, number, number, number];
-export const sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-export const unzip_docx: (a: number, b: number) => [number, number, number];
-export const __wbindgen_malloc: (a: number, b: number) => number;
-export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
-export const __wbindgen_exn_store: (a: number) => void;
-export const __externref_table_alloc: () => number;
 export const __wbindgen_externrefs: WebAssembly.Table;
+export const __wbindgen_malloc: (a: number, b: number) => number;
 export const __externref_table_dealloc: (a: number) => void;
 export const __wbindgen_free: (a: number, b: number, c: number) => void;
+export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_start: () => void;

--- a/packages/pptx/src/wasm/generated/pptx_wasm.d.ts
+++ b/packages/pptx/src/wasm/generated/pptx_wasm.d.ts
@@ -73,18 +73,6 @@ export function parsePptxJson(data: Uint8Array): string;
 
 export function rendererVersion(): string;
 
-/**
- * Rezip from a JS object `{ [path]: Uint8Array }` into a DOCX byte array.
- */
-export function rezip_docx(entries: any): Uint8Array;
-
-export function sanitizeOoxml(data: Uint8Array, expected_format: string): Uint8Array;
-
-/**
- * Unzip a DOCX; returns a JS object `{ [path]: Uint8Array }`.
- */
-export function unzip_docx(data: Uint8Array): any;
-
 export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 export interface InitOutput {
@@ -140,14 +128,11 @@ export interface InitOutput {
     readonly pptxdocument_storyJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly pptxdocument_undoJson: (a: number) => [number, number, number, number];
     readonly pptxdocument_version: () => [number, number];
-    readonly rezip_docx: (a: any) => [number, number, number, number];
-    readonly sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-    readonly unzip_docx: (a: number, b: number) => [number, number, number];
-    readonly __wbindgen_malloc: (a: number, b: number) => number;
-    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_exn_store: (a: number) => void;
     readonly __externref_table_alloc: () => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __externref_table_dealloc: (a: number) => void;
     readonly __wbindgen_free: (a: number, b: number, c: number) => void;
     readonly __wbindgen_start: () => void;

--- a/packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm.d.ts
+++ b/packages/pptx/src/wasm/generated/pptx_wasm_bg.wasm.d.ts
@@ -52,14 +52,11 @@ export const pptxdocument_startUpdateObservation: (a: number) => [number, number
 export const pptxdocument_storyJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const pptxdocument_undoJson: (a: number) => [number, number, number, number];
 export const pptxdocument_version: () => [number, number];
-export const rezip_docx: (a: any) => [number, number, number, number];
-export const sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-export const unzip_docx: (a: number, b: number) => [number, number, number];
-export const __wbindgen_malloc: (a: number, b: number) => number;
-export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_exn_store: (a: number) => void;
 export const __externref_table_alloc: () => number;
 export const __wbindgen_externrefs: WebAssembly.Table;
+export const __wbindgen_malloc: (a: number, b: number) => number;
+export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __externref_table_dealloc: (a: number) => void;
 export const __wbindgen_free: (a: number, b: number, c: number) => void;
 export const __wbindgen_start: () => void;

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm.d.ts
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm.d.ts
@@ -125,18 +125,6 @@ export class XlsxDocument {
     readonly clientId: number;
 }
 
-/**
- * Rezip from a JS object `{ [path]: Uint8Array }` into a DOCX byte array.
- */
-export function rezip_docx(entries: any): Uint8Array;
-
-export function sanitizeOoxml(data: Uint8Array, expected_format: string): Uint8Array;
-
-/**
- * Unzip a DOCX; returns a JS object `{ [path]: Uint8Array }`.
- */
-export function unzip_docx(data: Uint8Array): any;
-
 export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 export interface InitOutput {
@@ -181,14 +169,11 @@ export interface InitOutput {
     readonly xlsxdocument_startUpdateObservation: (a: number) => [number, number];
     readonly xlsxdocument_undoJson: (a: number) => [number, number, number, number];
     readonly xlsxdocument_version: () => [number, number];
-    readonly rezip_docx: (a: any) => [number, number, number, number];
-    readonly sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-    readonly unzip_docx: (a: number, b: number) => [number, number, number];
-    readonly __wbindgen_malloc: (a: number, b: number) => number;
-    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_exn_store: (a: number) => void;
     readonly __externref_table_alloc: () => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __externref_table_dealloc: (a: number) => void;
     readonly __wbindgen_free: (a: number, b: number, c: number) => void;
     readonly __wbindgen_start: () => void;

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm_bg.wasm.d.ts
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm_bg.wasm.d.ts
@@ -41,14 +41,11 @@ export const xlsxdocument_sheetInfoJson: (a: number) => [number, number, number,
 export const xlsxdocument_startUpdateObservation: (a: number) => [number, number];
 export const xlsxdocument_undoJson: (a: number) => [number, number, number, number];
 export const xlsxdocument_version: () => [number, number];
-export const rezip_docx: (a: any) => [number, number, number, number];
-export const sanitizeOoxml: (a: number, b: number, c: number, d: number) => [number, number, number, number];
-export const unzip_docx: (a: number, b: number) => [number, number, number];
-export const __wbindgen_malloc: (a: number, b: number) => number;
-export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_exn_store: (a: number) => void;
 export const __externref_table_alloc: () => number;
 export const __wbindgen_externrefs: WebAssembly.Table;
+export const __wbindgen_malloc: (a: number, b: number) => number;
+export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
 export const __externref_table_dealloc: (a: number) => void;
 export const __wbindgen_free: (a: number, b: number, c: number) => void;
 export const __wbindgen_start: () => void;


### PR DESCRIPTION
TL;DR:


Summary:
- Regenerate the committed wasm declaration files for the docx, pptx and xlsx modules after #341 made the opc crate's `wasm` feature opt-in.
- The modules no longer re-export opc's JavaScript glue (`unzip_docx`, `rezip_docx`, `sanitizeOoxml`); the docx package's opc module, which is built with the feature on, keeps exporting them.
- No source change; this restores the green "Check generated Wasm declarations" step on main.

Test plan:
- [x] `bun run build:docx-wasm && bun run build:xlsx-wasm && bun run build:pptx-wasm` from a clean cache, then `git diff --exit-code -- 'packages/*/src/wasm/generated/*'` clean
- [x] `bun run typecheck:packages`
- [x] `bun test` for packages/docx, packages/pptx and packages/xlsx
