### PR TITLE
fix(docx): improve table pagination and text spacing

### DIFF
--- a/.changeset/docx-fractional-canvas.md
+++ b/.changeset/docx-fractional-canvas.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/docx": patch
+---
+
+Round page canvas dimensions up so fractional pixel edges remain visible at different zoom and display scales.

--- a/.changeset/docx-indented-alignment.md
+++ b/.changeset/docx-indented-alignment.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/docx": patch
+---
+
+Center and right-align the first line within its indented width, including hanging indents.

--- a/.changeset/docx-table-keep-next.md
+++ b/.changeset/docx-table-keep-next.md
@@ -1,0 +1,5 @@
+---
+'@betteroffice/docx': patch
+---
+
+Keep table heading rows with their following rows when the group fits on a page, and prevent shorter fonts from adding extra leading below taller fonts on the same line.

--- a/.changeset/docx-table-wrapping.md
+++ b/.changeset/docx-table-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@betteroffice/docx": patch
+---
+
+Respect narrow text boundaries and preserve empty paragraphs after header and footer tables so wrapping and footer placement match Word.

--- a/crates/docx-layout/src/display_list.rs
+++ b/crates/docx-layout/src/display_list.rs
@@ -5823,7 +5823,8 @@ fn emit_line(
     let left_offset = line.left_offset.unwrap_or(0.0);
     let right_offset = line.right_offset.unwrap_or(0.0);
     let usable_width =
-        (geom.frag_width - pad_left - geom.indent_right - left_offset - right_offset).max(0.0);
+        (geom.frag_width - pad_left - text_indent - geom.indent_right - left_offset - right_offset)
+            .max(0.0);
 
     // distribute the measured line width over runs whose advance we don't know
     // individually: fixed-width runs (tabs, inline images) subtract first, the
@@ -10348,6 +10349,38 @@ mod tests {
         assert_eq!(image["flipH"], true);
         assert_eq!(image["w"], 44.641);
         assert_eq!(image["contentFrame"]["w"], 40);
+    }
+
+    #[test]
+    fn centered_and_right_aligned_first_lines_use_the_indented_width() {
+        for (alignment, first_line, hanging, expected_x) in [
+            ("center", 20, 0, 130.0),
+            ("center", 0, 20, 110.0),
+            ("right", 20, 0, 190.0),
+            ("right", 0, 20, 190.0),
+        ] {
+            let input = json!({
+                "measured":[{
+                    "block":{"kind":"paragraph","id":"p","runs":[{"kind":"text","text":"X"}],"attrs":{"alignment":alignment,"indent":{"left":40,"firstLine":first_line,"hanging":hanging}}},
+                    "measure":{"kind":"paragraph","totalHeight":20,"lines":[{"headRun":0,"headChar":0,"tailRun":0,"tailChar":1,"width":20,"ascent":11,"descent":3,"lineHeight":20}]}
+                }],
+                "options":{},
+                "layout":{"pages":[{"number":1,"size":{"w":300,"h":500},"margins":{"top":20,"right":20,"bottom":20,"left":20},"fragments":[{"kind":"paragraph","blockId":"p","x":10,"y":20,"width":200,"height":20,"fromLine":0,"toLine":1}]}]}
+            });
+            let output: Value =
+                serde_json::from_str(&build_display_list_json(&input.to_string()).unwrap())
+                    .unwrap();
+            let text = output["pages"][0]["primitives"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|primitive| primitive["text"] == "X")
+                .unwrap();
+            assert_eq!(
+                text["x"], expected_x,
+                "{alignment}, first {first_line}, hanging {hanging}"
+            );
+        }
     }
 
     #[test]

--- a/crates/docx-layout/src/header_footer.rs
+++ b/crates/docx-layout/src/header_footer.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::measure_blocks::{MeasurementConfig, extent_height, measure_blocks, measure_paragraph};
 use crate::types::{
     BlockExtent, BlockId, FieldRun, ImageRun, Layout, LayoutBlock, MeasuredBlock, PageMargins,
-    ParagraphBlock, Run, RunFormatting, Size, TableBlock,
+    ParagraphBlock, Run, RunFormatting, Size,
 };
 
 const DEFAULT_HF_DISTANCE_PX: f64 = 48.0;
@@ -116,7 +116,7 @@ pub fn measure_header_footer(
     if blocks.is_empty() {
         return Ok(None);
     }
-    let mut blocks = normalize_header_footer_blocks(blocks);
+    let mut blocks = blocks;
     let measures = measure_blocks(&mut blocks, content_width, config)?;
     let height = measures.iter().map(extent_height).sum();
     let mut flow = HeaderFooterFlow::default();
@@ -245,59 +245,6 @@ fn measure_field_text(
     };
     let extent = measure_paragraph(&paragraph, 1_000_000.0, config)?;
     Ok(extent.lines.first().map_or(0.0, |line| line.width))
-}
-
-pub fn normalize_header_footer_blocks(mut blocks: Vec<LayoutBlock>) -> Vec<LayoutBlock> {
-    normalize_block_slice(&mut blocks);
-    blocks
-}
-
-fn normalize_block_slice(blocks: &mut [LayoutBlock]) {
-    let trailing_empty: Vec<usize> = (1..blocks.len())
-        .filter(|index| {
-            matches!(blocks[index - 1], LayoutBlock::Table(_))
-                && matches!(&blocks[*index], LayoutBlock::Paragraph(paragraph)
-                    if paragraph.runs.is_empty() && !has_authored_visuals(paragraph))
-        })
-        .collect();
-    for block in blocks.iter_mut() {
-        if let LayoutBlock::Table(table) = block {
-            normalize_table(table);
-        }
-    }
-    for index in trailing_empty {
-        let LayoutBlock::Paragraph(paragraph) = &mut blocks[index] else {
-            continue;
-        };
-        let attrs = paragraph.attrs.get_or_insert_with(Default::default);
-        attrs.suppress_empty_paragraph_height = Some(true);
-        if let Some(spacing) = attrs.spacing.as_mut() {
-            spacing.before = None;
-            spacing.after = None;
-        }
-    }
-}
-
-fn normalize_table(table: &mut TableBlock) {
-    for row in &mut table.rows {
-        for cell in &mut row.cells {
-            normalize_block_slice(&mut cell.blocks);
-        }
-    }
-}
-
-fn has_authored_visuals(paragraph: &crate::types::ParagraphBlock) -> bool {
-    let Some(attrs) = &paragraph.attrs else {
-        return false;
-    };
-    attrs
-        .borders
-        .as_ref()
-        .is_some_and(|borders| borders.top.is_some() || borders.bottom.is_some())
-        || attrs
-            .spacing_explicit
-            .as_ref()
-            .is_some_and(|spacing| spacing.before == Some(true) || spacing.after == Some(true))
 }
 
 pub fn contributes_to_flow(block: &LayoutBlock) -> bool {
@@ -488,27 +435,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalization_preserves_style_spacing_except_for_empty_table_tails() {
-        let blocks: Vec<LayoutBlock> = serde_json::from_value(json!([
-            {"kind": "paragraph", "id": "heading", "runs": [{"kind":"text","text":"Heading"}], "attrs": {"spacing": {"before": 8, "after": 9}}},
-            {"kind": "table", "id": "t", "rows": []},
-            {"kind": "paragraph", "id": "p", "runs": [], "attrs": {"spacing": {"before": 8, "after": 9}}}
-        ]))
-        .unwrap();
-
-        let normalized = normalize_header_footer_blocks(blocks);
-        let LayoutBlock::Paragraph(heading) = &normalized[0] else {
-            panic!("paragraph expected");
-        };
-        let spacing = heading.attrs.as_ref().unwrap().spacing.as_ref().unwrap();
-        assert_eq!((spacing.before, spacing.after), (Some(8.0), Some(9.0)));
-        let LayoutBlock::Paragraph(paragraph) = &normalized[2] else {
-            panic!("paragraph expected");
-        };
-        let attrs = paragraph.attrs.as_ref().unwrap();
-        assert_eq!(attrs.spacing.as_ref().unwrap().before, None);
-        assert_eq!(attrs.spacing.as_ref().unwrap().after, None);
-        assert_eq!(attrs.suppress_empty_paragraph_height, Some(true));
+    fn empty_paragraph_after_table_reserves_header_footer_space() {
+        for kind in [HeaderFooterKind::Header, HeaderFooterKind::Footer] {
+            let blocks = serde_json::from_value(json!([
+                {"kind":"table","id":"table","rows":[{"id":"row","height":20,"heightRule":"exact","cells":[{"id":"cell","blocks":[]}]}]},
+                {"kind":"paragraph","id":"tail","runs":[],"attrs":{"spacing":{"before":2,"after":3,"line":12,"lineRule":"exact"}}}
+            ])).unwrap();
+            let size = Size { w: 300.0, h: 500.0 };
+            let margins = PageMargins {
+                top: 40.0,
+                right: 40.0,
+                bottom: 40.0,
+                left: 40.0,
+                header: Some(20.0),
+                footer: Some(20.0),
+            };
+            let variant = measure_header_footer(
+                "hf".to_owned(),
+                kind,
+                HeaderFooterType::Default,
+                0,
+                blocks,
+                220.0,
+                HeaderFooterMetrics {
+                    kind,
+                    page_size: &size,
+                    margins: &margins,
+                },
+                &MeasurementConfig::default(),
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(variant.flow_height, 37.0);
+            let BlockExtent::Paragraph(tail) = &variant.measured[1].measure else {
+                panic!("paragraph expected");
+            };
+            assert_eq!(tail.total_height, 17.0);
+            assert_eq!(tail.lines[0].line_height, 12.0);
+        }
     }
 
     #[test]

--- a/crates/docx-layout/src/hooks.rs
+++ b/crates/docx-layout/src/hooks.rs
@@ -99,6 +99,33 @@ fn get_header_rows_height(measure: &TableExtent, header_row_count: usize) -> f64
     height
 }
 
+fn row_keep_heights(block: &TableBlock, measure: &TableExtent) -> Vec<f64> {
+    let mut heights = vec![0.0_f64; measure.rows.len()];
+    for index in (0..measure.rows.len().saturating_sub(1)).rev() {
+        let keeps_next = block.rows.get(index).is_some_and(|row| {
+            row.cells.iter().any(|cell| {
+                matches!(cell.blocks.last(), Some(LayoutBlock::Paragraph(paragraph))
+                    if paragraph.attrs.as_ref().and_then(|attrs| attrs.keep_next) == Some(true))
+            })
+        });
+        if keeps_next {
+            heights[index] =
+                measure.rows[index].height + heights[index + 1].max(measure.rows[index + 1].height);
+        }
+    }
+    for index in 0..heights.len() {
+        if heights[index] == 0.0 {
+            continue;
+        }
+        let mut next = index + 1;
+        while next < heights.len() && heights[next] > 0.0 {
+            heights[next] = 0.0;
+            next += 1;
+        }
+    }
+    heights
+}
+
 /// Places an in-flow table, emitting one fragment per page or column it spans.
 ///
 /// The cursor is `(row_index, consumed)`, where `consumed` is how many pixels
@@ -127,11 +154,12 @@ pub fn layout_table(
     let header_row_count = tally_header_rows(block);
     let header_rows_height = get_header_rows_height(measure, header_row_count);
     let break_info = build_table_row_break_info(block, measure);
+    let keep_heights = row_keep_heights(block, measure);
 
     let mut row_index = 0usize;
     let mut consumed = 0.0f64; // px of rows[row_index] already placed on a previous fragment
 
-    while row_index < rows.len() {
+    'rows: while row_index < rows.len() {
         let state_idx = paginator.get_current();
         let is_first_fragment = row_index == 0 && consumed == 0.0;
         let column_capacity =
@@ -187,6 +215,19 @@ pub fn layout_table(
         let mut last_row_partial = false;
 
         while cur < rows.len() {
+            let keep_height = keep_heights[cur];
+            if (cur > start_row || consumed == 0.0)
+                && keep_height > available_height - used
+                && keep_height <= column_capacity - header_overhead
+            {
+                if cur > start_row {
+                    break;
+                }
+                if paginator.state(state_idx).pen_y != paginator.state(state_idx).content_top {
+                    paginator.ensure_fits(keep_height + header_overhead + pending_spacing);
+                    continue 'rows;
+                }
+            }
             let row_height = rows[cur].height;
             let start_off = if cur == start_row {
                 first_row_offset

--- a/crates/docx-layout/tests/table_keep_next.rs
+++ b/crates/docx-layout/tests/table_keep_next.rs
@@ -1,0 +1,75 @@
+use serde_json::{Value, json};
+
+fn input() -> Value {
+    let mut input: Value = serde_json::from_str(include_str!(
+        "fixtures/table-splits-with-repeated-header.input.json"
+    ))
+    .unwrap();
+    for row in input["measured"][0]["block"]["rows"]
+        .as_array_mut()
+        .unwrap()
+    {
+        row["cantSplit"] = json!(true);
+    }
+    input
+}
+
+fn layout(input: &Value) -> Value {
+    serde_json::from_str(&docx_layout::layout_to_canonical_json(&input.to_string()).unwrap())
+        .unwrap()
+}
+
+fn keep_next(input: &mut Value, row: usize) {
+    input["measured"][0]["block"]["rows"][row]["cells"][0]["blocks"][0]["attrs"] =
+        json!({"keepNext": true});
+}
+
+#[test]
+fn a_heading_row_moves_with_the_following_row() {
+    let mut input = input();
+    keep_next(&mut input, 2);
+    let result = layout(&input);
+    assert_eq!(result["pages"][0]["fragments"][0]["rowEnd"], 2);
+    assert_eq!(result["pages"][0]["fragments"][0]["height"], 168);
+    assert_eq!(result["pages"][1]["fragments"][0]["rowStart"], 2);
+    assert_eq!(result["pages"][1]["fragments"][0]["rowEnd"], 4);
+}
+
+#[test]
+fn a_heading_and_follower_that_fit_stay_on_the_current_page() {
+    let mut input = input();
+    let expected = layout(&input);
+    keep_next(&mut input, 1);
+    assert_eq!(layout(&input), expected);
+}
+
+#[test]
+fn oversized_keep_chains_do_not_create_blank_pages() {
+    let mut input = input();
+    let expected = layout(&input);
+    keep_next(&mut input, 1);
+    keep_next(&mut input, 2);
+    assert_eq!(layout(&input), expected);
+}
+
+#[test]
+fn a_kept_table_group_can_move_to_the_next_column() {
+    let mut input = input();
+    input["options"]["columns"] = json!({"count": 2, "gap": 24});
+    keep_next(&mut input, 2);
+    let result = layout(&input);
+    let fragments = result["pages"][0]["fragments"].as_array().unwrap();
+    assert_eq!(fragments.len(), 2);
+    assert_eq!(fragments[0]["rowEnd"], 2);
+    assert_eq!(fragments[1]["rowStart"], 2);
+    assert!(fragments[1]["x"].as_f64().unwrap() > fragments[0]["x"].as_f64().unwrap());
+}
+
+#[test]
+fn a_table_cell_page_break_does_not_force_a_row_break() {
+    let mut input = input();
+    let expected = layout(&input);
+    input["measured"][0]["block"]["rows"][2]["cells"][0]["blocks"][0]["attrs"] =
+        json!({"pageBreakBefore": true});
+    assert_eq!(layout(&input), expected);
+}

--- a/crates/ooxml-text/src/measure/line_filler.rs
+++ b/crates/ooxml-text/src/measure/line_filler.rs
@@ -97,7 +97,7 @@ struct LineState {
     max_font: Option<FontId>,
     max_ascent: f32,
     max_descent: f32,
-    max_leading: Option<f32>,
+    max_below_baseline: f32,
     /// Tallest inline-image footprint on the line.
     max_image_height_px: f32,
     available: f32,
@@ -210,7 +210,7 @@ pub(super) fn fill(p: FillParams) -> Result<ParagraphExtentOut, MeasureError> {
             max_font: None,
             max_ascent: 0.0,
             max_descent: 0.0,
-            max_leading: None,
+            max_below_baseline: 0.0,
             max_image_height_px: 0.0,
             available: first_available,
             left_offset: first_margins.left,
@@ -543,11 +543,7 @@ impl Filler<'_> {
         Ok(())
     }
 
-    /// Folds one font-bearing contribution into the line's metrics: the first
-    /// claims the line and only a strictly larger size displaces it, while
-    /// ascent, descent and leading accumulate as maxima across every
-    /// contribution. Super/subscript baseline shifts move ascent and descent
-    /// in opposite directions and never go negative.
+    /// Accumulates each run's extents above and below the shared baseline.
     fn update_max_font(&mut self, font_size_pt: f32, font: FontId, baseline_shift_px: f32) {
         if self.cur.max_font.is_none() || font_size_pt > self.cur.max_font_size_pt {
             self.cur.max_font_size_pt = font_size_pt;
@@ -563,11 +559,10 @@ impl Filler<'_> {
                 .cur
                 .max_descent
                 .max((line.descent - baseline_shift_px).max(0.0));
-            self.cur.max_leading = Some(
-                self.cur
-                    .max_leading
-                    .map_or(line.leading, |leading| leading.max(line.leading)),
-            );
+            self.cur.max_below_baseline = self
+                .cur
+                .max_below_baseline
+                .max((line.descent + line.leading - baseline_shift_px).max(0.0));
         }
     }
 
@@ -664,7 +659,7 @@ impl Filler<'_> {
             Some(_) => wm::LineBox {
                 ascent: self.cur.max_ascent,
                 descent: self.cur.max_descent,
-                leading: self.cur.max_leading.unwrap_or(0.0),
+                leading: self.cur.max_below_baseline - self.cur.max_descent,
             },
             // Fontless lines use a 0.8/0.2 em split.
             None => wm::LineBox {
@@ -829,7 +824,7 @@ impl Filler<'_> {
             max_font: None,
             max_ascent: 0.0,
             max_descent: 0.0,
-            max_leading: None,
+            max_below_baseline: 0.0,
             max_image_height_px: 0.0,
             available,
             left_offset: margins.left,

--- a/crates/ooxml-text/src/measure/line_filler.rs
+++ b/crates/ooxml-text/src/measure/line_filler.rs
@@ -6,9 +6,7 @@
 //! which [`TypesetRowOut`] fields come out. The rules it enforces:
 //!
 //! - Trailing spaces retain their advance but do not force a word to wrap.
-//!   A line accepts
-//!   an overshoot of up to [`WRAP_SLACK_PX`], so a sub-half-pixel rounding
-//!   artifact never forces a wrap that exact twip arithmetic would not make.
+//!   [`WRAP_SLACK_PX`] absorbs floating-point rounding at the line edge.
 //! - A word too wide for a whole line is chopped: the current line takes what
 //!   fits, then each following line takes the longest cluster prefix that
 //!   fits, with a forced minimum of one cluster so filling always terminates.
@@ -52,9 +50,8 @@ use crate::word_metrics as wm;
 
 use super::tabs;
 
-/// Half-pixel wrap tolerance: an overshoot this small must not force a wrap
-/// that exact twip arithmetic would never make.
-const WRAP_SLACK_PX: f32 = 0.5;
+/// Floating-point tolerance at the line edge.
+const WRAP_SLACK_PX: f32 = 1e-3;
 /// Empty-paragraph line height floor, as a multiple of the font size; applies
 /// under the `auto` and `atLeast` rules only.
 const WORD_SINGLE_LINE_FLOOR: f32 = 1.15;

--- a/crates/ooxml-text/src/measure/mod.rs
+++ b/crates/ooxml-text/src/measure/mod.rs
@@ -45,7 +45,7 @@
 //!   `size_px × usWinAscent/upem` and `size_px × usWinDescent/upem`, and the
 //!   single-line basis is their sum plus GDI external leading
 //!   ([`crate::word_metrics`]).
-//! - **Wrapping is greedy** with a half-pixel tolerance: a line takes the
+//! - **Wrapping is greedy** with a floating-point tolerance: a line takes the
 //!   last break opportunity that fits. Opportunities are UAX-14
 //!   ([`crate::line_break`]), so consecutive spaces collapse into a single
 //!   opportunity and a soft hyphen permits a break.

--- a/crates/ooxml-text/tests/measure.rs
+++ b/crates/ooxml-text/tests/measure.rs
@@ -311,6 +311,36 @@ fn multi_run_line_takes_max_font_basis() {
     approx(line["lineHeight"].as_f64().unwrap(), 2.0 * LH, "24pt line");
 }
 
+#[test]
+fn a_shorter_font_does_not_add_leading_below_a_taller_font() {
+    let mut store = store();
+    store.register(NOTO_NASKH_ARABIC.to_vec()).unwrap();
+    let latin = json!({"kind": "text", "text": "x", "fontFamily": "Liberation Sans"});
+    let arabic = json!({"kind": "text", "text": "ا", "fontFamily": "Noto Naskh Arabic"});
+    for runs in [
+        json!([arabic, latin]),
+        json!([latin, arabic]),
+        json!([arabic, latin, arabic]),
+    ] {
+        let input = json!({
+            "block": {"kind": "paragraph", "runs": runs},
+            "maxWidth": 500,
+            "fontChains": {"liberation sans|0|0": [0], "noto naskh arabic|0|0": [1]},
+            "defaults": {"fontSize": 12, "fontFamily": "Liberation Sans"}
+        });
+        let out = measure_paragraph_json(&store, &input.to_string()).unwrap();
+        let result: Value = serde_json::from_str(&out).unwrap();
+        let line = &result["lines"][0];
+        approx(line["ascent"].as_f64().unwrap(), 16.0 * 1.405, "ascent");
+        approx(line["descent"].as_f64().unwrap(), 16.0 * 0.634, "descent");
+        approx(
+            line["lineHeight"].as_f64().unwrap(),
+            16.0 * 2.039,
+            "line height",
+        );
+    }
+}
+
 // 6. line rules preserve typography metrics
 #[test]
 fn line_rules_match_typography_semantics() {

--- a/crates/ooxml-text/tests/measure.rs
+++ b/crates/ooxml-text/tests/measure.rs
@@ -140,6 +140,27 @@ fn wrap_at_space_keeps_trailing_space_in_line_width() {
 }
 
 #[test]
+fn words_wrap_on_subpixel_overflow() {
+    let text = json!([{ "kind": "text", "text": "00 00" }]);
+    let width = 4.0 * W0 + SP;
+    for overflow in [0.01, 0.05, 0.25] {
+        let value = measure(text.clone(), width - overflow).unwrap();
+        assert_eq!(spans(&value), vec![(0, 0, 0, 3), (0, 3, 0, 5)]);
+    }
+    let value = measure(text, width).unwrap();
+    assert_eq!(spans(&value), vec![(0, 0, 0, 5)]);
+}
+
+#[test]
+fn unbreakable_words_wrap_on_subpixel_overflow() {
+    let text = json!([{ "kind": "text", "text": "000" }]);
+    let value = measure(text.clone(), 3.0 * W0 - 0.05).unwrap();
+    assert_eq!(spans(&value), vec![(0, 0, 0, 2), (0, 2, 0, 3)]);
+    let value = measure(text, 3.0 * W0).unwrap();
+    assert_eq!(spans(&value), vec![(0, 0, 0, 3)]);
+}
+
+#[test]
 fn trailing_spaces_can_overhang_without_wrapping_the_word() {
     for spaces in [" ", "   "] {
         let text = format!("0 00{spaces}0");
@@ -1965,7 +1986,7 @@ fn zone_composes_with_marker_and_first_line_indent() {
     let v = measure_with(block.clone(), 150.0).unwrap();
     assert_eq!(spans(&v), vec![(0, 0, 0, 11)]);
 
-    // zone leftMargin 40 → 62px: exactly two words fit (62.28 ≤ 62.5 slack),
+    // zone leftMargin 40 → 62px: exactly two words fit (57.84px visible),
     // the third wraps to a full-width second line
     let v = measure_block_floats(
         block,

--- a/packages/docx/src/layout/render/canvasBackend.test.ts
+++ b/packages/docx/src/layout/render/canvasBackend.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, spyOn } from 'bun:test';
+import { beforeAll, describe, expect, it, mock, spyOn } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -7,7 +7,11 @@ import {
   preloadLayoutWasm,
   registerMeasureFont,
 } from '../../wasm/layout';
-import { drawPrimitive } from './canvasBackend';
+import {
+  drawPrimitive,
+  rasterizeDisplayPageToBackBuffer,
+  sizeCanvasForPage,
+} from './canvasBackend';
 import type {
   DisplayList,
   DisplayPaintClip,
@@ -246,6 +250,65 @@ function syntheticMixedFamilyDisplayList(): DisplayList {
   };
   return JSON.parse(buildDisplayListJson(JSON.stringify(input))) as DisplayList;
 }
+
+describe('Canvas page extents', () => {
+  it.each(['direct', 'back buffer'] as const)(
+    'keeps fractional page edges in the %s raster',
+    async (mode) => {
+      let width = 0;
+      let height = 0;
+      let resizes = 0;
+      const context = {
+        scale: mock(() => {}),
+        resetTransform: mock(() => {}),
+        clearRect: mock(() => {}),
+      } as unknown as CanvasRenderingContext2D;
+      const canvas = {
+        get width() {
+          return width;
+        },
+        set width(value: number) {
+          width = Math.trunc(value);
+          resizes += 1;
+        },
+        get height() {
+          return height;
+        },
+        set height(value: number) {
+          height = Math.trunc(value);
+          resizes += 1;
+        },
+        style: { width: '', height: '' },
+        getContext: () => context,
+      };
+      const page = {
+        pageIndex: 0,
+        width: 11906 / 15,
+        height: 16838 / 15,
+        primitives: [],
+      };
+      if (mode === 'direct') {
+        sizeCanvasForPage(canvas, context, page, 1.25, 1.25);
+        expect(canvas.style.width).toBe(`${page.width * 1.25}px`);
+        expect(canvas.style.height).toBe(`${page.height * 1.25}px`);
+      } else {
+        for (let frame = 0; frame < 2; frame += 1) {
+          await rasterizeDisplayPageToBackBuffer(
+            canvas as unknown as HTMLCanvasElement,
+            page,
+            {},
+            1.25,
+            1.25
+          );
+        }
+        expect(resizes).toBe(2);
+      }
+      expect(canvas.width).toBe(1241);
+      expect(canvas.height).toBe(1754);
+      expect(context.scale).toHaveBeenLastCalledWith(1.5625, 1.5625);
+    }
+  );
+});
 
 describe('Canvas text-run slot clipping', () => {
   it('clips a Rust-shaped run from a synthetic mixed-family line', async () => {

--- a/packages/docx/src/layout/render/canvasBackend.ts
+++ b/packages/docx/src/layout/render/canvasBackend.ts
@@ -66,8 +66,8 @@ export async function rasterizeDisplayPageToBackBuffer(
   const ctx = canvas.getContext('2d') as PageCanvasContext | null;
   if (!ctx) throw new Error('Canvas 2D context is unavailable');
   const scale = devicePixelRatio * zoom;
-  const width = page.width * scale;
-  const height = page.height * scale;
+  const width = Math.ceil(page.width * scale);
+  const height = Math.ceil(page.height * scale);
   if (canvas.width !== width) canvas.width = width;
   if (canvas.height !== height) canvas.height = height;
   ctx.resetTransform();
@@ -161,8 +161,8 @@ export function sizeCanvasForPage(
   zoom: number = 1
 ): void {
   const backingScale = devicePixelRatio * zoom;
-  canvas.width = page.width * backingScale;
-  canvas.height = page.height * backingScale;
+  canvas.width = Math.ceil(page.width * backingScale);
+  canvas.height = Math.ceil(page.height * backingScale);
   canvas.style.width = `${page.width * zoom}px`;
   canvas.style.height = `${page.height * zoom}px`;
   ctx.scale(backingScale, backingScale);

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -19,7 +19,7 @@ QUALITY_OUTPUT=.source/office-quality/run \
 node scripts/office-quality/readme.mjs .source/office-quality/run/report.json
 ```
 
-The runner compares the latest npm releases with the checked-out source using pinned CDN fonts. Commit source changes first and choose an empty output directory. The default [`office-quality` collection](https://corpus.betteroffice.dev/collections/office-quality.json) selects the three demos and `bo-corpus-1`, a redacted industry document. The [`docx` collection](https://corpus.betteroffice.dev/collections/docx.json) contains exactly `betteroffice-demo` and `bo-corpus-1`. Set `QUALITY_COLLECTION` to another collection or `QUALITY_SAMPLES='["betteroffice-demo"]'` to select a subset, overriding the collection. Runs support up to 100 samples.
+The runner compares the latest npm releases with the checked-out source using pinned CDN fonts. Commit source changes first and choose an empty output directory. The default [`office-quality` collection](https://corpus.betteroffice.dev/collections/office-quality.json) selects the three demos and two redacted industry documents, `bo-corpus-1` and `bo-corpus-2`. The [`docx` collection](https://corpus.betteroffice.dev/collections/docx.json) contains exactly `betteroffice-demo`, `bo-corpus-1`, and `bo-corpus-2`. Set `QUALITY_COLLECTION` to another collection or `QUALITY_SAMPLES='["betteroffice-demo"]'` to select a subset, overriding the collection. Runs support up to 100 samples.
 
 XLSX capture uses `printDisplayList` when available, with font metrics measured
 at 72 layout DPI for the frozen Mac Office capture and the worksheet's explicit defaults.
@@ -100,10 +100,11 @@ The `betteroffice-corpus` R2 bucket is served at **https://corpus.betteroffice.d
 | --- | --- | ---: |
 | [betteroffice-demo](https://corpus.betteroffice.dev/betteroffice-demo/metadata.json) | DOCX | 2 |
 | [bo-corpus-1](https://corpus.betteroffice.dev/bo-corpus-1/metadata.json) | DOCX | 17 |
+| [bo-corpus-2](https://corpus.betteroffice.dev/bo-corpus-2/metadata.json) | DOCX | 8 |
 | [betteroffice-slides](https://corpus.betteroffice.dev/betteroffice-slides/metadata.json) | PPTX | 3 |
 | [betteroffice-workbook](https://corpus.betteroffice.dev/betteroffice-workbook/metadata.json) | XLSX | 9 |
 
-Collection manifests live at `collections/<id>.json` with `schema_version: 1`, the collection `id`, and a `samples` array of folder names. Sample metadata links the source and PNGs and records capture provenance, hashes, comparisons, and licensing. The DOCX corpus contains only the demo and the authorized redacted sample; private inputs and captures stay local. Publishing additional authorized samples requires authenticated Wrangler:
+Collection manifests live at `collections/<id>.json` with `schema_version: 1`, the collection `id`, and a `samples` array of folder names. Sample metadata links the source and PNGs and records capture provenance, hashes, comparisons, and licensing. The DOCX corpus contains only the demo and the two authorized redacted samples; original private inputs stay local, and reference images live in the bucket. Publishing additional authorized samples requires authenticated Wrangler:
 
 ```sh
 bunx wrangler r2 object put betteroffice-corpus/<key> --file <local-file> --remote

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -100,11 +100,13 @@ The `betteroffice-corpus` R2 bucket is served at **https://corpus.betteroffice.d
 | --- | --- | ---: |
 | [betteroffice-demo](https://corpus.betteroffice.dev/betteroffice-demo/metadata.json) | DOCX | 2 |
 | [bo-corpus-1](https://corpus.betteroffice.dev/bo-corpus-1/metadata.json) | DOCX | 17 |
-| [bo-corpus-2](https://corpus.betteroffice.dev/bo-corpus-2/metadata.json) | DOCX | 8 |
+| [bo-corpus-2](https://corpus.betteroffice.dev/bo-corpus-2/metadata.json) | DOCX | 7 |
 | [betteroffice-slides](https://corpus.betteroffice.dev/betteroffice-slides/metadata.json) | PPTX | 3 |
 | [betteroffice-workbook](https://corpus.betteroffice.dev/betteroffice-workbook/metadata.json) | XLSX | 9 |
 
 Collection manifests live at `collections/<id>.json` with `schema_version: 1`, the collection `id`, and a `samples` array of folder names. Sample metadata links the source and PNGs and records capture provenance, hashes, comparisons, and licensing. The DOCX corpus contains only the demo and the two authorized redacted samples; original private inputs stay local, and reference images live in the bucket. Publishing additional authorized samples requires authenticated Wrangler:
+
+`bo-corpus-2` uses Arial throughout, resolved by the renderer to the registry's metric-compatible Liberation Sans. Its Word reference was regenerated from that converted source; the pair uses different font files, and the metadata records the font normalization and previous reference.
 
 ```sh
 bunx wrangler r2 object put betteroffice-corpus/<key> --file <local-file> --remote

--- a/scripts/office-quality/README.md
+++ b/scripts/office-quality/README.md
@@ -104,9 +104,9 @@ The `betteroffice-corpus` R2 bucket is served at **https://corpus.betteroffice.d
 | [betteroffice-slides](https://corpus.betteroffice.dev/betteroffice-slides/metadata.json) | PPTX | 3 |
 | [betteroffice-workbook](https://corpus.betteroffice.dev/betteroffice-workbook/metadata.json) | XLSX | 9 |
 
-Collection manifests live at `collections/<id>.json` with `schema_version: 1`, the collection `id`, and a `samples` array of folder names. Sample metadata links the source and PNGs and records capture provenance, hashes, comparisons, and licensing. The DOCX corpus contains only the demo and the two authorized redacted samples; original private inputs stay local, and reference images live in the bucket. Publishing additional authorized samples requires authenticated Wrangler:
-
 `bo-corpus-2` uses Arial throughout, resolved by the renderer to the registry's metric-compatible Liberation Sans. Its Word reference was regenerated from that converted source; the pair uses different font files, and the metadata records the font normalization and previous reference.
+
+Collection manifests live at `collections/<id>.json` with `schema_version: 1`, the collection `id`, and a `samples` array of folder names. Sample metadata links the source and PNGs and records capture provenance, hashes, comparisons, and licensing. The DOCX corpus contains only the demo and the two authorized redacted samples; original private inputs stay local, and reference images live in the bucket. Publishing additional authorized samples requires authenticated Wrangler:
 
 ```sh
 bunx wrangler r2 object put betteroffice-corpus/<key> --file <local-file> --remote


### PR DESCRIPTION
TL;DR:

Repro file:

- [Current corpus source, normalized to Arial](https://corpus.betteroffice.dev/bo-corpus-2/versions/arial-ae787887/bo-corpus-2.docx) · [matching Word PDF](https://corpus.betteroffice.dev/bo-corpus-2/versions/arial-ae787887/reference/reference.pdf) · [metadata](https://corpus.betteroffice.dev/bo-corpus-2/metadata.json)
- [Original font-mix repro](https://corpus.betteroffice.dev/bo-corpus-2/bo-corpus-2.docx) · [original Word PDF](https://corpus.betteroffice.dev/bo-corpus-2/reference/reference.pdf)

Summary:

- Keep table heading rows with their following rows when the group fits on a page or column.
- Measure mixed-font lines from their extents above and below the baseline, avoiding extra leading from shorter fonts.
- Wrap text that exceeds its line width instead of allowing half a pixel of overflow.
- Preserve empty paragraphs after header and footer tables, and align first lines within their indented width.
- Round fractional canvas dimensions up and avoid repeatedly resizing the back buffer.
- Document the three-document DOCX collection and its updated, seven-page bo-corpus-2 reference.

The current corpus revision uses **Arial in Word and the registry's metric-compatible Liberation Sans**. It scores **0.874882 SSIM**, with **7/7 pages**, at 150 DPI using pinned CDN fonts and no image resizing or alignment correction. These are different font files with compatible metrics. The converted DOCX and its freshly exported Word reference are published together under an immutable revision path; the previous source and reference remain available.

Font conversion changes the document, so this score is not a renderer-only improvement over the original eight-page sample. The original revision scores **0.798062** on this branch, versus **0.799625** before the table-group and mixed-font fixes; the heading placement now follows Word's keep-with-next behavior. Existing corpus results remain unchanged: **0.926307** for bo-corpus-1 (17 pages) and **0.862558** for the demo (2 pages).

Test plan:

- [x] Validate every XML part and confirm font conversion preserves all text, relationships, binary parts, and unique custom property names.
- [x] Open the exact converted source read-only in Word without repair, export its seven-page PDF, and verify the PDF's fonts and redacted text.
- [x] Run shared text and DOCX layout tests: 421 passed, including table keep groups, oversized groups, columns, ignored cell page breaks, and mixed-font leading.
- [x] Run canvas and office-quality JavaScript tests: 44 passed; DOCX type checking passed.
- [x] Pass Rust formatting, clippy with warnings denied, and DOCX package builds.
- [x] Compare the converted sample, original font-mix repro, and both existing DOCX corpus samples against their matching references.
- [x] Verify public hashes for all uploaded assets and preserve the three-document DOCX collection.
- [ ] Pass the latest PR CI checks before requesting review.
