### PR TITLE
fix(pptx): reject a WMF MOVETO or LINETO too short to hold its point

### DIFF
--- a/.changeset/pptx-wmf-short-point.md
+++ b/.changeset/pptx-wmf-short-point.md
@@ -1,0 +1,6 @@
+---
+"@betteroffice/pptx": patch
+"@betteroffice/rust-crates": patch
+---
+
+Reject a WMF picture whose MOVETO or LINETO record is too short to hold its point, instead of drawing it without that line.

--- a/crates/pptx-render/src/metafile.rs
+++ b/crates/pptx-render/src/metafile.rs
@@ -1277,16 +1277,14 @@ fn wmf_record(player: &mut Player, bytes: &[u8], function: usize, body: usize) -
         }
         0x0127 => player.restore(i32::from(i16_at(bytes, body)?))?,
         0x0214 => {
-            if let Some(point) = point_at(body) {
-                player.flush_pending();
-                player.move_to(point.0, point.1);
-            }
+            let point = point_at(body)?;
+            player.flush_pending();
+            player.move_to(point.0, point.1);
         }
         0x0213 => {
-            if let Some(point) = point_at(body) {
-                player.line_to(point.0, point.1);
-                player.pending_stroke = true;
-            }
+            let point = point_at(body)?;
+            player.line_to(point.0, point.1);
+            player.pending_stroke = true;
         }
         0x02FA => {
             let (Some(style), Some(width), Some(color)) = (
@@ -1623,6 +1621,27 @@ mod tests {
         let mut lying = emf_header([0, 0, 99, 99], [100, 100]);
         lying.extend(record(86, &i32s(&[0, 0, 0, 0, 100_000])));
         assert!(decode(&lying).is_none());
+    }
+
+    const WMF_LINETO_SHORTER_THAN_ITS_POINT: &[u8] = &[
+        0x01, 0x00, 0x09, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x13, 0x02, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00,
+        0x24, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn a_wmf_move_or_line_too_short_for_its_point_rejects_the_metafile() {
+        for function in [0x0213u16, 0x0214] {
+            let mut short = WMF_LINETO_SHORTER_THAN_ITS_POINT.to_vec();
+            short[22..24].copy_from_slice(&function.to_le_bytes());
+            assert!(decode(&short).is_none(), "function {function:#06x}");
+
+            let mut honest = short.clone();
+            honest[18] = 5;
+            honest.splice(26..26, [0, 0]);
+            assert!(decode(&honest).is_some(), "function {function:#06x}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
TL;DR:


Repro file:
`WMF_LINETO_SHORTER_THAN_ITS_POINT` and `a_wmf_move_or_line_too_short_for_its_point_rejects_the_metafile` in `crates/pptx-render/src/metafile.rs`. They hold a 52-byte WMF: an 18-byte header, a META_LINETO whose declared size (4 words) leaves a 2-byte body where the point needs 4 bytes, a filled three-point META_POLYGON, and the end record.

```
00000000: 0100 0900 0003 0000 0000 0000 0000 0000  header, 18 bytes
00000010: 0000 0400 0000 1302 0000 0a00 0000 2403  LINETO: 4 words, 2-byte body; POLYGON: 10 words
00000020: 0300 0000 0000 0100 0000 0000 0100 0300  count 3: (0,0) (1,0) (0,1); EOF
00000030: 0000 0000
```

Before this change, `decode` returns the filled triangle and drops the line. After it, `decode` returns `None`.

Summary:
- Changed META_MOVETO (`0x0214`) and META_LINETO (`0x0213`) to read their point with `?`, the way every other WMF record reads its fields. A record too short for its point now rejects the whole metafile instead of being skipped. This applies the #318 rule: a record that disagrees with its content produces no drawing, never a wrong one.
- Only malformed files are affected. Each record is decoded from a slice bounded to its own declared size, so a short record never borrows bytes from the next one. The 8 WMFs embedded in the render corpus contain no MOVETO or LINETO records at all. There is no Before/After, because no well-formed file draws differently.
- Added a regression test that runs the 52 bytes with the record set to LINETO and then to MOVETO. It also checks that the same bytes with an honest 5-word record do decode, so a `None` cannot come from something unrelated such as the header being rejected.
- Left EMF DELETEOBJECT (kind 40) and WMF META_DELETEOBJECT (`0x01F0`) as they are, although they use the same `if let` shape. A skipped delete is a no-op, exactly like a well-formed delete of an empty or out-of-range slot, so the skip cannot produce a drawing that no honest file produces. None of the corpus's 79 META_DELETEOBJECT records is short.
- Follow-up, not in this PR: once this and #393 have landed, add the 52-byte reproducer to `fuzz/corpus/metafile-decode/`. #393's fuzz package is not on `main`, and until this fix lands the fuzz target reports the input as a failure.

Test plan:
- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --tests -- -D warnings`
- [ ] `cargo fmt --check`
- [ ] `cargo check --manifest-path apps/native-viewer/Cargo.toml --no-default-features --features pptx`
- [ ] With the two arms reverted to `if let Some(point)`, `a_wmf_move_or_line_too_short_for_its_point_rejects_the_metafile` fails (`function 0x0213`), and it passes with the change
- [ ] With only the MOVETO arm reverted, the same test fails at `function 0x0214`, so each arm is pinned on its own rather than MOVETO riding on LINETO

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
