### PR TITLE
fix(docx): preserve aligned cell text at page breaks

### DIFF
--- a/.changeset/docx-aligned-table-breaks.md
+++ b/.changeset/docx-aligned-table-breaks.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/docx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Keep vertically aligned table-cell text intact at page breaks by using its painted position when selecting row split points. Apply the same default vertical cell padding during measurement and rendering.

--- a/crates/docx-layout/src/cell_layout.rs
+++ b/crates/docx-layout/src/cell_layout.rs
@@ -80,7 +80,8 @@ pub fn layout_cell_content(
             prev_after = spacing.and_then(|s| s.after).unwrap_or(0.0);
         } else if let Some(total_height) = extent_total_height(measure) {
             // Nested table / non-paragraph: one atomic block (break only at its bottom).
-            y += prev_after + total_height;
+            y += prev_after;
+            y += total_height;
             line_tops.push(Vec::new());
             flat_bottoms.push(y);
             prev_after = 0.0;

--- a/crates/docx-layout/src/cell_layout.rs
+++ b/crates/docx-layout/src/cell_layout.rs
@@ -16,11 +16,34 @@ pub struct CellContentLayout {
     pub content_height: f64,
 }
 
-/// Returns the numeric total height carried by paragraph and table extents.
+pub(crate) fn cell_vertical_offset(
+    alignment: Option<&str>,
+    cell_height: f64,
+    measured_height: f64,
+    content_height: f64,
+    top_inset: f64,
+    bottom_inset: f64,
+) -> f64 {
+    if measured_height >= cell_height - 0.5 {
+        return 0.0;
+    }
+    let slack = (cell_height - top_inset - bottom_inset - content_height).max(0.0);
+    match alignment {
+        Some("center") => slack / 2.0,
+        Some("bottom") => slack,
+        _ => 0.0,
+    }
+}
+
+/// Returns a measured block's stacked height.
 fn extent_total_height(measure: &BlockExtent) -> Option<f64> {
     match measure {
         BlockExtent::Paragraph(p) => Some(p.total_height),
         BlockExtent::Table(t) => Some(t.total_height),
+        BlockExtent::Image(image) => Some(image.height),
+        BlockExtent::TextBox(text_box) => Some(text_box.height),
+        BlockExtent::Shape(shape) => Some(shape.height),
+        BlockExtent::Chart(chart) => Some(chart.height),
         _ => None,
     }
 }
@@ -170,5 +193,23 @@ mod tests {
         assert_eq!(layout.line_tops[0], vec![5.0, 5.0 + LINE]);
         assert_eq!(layout.line_tops[1], vec![5.0 + 2.0 * LINE]);
         assert_eq!(layout.content_height, 3.0 * LINE);
+    }
+
+    #[test]
+    fn includes_atomic_images_in_cell_height_and_break_boundaries() {
+        let image: LayoutBlock = serde_json::from_value(json!({
+            "kind": "image", "id": 1, "src": "rId1", "width": 50, "height": 40
+        }))
+        .unwrap();
+        let image_measure: BlockExtent = serde_json::from_value(json!({
+            "kind": "image", "width": 50, "height": 40
+        }))
+        .unwrap();
+        let blocks = vec![para(Some((0.0, 5.0))), image, para(None)];
+        let measures = vec![pm(1, Some((0.0, 5.0))), image_measure, pm(1, None)];
+        let layout = layout_cell_content(Some(&blocks), Some(&measures), 2.0);
+        assert_eq!(layout.line_tops, vec![vec![2.0], vec![], vec![67.0]]);
+        assert_eq!(layout.flat_bottoms, vec![22.0, 67.0, 87.0]);
+        assert_eq!(layout.content_height, 85.0);
     }
 }

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -8948,9 +8948,9 @@ fn emit_cell_content(
         return;
     };
     let pad_left = cell.padding.and_then(|pd| pd.left).unwrap_or(7.0);
-    let pad_top = cell.padding.and_then(|pd| pd.top).unwrap_or(1.0);
+    let pad_top = cell.padding.and_then(|pd| pd.top).unwrap_or(0.0);
     let pad_right = cell.padding.and_then(|pd| pd.right).unwrap_or(7.0);
-    let pad_bottom = cell.padding.and_then(|pd| pd.bottom).unwrap_or(1.0);
+    let pad_bottom = cell.padding.and_then(|pd| pd.bottom).unwrap_or(0.0);
     let content_width = (p.width - pad_left - pad_right).max(0.0);
 
     // Drawn border widths inset the cell content box.
@@ -9020,17 +9020,14 @@ fn emit_cell_content(
     let content_height = stack_cursor + prev_after;
 
     // Content that fills or overflows the cell remains top-aligned.
-    let avail = (cell_h - border_top - border_bottom - pad_top - pad_bottom).max(0.0);
-    let content_fills = cell_measure.height >= cell_h - 0.5;
-    let v_offset = if content_fills {
-        0.0
-    } else {
-        match cell.vertical_align.as_deref() {
-            Some("center") => ((avail - content_height) / 2.0).max(0.0),
-            Some("bottom") => (avail - content_height).max(0.0),
-            _ => 0.0,
-        }
-    };
+    let v_offset = crate::cell_layout::cell_vertical_offset(
+        cell.vertical_align.as_deref(),
+        cell_h,
+        cell_measure.height,
+        content_height,
+        border_top + pad_top,
+        border_bottom + pad_bottom,
+    );
 
     let content_x = cx + border_left + pad_left;
     let content_top = cy + border_top + pad_top + v_offset;

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -8783,7 +8783,6 @@ pub(crate) fn emit_table_fragment(
             cx,
             cy,
             p.cell_h,
-            p.is_first_row,
             is_first_col,
             clip_top_y,
             clip_bottom_y,
@@ -8920,9 +8919,7 @@ pub(crate) fn emit_table_fragment(
 /// Adjacent paragraphs collapse `spacing.after` against the next
 /// `spacing.before`, a nested table flows after the previous paragraph's
 /// after-spacing, and a trailing after-spacing acts as the content box's bottom
-/// padding. Drawn border widths and padding inset the box on the sides this
-/// cell actually paints, and the resulting box is what `w:vAlign` measures its
-/// slack against.
+/// padding. Authored border insets remain stable across fragment cuts.
 #[allow(clippy::too_many_arguments)]
 fn emit_cell_content(
     prims: &mut Vec<Primitive>,
@@ -8932,7 +8929,6 @@ fn emit_cell_content(
     cx: f64,
     cy: f64,
     cell_h: f64,
-    is_first_row: bool,
     is_first_col: bool,
     clip_top_y: f64,
     clip_bottom_y: f64,
@@ -8963,7 +8959,11 @@ fn emit_cell_content(
     let (border_left, border_top, border_bottom) = match &cell.borders {
         Some(b) => (
             if is_first_col { edge_w(&b.left) } else { 0.0 },
-            if is_first_row { edge_w(&b.top) } else { 0.0 },
+            if p.row_index == 0 {
+                edge_w(&b.top)
+            } else {
+                0.0
+            },
             edge_w(&b.bottom),
         ),
         None => (0.0, 0.0, 0.0),

--- a/crates/docx-layout/src/table_row_break.rs
+++ b/crates/docx-layout/src/table_row_break.rs
@@ -160,12 +160,13 @@ pub fn build_table_row_break_info(block: &TableBlock, measure: &TableExtent) -> 
                     add_unique(&mut offsets, off);
                 }
             }
-            for (top, bottom) in cell_unbreakable_ranges(
-                &source_cell.blocks,
-                &measured_cell.blocks,
-                pad_top + content_offset,
-            ) {
-                unbreakable_ranges.push((top - shift, bottom - shift));
+            for (top, bottom) in
+                cell_unbreakable_ranges(&source_cell.blocks, &measured_cell.blocks, pad_top)
+            {
+                unbreakable_ranges.push((
+                    top + content_offset - shift,
+                    bottom + content_offset - shift,
+                ));
             }
         }
         offsets.retain(|offset| {
@@ -446,5 +447,36 @@ mod tests {
         let info = build_table_row_break_info(&block, &measure);
         assert_eq!(info.break_offsets[0], vec![60.0]);
         assert_eq!(snap_row_break(&info, 0, 0.0, 40.0), 0.0);
+    }
+
+    #[test]
+    fn preserves_aligned_line_boundaries_with_fractional_padding() {
+        let padding = 1.0 / 15.0;
+        let line_height = 17.89453125;
+        let block: TableBlock = serde_json::from_value(json!({
+            "id": 0,
+            "rows": [{ "id": 0, "cells": [{
+                "id": 0,
+                "verticalAlign": "center",
+                "padding": { "top": padding, "bottom": padding, "left": 0, "right": 0 },
+                "blocks": [para()]
+            }] }],
+            "columnWidths": [100],
+        }))
+        .unwrap();
+        let mut paragraph = para_measure(2);
+        for line in paragraph["lines"].as_array_mut().unwrap() {
+            line["lineHeight"] = json!(line_height);
+        }
+        paragraph["totalHeight"] = json!(2.0 * line_height);
+        let measure: TableExtent = serde_json::from_value(json!({
+            "rows": [{ "height": 100, "cells": [{
+                "blocks": [paragraph], "width": 100, "height": 2.0 * (line_height + padding)
+            }] }],
+            "columnWidths": [100], "totalWidth": 100, "totalHeight": 100,
+        }))
+        .unwrap();
+        let info = build_table_row_break_info(&block, &measure);
+        assert_eq!(snap_row_break(&info, 0, 0.0, 50.0), 50.0);
     }
 }

--- a/crates/docx-layout/src/table_row_break.rs
+++ b/crates/docx-layout/src/table_row_break.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use crate::cell_layout::layout_cell_content;
+use crate::cell_layout::{cell_vertical_offset, layout_cell_content};
 use crate::table_grid::resolve_cell_grid;
 use crate::types::{BlockExtent, LayoutBlock, TableBlock, TableExtent};
 
@@ -57,6 +57,8 @@ fn cell_unbreakable_ranges(
             BlockExtent::Image(value) => Some(value.height),
             BlockExtent::TextBox(value) => Some(value.height),
             BlockExtent::Table(value) => Some(value.total_height),
+            BlockExtent::Shape(value) => Some(value.height),
+            BlockExtent::Chart(value) => Some(value.height),
             _ => None,
         };
         if let Some(height) = height {
@@ -116,24 +118,53 @@ pub fn build_table_row_break_info(block: &TableBlock, measure: &TableExtent) -> 
             };
             // OOXML TableNormal defaults top padding to zero.
             let pad_top = source_cell.padding.as_ref().map(|p| p.top).unwrap_or(0.0);
+            let pad_bottom = source_cell
+                .padding
+                .as_ref()
+                .map(|p| p.bottom)
+                .unwrap_or(0.0);
+            let border_width = |edge: Option<&crate::types::CellBorderSpec>| {
+                edge.filter(|edge| !matches!(edge.style.as_deref(), Some("none" | "nil")))
+                    .map_or(0.0, |edge| edge.width.unwrap_or(1.0))
+            };
+            let border_top = if g.row_index == 0 {
+                border_width(source_cell.borders.as_ref().and_then(|b| b.top.as_ref()))
+            } else {
+                0.0
+            };
+            let border_bottom =
+                border_width(source_cell.borders.as_ref().and_then(|b| b.bottom.as_ref()));
             let layout = layout_cell_content(
                 Some(&source_cell.blocks),
                 Some(&measured_cell.blocks),
                 pad_top,
             );
+            let cell_end = (g.row_index + g.row_span).min(row_count);
+            let cell_height = row_tops[cell_end] - row_tops[g.row_index];
+            let content_offset = border_top
+                + cell_vertical_offset(
+                    source_cell.vertical_align.as_deref(),
+                    cell_height,
+                    measured_cell.height,
+                    layout.content_height,
+                    pad_top + border_top,
+                    pad_bottom + border_bottom,
+                );
             // Map cell-content y (relative to the cell/region top at
             // row_tops[start_row]) into this row's coordinate space
             // (relative to row_tops[r]).
             let shift = row_tops[r] - row_tops[g.row_index];
             for &b in &layout.flat_bottoms {
-                let off = b - shift;
+                let off = b + content_offset - shift;
                 if off > 0.0 && off < row_height {
                     add_unique(&mut offsets, off);
                 }
             }
-            for (top, bottom) in
-                cell_unbreakable_ranges(&source_cell.blocks, &measured_cell.blocks, pad_top)
-            {
+            for (top, bottom) in cell_unbreakable_ranges(
+                &source_cell.blocks,
+                &measured_cell.blocks,
+                pad_top + content_offset,
+            ) {
                 unbreakable_ranges.push((top - shift, bottom - shift));
             }
         }
@@ -364,6 +395,52 @@ mod tests {
                 measured_cell(vec![line20]), measured_cell(vec![line30])
             ] }],
             "columnWidths": [100, 100], "totalWidth": 200, "totalHeight": 60,
+        }))
+        .unwrap();
+        let info = build_table_row_break_info(&block, &measure);
+        assert_eq!(info.break_offsets[0], vec![60.0]);
+        assert_eq!(snap_row_break(&info, 0, 0.0, 40.0), 0.0);
+    }
+
+    #[test]
+    fn keeps_centered_cell_text_whole_across_a_page_break() {
+        let block: TableBlock = serde_json::from_value(json!({
+            "id": 0,
+            "rows": [{ "id": 0, "cells": [
+                { "id": 0, "verticalAlign": "center", "blocks": [para()] },
+                { "id": 1, "blocks": [para()] }
+            ] }],
+            "columnWidths": [100, 100],
+        }))
+        .unwrap();
+        let measure: TableExtent = serde_json::from_value(json!({
+            "rows": [{ "height": 40, "cells": [
+                { "blocks": [para_measure(1)], "width": 100, "height": 20 },
+                { "blocks": [para_measure(2)], "width": 100, "height": 40 }
+            ] }],
+            "columnWidths": [100, 100], "totalWidth": 200, "totalHeight": 40,
+        }))
+        .unwrap();
+        let info = build_table_row_break_info(&block, &measure);
+        assert_eq!(info.break_offsets[0], vec![40.0]);
+        assert_eq!(snap_row_break(&info, 0, 0.0, 30.0), 0.0);
+    }
+
+    #[test]
+    fn offsets_bottom_aligned_text_inside_a_tall_row() {
+        let block: TableBlock = serde_json::from_value(json!({
+            "id": 0,
+            "rows": [{ "id": 0, "cells": [
+                { "id": 0, "verticalAlign": "bottom", "blocks": [para()] }
+            ] }],
+            "columnWidths": [100],
+        }))
+        .unwrap();
+        let measure: TableExtent = serde_json::from_value(json!({
+            "rows": [{ "height": 60, "cells": [
+                { "blocks": [para_measure(1)], "width": 100, "height": 20 }
+            ] }],
+            "columnWidths": [100], "totalWidth": 100, "totalHeight": 60,
         }))
         .unwrap();
         let info = build_table_row_break_info(&block, &measure);

--- a/crates/docx-layout/tests/display_list.rs
+++ b/crates/docx-layout/tests/display_list.rs
@@ -1061,15 +1061,13 @@ fn cell_anchored_floating_images_paint_at_cell_relative_geometry() {
     };
     let nf = |n: &serde_json::Number| n.as_f64().unwrap();
 
-    // cell content box origin: cx(50) + padLeft(7) = 57 x, cy(50) + padTop(1) = 51 y
-    // front float is flush-right: x = contentX + (contentWidth 186 - width 40) = 203
     let front = image("rIdFront");
     assert!(
         (nf(&front.x) - 203.0).abs() < 0.001,
         "front x {:?}",
         front.x
     );
-    assert!((nf(&front.y) - 51.0).abs() < 0.001, "front y {:?}", front.y);
+    assert!((nf(&front.y) - 50.0).abs() < 0.001, "front y {:?}", front.y);
     assert!((nf(&front.w) - 40.0).abs() < 0.001);
     assert!((nf(&front.h) - 30.0).abs() < 0.001);
     assert_eq!(front.alt_text.as_deref(), Some("front logo"));
@@ -1091,7 +1089,7 @@ fn cell_anchored_floating_images_paint_at_cell_relative_geometry() {
         behind.x
     );
     assert!(
-        (nf(&behind.y) - 51.0).abs() < 0.001,
+        (nf(&behind.y) - 50.0).abs() < 0.001,
         "behind y {:?}",
         behind.y
     );

--- a/crates/docx-layout/tests/display_list.rs
+++ b/crates/docx-layout/tests/display_list.rs
@@ -1898,6 +1898,76 @@ fn table_cell_content_insets_border_and_honors_valign() {
     );
 }
 
+#[test]
+fn carried_table_borders_preserve_cell_content_across_slices() {
+    use serde_json::json;
+
+    for (alignment, first_baseline) in [("top", 14.0), ("center", 42.0), ("bottom", 70.0)] {
+        let paragraphs: Vec<_> = (0..4)
+            .map(|index| {
+                json!({ "kind": "paragraph", "id": 70 + index,
+                    "runs": [{ "kind": "text", "text": index.to_string() }] })
+            })
+            .collect();
+        let paragraph_measure = json!({ "kind": "paragraph", "totalHeight": 20.0,
+            "lines": [{ "headRun": 0, "headChar": 0, "tailRun": 0, "tailChar": 1,
+                "width": 8.0, "ascent": 12.0, "descent": 4.0, "lineHeight": 20.0 }] });
+        let mut input = json!({
+            "measured": [{
+                "block": { "kind": "table", "id": 7, "rows": [
+                    { "id": 0, "cells": [{ "id": 0, "blocks": [] }] },
+                    { "id": 1, "cells": [{ "id": 1, "verticalAlign": alignment,
+                        "borders": { "top": { "style": "single", "width": 8.0 },
+                            "bottom": { "style": "single", "width": 4.0 } },
+                        "blocks": paragraphs }] }
+                ] },
+                "measure": { "kind": "table", "columnWidths": [100.0],
+                    "totalWidth": 100.0, "totalHeight": 230.0, "rows": [
+                        { "height": 90.0, "cells": [{ "width": 100.0, "height": 0.0, "blocks": [] }] },
+                        { "height": 140.0, "cells": [{ "width": 100.0, "height": 80.0,
+                            "blocks": vec![paragraph_measure; 4] }] }
+                    ] }
+            }],
+            "options": { "pageSize": { "w": 200.0, "h": 100.0 },
+                "margins": { "top": 0.0, "right": 0.0, "bottom": 0.0, "left": 0.0 } }
+        });
+        input["layout"] = serde_json::from_str(
+            &docx_layout::layout_to_canonical_json(&input.to_string()).unwrap(),
+        )
+        .unwrap();
+        let dl = build_dl(&input.to_string());
+        assert_eq!(dl.pages.len(), 3, "{alignment}");
+        assert_eq!(input["layout"]["pages"][1]["fragments"][0]["rowStart"], 1);
+        assert!(dl.pages[1].primitives.iter().any(|primitive| {
+            matches!(primitive, Primitive::Line(line)
+                if line.attrs.cell.as_ref().is_some_and(|cell| cell.owns_top_border == Some(true)))
+        }));
+        let mut seen = Vec::new();
+        for (page_index, page) in dl.pages.iter().enumerate().skip(1) {
+            let fragment = &input["layout"]["pages"][page_index]["fragments"][0];
+            let clipped = fragment["clipTop"].as_f64().unwrap_or(0.0);
+            let height = fragment["height"].as_f64().unwrap();
+            for (text, _, _, baseline, _) in text_prims(&page.primitives) {
+                let index = text.parse::<usize>().unwrap();
+                assert_eq!(
+                    baseline + clipped,
+                    first_baseline + index as f64 * 20.0,
+                    "{alignment}, page {page_index}, line {index}"
+                );
+                if baseline - 14.0 >= height || baseline + 6.0 <= 0.0 {
+                    continue;
+                }
+                assert!(
+                    baseline >= 14.0 && baseline + 6.0 <= height,
+                    "{alignment}, line {index} crosses the fragment clip"
+                );
+                seen.push(index);
+            }
+        }
+        assert_eq!(seen, vec![0, 1, 2, 3], "{alignment}");
+    }
+}
+
 /// Cell paragraphs use max-collapsed inter-paragraph spacing.
 #[test]
 fn cell_paragraphs_stack_with_collapsed_spacing() {

--- a/crates/docx-layout/tests/fixtures/table-splits-with-repeated-header.displaylist.json
+++ b/crates/docx-layout/tests/fixtures/table-splits-with-repeated-header.displaylist.json
@@ -19,7 +19,7 @@
       "pageIndex": 0,
       "primitives": [
         {
-          "baselineY": 80.2,
+          "baselineY": 79.2,
           "blockId": 500000,
           "cell": {
             "cellId": "50-r0-c0",
@@ -55,7 +55,7 @@
           "x": 67
         },
         {
-          "baselineY": 104.2,
+          "baselineY": 103.2,
           "blockId": 500001,
           "cell": {
             "cellId": "50-r1-c0",
@@ -93,7 +93,7 @@
           "x": 67
         },
         {
-          "baselineY": 128.2,
+          "baselineY": 127.2,
           "blockId": 500001,
           "cell": {
             "cellId": "50-r1-c0",
@@ -131,7 +131,7 @@
           "x": 67
         },
         {
-          "baselineY": 152.2,
+          "baselineY": 151.2,
           "blockId": 500001,
           "cell": {
             "cellId": "50-r1-c0",
@@ -169,7 +169,7 @@
           "x": 67
         },
         {
-          "baselineY": 176.2,
+          "baselineY": 175.2,
           "blockId": 500001,
           "cell": {
             "cellId": "50-r1-c0",
@@ -207,7 +207,7 @@
           "x": 67
         },
         {
-          "baselineY": 200.2,
+          "baselineY": 199.2,
           "blockId": 500001,
           "cell": {
             "cellId": "50-r1-c0",
@@ -245,7 +245,7 @@
           "x": 67
         },
         {
-          "baselineY": 224.2,
+          "baselineY": 223.2,
           "blockId": 500001,
           "cell": {
             "cellId": "50-r1-c0",
@@ -283,7 +283,7 @@
           "x": 67
         },
         {
-          "baselineY": 248.2,
+          "baselineY": 247.2,
           "blockId": 500002,
           "cell": {
             "cellId": "50-r2-c0",
@@ -321,7 +321,7 @@
           "x": 67
         },
         {
-          "baselineY": 272.2,
+          "baselineY": 271.2,
           "blockId": 500002,
           "cell": {
             "cellId": "50-r2-c0",
@@ -359,7 +359,7 @@
           "x": 67
         },
         {
-          "baselineY": 296.2,
+          "baselineY": 295.2,
           "blockId": 500002,
           "cell": {
             "cellId": "50-r2-c0",
@@ -397,7 +397,7 @@
           "x": 67
         },
         {
-          "baselineY": 320.2,
+          "baselineY": 319.2,
           "blockId": 500002,
           "cell": {
             "cellId": "50-r2-c0",
@@ -435,7 +435,7 @@
           "x": 67
         },
         {
-          "baselineY": 344.2,
+          "baselineY": 343.2,
           "blockId": 500002,
           "cell": {
             "cellId": "50-r2-c0",
@@ -473,7 +473,7 @@
           "x": 67
         },
         {
-          "baselineY": 368.2,
+          "baselineY": 367.2,
           "blockId": 500002,
           "cell": {
             "cellId": "50-r2-c0",
@@ -511,7 +511,7 @@
           "x": 67
         },
         {
-          "baselineY": 392.2,
+          "baselineY": 391.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -549,7 +549,7 @@
           "x": 67
         },
         {
-          "baselineY": 416.2,
+          "baselineY": 415.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -608,7 +608,7 @@
       "pageIndex": 1,
       "primitives": [
         {
-          "baselineY": 80.2,
+          "baselineY": 79.2,
           "blockId": 500000,
           "cell": {
             "cellId": "50-r0-c0",
@@ -645,45 +645,7 @@
           "x": 67
         },
         {
-          "baselineY": 56.2,
-          "blockId": 500003,
-          "cell": {
-            "cellId": "50-r3-c0",
-            "col": 0,
-            "colSpan": 1,
-            "headerIds": [
-              "50-r0-c0"
-            ],
-            "row": 3,
-            "rowSpan": 1
-          },
-          "clipGroup": {
-            "clip": {
-              "h": 120,
-              "w": 400,
-              "x": 60,
-              "y": 60
-            },
-            "id": "clip-50-r3-c0"
-          },
-          "color": "#000000",
-          "font": "400 14.667px Calibri, sans-serif",
-          "kind": "text",
-          "lineIndex": 0,
-          "table": {
-            "columnCount": 1,
-            "headerRowCount": 1,
-            "rowCount": 7,
-            "rowEnd": 6,
-            "rowStart": 3,
-            "tableId": "50"
-          },
-          "text": "c",
-          "width": 400,
-          "x": 67
-        },
-        {
-          "baselineY": 80.2,
+          "baselineY": 79.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -721,7 +683,7 @@
           "x": 67
         },
         {
-          "baselineY": 104.2,
+          "baselineY": 103.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -759,7 +721,7 @@
           "x": 67
         },
         {
-          "baselineY": 128.2,
+          "baselineY": 127.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -797,7 +759,7 @@
           "x": 67
         },
         {
-          "baselineY": 152.2,
+          "baselineY": 151.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -835,7 +797,7 @@
           "x": 67
         },
         {
-          "baselineY": 176.2,
+          "baselineY": 175.2,
           "blockId": 500003,
           "cell": {
             "cellId": "50-r3-c0",
@@ -873,7 +835,7 @@
           "x": 67
         },
         {
-          "baselineY": 200.2,
+          "baselineY": 199.2,
           "blockId": 500004,
           "cell": {
             "cellId": "50-r4-c0",
@@ -911,7 +873,7 @@
           "x": 67
         },
         {
-          "baselineY": 224.2,
+          "baselineY": 223.2,
           "blockId": 500004,
           "cell": {
             "cellId": "50-r4-c0",
@@ -949,7 +911,7 @@
           "x": 67
         },
         {
-          "baselineY": 248.2,
+          "baselineY": 247.2,
           "blockId": 500004,
           "cell": {
             "cellId": "50-r4-c0",
@@ -987,7 +949,7 @@
           "x": 67
         },
         {
-          "baselineY": 272.2,
+          "baselineY": 271.2,
           "blockId": 500004,
           "cell": {
             "cellId": "50-r4-c0",
@@ -1025,7 +987,7 @@
           "x": 67
         },
         {
-          "baselineY": 296.2,
+          "baselineY": 295.2,
           "blockId": 500004,
           "cell": {
             "cellId": "50-r4-c0",
@@ -1063,7 +1025,7 @@
           "x": 67
         },
         {
-          "baselineY": 320.2,
+          "baselineY": 319.2,
           "blockId": 500004,
           "cell": {
             "cellId": "50-r4-c0",
@@ -1101,7 +1063,7 @@
           "x": 67
         },
         {
-          "baselineY": 344.2,
+          "baselineY": 343.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1139,7 +1101,7 @@
           "x": 67
         },
         {
-          "baselineY": 368.2,
+          "baselineY": 367.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1177,7 +1139,7 @@
           "x": 67
         },
         {
-          "baselineY": 392.2,
+          "baselineY": 391.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1215,7 +1177,7 @@
           "x": 67
         },
         {
-          "baselineY": 416.2,
+          "baselineY": 415.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1274,7 +1236,7 @@
       "pageIndex": 2,
       "primitives": [
         {
-          "baselineY": 80.2,
+          "baselineY": 79.2,
           "blockId": 500000,
           "cell": {
             "cellId": "50-r0-c0",
@@ -1311,45 +1273,7 @@
           "x": 67
         },
         {
-          "baselineY": 56.2,
-          "blockId": 500005,
-          "cell": {
-            "cellId": "50-r5-c0",
-            "col": 0,
-            "colSpan": 1,
-            "headerIds": [
-              "50-r0-c0"
-            ],
-            "row": 5,
-            "rowSpan": 1
-          },
-          "clipGroup": {
-            "clip": {
-              "h": 72,
-              "w": 400,
-              "x": 60,
-              "y": 60
-            },
-            "id": "clip-50-r5-c0"
-          },
-          "color": "#000000",
-          "font": "400 14.667px Calibri, sans-serif",
-          "kind": "text",
-          "lineIndex": 2,
-          "table": {
-            "columnCount": 1,
-            "headerRowCount": 1,
-            "rowCount": 7,
-            "rowEnd": 7,
-            "rowStart": 5,
-            "tableId": "50"
-          },
-          "text": "c",
-          "width": 400,
-          "x": 67
-        },
-        {
-          "baselineY": 80.2,
+          "baselineY": 79.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1387,7 +1311,7 @@
           "x": 67
         },
         {
-          "baselineY": 104.2,
+          "baselineY": 103.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1425,7 +1349,7 @@
           "x": 67
         },
         {
-          "baselineY": 128.2,
+          "baselineY": 127.2,
           "blockId": 500005,
           "cell": {
             "cellId": "50-r5-c0",
@@ -1463,7 +1387,7 @@
           "x": 67
         },
         {
-          "baselineY": 152.2,
+          "baselineY": 151.2,
           "blockId": 500006,
           "cell": {
             "cellId": "50-r6-c0",
@@ -1501,7 +1425,7 @@
           "x": 67
         },
         {
-          "baselineY": 176.2,
+          "baselineY": 175.2,
           "blockId": 500006,
           "cell": {
             "cellId": "50-r6-c0",
@@ -1539,7 +1463,7 @@
           "x": 67
         },
         {
-          "baselineY": 200.2,
+          "baselineY": 199.2,
           "blockId": 500006,
           "cell": {
             "cellId": "50-r6-c0",
@@ -1577,7 +1501,7 @@
           "x": 67
         },
         {
-          "baselineY": 224.2,
+          "baselineY": 223.2,
           "blockId": 500006,
           "cell": {
             "cellId": "50-r6-c0",
@@ -1615,7 +1539,7 @@
           "x": 67
         },
         {
-          "baselineY": 248.2,
+          "baselineY": 247.2,
           "blockId": 500006,
           "cell": {
             "cellId": "50-r6-c0",
@@ -1653,7 +1577,7 @@
           "x": 67
         },
         {
-          "baselineY": 272.2,
+          "baselineY": 271.2,
           "blockId": 500006,
           "cell": {
             "cellId": "50-r6-c0",

--- a/crates/docx-layout/tests/fixtures/vertically-merged-cell-continuation.displaylist.json
+++ b/crates/docx-layout/tests/fixtures/vertically-merged-cell-continuation.displaylist.json
@@ -19,7 +19,7 @@
       "pageIndex": 0,
       "primitives": [
         {
-          "baselineY": 70.2,
+          "baselineY": 69.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -53,7 +53,7 @@
           "x": 57
         },
         {
-          "baselineY": 94.2,
+          "baselineY": 93.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -87,7 +87,7 @@
           "x": 57
         },
         {
-          "baselineY": 118.2,
+          "baselineY": 117.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -121,7 +121,7 @@
           "x": 57
         },
         {
-          "baselineY": 142.2,
+          "baselineY": 141.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -155,7 +155,7 @@
           "x": 57
         },
         {
-          "baselineY": 166.2,
+          "baselineY": 165.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -189,7 +189,7 @@
           "x": 57
         },
         {
-          "baselineY": 190.2,
+          "baselineY": 189.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -223,7 +223,7 @@
           "x": 57
         },
         {
-          "baselineY": 214.2,
+          "baselineY": 213.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -257,7 +257,7 @@
           "x": 57
         },
         {
-          "baselineY": 238.2,
+          "baselineY": 237.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -291,7 +291,7 @@
           "x": 57
         },
         {
-          "baselineY": 262.2,
+          "baselineY": 261.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -325,7 +325,7 @@
           "x": 57
         },
         {
-          "baselineY": 286.2,
+          "baselineY": 285.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -359,7 +359,7 @@
           "x": 57
         },
         {
-          "baselineY": 310.2,
+          "baselineY": 309.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -393,7 +393,7 @@
           "x": 57
         },
         {
-          "baselineY": 334.2,
+          "baselineY": 333.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -427,7 +427,7 @@
           "x": 57
         },
         {
-          "baselineY": 358.2,
+          "baselineY": 357.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -461,7 +461,7 @@
           "x": 57
         },
         {
-          "baselineY": 382.2,
+          "baselineY": 381.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -495,7 +495,7 @@
           "x": 57
         },
         {
-          "baselineY": 406.2,
+          "baselineY": 405.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -529,7 +529,7 @@
           "x": 57
         },
         {
-          "baselineY": 430.2,
+          "baselineY": 429.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -563,7 +563,7 @@
           "x": 57
         },
         {
-          "baselineY": 454.2,
+          "baselineY": 453.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -597,7 +597,7 @@
           "x": 57
         },
         {
-          "baselineY": 478.2,
+          "baselineY": 477.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -631,7 +631,7 @@
           "x": 57
         },
         {
-          "baselineY": 502.2,
+          "baselineY": 501.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -665,7 +665,7 @@
           "x": 57
         },
         {
-          "baselineY": 526.2,
+          "baselineY": 525.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -699,7 +699,7 @@
           "x": 57
         },
         {
-          "baselineY": 70.2,
+          "baselineY": 69.2,
           "blockId": 600002,
           "cell": {
             "cellId": "60-r0-c1",
@@ -733,7 +733,7 @@
           "x": 157
         },
         {
-          "baselineY": 94.2,
+          "baselineY": 93.2,
           "blockId": 600004,
           "cell": {
             "cellId": "60-r1-c1",
@@ -767,7 +767,7 @@
           "x": 157
         },
         {
-          "baselineY": 118.2,
+          "baselineY": 117.2,
           "blockId": 600006,
           "cell": {
             "cellId": "60-r2-c1",
@@ -822,42 +822,7 @@
       "pageIndex": 1,
       "primitives": [
         {
-          "baselineY": 46.2,
-          "blockId": 600001,
-          "cell": {
-            "cellId": "60-r0-c0",
-            "col": 0,
-            "colSpan": 1,
-            "continuation": true,
-            "row": 0,
-            "rowSpan": 3
-          },
-          "clipGroup": {
-            "clip": {
-              "h": 480,
-              "w": 100,
-              "x": 50,
-              "y": 50
-            },
-            "id": "clip-60-r0-c0"
-          },
-          "color": "#000000",
-          "font": "400 14.667px Calibri, sans-serif",
-          "kind": "text",
-          "lineIndex": 19,
-          "table": {
-            "columnCount": 2,
-            "rowCount": 3,
-            "rowEnd": 3,
-            "rowStart": 2,
-            "tableId": "60"
-          },
-          "text": "m",
-          "width": 100,
-          "x": 57
-        },
-        {
-          "baselineY": 70.2,
+          "baselineY": 69.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -892,7 +857,7 @@
           "x": 57
         },
         {
-          "baselineY": 94.2,
+          "baselineY": 93.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -927,7 +892,7 @@
           "x": 57
         },
         {
-          "baselineY": 118.2,
+          "baselineY": 117.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -962,7 +927,7 @@
           "x": 57
         },
         {
-          "baselineY": 142.2,
+          "baselineY": 141.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -997,7 +962,7 @@
           "x": 57
         },
         {
-          "baselineY": 166.2,
+          "baselineY": 165.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1032,7 +997,7 @@
           "x": 57
         },
         {
-          "baselineY": 190.2,
+          "baselineY": 189.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1067,7 +1032,7 @@
           "x": 57
         },
         {
-          "baselineY": 214.2,
+          "baselineY": 213.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1102,7 +1067,7 @@
           "x": 57
         },
         {
-          "baselineY": 238.2,
+          "baselineY": 237.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1137,7 +1102,7 @@
           "x": 57
         },
         {
-          "baselineY": 262.2,
+          "baselineY": 261.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1172,7 +1137,7 @@
           "x": 57
         },
         {
-          "baselineY": 286.2,
+          "baselineY": 285.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1207,7 +1172,7 @@
           "x": 57
         },
         {
-          "baselineY": 310.2,
+          "baselineY": 309.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1242,7 +1207,7 @@
           "x": 57
         },
         {
-          "baselineY": 334.2,
+          "baselineY": 333.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1277,7 +1242,7 @@
           "x": 57
         },
         {
-          "baselineY": 358.2,
+          "baselineY": 357.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1312,7 +1277,7 @@
           "x": 57
         },
         {
-          "baselineY": 382.2,
+          "baselineY": 381.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1347,7 +1312,7 @@
           "x": 57
         },
         {
-          "baselineY": 406.2,
+          "baselineY": 405.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1382,7 +1347,7 @@
           "x": 57
         },
         {
-          "baselineY": 430.2,
+          "baselineY": 429.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1417,7 +1382,7 @@
           "x": 57
         },
         {
-          "baselineY": 454.2,
+          "baselineY": 453.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1452,7 +1417,7 @@
           "x": 57
         },
         {
-          "baselineY": 478.2,
+          "baselineY": 477.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1487,7 +1452,7 @@
           "x": 57
         },
         {
-          "baselineY": 502.2,
+          "baselineY": 501.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",
@@ -1522,7 +1487,7 @@
           "x": 57
         },
         {
-          "baselineY": 526.2,
+          "baselineY": 525.2,
           "blockId": 600001,
           "cell": {
             "cellId": "60-r0-c0",


### PR DESCRIPTION
TL;DR:

Before/After:
Screenshots pending upload; local before/after renders have been verified. The first table row is clipped at the top of page 2 before the change and appears intact afterward.

Repro file:
[BetterOffice demo](https://corpus.betteroffice.dev/betteroffice-demo/source.docx) · [Word reference metadata](https://corpus.betteroffice.dev/betteroffice-demo/metadata.json)

Summary:
- Keep table text intact when a page break intersects centered or bottom-aligned cell content.
- Use the same vertical cell offsets for pagination and rendering, including borders and atomic cell content.
- Match rendering to the layout engine's zero default vertical cell padding.
- Frozen Word demo SSIM with CDN fonts: **0.7711 → 0.7861**, with 2/2 pages and no image resizing or alignment. Calibri Light substitution and other layout differences remain.

Test plan:
- [x] DOCX layout tests (292 passed), including aligned-cell pagination, fractional padding, carried borders, and atomic image regressions.
- [x] Strict Clippy for all DOCX layout targets.
- [x] Resident DOCX editing tests (212 passed, 1 existing ignored).
- [x] Production DOCX Wasm/package build and frozen-reference capture of `2e8ce5edeb0498ca4f5ad0508194e5c54c582b8f`.
- [x] Five additional Open XML SDK table fixtures: identical before/after PNGs, SSIM 0.9144–0.9744.
- [x] Previously hanging Japanese document: 2 pages in 5.47s with CDN fonts and 4.52s without fonts; source and renders stay local.
- [ ] Attach the verified before/after screenshots.
