### PR TITLE
feat(xlsx): improve Excel range print fidelity

### DIFF
--- a/.changeset/friendly-workbook-print.md
+++ b/.changeset/friendly-workbook-print.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/xlsx": minor
+---
+
+Add font-aware range printing with device-specific grid geometry and optional print gridlines. Paint cell and preview fonts at their declared point size, with consistent text alignment across canvas and raster rendering.

--- a/crates/betteroffice-xlsx/src/lib.rs
+++ b/crates/betteroffice-xlsx/src/lib.rs
@@ -30,7 +30,7 @@ pub use xlsx_ops::{
 };
 pub use xlsx_render::{
     Align, ChartA11yAttrs, ChartRegion, DisplayList, DrawCmd, GridGeometry, GridMeta,
-    HyperlinkRegion, PathStroke, Rect, RenderError, Viewport, viewport_for_range,
+    HyperlinkRegion, PathStroke, PrintMetrics, Rect, RenderError, Viewport, viewport_for_range,
     viewport_for_used_range, viewport_for_used_range_within,
 };
 

--- a/crates/betteroffice-xlsx/src/workbook.rs
+++ b/crates/betteroffice-xlsx/src/workbook.rs
@@ -17,9 +17,9 @@ use xlsx_ops::{
     cell_state_for_input_no_eval, insertion_keeps_chart_anchor_on_grid,
 };
 use xlsx_render::{
-    ChartRegion, DisplayList, GhostEdit, GridGeometry, RenderError, Viewport,
-    build_display_list_with_charts_and_ghosts, chart_at_point, chart_regions, display_text,
-    moved_chart_anchor, resolve_chart_anchor,
+    ChartRegion, DisplayList, GhostEdit, GridGeometry, PrintMetrics, RenderError, Viewport,
+    build_display_list_with_charts_and_ghosts, build_print_display_list_with_charts,
+    chart_at_point, chart_regions, display_text, moved_chart_anchor, resolve_chart_anchor,
 };
 #[cfg(feature = "raster")]
 use xlsx_render::{
@@ -1424,6 +1424,61 @@ impl Workbook {
 
     pub fn reject_proposal(&mut self, id: &str) -> bool {
         self.proposals.remove(id)
+    }
+
+    /// Prints one range without changing workbook data or viewport state.
+    pub fn print_display_list(
+        &self,
+        sheet: SheetId,
+        range: CellRange,
+        metrics: &PrintMetrics,
+        gridlines: bool,
+    ) -> Result<DisplayList> {
+        validate_cell_ref(range.start)?;
+        validate_cell_ref(range.end)?;
+        if range.start.row > range.end.row || range.start.col > range.end.col || !metrics.is_valid()
+        {
+            return Err(Error::InvalidViewport);
+        }
+        let cells = (u64::from(range.end.row - range.start.row) + 2)
+            * (u64::from(range.end.col - range.start.col) + 2);
+        if cells > MAX_DISPLAY_CELLS {
+            return Err(Error::DisplayTooLarge {
+                cells,
+                max: MAX_DISPLAY_CELLS,
+            });
+        }
+        let sheet_ref = self.sheet(sheet)?;
+        let geometry = GridGeometry::for_print(sheet_ref, metrics);
+        let viewport = Viewport {
+            x: geometry.col_x(range.start.col),
+            y: geometry.row_y(range.start.row),
+            width: geometry.col_x(range.end.col + 1) - geometry.col_x(range.start.col),
+            height: geometry.row_y(range.end.row + 1) - geometry.row_y(range.start.row),
+        };
+        validate_viewport(&viewport)?;
+        let mut frame = build_print_display_list_with_charts(
+            &self.model,
+            sheet,
+            &viewport,
+            metrics,
+            gridlines,
+            |chart| {
+                resolve_chart_space(
+                    self.source_package.as_ref(),
+                    &self.model.styles.theme,
+                    &self.model,
+                    &sheet_ref.name,
+                    chart,
+                )
+            },
+        )
+        .map_err(Error::from)?;
+        if gridlines {
+            frame.width += 96.0 / metrics.dpi;
+            frame.height += 96.0 / metrics.dpi;
+        }
+        Ok(frame)
     }
 
     pub fn display_list(&self, viewport: &Viewport) -> Result<DisplayList> {

--- a/crates/betteroffice-xlsx/tests/print_render.rs
+++ b/crates/betteroffice-xlsx/tests/print_render.rs
@@ -1,7 +1,8 @@
 use betteroffice_xlsx::{
-    Cell, CellRange, CellRef, CellValue, DrawCmd, Error, FreezePane, GridGeometry, PrintMetrics,
-    Sheet, SheetId, Viewport, Workbook, WorkbookModel,
+    Cell, CellRange, CellRef, CellValue, DrawCmd, Error, FreezePane, GridGeometry, Hyperlink,
+    PrintMetrics, Sheet, SheetId, Viewport, Workbook, WorkbookModel,
 };
+use xlsx_model::styles::{Border, BorderEdge, BorderStyle, Color, Fill, Stylesheet, Xf};
 
 fn metrics() -> PrintMetrics {
     PrintMetrics {
@@ -129,4 +130,155 @@ fn print_gridlines_are_optional_and_invalid_metrics_are_rejected() {
         ),
         Err(Error::DisplayTooLarge { .. })
     ));
+}
+
+#[test]
+fn partial_merged_print_ranges_clip_without_moving_the_anchor() {
+    let mut sheet = Sheet::new("Merged");
+    sheet.merges.push(CellRange::parse_a1("A1:C3").unwrap());
+    for col in 0..3 {
+        sheet.col_widths.insert(col, 12.0);
+    }
+    sheet.set_cell(
+        CellRef::new(0, 0),
+        Cell {
+            value: CellValue::Text {
+                value: "Merged content".into(),
+            },
+            style: Some(0),
+            ..Cell::default()
+        },
+    );
+    let edge = BorderEdge {
+        style: BorderStyle::Thin,
+        color: Some(Color::Rgb("#0000ff".into())),
+    };
+    let mut styles = Stylesheet::default();
+    styles.fills = vec![Fill::Solid(Color::Rgb("#ffd700".into()))];
+    styles.borders = vec![Border {
+        left: Some(edge.clone()),
+        right: Some(edge.clone()),
+        top: Some(edge.clone()),
+        bottom: Some(edge),
+    }];
+    styles.cell_xfs = vec![Xf {
+        fill: Some(0),
+        border: Some(0),
+        ..Xf::default()
+    }];
+    let workbook = Workbook::from_model(WorkbookModel {
+        sheets: vec![sheet],
+        styles,
+        ..WorkbookModel::default()
+    })
+    .unwrap();
+    let render = |range| {
+        workbook
+            .print_display_list(
+                SheetId(0),
+                CellRange::parse_a1(range).unwrap(),
+                &metrics(),
+                false,
+            )
+            .unwrap()
+    };
+    let full = render("A1:C3");
+    let partial = render("B2:C3");
+    let texts = |list: &betteroffice_xlsx::DisplayList| {
+        list.commands
+            .iter()
+            .filter_map(|cmd| {
+                if let DrawCmd::Text { x, y, clip, .. } = cmd {
+                    Some((*x, *y, *clip))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    };
+    let full_text = texts(&full);
+    let partial_text = texts(&partial);
+    assert_eq!(full_text.len(), 1);
+    assert_eq!(partial_text.len(), 1);
+    assert!((partial_text[0].0 - (full_text[0].0 - 96.0)).abs() < 0.001);
+    assert!((partial_text[0].1 - (full_text[0].1 - 56.0 / 3.0)).abs() < 0.001);
+    assert_eq!(partial_text[0].2.x, 0.0);
+    assert_eq!(partial_text[0].2.y, 0.0);
+    assert_eq!(partial_text[0].2.w, partial.width);
+    assert_eq!(partial_text[0].2.h, partial.height);
+    assert!(partial.commands.iter().any(|cmd| matches!(cmd,
+        DrawCmd::FillRect { x, y, w, h, color, .. }
+        if *x == 0.0 && *y == 0.0 && *w == partial.width && *h == partial.height && color == "#ffd700"
+    )));
+    assert_eq!(
+        partial
+            .commands
+            .iter()
+            .filter(|cmd| matches!(cmd,
+                DrawCmd::Line { color, .. } if color == "#0000ff"
+            ))
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn display_only_hyperlinks_use_the_same_print_font_and_position_as_cells() {
+    let mut sheet = Sheet::new("Links");
+    sheet.set_cell(CellRef::new(0, 0), Cell::default());
+    for col in 0..2 {
+        sheet.hyperlinks.push(Hyperlink {
+            range: CellRange::new(CellRef::new(0, col), CellRef::new(0, col)),
+            external_target: Some("https://example.com".into()),
+            location: None,
+            tooltip: None,
+            display: Some("Link".into()),
+        });
+    }
+    let workbook = Workbook::from_model(WorkbookModel {
+        sheets: vec![sheet],
+        ..WorkbookModel::default()
+    })
+    .unwrap();
+    let mut metrics = metrics();
+    metrics.font_family = "Example Font".into();
+    metrics.font_size_pt = 16.0;
+    metrics.default_row_height_pt = 24.0;
+    metrics.font_ascent = 15.0;
+    metrics.font_descent = 4.0;
+    let printed = workbook
+        .print_display_list(
+            SheetId(0),
+            CellRange::parse_a1("A1:B1").unwrap(),
+            &metrics,
+            false,
+        )
+        .unwrap();
+    let texts: Vec<_> = printed
+        .commands
+        .iter()
+        .filter_map(|cmd| {
+            if let DrawCmd::Text {
+                x,
+                y,
+                font_family,
+                font_size,
+                underline,
+                ..
+            } = cmd
+            {
+                assert_eq!(font_family.as_deref(), Some("Example Font"));
+                assert_eq!(*font_size, 16.0);
+                assert!(*underline);
+                Some((*x, *y))
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(texts.len(), 2);
+    assert_eq!(texts[0].1, texts[1].1);
+    assert!((texts[1].0 - texts[0].0 - printed.grid.col_offsets[1]).abs() < 0.001);
+    assert_eq!(texts[0].0, 4.0);
+    assert!((texts[0].1 - 80.0 / 3.0).abs() < 0.001);
 }

--- a/crates/betteroffice-xlsx/tests/print_render.rs
+++ b/crates/betteroffice-xlsx/tests/print_render.rs
@@ -1,0 +1,132 @@
+use betteroffice_xlsx::{
+    Cell, CellRange, CellRef, CellValue, DrawCmd, Error, FreezePane, GridGeometry, PrintMetrics,
+    Sheet, SheetId, Viewport, Workbook, WorkbookModel,
+};
+
+fn metrics() -> PrintMetrics {
+    PrintMetrics {
+        dpi: 72.0,
+        max_digit_width: 6.0,
+        default_row_height_pt: 14.0,
+        default_column_width: None,
+        font_size_pt: 11.0,
+        font_family: "Calibri".into(),
+        font_ascent: 10.0,
+        font_descent: 3.0,
+    }
+}
+
+fn workbook() -> Workbook {
+    let mut sheet = Sheet::new("Data");
+    sheet.col_widths.insert(0, 12.0);
+    sheet.col_widths.insert(1, 13.0);
+    sheet.row_heights.insert(1, 24.0);
+    sheet.freeze_pane = Some(FreezePane::new(1, 1, CellRef::new(1, 1)));
+    for row in 0..4 {
+        sheet.set_cell(
+            CellRef::new(row, 0),
+            Cell {
+                value: CellValue::Text {
+                    value: format!("Row {row}"),
+                },
+                ..Cell::default()
+            },
+        );
+    }
+    Workbook::from_model(WorkbookModel {
+        sheets: vec![sheet, Sheet::new("Other")],
+        ..WorkbookModel::default()
+    })
+    .unwrap()
+}
+
+#[test]
+fn printing_uses_font_device_metrics_without_changing_screen_or_source() {
+    let mut workbook = workbook();
+    workbook.set_active_sheet(SheetId(1)).unwrap();
+    let model = workbook.model().clone();
+    let saved = workbook.save().unwrap();
+    let screen_geometry = GridGeometry::new(&model.sheets[0]);
+    let viewport = Viewport {
+        x: 0.0,
+        y: 0.0,
+        width: 300.0,
+        height: 200.0,
+    };
+    let screen = workbook.display_list_for(SheetId(0), &viewport).unwrap();
+    let printed = workbook
+        .print_display_list(
+            SheetId(0),
+            CellRange::parse_a1("A2:B3").unwrap(),
+            &metrics(),
+            true,
+        )
+        .unwrap();
+    assert!((printed.width - 604.0 / 3.0).abs() < 0.001);
+    assert!((printed.height - 52.0).abs() < 0.001);
+    assert_eq!(printed.grid.start_row, 1);
+    assert_eq!(printed.grid.col_offsets[1], 96.0);
+    assert!(printed.commands.iter().any(|c| matches!(c, DrawCmd::Text { text, font_family, .. } if text == "Row 1" && font_family.as_deref() == Some("Calibri"))));
+    assert!(
+        !printed
+            .commands
+            .iter()
+            .any(|c| matches!(c, DrawCmd::Text { text, .. } if text == "Row 0" || text == "Row 3"))
+    );
+    assert!(printed.commands.iter().any(|c| matches!(c, DrawCmd::Line { color, width, .. } if color == "#000000" && (*width - 4.0 / 3.0).abs() < 0.001)));
+    assert_eq!(workbook.model(), &model);
+    assert_eq!(workbook.active_sheet(), SheetId(1));
+    assert_eq!(workbook.save().unwrap(), saved);
+    assert_eq!(
+        workbook.display_list_for(SheetId(0), &viewport).unwrap(),
+        screen
+    );
+    assert_eq!(
+        GridGeometry::new(&model.sheets[0]).col_x(1),
+        screen_geometry.col_x(1)
+    );
+}
+
+#[test]
+fn stored_column_width_includes_padding_and_device_rounding() {
+    let mut metrics = metrics();
+    metrics.dpi = 96.0;
+    metrics.max_digit_width = 7.0;
+    assert_eq!(metrics.column_pixels(8.7109375), 61.0);
+    assert_eq!(metrics.column_pixels(0.0), 0.0);
+    metrics.dpi = 72.0;
+    metrics.max_digit_width = 6.0;
+    assert_eq!(metrics.column_pixels(12.0), 96.0);
+}
+
+#[test]
+fn print_gridlines_are_optional_and_invalid_metrics_are_rejected() {
+    let workbook = workbook();
+    let range = CellRange::parse_a1("A1:B3").unwrap();
+    let printed = workbook
+        .print_display_list(SheetId(0), range, &metrics(), false)
+        .unwrap();
+    assert!(
+        !printed
+            .commands
+            .iter()
+            .any(|c| matches!(c, DrawCmd::Line { .. }))
+    );
+    for dpi in [0.0, -1.0, f32::NAN, f32::INFINITY, 601.0] {
+        let mut invalid = metrics();
+        invalid.dpi = dpi;
+        assert!(matches!(
+            workbook.print_display_list(SheetId(0), range, &invalid, true),
+            Err(Error::InvalidViewport)
+        ));
+    }
+    assert!(matches!(
+        workbook.print_display_list(
+            SheetId(0),
+            CellRange::parse_a1("A1:XFD1048576").unwrap(),
+            &metrics(),
+            true
+        ),
+        Err(Error::DisplayTooLarge { .. })
+    ));
+}

--- a/crates/xlsx-render/src/geometry.rs
+++ b/crates/xlsx-render/src/geometry.rs
@@ -38,6 +38,42 @@ pub fn emu_to_px(emu: i64) -> f64 {
     emu as f64 / EMU_PER_PT * PX_PER_PT
 }
 
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrintMetrics {
+    pub dpi: f32,
+    pub max_digit_width: f32,
+    pub default_row_height_pt: f32,
+    pub default_column_width: Option<f64>,
+    pub font_size_pt: f32,
+    pub font_family: String,
+    pub font_ascent: f32,
+    pub font_descent: f32,
+}
+
+impl PrintMetrics {
+    pub fn is_valid(&self) -> bool {
+        !self.font_family.is_empty()
+            && self.font_family.len() <= 1024
+            && (36.0..=600.0).contains(&self.dpi)
+            && (1.0..=256.0).contains(&self.max_digit_width)
+            && (1.0..=409.0).contains(&self.default_row_height_pt)
+            && self
+                .default_column_width
+                .is_none_or(|w| w.is_finite() && w > 0.0 && w <= 255.0)
+            && (1.0..=409.0).contains(&self.font_size_pt)
+            && (0.0..=4096.0).contains(&self.font_ascent)
+            && (0.0..=4096.0).contains(&self.font_descent)
+            && self.font_ascent + self.font_descent > 0.0
+    }
+
+    pub fn column_pixels(&self, width: f64) -> f32 {
+        let digit = self.max_digit_width as f64;
+        (((256.0 * width + (128.0 / digit).floor()) / 256.0 * digit).floor() * 96.0
+            / self.dpi as f64) as f32
+    }
+}
+
 /// cumulative left-edge x offsets for columns and top-edge y offsets for rows,
 /// both in pixels from the sheet origin.
 #[derive(Debug, Clone)]
@@ -54,9 +90,33 @@ pub struct GridGeometry {
 impl GridGeometry {
     /// build cumulative offset tables from a sheet's custom widths/heights.
     pub fn new(sheet: &Sheet) -> Self {
-        let default_col_px = col_chars_to_px(DEFAULT_COL_WIDTH_CHARS);
-        let default_row_px = row_pt_to_px(DEFAULT_ROW_HEIGHT_PT);
+        Self::with_sizes(
+            sheet,
+            col_chars_to_px(DEFAULT_COL_WIDTH_CHARS),
+            row_pt_to_px(DEFAULT_ROW_HEIGHT_PT),
+            col_chars_to_px,
+        )
+    }
 
+    pub fn for_print(sheet: &Sheet, metrics: &PrintMetrics) -> Self {
+        Self::with_sizes(
+            sheet,
+            metrics
+                .default_column_width
+                .map_or(col_chars_to_px(DEFAULT_COL_WIDTH_CHARS), |width| {
+                    metrics.column_pixels(width)
+                }),
+            row_pt_to_px(metrics.default_row_height_pt as f64),
+            |width| metrics.column_pixels(width),
+        )
+    }
+
+    fn with_sizes(
+        sheet: &Sheet,
+        default_col_px: f32,
+        default_row_px: f32,
+        column_pixels: impl Fn(f64) -> f32,
+    ) -> Self {
         let n_cols = sheet
             .col_widths
             .keys()
@@ -76,7 +136,7 @@ impl GridGeometry {
             let w = sheet
                 .col_widths
                 .get(&c)
-                .map(|&w| col_chars_to_px(w))
+                .map(|&w| column_pixels(w))
                 .unwrap_or(default_col_px);
             let start = col_x.last().copied().unwrap_or(0.0);
             col_x.push(start + w);

--- a/crates/xlsx-render/src/lib.rs
+++ b/crates/xlsx-render/src/lib.rs
@@ -29,7 +29,7 @@ pub use display_list::{
     Align, ChartA11yAttrs, ChartRegion, DisplayList, DrawCmd, GridMeta, HyperlinkRegion,
     PathStroke, Rect, scaled,
 };
-pub use geometry::GridGeometry;
+pub use geometry::{GridGeometry, PrintMetrics};
 pub use hit::chart_at_point;
 pub use region::{viewport_for_range, viewport_for_used_range, viewport_for_used_range_within};
 
@@ -283,7 +283,42 @@ pub fn build_display_list_with_charts_and_ghosts<F>(
     sheet: SheetId,
     viewport: &Viewport,
     ghosts: &[GhostEdit],
+    resolver: F,
+) -> Result<DisplayList, RenderError>
+where
+    F: FnMut(&SheetChart) -> Result<ChartSpace, RenderError>,
+{
+    build_frame(wb, sheet, viewport, ghosts, resolver, None)
+}
+
+pub fn build_print_display_list_with_charts<F>(
+    wb: &Workbook,
+    sheet: SheetId,
+    viewport: &Viewport,
+    metrics: &PrintMetrics,
+    gridlines: bool,
+    resolver: F,
+) -> Result<DisplayList, RenderError>
+where
+    F: FnMut(&SheetChart) -> Result<ChartSpace, RenderError>,
+{
+    build_frame(
+        wb,
+        sheet,
+        viewport,
+        &[],
+        resolver,
+        Some((metrics, gridlines)),
+    )
+}
+
+fn build_frame<F>(
+    wb: &Workbook,
+    sheet: SheetId,
+    viewport: &Viewport,
+    ghosts: &[GhostEdit],
     mut resolver: F,
+    print: Option<(&PrintMetrics, bool)>,
 ) -> Result<DisplayList, RenderError>
 where
     F: FnMut(&SheetChart) -> Result<ChartSpace, RenderError>,
@@ -313,10 +348,17 @@ where
     let styles = &wb.styles;
     let theme = &styles.theme;
     let hyperlink_color = theme.slot(10).unwrap_or(HYPERLINK_COLOR);
-    let geom = GridGeometry::new(sheet_ref);
-    let (frozen_rows, frozen_cols) = sheet_ref
-        .freeze_pane
-        .map_or((0, 0), |pane| (pane.rows, pane.cols));
+    let geom = print.map_or_else(
+        || GridGeometry::new(sheet_ref),
+        |(metrics, _)| GridGeometry::for_print(sheet_ref, metrics),
+    );
+    let (frozen_rows, frozen_cols) = if print.is_some() {
+        (0, 0)
+    } else {
+        sheet_ref
+            .freeze_pane
+            .map_or((0, 0), |pane| (pane.rows, pane.cols))
+    };
     let rows = AxisLayout::new(
         MAX_ROWS,
         frozen_rows,
@@ -359,12 +401,80 @@ where
             tooltip: link.tooltip.clone(),
         })
         .collect();
-    let anchors = visible_anchors(sheet_ref, &rows, &cols);
+    let mut anchors = visible_anchors(sheet_ref, &rows, &cols);
+    if print.is_some() {
+        anchors.retain(|(at, _)| {
+            geom.row_y(at.row) < viewport.y + viewport.height
+                && geom.col_x(at.col) < viewport.x + viewport.width
+        });
+    }
     let changed_ghost_cells: std::collections::HashSet<(u32, u32)> = ghosts
         .iter()
         .filter(|g| g.old_text != g.new_text)
         .map(|g| (g.row, g.col))
         .collect();
+
+    let mut grid_commands = Vec::new();
+    let grid_offset = print.map_or(0.0, |(m, _)| 48.0 / m.dpi);
+    let row_offsets = rows.offsets();
+    let col_offsets = cols.offsets();
+    let top = row_offsets.first().copied().unwrap_or(0.0);
+    let bottom = row_offsets.last().copied().unwrap_or(0.0);
+    let left = col_offsets.first().copied().unwrap_or(0.0);
+    let right = col_offsets.last().copied().unwrap_or(0.0);
+    for &x in &col_offsets {
+        grid_commands.push(DrawCmd::Line {
+            x1: x + grid_offset,
+            y1: top + grid_offset,
+            x2: x + grid_offset,
+            y2: bottom + grid_offset,
+            width: print.map_or(GRIDLINE_WIDTH, |(m, _)| 96.0 / m.dpi),
+            color: if print.is_some() {
+                TEXT_COLOR
+            } else {
+                GRIDLINE_COLOR
+            }
+            .to_string(),
+            style: None,
+            clip: None,
+        });
+    }
+    for &y in &row_offsets {
+        grid_commands.push(DrawCmd::Line {
+            x1: left + grid_offset,
+            y1: y + grid_offset,
+            x2: right + grid_offset,
+            y2: y + grid_offset,
+            width: print.map_or(GRIDLINE_WIDTH, |(m, _)| 96.0 / m.dpi),
+            color: if print.is_some() {
+                TEXT_COLOR
+            } else {
+                GRIDLINE_COLOR
+            }
+            .to_string(),
+            style: None,
+            clip: None,
+        });
+    }
+
+    if let Some((metrics, gridlines)) = print {
+        if gridlines {
+            commands.extend(grid_commands.iter().cloned());
+        }
+        for merge in &sheet_ref.merges {
+            if let Some(cell_box) = cell_box(&geom, &rows, &cols, sheet_ref, merge.start) {
+                let inset = 96.0 / metrics.dpi / 2.0;
+                commands.push(DrawCmd::FillRect {
+                    x: cell_box.x + inset,
+                    y: cell_box.y + inset,
+                    w: (cell_box.w - 2.0 * inset).max(0.0),
+                    h: (cell_box.h - 2.0 * inset).max(0.0),
+                    color: BACKGROUND_COLOR.to_string(),
+                    clip: Some(cell_box.clip),
+                });
+            }
+        }
+    }
 
     for &(at, cell) in &anchors {
         let Some(style) = cell.style else { continue };
@@ -388,35 +498,39 @@ where
         });
     }
 
-    let row_offsets = rows.offsets();
-    let col_offsets = cols.offsets();
-    let top = row_offsets.first().copied().unwrap_or(0.0);
-    let bottom = row_offsets.last().copied().unwrap_or(0.0);
-    let left = col_offsets.first().copied().unwrap_or(0.0);
-    let right = col_offsets.last().copied().unwrap_or(0.0);
-    for &x in &col_offsets {
-        commands.push(DrawCmd::Line {
-            x1: x,
-            y1: top,
-            x2: x,
-            y2: bottom,
-            width: GRIDLINE_WIDTH,
-            color: GRIDLINE_COLOR.to_string(),
-            style: None,
-            clip: None,
-        });
+    if print.is_none() {
+        commands.extend(grid_commands);
     }
-    for &y in &row_offsets {
-        commands.push(DrawCmd::Line {
-            x1: left,
-            y1: y,
-            x2: right,
-            y2: y,
-            width: GRIDLINE_WIDTH,
-            color: GRIDLINE_COLOR.to_string(),
-            style: None,
-            clip: None,
-        });
+    if let Some((metrics, true)) = print {
+        let width = 96.0 / metrics.dpi;
+        let offset = width / 2.0;
+        for (x1, y1, x2, y2) in [
+            (offset, offset, viewport.width + offset, offset),
+            (offset, offset, offset, viewport.height + offset),
+            (
+                offset,
+                viewport.height + offset,
+                viewport.width + offset,
+                viewport.height + offset,
+            ),
+            (
+                viewport.width + offset,
+                offset,
+                viewport.width + offset,
+                viewport.height + offset,
+            ),
+        ] {
+            commands.push(DrawCmd::Line {
+                x1,
+                y1,
+                x2,
+                y2,
+                width,
+                color: TEXT_COLOR.to_string(),
+                style: None,
+                clip: None,
+            });
+        }
     }
 
     for &(at, cell) in &anchors {
@@ -464,7 +578,7 @@ where
         let size = font
             .and_then(|f| f.size_pt)
             .map(|p| p as f32)
-            .unwrap_or(FONT_SIZE_PT);
+            .unwrap_or_else(|| print.map_or(FONT_SIZE_PT, |(m, _)| m.font_size_pt));
         let align = resolve_align(styles, cell);
         let valign = cell
             .style
@@ -472,11 +586,27 @@ where
             .and_then(|a| a.v);
 
         let tx = match align {
-            Align::Left => cell_box.x + TEXT_PAD_PX,
-            Align::Right => cell_box.x + cell_box.w - TEXT_PAD_PX,
+            Align::Left => cell_box.x + print.map_or(TEXT_PAD_PX, |(m, _)| 3.0 * 96.0 / m.dpi),
+            Align::Right => {
+                cell_box.x + cell_box.w - print.map_or(TEXT_PAD_PX, |(m, _)| 2.0 * 96.0 / m.dpi)
+            }
             Align::Center => cell_box.x + cell_box.w / 2.0,
         };
-        let ty = baseline_y(cell_box.y, cell_box.h, size, valign);
+        let ty = print.map_or_else(
+            || baseline_y(cell_box.y, cell_box.h, size, valign),
+            |(m, _)| {
+                let ratio = size / m.font_size_pt * 96.0 / m.dpi;
+                let ascent = m.font_ascent * ratio;
+                let descent = m.font_descent * ratio;
+                match valign {
+                    Some(VAlign::Top) => cell_box.y + ascent,
+                    Some(VAlign::Center | VAlign::Justify | VAlign::Distributed) => {
+                        cell_box.y + (cell_box.h + ascent - descent) / 2.0
+                    }
+                    Some(VAlign::Bottom) | None => cell_box.y + cell_box.h - descent,
+                }
+            },
+        );
 
         commands.push(DrawCmd::Text {
             x: tx,
@@ -492,7 +622,9 @@ where
             strike: font.is_some_and(|f| f.strike),
             highlight: None,
             dashed_underline: false,
-            font_family: font.and_then(|f| f.name.clone()),
+            font_family: font
+                .and_then(|f| f.name.clone())
+                .or_else(|| print.map(|(m, _)| m.font_family.clone())),
             ghost: false,
             chart: false,
         });
@@ -706,12 +838,12 @@ fn emit_ghost(
         return;
     }
 
-    let line_ratio = ASCENT_RATIO + DESCENT_RATIO;
+    let line_ratio = (ASCENT_RATIO + DESCENT_RATIO) * geometry::PX_PER_PT as f32;
     let scale = (ch / (2.0 * full_size * line_ratio)).clamp(GHOST_MIN_SCALE, 1.0);
     let size = full_size * scale;
     let line_h = size * line_ratio;
     let top = cy0 + ((ch - 2.0 * line_h) / 2.0).max(0.0);
-    let first_baseline = top + size * ASCENT_RATIO;
+    let first_baseline = top + size * geometry::PX_PER_PT as f32 * ASCENT_RATIO;
     line(
         x,
         first_baseline,
@@ -737,7 +869,7 @@ fn emit_ghost(
 /// estimated advance width of `text` at `size`, deliberately generous so fit
 /// decisions err toward ellipsizing rather than overlap.
 fn ghost_text_width(text: &str, size: f32) -> f32 {
-    text.chars().count() as f32 * size * GHOST_CHAR_W_RATIO
+    text.chars().count() as f32 * size * geometry::PX_PER_PT as f32 * GHOST_CHAR_W_RATIO
 }
 
 /// `text` unchanged when its estimate fits `budget`, else a truncated prefix
@@ -746,7 +878,7 @@ fn ellipsize(text: &str, budget: f32, size: f32) -> String {
     if ghost_text_width(text, size) <= budget {
         return text.to_string();
     }
-    let char_w = size * GHOST_CHAR_W_RATIO;
+    let char_w = size * geometry::PX_PER_PT as f32 * GHOST_CHAR_W_RATIO;
     let keep = ((budget / char_w) as i32 - 1).max(0) as usize;
     let prefix: String = text.chars().take(keep).collect();
     format!("{prefix}…")
@@ -888,13 +1020,15 @@ fn resolve_align_with_value(
     }
 }
 
-/// baseline y for a cell's text given its vertical alignment; unset (or center)
-/// keeps the centered baseline.
+/// Alphabetic baseline in pixels for a point-sized cell font.
 fn baseline_y(cy0: f32, ch: f32, size: f32, valign: Option<VAlign>) -> f32 {
+    let size_px = size * geometry::PX_PER_PT as f32;
     match valign {
-        Some(VAlign::Top) => cy0 + TEXT_PAD_PX + size * ASCENT_RATIO,
-        Some(VAlign::Bottom) => cy0 + ch - TEXT_PAD_PX - size * DESCENT_RATIO,
-        _ => cy0 + (ch + size * ASCENT_RATIO) / 2.0,
+        Some(VAlign::Top) => cy0 + TEXT_PAD_PX + size_px * ASCENT_RATIO,
+        Some(VAlign::Center | VAlign::Justify | VAlign::Distributed) => {
+            cy0 + (ch + size_px * (ASCENT_RATIO - DESCENT_RATIO)) / 2.0
+        }
+        Some(VAlign::Bottom) | None => cy0 + ch - TEXT_PAD_PX - size_px * DESCENT_RATIO,
     }
 }
 
@@ -1446,7 +1580,9 @@ mod tests {
             })
             .collect();
         assert!(lines[0].0 < lines[1].0);
-        assert_eq!((lines[0].1, lines[1].1), (FONT_SIZE_PT, FONT_SIZE_PT));
+        assert_eq!(lines[0].1, lines[1].1);
+        assert!(lines[0].1 < FONT_SIZE_PT);
+        assert!(lines[0].1 >= FONT_SIZE_PT * GHOST_MIN_SCALE);
     }
 
     #[test]

--- a/crates/xlsx-render/src/lib.rs
+++ b/crates/xlsx-render/src/lib.rs
@@ -100,6 +100,7 @@ struct AxisLayout {
     divider: Option<f32>,
     frozen: u32,
     scroll: f32,
+    print_extent: Option<f32>,
 }
 
 #[derive(Clone, Copy)]
@@ -174,6 +175,7 @@ impl AxisLayout {
             divider: (frozen > 0 && frozen_extent < extent).then_some(frozen_extent),
             frozen,
             scroll,
+            print_extent: None,
         }
     }
 
@@ -206,12 +208,27 @@ impl AxisLayout {
     }
 
     fn intersects(&self, start: u32, end: u32) -> bool {
-        self.tracks
+        self.ranges
             .iter()
-            .any(|track| (start..=end).contains(&track.index))
+            .any(|range| range.start <= end && range.end > start)
     }
 
     fn span(&self, start: u32, end: u32, edge: impl Fn(u32) -> f32) -> Option<AxisSpan> {
+        if let Some(extent) = self.print_extent {
+            if !self.intersects(start, end) {
+                return None;
+            }
+            let raw_start = edge(start) - self.scroll;
+            let raw_end = edge(end.saturating_add(1)) - self.scroll;
+            let start = raw_start.max(0.0);
+            let end = raw_end.min(extent);
+            return (end > start).then_some(AxisSpan {
+                raw_start,
+                raw_end,
+                start,
+                end,
+            });
+        }
         let first = self
             .tracks
             .binary_search_by_key(&start, |track| track.index)
@@ -359,7 +376,7 @@ where
             .freeze_pane
             .map_or((0, 0), |pane| (pane.rows, pane.cols))
     };
-    let rows = AxisLayout::new(
+    let mut rows = AxisLayout::new(
         MAX_ROWS,
         frozen_rows,
         viewport.y,
@@ -367,7 +384,7 @@ where
         |row| geom.row_y(row),
         |y| geom.row_at_y(y),
     );
-    let cols = AxisLayout::new(
+    let mut cols = AxisLayout::new(
         MAX_COLS,
         frozen_cols,
         viewport.x,
@@ -375,6 +392,10 @@ where
         |col| geom.col_x(col),
         |x| geom.col_at_x(x),
     );
+    if print.is_some() {
+        rows.print_extent = Some(viewport.height);
+        cols.print_extent = Some(viewport.width);
+    }
 
     let grid = GridMeta {
         start_row: rows.start(),
@@ -403,6 +424,16 @@ where
         .collect();
     let mut anchors = visible_anchors(sheet_ref, &rows, &cols);
     if print.is_some() {
+        for merge in &sheet_ref.merges {
+            if rows.intersects(merge.start.row, merge.end.row)
+                && cols.intersects(merge.start.col, merge.end.col)
+                && let Some(cell) = sheet_ref.cell(merge.start)
+            {
+                anchors.push((merge.start, cell));
+            }
+        }
+        anchors.sort_unstable_by_key(|(at, _)| (at.row, at.col));
+        anchors.dedup_by_key(|(at, _)| (at.row, at.col));
         anchors.retain(|(at, _)| {
             geom.row_y(at.row) < viewport.y + viewport.height
                 && geom.col_x(at.col) < viewport.x + viewport.width
@@ -592,21 +623,7 @@ where
             }
             Align::Center => cell_box.x + cell_box.w / 2.0,
         };
-        let ty = print.map_or_else(
-            || baseline_y(cell_box.y, cell_box.h, size, valign),
-            |(m, _)| {
-                let ratio = size / m.font_size_pt * 96.0 / m.dpi;
-                let ascent = m.font_ascent * ratio;
-                let descent = m.font_descent * ratio;
-                match valign {
-                    Some(VAlign::Top) => cell_box.y + ascent,
-                    Some(VAlign::Center | VAlign::Justify | VAlign::Distributed) => {
-                        cell_box.y + (cell_box.h + ascent - descent) / 2.0
-                    }
-                    Some(VAlign::Bottom) | None => cell_box.y + cell_box.h - descent,
-                }
-            },
-        );
+        let ty = text_baseline(cell_box, size, valign, print.map(|(m, _)| m));
 
         commands.push(DrawCmd::Text {
             x: tx,
@@ -632,7 +649,9 @@ where
 
     for link in &sheet_ref.hyperlinks {
         let at = link.range.start;
-        if sheet_ref.cell(at).is_some() || !rows.contains(at.row) || !cols.contains(at.col) {
+        if sheet_ref.cell(at).is_some()
+            || (print.is_none() && (!rows.contains(at.row) || !cols.contains(at.col)))
+        {
             continue;
         }
         let Some(text) = link.display.as_ref().filter(|display| !display.is_empty()) else {
@@ -641,11 +660,12 @@ where
         let Some(cell_box) = cell_box(&geom, &rows, &cols, sheet_ref, at) else {
             continue;
         };
+        let size = print.map_or(FONT_SIZE_PT, |(m, _)| m.font_size_pt);
         commands.push(DrawCmd::Text {
-            x: cell_box.x + TEXT_PAD_PX,
-            y: baseline_y(cell_box.y, cell_box.h, FONT_SIZE_PT, None),
+            x: cell_box.x + print.map_or(TEXT_PAD_PX, |(m, _)| 3.0 * 96.0 / m.dpi),
+            y: text_baseline(cell_box, size, None, print.map(|(m, _)| m)),
             text: text.clone(),
-            font_size: FONT_SIZE_PT,
+            font_size: size,
             color: hyperlink_color.to_string(),
             clip: cell_box.clip,
             align: Align::Left,
@@ -655,7 +675,7 @@ where
             strike: false,
             highlight: None,
             dashed_underline: false,
-            font_family: None,
+            font_family: print.map(|(m, _)| m.font_family.clone()),
             ghost: false,
             chart: false,
         });
@@ -1029,6 +1049,27 @@ fn baseline_y(cy0: f32, ch: f32, size: f32, valign: Option<VAlign>) -> f32 {
             cy0 + (ch + size_px * (ASCENT_RATIO - DESCENT_RATIO)) / 2.0
         }
         Some(VAlign::Bottom) | None => cy0 + ch - TEXT_PAD_PX - size_px * DESCENT_RATIO,
+    }
+}
+
+fn text_baseline(
+    cell: CellBox,
+    size: f32,
+    valign: Option<VAlign>,
+    print: Option<&PrintMetrics>,
+) -> f32 {
+    let Some(metrics) = print else {
+        return baseline_y(cell.y, cell.h, size, valign);
+    };
+    let ratio = size / metrics.font_size_pt * 96.0 / metrics.dpi;
+    let ascent = metrics.font_ascent * ratio;
+    let descent = metrics.font_descent * ratio;
+    match valign {
+        Some(VAlign::Top) => cell.y + ascent,
+        Some(VAlign::Center | VAlign::Justify | VAlign::Distributed) => {
+            cell.y + (cell.h + ascent - descent) / 2.0
+        }
+        Some(VAlign::Bottom) | None => cell.y + cell.h - descent,
     }
 }
 

--- a/crates/xlsx-wasm/src/core.rs
+++ b/crates/xlsx-wasm/src/core.rs
@@ -2,7 +2,7 @@
 use betteroffice_xlsx::RenderOptions;
 use betteroffice_xlsx::{
     CalculationOptions, CapturedFormat, CellAddress, CellInput as WorkbookCellInput, CellRange,
-    CellRef, MutationResult, NumberFormatMutation, Op, Proposal,
+    CellRef, MutationResult, NumberFormatMutation, Op, PrintMetrics, Proposal,
     ProposalEditInput as WorkbookProposalEditInput, ProposalRequest, SheetId, StylePatch,
     UpdateEvent, UpdateSubscription, Viewport, Workbook,
 };
@@ -248,6 +248,23 @@ impl Session {
         self.workbook
             .observe_update_v1(callback)
             .map_err(|error| error.to_string())
+    }
+
+    pub fn print_display_list_json(&self, args: &str) -> Result<String, String> {
+        #[derive(Deserialize)]
+        struct Args {
+            sheet: u32,
+            range: String,
+            metrics: PrintMetrics,
+            gridlines: bool,
+        }
+        let args: Args = serde_json::from_str(args).map_err(|e| format!("bad print args: {e}"))?;
+        let range = CellRange::parse_a1(&args.range).map_err(|e| e.to_string())?;
+        let display_list = self
+            .workbook
+            .print_display_list(SheetId(args.sheet), range, &args.metrics, args.gridlines)
+            .map_err(|e| e.to_string())?;
+        serde_json::to_string(&display_list).map_err(|e| e.to_string())
     }
 
     pub fn display_list_json(&self, viewport_json: &str) -> Result<String, String> {
@@ -1143,14 +1160,15 @@ mod tests {
         let ghosted = session
             .display_list_json(r#"{"x":0,"y":0,"width":200,"height":80}"#)
             .unwrap();
-        assert!(
-            ghosted.contains(r##""text":"$2,000.00","fontSize":11.0,"color":"#2e7d32""##),
-            "{ghosted}"
-        );
-        assert!(
-            ghosted.contains(r##""text":"$1,000.00","fontSize":11.0,"color":"#c62828""##),
-            "{ghosted}"
-        );
+        let rendered: serde_json::Value = serde_json::from_str(&ghosted).unwrap();
+        let commands = rendered["commands"].as_array().unwrap();
+        for (text, color) in [("$2,000.00", "#2e7d32"), ("$1,000.00", "#c62828")] {
+            assert!(
+                commands
+                    .iter()
+                    .any(|command| command["text"] == text && command["color"] == color)
+            );
+        }
         assert!(ghosted.contains(r#""strike":true"#), "{ghosted}");
         session
             .edit_cell_json(r#"{"sheet":0,"row":0,"col":0,"input":"3000"}"#, None)

--- a/crates/xlsx-wasm/src/lib.rs
+++ b/crates/xlsx-wasm/src/lib.rs
@@ -173,6 +173,13 @@ impl XlsxDocument {
         Ok(encoded)
     }
 
+    #[wasm_bindgen(js_name = printDisplayListJson)]
+    pub fn print_display_list_json(&self, args: &str) -> Result<String, JsValue> {
+        self.session
+            .print_display_list_json(args)
+            .map_err(|e| JsValue::from_str(&e))
+    }
+
     /// serialized `DisplayList` for a serialized `Viewport`.
     #[wasm_bindgen(js_name = displayListJson)]
     pub fn display_list_json(&self, viewport_json: &str) -> Result<String, JsValue> {

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -48,6 +48,20 @@ handle itself covers styling (`patchRangeStyle`, `setNumberFormat`), undo/redo,
 and PNG export (`renderPng` / `renderRangePng`; guard with
 `isPngExportAvailable`).
 
+## Print a range
+
+`workbook.printDisplayList(sheet, range, metrics, gridlines)` renders a range
+without changing workbook data, the active sheet, or screen geometry. Pass
+`PrintMetrics` measured from the workbook's normal font: `dpi`, `maxDigitWidth`,
+`fontAscent`, and `fontDescent` use the layout device's pixels; `fontSizePt` and
+`defaultRowHeightPt` use points. `fontFamily` supplies the default face, and
+optional `defaultColumnWidth` uses the stored OOXML character width.
+
+The result uses 96-DPI logical coordinates. Paint it with `paintDisplayList(ctx,
+frame, scale, { x, y })`; the optional origin uses backing-store pixels, so page
+margins need no intermediate image. Cell ranges, paper size, and pagination are
+chosen by the caller. See the [Office comparison harness](../../scripts/office-quality).
+
 ## AI agents / human-in-the-loop
 
 An agent stages edits as a proposal instead of applying them; a human reviews

--- a/packages/xlsx/src/display-list/types.ts
+++ b/packages/xlsx/src/display-list/types.ts
@@ -96,6 +96,7 @@ export interface TextCmd {
   x: number;
   y: number;
   text: string;
+  /** Font size in points. */
   fontSize: number;
   /** resolved font color (`#rrggbb`); a number-format color prefix wins upstream. */
   color: string;

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -90,6 +90,7 @@ export type {
   WasmInitInput,
   OpenWorkbookOptions,
   Viewport,
+  PrintMetrics,
   SheetInfo,
   WorkbookHandle,
   WorkbookUpdateListener,

--- a/packages/xlsx/src/render/canvas2d.test.ts
+++ b/packages/xlsx/src/render/canvas2d.test.ts
@@ -74,3 +74,50 @@ describe('Canvas2D paths', () => {
     expect({ fills, strokes }).toEqual({ fills: 1, strokes: 1 });
   });
 });
+
+describe('Canvas2D text', () => {
+  it('uses point-sized fonts for cells, ghosts, and charts at every display scale', () => {
+    const fonts: string[] = [];
+    const transforms: number[][] = [];
+    const context = {
+      font: '',
+      fillStyle: '',
+      textAlign: '',
+      textBaseline: '',
+      beginPath() {}, rect() {}, clip() {},
+      save() {},
+      restore() {},
+      setTransform(...values: number[]) { transforms.push(values); },
+      clearRect() {},
+      fillText() {
+        fonts.push(this.font);
+      },
+    };
+    const displayList: DisplayList = {
+      width: 120,
+      height: 80,
+      commands: [undefined, false, true].map((chart) => ({
+        op: 'text',
+        x: 0,
+        y: 20,
+        text: 'Quarterly revenue',
+        fontSize: 12,
+        fontFamily: 'Calibri',
+        color: '#000000',
+        chart,
+      })),
+    };
+    for (const scale of [1, 2]) {
+      paintDisplayList(
+        context as unknown as CanvasRenderingContext2D,
+        displayList,
+        scale
+      );
+    }
+    paintDisplayList(context as unknown as CanvasRenderingContext2D, { width: 1, height: 1, commands: [] }, 2, { x: 37.5, y: 37.5 });
+    expect(transforms[transforms.length - 1]).toEqual([2, 0, 0, 2, 37.5, 37.5]);
+    expect(fonts.map((font) => Number.parseFloat(font))).toEqual([
+      16, 16, 16, 16, 16, 16,
+    ]);
+  });
+});

--- a/packages/xlsx/src/render/canvas2d.ts
+++ b/packages/xlsx/src/render/canvas2d.ts
@@ -34,15 +34,19 @@ const LINE_DASH: Record<'dashed' | 'dotted', number[]> = {
 /**
  * Paint a display list into a 2D context. `dpr` maps device-independent list
  * coordinates onto the backing store, so callers size the canvas at
- * `width * dpr` × `height * dpr` and this sets the matching transform.
+ * `width * dpr` × `height * dpr`. `origin` is in backing-store pixels.
  */
 export function paintDisplayList(
   ctx: CanvasRenderingContext2D,
   dl: DisplayList,
-  dpr: number
+  dpr: number,
+  origin: { x: number; y: number } = { x: 0, y: 0 }
 ): void {
   ctx.save();
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.setTransform(dpr, 0, 0, dpr, origin.x, origin.y);
+  ctx.beginPath();
+  ctx.rect(0, 0, dl.width, dl.height);
+  ctx.clip();
   ctx.clearRect(0, 0, dl.width, dl.height);
   for (const cmd of dl.commands) paintCommand(ctx, cmd);
   ctx.restore();
@@ -194,7 +198,7 @@ function fontString(cmd: TextCmd): string {
 }
 
 function fontSizePx(cmd: TextCmd): number {
-  return cmd.chart ? cmd.fontSize * PX_PER_PT : cmd.fontSize;
+  return cmd.fontSize * PX_PER_PT;
 }
 
 function paintDecorations(ctx: CanvasRenderingContext2D, cmd: TextCmd): void {

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm.d.ts
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm.d.ts
@@ -72,6 +72,7 @@ export class XlsxDocument {
      */
     static openCollaborative(bytes: Uint8Array, client_id: number): XlsxDocument;
     patchRangeStyleJson(args: string): string;
+    printDisplayListJson(args: string): string;
     /**
      * register an agent proposal (preview only); returns the stored `Proposal` json.
      */
@@ -155,6 +156,7 @@ export interface InitOutput {
     readonly xlsxdocument_open: (a: number, b: number) => [number, number, number];
     readonly xlsxdocument_openCollaborative: (a: number, b: number, c: number) => [number, number, number];
     readonly xlsxdocument_patchRangeStyleJson: (a: number, b: number, c: number) => [number, number, number, number];
+    readonly xlsxdocument_printDisplayListJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly xlsxdocument_proposeJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly xlsxdocument_rangeCellsJson: (a: number, b: number, c: number) => [number, number, number, number];
     readonly xlsxdocument_redoJson: (a: number) => [number, number, number, number];

--- a/packages/xlsx/src/wasm/generated/xlsx_wasm_bg.wasm.d.ts
+++ b/packages/xlsx/src/wasm/generated/xlsx_wasm_bg.wasm.d.ts
@@ -27,6 +27,7 @@ export const xlsxdocument_moveChartJson: (a: number, b: number, c: number) => [n
 export const xlsxdocument_open: (a: number, b: number) => [number, number, number];
 export const xlsxdocument_openCollaborative: (a: number, b: number, c: number) => [number, number, number];
 export const xlsxdocument_patchRangeStyleJson: (a: number, b: number, c: number) => [number, number, number, number];
+export const xlsxdocument_printDisplayListJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const xlsxdocument_proposeJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const xlsxdocument_rangeCellsJson: (a: number, b: number, c: number) => [number, number, number, number];
 export const xlsxdocument_redoJson: (a: number) => [number, number, number, number];

--- a/packages/xlsx/src/wasm/loader.ts
+++ b/packages/xlsx/src/wasm/loader.ts
@@ -22,6 +22,17 @@ export interface Viewport {
   height: number;
 }
 
+export interface PrintMetrics {
+  dpi: number;
+  maxDigitWidth: number;
+  defaultRowHeightPt: number;
+  defaultColumnWidth?: number;
+  fontSizePt: number;
+  fontFamily: string;
+  fontAscent: number;
+  fontDescent: number;
+}
+
 /**
  * Chrome-facing sheet metadata: stable IDs, tab names, active index, and the
  * scrollable content extent of the active sheet. Mirrors the Rust `SheetInfo`.
@@ -281,6 +292,9 @@ export interface WorkbookHandle extends CollaborationReplica {
   sheetInfo(): SheetInfo;
   calculationStatus(): CalculationStatus;
   displayList(viewport: Viewport): DisplayList;
+  printDisplayList(
+    sheet: number, range: string, metrics: PrintMetrics, gridlines: boolean
+  ): DisplayList;
   /**
    * the chart under a viewport-local point on the active sheet, or `null`,
    * resolved against the current model from the same anchor geometry the
@@ -587,6 +601,11 @@ export function openWorkbook(
     },
     displayList(viewport: Viewport): DisplayList {
       return parseJson(() => doc.displayListJson(JSON.stringify(viewport)));
+    },
+    printDisplayList(sheet: number, range: string, metrics: PrintMetrics, gridlines: boolean): DisplayList {
+      return parseJson(() =>
+        doc.printDisplayListJson(JSON.stringify({ sheet, range, metrics, gridlines }))
+      );
     },
     chartAtPoint(viewport: Viewport, x: number, y: number): ChartRegion | null {
       return parseJson(() => doc.chartAtPointJson(JSON.stringify({ viewport, x, y })));

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -21,6 +21,13 @@ node scripts/office-quality/readme.mjs .source/office-quality/run/report.json
 
 The runner compares the latest npm releases with the checked-out source using pinned CDN fonts. Commit source changes first and choose an empty output directory. Set `QUALITY_SAMPLES='["betteroffice-demo"]'` to select a subset; all three demos run by default.
 
+XLSX capture uses `printDisplayList` when available, with font metrics measured
+at Mac Excel's 72-DPI layout scale and the source worksheet's explicit defaults.
+Older packages use the screen-range capture. Both keep the recorded ranges,
+150-DPI output, page margins, and SSIM scoring. Per-capture metadata identifies
+the mode and metrics. Unspecified column defaults, locale-specific dates, and
+chart typography can still differ from Excel.
+
 ## Manual CI and generated README
 
 After the [workflow](../../.github/workflows/visual-fidelity.yml) lands on `main`, use **Actions → Visual fidelity → Run workflow**, or:

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -22,7 +22,7 @@ node scripts/office-quality/readme.mjs .source/office-quality/run/report.json
 The runner compares the latest npm releases with the checked-out source using pinned CDN fonts. Commit source changes first and choose an empty output directory. Set `QUALITY_SAMPLES='["betteroffice-demo"]'` to select a subset; all three demos run by default.
 
 XLSX capture uses `printDisplayList` when available, with font metrics measured
-at Mac Excel's 72-DPI layout scale and the source worksheet's explicit defaults.
+at 72 layout DPI for the frozen Mac Office capture and the worksheet's explicit defaults.
 Older packages use the screen-range capture. Both keep the recorded ranges,
 150-DPI output, page margins, and SSIM scoring. Per-capture metadata identifies
 the mode and metrics. Unspecified column defaults, locale-specific dates, and

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -23,6 +23,7 @@ The runner compares the latest npm releases with the checked-out source using pi
 
 XLSX capture uses `printDisplayList` when available, with font metrics measured
 at 72 layout DPI for the frozen Mac Office capture and the worksheet's explicit defaults.
+The Normal style resolves through its built-in ID and `xfId`; missing declarations fall back to style XF zero, then font zero.
 Older packages use the screen-range capture. Both keep the recorded ranges,
 150-DPI output, page margins, and SSIM scoring. Per-capture metadata identifies
 the mode and metrics. Unspecified column defaults, locale-specific dates, and
@@ -49,7 +50,7 @@ Requires macOS and desktop Word, PowerPoint, or Excel. Run exports serially into
 
 The extension selects the app. Output includes `reference.pdf`, numbered PNGs at 150 DPI, and `result.json` with source hashes, Office/macOS versions, font names, UTC timestamps, and export status. The timeout defaults to 120 seconds; override it with `--timeout`.
 
-For XLSX comparisons, add `--xlsx-profile /path/to/profile.json`. The profile specifies `scale_percent`, `margin_pt`, and `pages` with zero-based `sheet` indices and A1 `range` values. Each range must fit one page. The demo's nine-page profile is stored in its metadata under `reference.capture_profile`. This measures worksheet range rendering, not automatic print pagination; frozen panes are unsupported. Print settings apply only to the temporary workbook, leaving source bytes unchanged.
+For XLSX comparisons, add `--xlsx-profile /path/to/profile.json`. The profile specifies `scale_percent`, `margin_pt`, and `pages` with zero-based `sheet` indices and A1 `range` values. Each range must fit one page. The demo's nine-page profile is stored in its metadata under `reference.capture_profile`. This measures worksheet range rendering, not automatic print pagination. The print API ignores frozen panes; the screen-range fallback rejects them. Print settings apply only to the temporary workbook, leaving source bytes unchanged.
 
 ## macOS permissions
 

--- a/scripts/office-quality/harness.ts
+++ b/scripts/office-quality/harness.ts
@@ -4,6 +4,7 @@ import { createFontProvider } from '../../packages/fonts/src/cdn';
 const api = window as any;
 const format = new URLSearchParams(location.search).get('format');
 let capture: (index: number) => Promise<string>;
+let printCapture: any;
 
 async function fontsFor(bytes: Uint8Array) {
   const zip = await JSZip.loadAsync(bytes);
@@ -39,6 +40,59 @@ async function fontsFor(bytes: Uint8Array) {
     }
   }
   return faces;
+}
+
+async function xlsxPrintMetrics(bytes: Uint8Array) {
+  const zip = await JSZip.loadAsync(bytes);
+  const xml = async (path: string) =>
+    new DOMParser().parseFromString((await zip.file(path)?.async('string')) ?? '<root/>', 'text/xml');
+  const styles = await xml('xl/styles.xml');
+  const normal = styles.querySelector('cellStyleXfs > xf');
+  const font =
+    styles.querySelectorAll('fonts > font')[Number(normal?.getAttribute('fontId') ?? 0)];
+  const family = font?.querySelector('name')?.getAttribute('val') ?? 'Calibri';
+  const size = Number(font?.querySelector('sz')?.getAttribute('val') ?? 11);
+  const dpi = 72;
+  const context = document.createElement('canvas').getContext('2d')!;
+  context.font = `${(size * dpi) / 72}px "${family.replace(/"/g, '\\"')}"`;
+  const bounds = context.measureText('0123456789');
+  const maxDigitWidth = Math.max(
+    ...[...'0123456789'].map((digit) => Math.round(context.measureText(digit).width))
+  );
+  const workbook = await xml('xl/workbook.xml');
+  const relationships = await xml('xl/_rels/workbook.xml.rels');
+  return Promise.all(
+    [...workbook.querySelectorAll('sheet')].map(async (sheet) => {
+      const id = sheet.getAttribute('r:id');
+      const target = [...relationships.querySelectorAll('Relationship')]
+        .find((rel) => rel.getAttribute('Id') === id)
+        ?.getAttribute('Target');
+      if (!target) throw new Error('Missing worksheet relationship');
+      const path = new URL(
+        target,
+        'https://package.invalid/xl/workbook.xml'
+      ).pathname.slice(1);
+      const format = (await xml(path)).querySelector('sheetFormatPr');
+      return {
+        dpi,
+        maxDigitWidth,
+        fontSizePt: size,
+        fontFamily: family,
+        fontAscent: bounds.fontBoundingBoxAscent,
+        fontDescent: bounds.fontBoundingBoxDescent,
+        defaultRowHeightPt: Number(
+          format?.getAttribute('defaultRowHeight') ??
+            ((bounds.fontBoundingBoxAscent + bounds.fontBoundingBoxDescent + 1) * 72) /
+              dpi
+        ),
+        ...(format?.hasAttribute('defaultColWidth')
+          ? {
+              defaultColumnWidth: Number(format.getAttribute('defaultColWidth')),
+            }
+          : {}),
+      };
+    })
+  );
 }
 
 function cell(value: string) {
@@ -89,6 +143,12 @@ api.oracleInit = async (input: number[], useFonts: boolean, profile: any) => {
     );
     await initWasm();
     const handle = openWorkbook(bytes);
+    const printMetrics = await xlsxPrintMetrics(bytes);
+    printCapture = {
+      mode:
+        typeof handle.printDisplayList === 'function' ? 'print-range' : 'screen-range',
+      metrics: printMetrics,
+    };
     if (
       !profile?.pages?.length ||
       !Number.isFinite(profile.scale_percent) ||
@@ -109,7 +169,7 @@ api.oracleInit = async (input: number[], useFonts: boolean, profile: any) => {
         throw new Error('Invalid worksheet index');
       handle.setActiveSheet(page.sheet);
       const info = handle.sheetInfo();
-      if (info.frozenRows || info.frozenCols)
+      if ((info.frozenRows || info.frozenCols) && typeof handle.printDisplayList !== 'function')
         throw new Error('XLSX print capture does not support frozen panes');
       const parts = page.range.split(':');
       if (parts.length !== 2) throw new Error('A rectangular print range is required');
@@ -117,10 +177,19 @@ api.oracleInit = async (input: number[], useFonts: boolean, profile: any) => {
       const end = cell(parts[1]);
       if (end.row < start.row || end.col < start.col)
         throw new Error('Reversed print range');
+      const printable =
+        typeof handle.printDisplayList === 'function'
+          ? handle.printDisplayList(
+              page.sheet,
+              page.range,
+              printMetrics[page.sheet],
+              profile.gridlines !== false
+            )
+          : undefined;
       const from = handle.cellPosition(page.sheet, start.row, start.col);
       const to = handle.cellPosition(page.sheet, end.row + 1, end.col + 1);
-      const width = to.x - from.x;
-      const height = to.y - from.y;
+      const width = printable?.width ?? to.x - from.x;
+      const height = printable?.height ?? to.y - from.y;
       const scale = ((150 / 96) * profile.scale_percent) / 100;
       const margin = (profile.margin_pt * 150) / 72;
       if (
@@ -133,21 +202,30 @@ api.oracleInit = async (input: number[], useFonts: boolean, profile: any) => {
         height * scale > page.height_px - margin * 2 + 1
       )
         throw new Error('Print range does not fit the recorded page');
-      const content = document.createElement('canvas');
-      content.width = Math.ceil(width * scale);
-      content.height = Math.ceil(height * scale);
-      paintDisplayList(
-        content.getContext('2d')!,
-        handle.displayList({ x: from.x, y: from.y, width, height }),
-        scale
-      );
       const canvas = document.createElement('canvas');
       canvas.width = page.width_px;
       canvas.height = page.height_px;
       const context = canvas.getContext('2d')!;
       context.fillStyle = '#fff';
       context.fillRect(0, 0, canvas.width, canvas.height);
-      context.drawImage(content, margin, margin);
+      if (printable) {
+        context.save();
+        context.beginPath();
+        context.rect(margin, margin, width * scale, height * scale);
+        context.clip();
+        paintDisplayList(context, printable, scale, { x: margin, y: margin });
+        context.restore();
+      } else {
+        const content = document.createElement('canvas');
+        content.width = Math.ceil(width * scale);
+        content.height = Math.ceil(height * scale);
+        paintDisplayList(
+          content.getContext('2d')!,
+          handle.displayList({ x: from.x, y: from.y, width, height }),
+          scale
+        );
+        context.drawImage(content, margin, margin);
+      }
       return canvas.toDataURL('image/png');
     };
   } else throw new Error('Unsupported capture format');
@@ -163,6 +241,7 @@ api.oracleInit = async (input: number[], useFonts: boolean, profile: any) => {
       ok: true,
     })),
     capture_profile: profile,
+    ...(printCapture ? { print_capture: printCapture } : {}),
   };
 };
 api.oraclePage = (index: number) => capture(index);

--- a/scripts/office-quality/harness.ts
+++ b/scripts/office-quality/harness.ts
@@ -1,5 +1,6 @@
 import JSZip from 'jszip';
 import { createFontProvider } from '../../packages/fonts/src/cdn';
+import { normalFontIndex } from './xlsx-styles';
 
 const api = window as any;
 const format = new URLSearchParams(location.search).get('format');
@@ -47,9 +48,15 @@ async function xlsxPrintMetrics(bytes: Uint8Array) {
   const xml = async (path: string) =>
     new DOMParser().parseFromString((await zip.file(path)?.async('string')) ?? '<root/>', 'text/xml');
   const styles = await xml('xl/styles.xml');
-  const normal = styles.querySelector('cellStyleXfs > xf');
-  const font =
-    styles.querySelectorAll('fonts > font')[Number(normal?.getAttribute('fontId') ?? 0)];
+  const fontIndex = normalFontIndex(
+    [...styles.querySelectorAll('cellStyles > cellStyle')].map((style) => ({
+      builtinId: style.hasAttribute('builtinId') ? Number(style.getAttribute('builtinId')) : undefined,
+      name: style.getAttribute('name') ?? undefined,
+      xfId: Number(style.getAttribute('xfId') ?? 0),
+    })),
+    [...styles.querySelectorAll('cellStyleXfs > xf')].map((xf) => Number(xf.getAttribute('fontId') ?? 0))
+  );
+  const font = styles.querySelectorAll('fonts > font')[fontIndex];
   const family = font?.querySelector('name')?.getAttribute('val') ?? 'Calibri';
   const size = Number(font?.querySelector('sz')?.getAttribute('val') ?? 11);
   const dpi = 72;

--- a/scripts/office-quality/xlsx-styles.test.ts
+++ b/scripts/office-quality/xlsx-styles.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'bun:test';
+import { normalFontIndex } from './xlsx-styles';
+
+test('resolves localized Normal through its builtin ID and xfId', () => {
+  expect(
+    normalFontIndex(
+      [
+        { name: 'Normal', xfId: 0 },
+        { name: '標準', builtinId: 0, xfId: 2 },
+      ],
+      [3, 1, 4]
+    )
+  ).toBe(4);
+});
+
+test('uses the named Normal style when the builtin ID is omitted', () => {
+  expect(normalFontIndex([{ name: 'Normal', xfId: 1 }], [3, 2])).toBe(2);
+});
+
+test('falls back to style XF zero, then font zero when Normal data is absent', () => {
+  expect(normalFontIndex([], [3, 2])).toBe(3);
+  expect(normalFontIndex([], [])).toBe(0);
+  expect(normalFontIndex([{ builtinId: 0, xfId: 99 }], [3])).toBe(0);
+});

--- a/scripts/office-quality/xlsx-styles.ts
+++ b/scripts/office-quality/xlsx-styles.ts
@@ -1,0 +1,8 @@
+type CellStyle = { builtinId?: number; name?: string; xfId?: number };
+
+export function normalFontIndex(styles: CellStyle[], styleFontIds: number[]) {
+  const normal =
+    styles.find((style) => style.builtinId === 0) ??
+    styles.find((style) => style.name === 'Normal');
+  return styleFontIds[normal?.xfId ?? 0] ?? 0;
+}


### PR DESCRIPTION
TL;DR:

Before/After:
Page 3 (`Data!A1:H45`) before/after captures are prepared; GitHub-hosted image attachments are pending.

Repro file:
[BetterOffice workbook demo](https://corpus.betteroffice.dev/betteroffice-workbook/source.xlsx) · [Frozen Excel reference and metadata](https://corpus.betteroffice.dev/betteroffice-workbook/metadata.json)

Summary:
- Add `printDisplayList` for font-aware worksheet range printing, including print gridlines, outer borders, merged fills, and frozen-pane handling.
- Paint cell and proposal fonts at their declared point size, and place page content directly at its margins.
- Preserve screen row/column geometry, workbook state, and collaboration fingerprints. Include an XLSX minor changeset and print API documentation.
- Use the print API in the Office harness when available; record the measured font/device metrics and retain the published-package fallback.

SSIM against the same nine frozen Excel 16.112.3 pages, with pinned CDN fonts:

| Renderer | SSIM | Pages |
| --- | ---: | ---: |
| Published `@betteroffice/xlsx@0.1.0` | 0.704588 | 9/9 |
| Main before this change | 0.704262 | 9/9 |
| `1a5e17f65f8fa21cbfdb2bc8cd53c2f8e45d7ea9` | **0.900371** | 9/9 |

The gain over main is **+0.196109**. Source SHA-256, Office PNGs, print ranges, 75% scale, 18pt margins, 150-DPI output, and grayscale SSIM settings are unchanged. No image resizing or post-capture alignment is used. The largest improvement comes from print geometry; point-size corrections alone do not improve this benchmark while the old screen geometry remains in use.

All seven data-sheet pages improve. The first two chart/summary pages decline from **0.860762 to 0.848122** and **0.872885 to 0.849287**; default column widths and chart typography remain follow-up work.

The capture explicitly uses 72 layout DPI for the frozen Mac Office reference; the engine accepts caller-supplied device metrics. Normal-font measurements are rounded to whole pixels, following [Microsoft's description of font-dependent worksheet geometry](https://support.microsoft.com/en-us/support/known-issues/differences-in-column-width-between-excel-2011-for-mac-and-later-versions). Stored column widths follow [the OOXML conversion](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.column?view=openxml-3.0.1). This is explicit range rendering. Automatic print pagination, unspecified column defaults, locale-specific dates, and chart typography remain separate work.

Test plan:
- [x] Run 268 native tests across the XLSX renderer, facade, raster backend, and Wasm boundary.
- [x] Run 229 JavaScript/React/harness tests; one existing feature-availability test remains skipped.
- [x] Pass strict Clippy on all affected native targets, package typecheck, and harness typecheck.
- [x] Build the XLSX Wasm/package and fonts package.
- [x] Re-render all nine pages at the exact commit and verify the unchanged source hash, dimensions, and frozen references.
- [x] Re-run published `0.1.0` with the final harness and reproduce its previous score exactly.
- [x] Verify print calls preserve saved bytes, parsed model, active sheet, and screen rendering; reject invalid metrics and excessive ranges.
- [x] Cover partial merged ranges, display-only hyperlinks, and localized/reordered Normal styles with regression tests.
- [ ] Attach the prepared before/after screenshots to this PR.
- [x] Complete CI checks.




