### PR TITLE
feat(ci): benchmark licensed Office corpus collections

### DIFF
--- a/.github/workflows/visual-fidelity.yml
+++ b/.github/workflows/visual-fidelity.yml
@@ -8,10 +8,15 @@ on:
         default: main
         required: true
         type: string
-      samples:
-        description: JSON array of public corpus sample folders
-        default: '["betteroffice-demo","betteroffice-slides","betteroffice-workbook"]'
+      collection:
+        description: Public corpus collection to benchmark
+        default: office-quality
         required: true
+        type: string
+      samples:
+        description: Optional JSON array of sample folders overriding the collection
+        default: ''
+        required: false
         type: string
 
 permissions:
@@ -84,11 +89,12 @@ jobs:
 
       - name: Check benchmark scripts
         run: |
-          bun test scripts/office-quality/readme.test.ts
+          bun test scripts/office-quality
           python -m unittest discover -s scripts/office-quality -p 'test_*.py'
 
       - name: Measure the latest release and source commit
         env:
+          QUALITY_COLLECTION: ${{ inputs.collection }}
           QUALITY_SAMPLES: ${{ inputs.samples }}
           QUALITY_OUTPUT: .source/office-quality/ci
         run: |

--- a/scripts/docx-quality/browser-task.mjs
+++ b/scripts/docx-quality/browser-task.mjs
@@ -122,12 +122,14 @@ try {
       Buffer.from(png.split(',')[1], 'base64')
     );
   }
+  const captureMetadata = await page.evaluate(() => window.oracleCaptureMetadata?.() ?? {});
   if (networkViolations.length)
     throw new Error(`Unexpected external requests: ${JSON.stringify(networkViolations)}`);
   const record = {
     status: 'ok',
     ...metadata,
     ...result,
+    ...captureMetadata,
     logs,
     externalRequests,
     ms: performance.now() - start,

--- a/scripts/docx-quality/harness.tsx
+++ b/scripts/docx-quality/harness.tsx
@@ -4,6 +4,11 @@ import { DocxEditor } from '@betteroffice/docx-react';
 import { setGoogleFontsEnabled } from '@betteroffice/docx/utils';
 import '@betteroffice/docx-react/styles.css';
 import { createFontProvider } from '../../packages/fonts/src/cdn';
+import {
+  capturePageExtent,
+  validatePageBounds,
+  type OfficePageBounds,
+} from '../office-quality/page-bounds';
 
 const provider = createFontProvider();
 setGoogleFontsEnabled(false);
@@ -43,7 +48,11 @@ let editor: React.RefObject<any>;
 let root: ReturnType<typeof createRoot>;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const api = window as any;
-api.oracleInit = async (input: number[], fonts: boolean) => {
+let captureProfile: OfficePageBounds | null = null;
+const pageExtents: ReturnType<typeof capturePageExtent>[] = [];
+api.oracleInit = async (input: number[], fonts: boolean, profile?: unknown) => {
+  captureProfile = validatePageBounds(profile);
+  pageExtents.length = 0;
   fontLoads.length = 0;
   const bytes = new Uint8Array(input).buffer;
   root?.unmount();
@@ -93,19 +102,27 @@ api.oraclePage = async (index: number) => {
       `canvas[data-page-index="${index}"]`
     );
     if (canvas?.width && canvas?.height) {
+      const extent = capturePageExtent(captureProfile, index, canvas.width, canvas.height);
       const output = document.createElement('canvas');
-      output.width = canvas.width;
-      output.height = canvas.height;
+      output.width = extent.output.width_px;
+      output.height = extent.output.height_px;
       const context = output.getContext('2d')!;
       context.fillStyle = '#ffffff';
       context.fillRect(0, 0, output.width, output.height);
       context.drawImage(canvas, 0, 0);
       const value = output.toDataURL('image/png');
       equal = value === previous ? equal + 1 : 0;
-      if (equal >= 2) return value;
+      if (equal >= 2) {
+        pageExtents[index] = extent;
+        return value;
+      }
       previous = value;
     }
     await sleep(200);
   }
 };
+api.oracleCaptureMetadata = () => ({
+  capture_profile: captureProfile,
+  page_extents: pageExtents,
+});
 api.oracleReady = true;

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -42,8 +42,6 @@ Requires macOS and desktop Word, PowerPoint, or Excel. Run exports serially into
 
 The extension selects the app. Output includes `reference.pdf`, numbered PNGs at 150 DPI, and `result.json` with source hashes, Office/macOS versions, font names, UTC timestamps, and export status. The timeout defaults to 120 seconds; override it with `--timeout`.
 
-DOCX references record each PDF page's physical and raster bounds. The capture profile permits a one-pixel canvas extent difference on each axis, adding white space or clipping at the right/bottom edge without moving or resampling rendered content. Larger differences fail; extra renderer pages retain their native bounds. Captures record the original and output dimensions for each page.
-
 For XLSX comparisons, add `--xlsx-profile /path/to/profile.json`. The profile specifies `scale_percent`, `margin_pt`, and `pages` with zero-based `sheet` indices and A1 `range` values. Each range must fit one page. The demo's nine-page profile is stored in its metadata under `reference.capture_profile`. This measures worksheet range rendering, not automatic print pagination; frozen panes are unsupported. Print settings apply only to the temporary workbook, leaving source bytes unchanged.
 
 ## macOS permissions
@@ -58,7 +56,15 @@ The scripts use local PDF export. For manual Word exports, choose **Best for pri
 
 ## Compare local captures
 
-Capture BetterOffice using the [DOCX instructions](../docx-quality/README.md). For PPTX/XLSX, set `QUALITY_FORMAT=pptx` or `xlsx` on the shared server and use the matching `?format=` in the capture URL. Pass the XLSX profile through `QUALITY_CAPTURE_CONFIG`. Document bytes stay local; external browser requests are limited to pinned font files.
+Capture BetterOffice using the [DOCX instructions](../docx-quality/README.md). For PPTX/XLSX, set `QUALITY_FORMAT=pptx` or `xlsx` on the shared server and use the matching `?format=` in the capture URL. Document bytes stay local; external browser requests are limited to pinned font files.
+
+DOCX references record each PDF page's physical and raster bounds. The capture profile permits a one-pixel canvas extent difference on each axis, adding white space or clipping at the right/bottom edge without moving or resampling rendered content. Larger differences fail; extra renderer pages retain their native bounds. Captures record the original and output dimensions for each page.
+
+For DOCX and XLSX, load the reference profile before running the capture command. Collection runs do this automatically:
+
+```sh
+export QUALITY_CAPTURE_CONFIG="$(jq -c '.capture_profile // null' .source/office-quality/example/office/result.json)"
+```
 
 ```sh
 .source/office-quality/venv/bin/python scripts/office-quality/compare.py \

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -1,6 +1,6 @@
 # Office visual quality harness
 
-Compare DOCX, PPTX, and XLSX renders against Microsoft Office. Inputs and generated files stay in ignored `.source/office-quality/`; the benchmark downloads the three public demo references listed below.
+Compare DOCX, PPTX, and XLSX renders against Microsoft Office. Inputs and generated files stay in ignored `.source/office-quality/`; references come from the public corpus.
 
 ## Local benchmark
 
@@ -19,7 +19,7 @@ QUALITY_OUTPUT=.source/office-quality/run \
 node scripts/office-quality/readme.mjs .source/office-quality/run/report.json
 ```
 
-The runner compares the latest npm releases with the checked-out source using pinned CDN fonts. Commit source changes first and choose an empty output directory. Set `QUALITY_SAMPLES='["betteroffice-demo"]'` to select a subset; all three demos run by default.
+The runner compares the latest npm releases with the checked-out source using pinned CDN fonts. Commit source changes first and choose an empty output directory. The default [`office-quality` collection](https://corpus.betteroffice.dev/collections/office-quality.json) selects the three demos and 48 English Open XML SDK fixtures. Set `QUALITY_COLLECTION` to another collection or `QUALITY_SAMPLES='["betteroffice-demo"]'` to select a subset, overriding the collection. Runs support up to 100 samples.
 
 ## Manual CI and generated README
 
@@ -29,7 +29,7 @@ After the [workflow](../../.github/workflows/visual-fidelity.yml) lands on `main
 gh workflow run visual-fidelity.yml --ref main -f branch=main
 ```
 
-Keep `--ref main`; set `branch` to the repository branch to measure. The action uses existing bot credentials to update the [README scores](../../README.md#visual-fidelity) as `openooxml-bot[bot]`. Unchanged results create no commit; a changed branch head requires a rerun. Runs are manual only. CI retains score JSON and generated Markdown; documents and page images are excluded from uploaded artifacts.
+Keep `--ref main`; set `branch` to the repository branch to measure. The optional `collection` and `samples` inputs select the corpus as above. The action uses existing bot credentials to update the [README scores](../../README.md#visual-fidelity) as `openooxml-bot[bot]`. Unchanged results create no commit; a changed branch head requires a rerun. Runs are manual only. CI retains score JSON and generated Markdown; documents and page images are excluded from uploaded artifacts.
 
 ## Office references
 
@@ -41,6 +41,8 @@ Requires macOS and desktop Word, PowerPoint, or Excel. Run exports serially into
 ```
 
 The extension selects the app. Output includes `reference.pdf`, numbered PNGs at 150 DPI, and `result.json` with source hashes, Office/macOS versions, font names, UTC timestamps, and export status. The timeout defaults to 120 seconds; override it with `--timeout`.
+
+DOCX references record each PDF page's physical and raster bounds. The capture profile permits a one-pixel canvas extent difference on each axis, adding white space or clipping at the right/bottom edge without moving or resampling rendered content. Larger differences fail; extra renderer pages retain their native bounds. Captures record the original and output dimensions for each page.
 
 For XLSX comparisons, add `--xlsx-profile /path/to/profile.json`. The profile specifies `scale_percent`, `margin_pt`, and `pages` with zero-based `sheet` indices and A1 `range` values. Each range must fit one page. The demo's nine-page profile is stored in its metadata under `reference.capture_profile`. This measures worksheet range rendering, not automatic print pagination; frozen panes are unsupported. Print settings apply only to the temporary workbook, leaving source bytes unchanged.
 
@@ -86,7 +88,7 @@ The `betteroffice-corpus` R2 bucket is served at **https://corpus.betteroffice.d
 | [betteroffice-slides](https://corpus.betteroffice.dev/betteroffice-slides/metadata.json) | PPTX | 3 |
 | [betteroffice-workbook](https://corpus.betteroffice.dev/betteroffice-workbook/metadata.json) | XLSX | 9 |
 
-Metadata links the source and PNGs and records capture provenance, hashes, and comparison results. Only the original project demos are public; private inputs and captures stay local. Publishing additional authorized samples requires authenticated Wrangler:
+Collection manifests live at `collections/<id>.json` with `schema_version: 1`, the collection `id`, and a `samples` array of folder names. Sample metadata links the source and PNGs and records capture provenance, hashes, comparisons, and licensing. The SDK fixtures retain their upstream MIT notice; private inputs and captures stay local. Publishing additional authorized samples requires authenticated Wrangler:
 
 ```sh
 bunx wrangler r2 object put betteroffice-corpus/<key> --file <local-file> --remote

--- a/scripts/office-quality/page-bounds.test.ts
+++ b/scripts/office-quality/page-bounds.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from 'bun:test';
+import { capturePageExtent, validatePageBounds } from './page-bounds';
+
+const a4 = { width_pt: 595.25, height_pt: 842, width_px: 1241, height_px: 1755 };
+const letter = { width_pt: 612, height_pt: 792, width_px: 1275, height_px: 1650 };
+const profile = (pages = [a4]) => ({ kind: 'office-page-bounds', pages });
+
+test('uses the recorded PDF extent for one-pixel A4 canvas differences', () => {
+  const bounds = validatePageBounds(profile());
+  expect(capturePageExtent(bounds, 0, 1240, 1754)).toEqual({
+    page: 1,
+    raw: { width_px: 1240, height_px: 1754 },
+    output: { width_px: 1241, height_px: 1755 },
+    adjustment: 'office-page-bounds',
+  });
+  expect(capturePageExtent(bounds, 0, 1242, 1756).output).toEqual({
+    width_px: 1241,
+    height_px: 1755,
+  });
+});
+
+test('leaves matching Letter pages and captures without a profile unchanged', () => {
+  for (const bounds of [validatePageBounds(profile([letter])), null]) {
+    const extent = capturePageExtent(bounds, 0, 1275, 1650);
+    expect(extent.output).toEqual(extent.raw);
+    expect(extent.adjustment).toBe('none');
+  }
+  expect(validatePageBounds(undefined)).toBeNull();
+  expect(validatePageBounds(null)).toBeNull();
+});
+
+test('preserves extra actual pages at native size', () => {
+  const extent = capturePageExtent(validatePageBounds(profile()), 1, 2550, 1650);
+  expect(extent).toEqual({
+    page: 2,
+    raw: { width_px: 2550, height_px: 1650 },
+    output: { width_px: 2550, height_px: 1650 },
+    adjustment: 'none',
+  });
+});
+
+test('rejects larger geometry differences on either axis', () => {
+  const bounds = validatePageBounds(profile());
+  for (const [width, height] of [
+    [1239, 1755],
+    [1243, 1755],
+    [1241, 1753],
+    [1241, 1757],
+    [1755, 1241],
+  ]) {
+    expect(() => capturePageExtent(bounds, 0, width, height)).toThrow('more than 1 pixel');
+  }
+});
+
+test('validates physical sizes and exact 150-DPI raster extents', () => {
+  for (const page of [
+    { ...a4, width_pt: NaN },
+    { ...a4, height_pt: Infinity },
+    { ...a4, width_pt: 0 },
+    { ...a4, height_pt: -1 },
+    { ...a4, width_pt: 10000 },
+    { ...a4, width_px: 0 },
+    { ...a4, height_px: 1755.5 },
+    { ...a4, width_px: 8193 },
+    { ...a4, width_px: 1240 },
+    { ...a4, height_px: 1754 },
+    { ...letter, width_px: 1224, height_px: 1584 },
+  ]) {
+    expect(() => validatePageBounds(profile([page]))).toThrow('150 DPI');
+  }
+  const fractional = { width_pt: 600.01, height_pt: 800.01, width_px: 1251, height_px: 1667 };
+  expect(validatePageBounds(profile([fractional]))?.pages).toEqual([fractional]);
+});
+
+test('rejects unknown or malformed profiles and excessive page counts', () => {
+  for (const value of [
+    false,
+    'office-page-bounds',
+    {},
+    { kind: 'other', pages: [a4] },
+    { kind: 'office-page-bounds', pages: null },
+    profile([]),
+    profile(Array.from({ length: 101 }, () => a4)),
+  ]) {
+    expect(() => validatePageBounds(value)).toThrow('Invalid Office page bounds profile');
+  }
+  expect(() => validatePageBounds({ kind: 'office-page-bounds', pages: [null] })).toThrow(
+    '150 DPI'
+  );
+  expect(validatePageBounds(profile(Array.from({ length: 100 }, () => a4)))?.pages).toHaveLength(100);
+});
+
+test('rejects invalid page indices and native canvas dimensions', () => {
+  for (const [index, width, height] of [
+    [-1, 1275, 1650],
+    [0.5, 1275, 1650],
+    [0, 0, 1650],
+    [0, 1275, Infinity],
+  ]) {
+    expect(() => capturePageExtent(null, index, width, height)).toThrow('native canvas');
+  }
+});

--- a/scripts/office-quality/page-bounds.ts
+++ b/scripts/office-quality/page-bounds.ts
@@ -1,0 +1,77 @@
+export type OfficePageBounds = {
+  kind: 'office-page-bounds';
+  pages: {
+    width_pt: number;
+    height_pt: number;
+    width_px: number;
+    height_px: number;
+  }[];
+};
+
+const maximumPixels = 8192;
+
+export function validatePageBounds(input: unknown): OfficePageBounds | null {
+  if (input == null) return null;
+  const profile = input as OfficePageBounds;
+  if (
+    profile.kind !== 'office-page-bounds' ||
+    !Array.isArray(profile.pages) ||
+    !profile.pages.length ||
+    profile.pages.length > 100
+  )
+    throw new Error('Invalid Office page bounds profile');
+  return {
+    kind: 'office-page-bounds',
+    pages: profile.pages.map((page) => {
+      if (
+        !page ||
+        [page.width_pt, page.height_pt].some(
+          (value) =>
+            !Number.isFinite(value) || value <= 0 || value > (maximumPixels * 72) / 150
+        ) ||
+        [page.width_px, page.height_px].some(
+          (value) => !Number.isInteger(value) || value < 1 || value > maximumPixels
+        ) ||
+        page.width_px !== Math.ceil((page.width_pt * 150) / 72) ||
+        page.height_px !== Math.ceil((page.height_pt * 150) / 72)
+      )
+        throw new Error('Office page bounds must match the PDF extent at 150 DPI');
+      return {
+        width_pt: page.width_pt,
+        height_pt: page.height_pt,
+        width_px: page.width_px,
+        height_px: page.height_px,
+      };
+    }),
+  };
+}
+
+export function capturePageExtent(
+  profile: OfficePageBounds | null,
+  index: number,
+  width: number,
+  height: number
+) {
+  if (
+    !Number.isInteger(index) ||
+    index < 0 ||
+    [width, height].some((value) => !Number.isInteger(value) || value < 1)
+  )
+    throw new Error('Invalid native canvas extent');
+  const target = profile?.pages[index];
+  const raw = { width_px: width, height_px: height };
+  const output = target
+    ? { width_px: target.width_px, height_px: target.height_px }
+    : { ...raw };
+  if (Math.abs(output.width_px - width) > 1 || Math.abs(output.height_px - height) > 1)
+    throw new Error(`Page ${index + 1}: Office and native canvas extents differ by more than 1 pixel`);
+  return {
+    page: index + 1,
+    raw,
+    output,
+    adjustment:
+      output.width_px === width && output.height_px === height
+        ? 'none'
+        : 'office-page-bounds',
+  };
+}

--- a/scripts/office-quality/readme.mjs
+++ b/scripts/office-quality/readme.mjs
@@ -58,7 +58,7 @@ export function renderSection(report) {
 | --- | --- | ---: | --- | ---: | ---: |
 ${rows.join('\n')}
 
-SSIM is the mean page-penalized grayscale score at 150 DPI, without resizing or alignment correction. Missing or extra pages are penalized. All formats use pinned CDN fonts. XLSX uses recorded print ranges and scale; its score measures range rendering, not automatic print pagination. Demo samples do not establish corpus-wide quality or a leaderboard rank.
+SSIM is the mean page-penalized grayscale score at 150 DPI, without resampling or alignment correction. DOCX uses recorded page bounds with at most a one-pixel edge adjustment. Missing or extra pages are penalized. All formats use pinned CDN fonts. XLSX uses recorded print ranges and scale; its score measures range rendering, not automatic print pagination. Scores cover the selected corpus samples.
 ${END}`;
 }
 

--- a/scripts/office-quality/reference.py
+++ b/scripts/office-quality/reference.py
@@ -108,9 +108,16 @@ end run
             if document.page_count == 0:
                 raise ValueError('Office exported no pages')
             fonts = set()
+            page_bounds = []
             for index, page in enumerate(document):
-                page.get_pixmap(dpi=args.dpi, alpha=False).save(args.out / f'page_{index + 1:04d}.png')
+                pixmap = page.get_pixmap(dpi=args.dpi, alpha=False)
+                pixmap.save(args.out / f'page_{index + 1:04d}.png')
                 fonts.update(font[3] for font in page.get_fonts())
+                if extension == '.docx' and args.dpi == 150:
+                    page_bounds.append(dict(width_pt=page.rect.width, height_pt=page.rect.height,
+                                            width_px=pixmap.width, height_px=pixmap.height))
+            if page_bounds:
+                record['capture_profile'] = dict(kind='office-page-bounds', pages=page_bounds)
             record.update(status='ok', pages=len(document), fonts=sorted(fonts), pdf_metadata=document.metadata)
         shutil.copy2(pdf, args.out / 'reference.pdf')
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError, OSError, fitz.FileDataError) as error:

--- a/scripts/office-quality/run.mjs
+++ b/scripts/office-quality/run.mjs
@@ -5,24 +5,11 @@ import { createServer } from 'node:net';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { FORMATS, renderSection } from './readme.mjs';
+import { CORPUS_ORIGIN as corpus, selectSamples } from './samples.mjs';
 
 const execute = promisify(execFile);
 const output = resolve(process.env.QUALITY_OUTPUT ?? '.source/office-quality/run');
-const corpus = 'https://corpus.betteroffice.dev';
 const python = process.env.QUALITY_PYTHON ?? 'python3';
-const ids = JSON.parse(
-  process.env.QUALITY_SAMPLES ??
-    '["betteroffice-demo","betteroffice-slides","betteroffice-workbook"]'
-);
-if (
-  !Array.isArray(ids) ||
-  !ids.length ||
-  ids.length > 20 ||
-  ids.some((id) => typeof id !== 'string' || !/^[a-z0-9-]+$/.test(id)) ||
-  new Set(ids).size !== ids.length
-) {
-  throw new Error('QUALITY_SAMPLES must contain 1–20 unique sample folder names');
-}
 if (
   (
     await command('git', [
@@ -39,6 +26,7 @@ if (
 if ((await readdir(output).catch(() => [])).length)
   throw new Error('QUALITY_OUTPUT must be empty');
 await mkdir(output, { recursive: true });
+const ids = await selectSamples(process.env, download);
 
 async function command(program, args, options = {}) {
   const result = await execute(program, args, {

--- a/scripts/office-quality/samples.mjs
+++ b/scripts/office-quality/samples.mjs
@@ -1,0 +1,32 @@
+export const CORPUS_ORIGIN = 'https://corpus.betteroffice.dev';
+
+function isFolderName(value) {
+  return typeof value === 'string' && value.length > 0 && !/[^a-z0-9-]/.test(value);
+}
+
+function validateSamples(ids, label) {
+  if (
+    !Array.isArray(ids) ||
+    !ids.length ||
+    ids.length > 100 ||
+    ids.some((id) => !isFolderName(id)) ||
+    new Set(ids).size !== ids.length
+  )
+    throw new Error(`${label} must contain 1–100 unique sample folder names`);
+  return ids;
+}
+
+export async function selectSamples(environment, download) {
+  if (environment.QUALITY_SAMPLES?.trim())
+    return validateSamples(JSON.parse(environment.QUALITY_SAMPLES), 'QUALITY_SAMPLES');
+
+  const id = environment.QUALITY_COLLECTION || 'office-quality';
+  if (!isFolderName(id))
+    throw new Error('QUALITY_COLLECTION must be a collection folder name');
+  const manifest = JSON.parse(
+    await download(`${CORPUS_ORIGIN}/collections/${id}.json`, 2 * 1024 * 1024)
+  );
+  if (manifest?.schema_version !== 1 || manifest.id !== id)
+    throw new Error(`Invalid corpus collection: ${id}`);
+  return validateSamples(manifest.samples, `Collection ${id}`);
+}

--- a/scripts/office-quality/samples.test.ts
+++ b/scripts/office-quality/samples.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from 'bun:test';
+import { selectSamples } from './samples.mjs';
+
+const samples = Array.from({ length: 53 }, (_, index) => `sample-${index}`);
+
+function collection(ids = samples, id = 'office-quality') {
+  return JSON.stringify({ schema_version: 1, id, samples: ids });
+}
+
+test('loads the default collection from the canonical origin with a bounded download', async () => {
+  const requests: unknown[][] = [];
+  const selected = await selectSamples({}, async (...args: unknown[]) => {
+    requests.push(args);
+    return collection();
+  });
+  expect(selected).toEqual(samples);
+  expect(requests).toEqual([
+    ['https://corpus.betteroffice.dev/collections/office-quality.json', 2 * 1024 * 1024],
+  ]);
+});
+
+test('explicit samples override the collection without downloading it', async () => {
+  const selected = await selectSamples(
+    { QUALITY_SAMPLES: '["betteroffice-workbook"]', QUALITY_COLLECTION: '../ignored' },
+    async () => {
+      throw new Error('Unexpected download');
+    }
+  );
+  expect(selected).toEqual(['betteroffice-workbook']);
+});
+
+test('empty sample overrides use the selected collection', async () => {
+  for (const value of ['', ' \n ']) {
+    const selected = await selectSamples(
+      { QUALITY_SAMPLES: value, QUALITY_COLLECTION: 'demos' },
+      async (url: string) => {
+        expect(url).toBe('https://corpus.betteroffice.dev/collections/demos.json');
+        return collection(['betteroffice-demo'], 'demos');
+      }
+    );
+    expect(selected).toEqual(['betteroffice-demo']);
+  }
+});
+
+test('rejects invalid collection names before downloading', async () => {
+  for (const id of [
+    '../other',
+    '/other',
+    'https://example.com',
+    'other?x=1',
+    'Docs',
+    'docs\n',
+  ]) {
+    await expect(
+      selectSamples({ QUALITY_COLLECTION: id }, async () => {
+        throw new Error('Unexpected download');
+      })
+    ).rejects.toThrow('QUALITY_COLLECTION');
+  }
+});
+
+test('requires the requested collection identity and schema', async () => {
+  for (const manifest of [
+    null,
+    {},
+    { schema_version: 1, id: 'other', samples },
+    { schema_version: '1', id: 'office-quality', samples },
+    { schema_version: 2, id: 'office-quality', samples },
+  ]) {
+    await expect(
+      selectSamples({}, async () => JSON.stringify(manifest))
+    ).rejects.toThrow('Invalid corpus collection');
+  }
+});
+
+test('validates sample IDs, uniqueness, and the 100-sample limit in both selection paths', async () => {
+  const hundred = Array.from({ length: 100 }, (_, index) => `sample-${index}`);
+  expect(
+    await selectSamples({ QUALITY_SAMPLES: JSON.stringify(hundred) }, async () => '')
+  ).toEqual(hundred);
+  expect(await selectSamples({}, async () => collection(hundred))).toEqual(hundred);
+
+  for (const ids of [
+    [],
+    null,
+    'sample',
+    ['sample', 'sample'],
+    [''],
+    [42],
+    ['../source'],
+    ['nested/sample'],
+    ['sample?x=1'],
+    ['Sample'],
+    ['sample\n'],
+    [...hundred, 'one-too-many'],
+  ]) {
+    await expect(
+      selectSamples({ QUALITY_SAMPLES: JSON.stringify(ids) }, async () => '')
+    ).rejects.toThrow('1–100 unique sample folder names');
+    await expect(
+      selectSamples({}, async () =>
+        JSON.stringify({ schema_version: 1, id: 'office-quality', samples: ids })
+      )
+    ).rejects.toThrow('1–100 unique sample folder names');
+  }
+});
+
+test('rejects malformed explicit JSON without falling back to a collection', async () => {
+  await expect(
+    selectSamples({ QUALITY_SAMPLES: 'not-json' }, async () => {
+      throw new Error('Unexpected download');
+    })
+  ).rejects.toBeInstanceOf(SyntaxError);
+});


### PR DESCRIPTION
TL;DR:

Summary:
- Select public corpus collections locally and in the manual Visual fidelity action; explicit sample lists still override the collection.
- Expand the default collection to the three project demos and 48 English Open XML SDK fixtures. Corpus sources, MIT notices, Word reference PNGs, and provenance metadata live in R2, outside Git.
- Record Office PDF page bounds and reconcile at most one pixel at the canvas edge without translating or resampling rendered content. Preserve missing/extra-page penalties and reject larger geometry differences.
- Keep per-file hashes, upstream revisions, Office versions, UTC capture times, and export exclusions in public metadata.

The 50-fixture selection was frozen before measurement. Word 16.112.3 could not export the green and orange background fixtures; both are excluded without replacement. The remaining 48 fixtures have 52 Word reference pages. These are synthetic feature tests, separate from the project-demo before/after comparisons in #363 and #364.

Corpus: [default collection](https://corpus.betteroffice.dev/collections/office-quality.json) · [SDK collection and provenance](https://corpus.betteroffice.dev/collections/openxmlsdk-en-48.json) · [upstream MIT license](https://github.com/dotnet/Open-XML-SDK/blob/431ab05cf160248cc3885a4a766026d4f8243792/LICENSE)

Baseline at `bb0b6a3e7bc2dece469e5cf983198c0bf153b6ae` (the later commit only clarifies documentation):

| Format | Samples | Latest release SSIM | Source SSIM | Reference / rendered pages |
| --- | ---: | ---: | ---: | ---: |
| DOCX | 49 | 0.928761 | 0.928761 | 54 / 53 |
| PPTX | 1 | 0.940397 | 0.939677 | 3 / 3 |
| XLSX | 1 | 0.704588 | 0.704262 | 9 / 9 |

The separate fidelity fixes in #363 and #364 are not included in this baseline. The DOCX mean includes the existing missing-page penalty for the even-page-header fixture. All samples use pinned CDN fonts; the comparator performs no resampling or alignment correction. Corpus files remain outside Git.

Test plan:
- [x] Pass 18 harness tests, seven Python comparator tests, typecheck, actionlint, and syntax checks.
- [x] Export all 48 included files locally with Word and verify source hashes and contiguous page PNGs.
- [x] Verify the A4 capture preserves every existing pixel and adds only the recorded white edge pixels.
- [x] Check every common native/Word page extent is within the one-pixel allowance; preserve the existing even-page-header pagination penalty.
- [x] Verify all 198 public corpus objects, including both collection manifests, through their canonical URLs.
- [x] Run all 102 latest-published/source comparisons across 51 samples; every source hash and render status verified.
- [x] Complete Package, Rust, Python, Security, and CLA checks.
